### PR TITLE
feat: Unset Output Variable in `dsp.generate` to Prevent Leakage

### DIFF
--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -62,7 +62,7 @@ def _generate(template: Template, **kwargs) -> Callable:
     generator = dsp.settings.lm
 
     def do_generate(
-        example: Example, stage: str, max_depth: int = 2, original_example=None
+        example: Example, stage: str, max_depth: int = 2, original_example=None, output_fields=["answer"]
     ):
         if not dsp.settings.lm:
             raise AssertionError("No LM is loaded.")
@@ -75,7 +75,7 @@ def _generate(template: Template, **kwargs) -> Callable:
         # Generate and extract the fields.
         prompt = template(example)
         completions: list[dict[str, Any]] = generator(prompt, **kwargs)
-        completions: list[Example] = [template.extract(example, p) for p in completions]
+        completions: list[Example] = [template.extract(example, p, output_fields=output_fields) for p in completions]
 
         # Find the completions that are most complete.
         field_names: list[str] = [field.input_variable for field in template.fields]

--- a/dsp/templates/template_v2.py
+++ b/dsp/templates/template_v2.py
@@ -129,13 +129,15 @@ class TemplateV2:
         )
 
     def extract(
-        self, example: Union[Example, dict[str, Any]], raw_pred: str
+        self, example: Union[Example, dict[str, Any]], raw_pred: str, output_fields: list = []
     ) -> Example:
         """Extracts the answer from the LM raw prediction using the template structure
 
         Args:
             example (Union[Example, dict[str, Any]]): Contains the input variables that raw_pred was completed on.
             raw_pred (str): LM generated string
+            output_fields (List[str]): List of field names that we expect to extract. Those fields will be set to an empty string 
+                                       if they cannot be extracted to prevent leakage of gold answers.
 
         Returns:
             Example: The example with the output variables filled in
@@ -144,7 +146,7 @@ class TemplateV2:
 
         # Unset the output variables to prevent leakage of gold answers
         for field in self.fields:
-            if field.output_variable in example:
+            if field.output_variable in example and field.output_variable in output_fields:
                 example[field.output_variable] = ""
 
         raw_pred = raw_pred.strip()

--- a/dsp/templates/template_v2.py
+++ b/dsp/templates/template_v2.py
@@ -142,6 +142,11 @@ class TemplateV2:
         """
         example = dsp.Example(example)
 
+        # Unset the output variables to prevent leakage of gold answers
+        for field in self.fields:
+            if field.output_variable in example:
+                example[field.output_variable] = ""
+
         raw_pred = raw_pred.strip()
 
         idx = 0

--- a/tests/extract_test.py
+++ b/tests/extract_test.py
@@ -1,0 +1,94 @@
+import sys
+import os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+import dsp
+
+class TestExtract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.Question = dsp.Type(
+            prefix="Question:", 
+            desc="${the question to be answered}")
+
+        self.Answer = dsp.Type(
+            prefix="Answer:", 
+            desc="${a short factoid answer, often between 1 and 5 words}", 
+            format=dsp.format_answers)
+
+        self.Context = dsp.Type(
+            prefix="Context:\n",
+            desc="${sources that may contain relevant content}",
+            format=dsp.passages2text)
+
+        self.Rationale = dsp.Type(
+            prefix="Rationale: Let's think step by step.",
+            desc="${a step-by-step deduction that identifies the correct response, which will be provided below}"
+        )
+
+        self.instructions = "Complete the prompt with short factoid answers. Answer very concisely."
+
+        self.example = dsp.Example(
+            id = "42",
+            title = "Capital of France",
+            context = "France is a country in Europe. Its capital is Paris.",
+            question = "What is the capital of France?"
+        )
+
+    def test_well_formed1(self):
+        template = dsp.Template(
+            instructions=self.instructions,
+            context=self.Context,
+            question=self.Question,
+            raionale=self.Rationale,
+            answer=self.Answer,
+        )
+
+        raw_pred = "Some rationale here. \nAnswer: Frankfurt"
+        example = dsp.Example(self.example, answer="Paris")
+
+        completion = template.extract(example, raw_pred, output_fields=["answer"])
+
+        for field in ("id", "title", "context", "question"):
+            self.assertEqual(getattr(completion, field), getattr(self.example, field))
+        self.assertEqual(completion.answer, "Frankfurt")
+
+    def test_well_formed2(self):
+        template = dsp.Template(
+            instructions=self.instructions,
+            context=self.Context,
+            question=self.Question,
+            answer=self.Answer,
+        )
+
+        raw_pred = "Frankfurt"
+        example = dsp.Example(self.example, answer="Paris")
+
+        completion = template.extract(example, raw_pred, output_fields=["answer"])
+
+        for field in ("id", "title", "context", "question"):
+            self.assertEqual(getattr(completion, field), getattr(self.example, field))
+        self.assertEqual(completion.answer, "Frankfurt")
+
+    def test_malformed(self):
+        template = dsp.Template(
+            instructions=self.instructions,
+            context=self.Context,
+            question=self.Question,
+            raionale=self.Rationale,
+            answer=self.Answer,
+        )
+
+        raw_pred = "Some rationale here, and the answer is Frankfurt."
+        example = dsp.Example(self.example, answer="Paris")
+
+        completion = template.extract(example, raw_pred, output_fields=["answer"])
+
+        for field in ("id", "title", "context", "question"):
+            self.assertEqual(getattr(completion, field), getattr(self.example, field))
+        self.assertEqual(completion.answer, "") # Answer should be empty string
+
+if __name__ == "__main__":
+    unittest.main()
+
+        


### PR DESCRIPTION
This PR addresses the issue raised in https://github.com/stanfordnlp/dsp/issues/47#issuecomment-1523430127.

The changes in this PR ensure that output variables in `dsp.generate` are unset if the template fails to parse the response corresponding to the output variables.

It is always recommended to pass only the necessary questions to `dsp.generate` or unset the output that users expect the function to produce. However, users often forget to do this when evaluating the dev set. In such cases, the gold answers remain in the output variable of the returned completion, which can lead to malformed output (e.g., a list) or an overestimation of performance. This PR serves as a temporary workaround for this issue.

closes: #47 