### PR TITLE
enhancement(documentation): Minor fixes

### DIFF
--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -4,6 +4,21 @@ This documentation provides an overview of the DSPy Language Model Clients.
 
 ## dspy.OpenAI
 
+### Quickstart
+
+```python
+import dspy
+
+lm = dspy.OpenAI(model='gpt-3.5-turbo')
+
+prompt = "Translate the following English text to Spanish: 'Hi, how are you?'"
+completions = lm(prompt, n=5, return_sorted=True)
+for i, completion in enumerate(completions):
+    print(f"Completion {i+1}: {completion}")
+```
+
+
+
 ### Constructor
 
 The constructor initializes the base class `LM` and verifies the provided arguments like the `api_provider`, `api_key`, and `api_base` to set up OpenAI request retrieval. The `kwargs` attribute is initialized with default values for relevant text generation parameters needed for communicating with the GPT API, such as `temperature`, `max_tokens`, `top_p`, `frequency_penalty`, `presence_penalty`, and `n`.
@@ -45,17 +60,6 @@ After generation, the completions are post-processed based on the `model_type` p
 
 **Returns:**
 - `List[Dict[str, Any]]`: List of completion choices.
-
-### Examples
-
-```python
-lm = dspy.OpenAI(model='gpt-3.5-turbo')
-
-prompt = "Translate the following English text to Spanish: 'Hi, how are you?'"
-completions = lm(prompt, n=5, return_sorted=True)
-for i, completion in enumerate(completions):
-    print(f"Completion {i+1}: {completion}")
-```
 
 ## dspy.Cohere
 

--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -1,4 +1,4 @@
-# dspy.LM Documentation
+# LM Documentation
 
 This documentation provides an overview of the DSPy Language Model Clients.
 
@@ -15,7 +15,7 @@ for i, completion in enumerate(completions):
     print(f"Completion {i+1}: {completion}")
 ```
 
-## dspy.OpenAI
+## OpenAI
 
 ### Usage
 
@@ -41,7 +41,7 @@ class OpenAI(LM):
 
 
 
-**Arguments:** 
+**Parameters:** 
 - `api_key` (Optional[str], optional): API provider authentication token. Defaults to None.
 - `api_provider` (Literal["openai", "azure"], optional): API provider to use. Defaults to "openai".
 - `model_type` (Literal["chat", "text"]): Specified model type to use.
@@ -57,7 +57,7 @@ Internally, the method handles the specifics of preparing the request prompt and
 
 After generation, the completions are post-processed based on the `model_type` parameter. If the parameter is set to 'chat', the generated content look like `choice["message"]["content"]`. Otherwise, the generated text will be `choice["text"]`.
 
-**Arguments:**
+**Parameters:**
 - `prompt` (_str_): Prompt to send to OpenAI.
 - `only_completed` (_bool_, _optional_): Flag to return only completed responses and ignore completion due to length. Defaults to True.
 - `return_sorted` (_bool_, _optional_): Flag to sort the completion choices using the returned averaged log-probabilities. Defaults to False.
@@ -66,7 +66,7 @@ After generation, the completions are post-processed based on the `model_type` p
 **Returns:**
 - `List[Dict[str, Any]]`: List of completion choices.
 
-## dspy.Cohere
+## Cohere
 
 ### Usage
 
@@ -88,7 +88,7 @@ class Cohere(LM):
     ):
 ```
 
-**Arguments:**
+**Parameters:**
 - `model` (_str_): Cohere pretrained models. Defaults to `command-xlarge-nightly`.
 - `api_key` (_Optional[str]_, _optional_): API provider from Cohere. Defaults to None.
 - `stop_sequences` (_List[str]_, _optional_): List of stopping tokens to end generation.
@@ -97,7 +97,7 @@ class Cohere(LM):
 
 Refer to `dspy.OpenAI` documentation.
 
-## dspy.TGI
+## TGI
 
 ### Usage
 
@@ -118,7 +118,7 @@ class HFClientTGI(HFModel):
     def __init__(self, model, port, url="http://future-hgx-1", **kwargs):
 ```
 
-**Arguments:**
+**Parameters:**
 - `model` (_HFModel_): Instance of Hugging Face model connected to the TGI server.
 - `port` (_int_): Port for TGI server.
 - `url` (_str_): Base URL where the TGI server is hosted. 
@@ -128,7 +128,7 @@ class HFClientTGI(HFModel):
 
 Refer to `dspy.OpenAI` documentation.
 
-## dspy.VLLM
+## VLLM
 
 ### Usage
 

--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -51,9 +51,9 @@ class OpenAI(LM):
 
 
 **Parameters:** 
-- `api_key` (Optional[str], optional): API provider authentication token. Defaults to None.
-- `api_provider` (Literal["openai", "azure"], optional): API provider to use. Defaults to "openai".
-- `model_type` (Literal["chat", "text"]): Specified model type to use.
+- `api_key` (_Optional[str]_, _optional_): API provider authentication token. Defaults to None.
+- `api_provider` (_Literal["openai", "azure"]_, _optional_): API provider to use. Defaults to "openai".
+- `model_type` (_Literal["chat", "text"]_): Specified model type to use.
 - `**kwargs`: Additional language model arguments to pass to the API provider.
 
 ### Methods

--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -104,7 +104,7 @@ class Cohere(LM):
 
 ### Methods
 
-Refer to `dspy.OpenAI` documentation.
+Refer to [`dspy.OpenAI`](#openai) documentation.
 
 ## TGI
 
@@ -135,7 +135,7 @@ class HFClientTGI(HFModel):
 
 ### Methods
 
-Refer to `dspy.OpenAI` documentation.
+Refer to [`dspy.OpenAI`](#openai) documentation.
 
 ## VLLM
 
@@ -151,8 +151,8 @@ Refer to the [vLLM Server](https://github.com/stanfordnlp/dspy/blob/local_models
 
 ### Constructor
 
-Refer to `dspy.TGI` documentation. Replace with `HFClientVLLM`.
+Refer to [`dspy.TGI`](#tgi) documentation. Replace with `HFClientVLLM`.
 
 ### Methods
 
-Refer to `dspy.OpenAI` documentation.
+Refer to [`dspy.OpenAI`](#openai) documentation.

--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -17,7 +17,7 @@ for i, completion in enumerate(completions):
 
 ## Supported LM Clients
 
-| LM Client | Link |
+| LM Client | Jump To |
 | --- | --- |
 | OpenAI | [OpenAI Section](#openai) |
 | Cohere | [Cohere Section](#cohere) |

--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -1,4 +1,4 @@
-# LM Documentation
+# LM Modules Documentation
 
 This documentation provides an overview of the DSPy Language Model Clients.
 

--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -15,6 +15,15 @@ for i, completion in enumerate(completions):
     print(f"Completion {i+1}: {completion}")
 ```
 
+## Supported LM Clients
+
+| LM Client | Link |
+| --- | --- |
+| OpenAI | [OpenAI Section](#openai) |
+| Cohere | [Cohere Section](#cohere) |
+| TGI | [TGI Section](#tgi) |
+| VLLM | [VLLM Section](#vllm) |
+
 ## OpenAI
 
 ### Usage

--- a/docs/language_models_client.md
+++ b/docs/language_models_client.md
@@ -2,8 +2,6 @@
 
 This documentation provides an overview of the DSPy Language Model Clients.
 
-## dspy.OpenAI
-
 ### Quickstart
 
 ```python
@@ -12,9 +10,17 @@ import dspy
 lm = dspy.OpenAI(model='gpt-3.5-turbo')
 
 prompt = "Translate the following English text to Spanish: 'Hi, how are you?'"
-completions = lm(prompt, n=5, return_sorted=True)
+completions = lm(prompt, n=5, return_sorted=False)
 for i, completion in enumerate(completions):
     print(f"Completion {i+1}: {completion}")
+```
+
+## dspy.OpenAI
+
+### Usage
+
+```python
+lm = dspy.OpenAI(model='gpt-3.5-turbo')
 ```
 
 ### Constructor
@@ -22,7 +28,7 @@ for i, completion in enumerate(completions):
 The constructor initializes the base class `LM` and verifies the provided arguments like the `api_provider`, `api_key`, and `api_base` to set up OpenAI request retrieval. The `kwargs` attribute is initialized with default values for relevant text generation parameters needed for communicating with the GPT API, such as `temperature`, `max_tokens`, `top_p`, `frequency_penalty`, `presence_penalty`, and `n`.
 
 ```python
-class GPT3(LM):
+class OpenAI(LM):
     def __init__(
         self,
         model: str = "text-davinci-002",
@@ -33,8 +39,9 @@ class GPT3(LM):
     ):
 ```
 
-**Arguments:**
-- `model` (str): OpenAI or Azure supported LLM model to use. Defaults to OpenAI's `"text-davinci-002"`.
+
+
+**Arguments:** 
 - `api_key` (Optional[str], optional): API provider authentication token. Defaults to None.
 - `api_provider` (Literal["openai", "azure"], optional): API provider to use. Defaults to "openai".
 - `model_type` (Literal["chat", "text"]): Specified model type to use.
@@ -44,16 +51,16 @@ class GPT3(LM):
 
 #### `__call__(self, prompt: str, only_completed: bool = True, return_sorted: bool = False, **kwargs) -> List[Dict[str, Any]]`
 
-Retrieves completions from GPT-3 by calling `request`. 
+Retrieves completions from OpenAI by calling `request`. 
 
 Internally, the method handles the specifics of preparing the request prompt and corresponding payload to obtain the response.
 
 After generation, the completions are post-processed based on the `model_type` parameter. If the parameter is set to 'chat', the generated content look like `choice["message"]["content"]`. Otherwise, the generated text will be `choice["text"]`.
 
 **Arguments:**
-- `prompt` (str): Prompt to send to GPT-3.
-- `only_completed` (bool, optional): Flag to return only completed responses and ignore completion due to length. Defaults to True.
-- `return_sorted` (bool, optional): Flag to sort the completion choices using the returned averaged log-probabilities. Defaults to False.
+- `prompt` (_str_): Prompt to send to OpenAI.
+- `only_completed` (_bool_, _optional_): Flag to return only completed responses and ignore completion due to length. Defaults to True.
+- `return_sorted` (_bool_, _optional_): Flag to sort the completion choices using the returned averaged log-probabilities. Defaults to False.
 - `**kwargs`: Additional keyword arguments for completion request.
 
 **Returns:**
@@ -61,9 +68,15 @@ After generation, the completions are post-processed based on the `model_type` p
 
 ## dspy.Cohere
 
+### Usage
+
+```python
+lm = dsp.Cohere(model='command-xlarge-nightly')
+```
+
 ### Constructor
 
-The constructor initializes the base class `LM` and verifies the `api_key` to set up OpenAI request retrieval.
+The constructor initializes the base class `LM` and verifies the `api_key` to set up Cohere request retrieval.
 
 ```python
 class Cohere(LM):
@@ -76,23 +89,21 @@ class Cohere(LM):
 ```
 
 **Arguments:**
-- `model` (str): Cohere pretrained models. Defaults to `command-xlarge-nightly`.
-- `api_key` (Optional[str], optional): API provider from Cohere. Defaults to None.
-- `stop_sequences` (List[str], optional): List of stopping tokens to end generation.
+- `model` (_str_): Cohere pretrained models. Defaults to `command-xlarge-nightly`.
+- `api_key` (_Optional[str]_, _optional_): API provider from Cohere. Defaults to None.
+- `stop_sequences` (_List[str]_, _optional_): List of stopping tokens to end generation.
 
 ### Methods
 
 Refer to `dspy.OpenAI` documentation.
 
-### Examples
+## dspy.TGI
 
-Refer to `dspy.OpenAI` documentation. Replace with
+### Usage
 
 ```python
-lm = dsp.Cohere(model='command-xlarge-nightly')
+lm = dspy.HFClientTGI(model="meta-llama/Llama-2-7b-hf", port=8080, url="http://localhost")
 ```
-
-## dspy.TGI
 
 ### Prerequisites
 
@@ -108,24 +119,22 @@ class HFClientTGI(HFModel):
 ```
 
 **Arguments:**
-- `model` (HFModel): Instance of Hugging Face model connected to the TGI server.
-- `port` (int): Port for TGI server.
-- `url` (str): Base URL where the TGI server is hosted. 
+- `model` (_HFModel_): Instance of Hugging Face model connected to the TGI server.
+- `port` (_int_): Port for TGI server.
+- `url` (_str_): Base URL where the TGI server is hosted. 
 - `**kwargs`: Additional keyword arguments to configure the client.
 
 ### Methods
 
 Refer to `dspy.OpenAI` documentation.
 
-### Examples
+## dspy.VLLM
 
-Refer to `dspy.OpenAI` documentation. Replace with
+### Usage
 
 ```python
-lm = dspy.HFClientTGI(model="meta-llama/Llama-2-7b-hf", port=8080, url="http://localhost")
+lm = dspy.HFClientVLLM(model="meta-llama/Llama-2-7b-hf", port=8080, url="http://localhost")
 ```
-
-## dspy.VLLM
 
 ### Prerequisites
 
@@ -138,11 +147,3 @@ Refer to `dspy.TGI` documentation. Replace with `HFClientVLLM`.
 ### Methods
 
 Refer to `dspy.OpenAI` documentation.
-
-### Examples
-
-Refer to `dspy.OpenAI` documentation. Replace with
-
-```python
-lm = dspy.HFClientVLLM(model="meta-llama/Llama-2-7b-hf", port=8080, url="http://localhost")
-```

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -2,6 +2,14 @@
 
 This documentation provides an overview of the DSPy Modules.
 
+## DSPy Modules
+
+| Module | Jump To |
+| --- | --- |
+| Predict | [Predict Section](#dspypredict) |
+| Retrieve | [Retrieve Section](#dspyretrieve) |
+| ChainOfThought | [ChainOfThought Section](#dspychainofthought) |
+
 ## dspy.Predict
 
 ### Constructor
@@ -40,9 +48,9 @@ class Predict(Parameter):
             self.signature = dsp.Template(instructions, **inputs, **outputs)
 ```
 
-**Arguments:**
-- `signature` (Any): Signature of predictive model.
-- `**config` (dict): Additional configuration parameters for model.
+**Parameters:**
+- `signature` (_Any_): Signature of predictive model.
+- `**config` (_dict_): Additional configuration parameters for model.
 
 ### Method
 
@@ -50,7 +58,7 @@ class Predict(Parameter):
 
 This method serves as a wrapper for the `forward` method. It allows making predictions using the `Predict` class by providing keyword arguments.
 
-**Arguments:**
+**Paramters:**
 - `**kwargs`: Keyword arguments required for prediction.
 
 **Returns:**
@@ -90,8 +98,8 @@ class Retrieve(Parameter):
         self.k = k
 ```
 
-**Arguments:**
-- `k` (Any): Number of retrieval responses
+**Parameters:**
+- `k` (_Any_): Number of retrieval responses
 
 ### Method
 
@@ -99,7 +107,7 @@ class Retrieve(Parameter):
 
 This method serves as a wrapper for the `forward` method. It allows making retrievals on an input query using the `Retrieve` class.
 
-**Arguments:**
+**Parameters:**
 - `**args`: Arguments required for retrieval.
 - `**kwargs`: Keyword arguments required for retrieval.
 
@@ -148,11 +156,11 @@ class ChainOfThought(Predict):
         self.extended_signature = dsp.Template(signature.instructions, **extended_kwargs)
 ```
 
-**Arguments:**
-- `signature` (Any): Signature of predictive model.
-- `rationale_type` (dsp.Type, optional): Rationale type for reasoning steps. Defaults to `None`.
-- `activated` (bool, optional): Flag for activated chain of thought processing. Defaults to `True`.
-- `**config` (dict): Additional configuration parameters for model.
+**Parameters:**
+- `signature` (_Any_): Signature of predictive model.
+- `rationale_type` (_dsp.Type_, _optional_): Rationale type for reasoning steps. Defaults to `None`.
+- `activated` (_bool_, _optional_): Flag for activated chain of thought processing. Defaults to `True`.
+- `**config` (_dict_): Additional configuration parameters for model.
 
 ### Method
 
@@ -160,7 +168,7 @@ class ChainOfThought(Predict):
 
 This method extends the parent `Predict` class' forward pass while updating the signature when chain of thought reasoning is activated or if the language model is a GPT3 model.
 
-**Arguments:**
+**Parameters:**
 - `**kwargs`: Keyword arguments required for prediction.
 
 **Returns:**

--- a/docs/retrieval_models_client.md
+++ b/docs/retrieval_models_client.md
@@ -4,7 +4,7 @@ This documentation provides an overview of the DSPy Retrieval Model Clients.
 
 ## Supported LM Clients
 
-| LM Client | Link |
+| LM Client | Jump To |
 | --- | --- |
 | ColBERTv2 | [ColBERTv2 Section](#ColBERTv2) |
 | AzureCognitiveSearch | [AzureCognitiveSearch Section](#AzureCognitiveSearch) |

--- a/docs/retrieval_models_client.md
+++ b/docs/retrieval_models_client.md
@@ -1,8 +1,29 @@
-# dspy.RM Documentation
+# Retriever Modules Documentation
 
 This documentation provides an overview of the DSPy Retrieval Model Clients.
 
-## dspy.ColBERTv2
+## Supported LM Clients
+
+| LM Client | Link |
+| --- | --- |
+| ColBERTv2 | [ColBERTv2 Section](#ColBERTv2) |
+| AzureCognitiveSearch | [AzureCognitiveSearch Section](#AzureCognitiveSearch) |
+
+## ColBERTv2
+
+### Quickstart
+
+```python
+import dspy
+
+colbertv2_wiki17_abstracts = dspy.ColBERTv2(url='http://20.102.90.50:2017/wiki17_abstracts')
+
+retrieval_response = colbertv2_wiki17_abstracts('When was the first FIFA World Cup held?', k=5)
+
+for result in retrieval_response:
+    print("Text:", result['text'], "\n")
+```
+
 
 ### Constructor
 
@@ -19,9 +40,9 @@ class ColBERTv2:
 ```
 
 **Arguments:**
-- `url` (str): URL for ColBERTv2 server.
-- `port` (Optional[Union[str, int]]): Port endpoint for ColBERTv2 server. Defaults to `None`.
-- `post_requests` (bool, optional): Flag for using HTTP POST requests. Defaults to `False`.
+- `url` (_str_): URL for ColBERTv2 server.
+- `port` (_Union[str, int]_, _Optional_): Port endpoint for ColBERTv2 server. Defaults to `None`.
+- `post_requests` (_bool_, _Optional_): Flag for using HTTP POST requests. Defaults to `False`.
 
 ### Methods
 
@@ -29,26 +50,19 @@ class ColBERTv2:
 
 Enables making queries to the ColBERTv2 server for retrieval. Internally, the method handles the specifics of preparing the request prompt and corresponding payload to obtain the response. The function handles the retrieval of the top-k passages based on the provided query.
 
-**Arguments:**
-- `query` (str): Query string used for retrieval.
-- `k` (int, optional): Number of passages to retrieve. Defaults to 10.
-- `simplify` (bool, optional): Flag for simplifying output to a list of strings. Defaults to False.
+**Parameters:**
+- `query` (_str_): Query string used for retrieval.
+- `k` (_int_, _optional_): Number of passages to retrieve. Defaults to 10.
+- `simplify` (_bool_, _optional_): Flag for simplifying output to a list of strings. Defaults to False.
 
 **Returns:**
 - `Union[list[str], list[dotdict]]`: Depending on `simplify` flag, either a list of strings representing the passage content (`True`) or a list of `dotdict` instances containing passage details (`False`).
 
-### Examples
+## AzureCognitiveSearch
 
-```python
-colbertv2_wiki17_abstracts = dspy.ColBERTv2(url='http://20.102.90.50:2017/wiki17_abstracts')
+### Usage
 
-retrieval_response = colbertv2_wiki17_abstracts('When was the first FIFA World Cup held?', k=5)
-
-for result in retrieval_response:
-    print("Text:", result['text'], "\n")
-```
-
-## dspy.AzureCognitiveSearch
+#TODO
 
 ### Constructor
 
@@ -66,18 +80,15 @@ class AzureCognitiveSearch:
     ):
 ```
 
-**Arguments:**
-- `search_service_name` (str): Name of Azure Cognitive Search server.
-- `search_api_key` (str): API Authentication token for accessing Azure Cognitive Search server.
-- `search_index_name` (str): Name of search index in the Azure Cognitive Search server.
-- `field_text` (str): Field name that maps to DSP "content" field.
-- `field_score` (str): Field name that maps to DSP "score" field.
+**Parameters:**
+- `search_service_name` (_str_): Name of Azure Cognitive Search server.
+- `search_api_key` (_str_): API Authentication token for accessing Azure Cognitive Search server.
+- `search_index_name` (_str_): Name of search index in the Azure Cognitive Search server.
+- `field_text` (_str_): Field name that maps to DSP "content" field.
+- `field_score` (_str_): Field name that maps to DSP "score" field.
 
 ### Methods
 
-Refer to dspy.ColBERTv2 documentation. Keep in mind there is no `simplify` flag for AzureCognitiveSearch.
+Refer to [ColBERTv2](#ColBERTv2) documentation. Keep in mind there is no `simplify` flag for AzureCognitiveSearch.
 
 AzureCognitiveSearch supports sending queries and processing the received results, mapping content and scores to a correct format for the Azure Cognitive Search server.
-
-### Example
-#TODO

--- a/docs/retrieval_models_client.md
+++ b/docs/retrieval_models_client.md
@@ -39,7 +39,7 @@ class ColBERTv2:
     ):
 ```
 
-**Arguments:**
+**Parameters:**
 - `url` (_str_): URL for ColBERTv2 server.
 - `port` (_Union[str, int]_, _Optional_): Port endpoint for ColBERTv2 server. Defaults to `None`.
 - `post_requests` (_bool_, _Optional_): Flag for using HTTP POST requests. Defaults to `False`.
@@ -60,7 +60,7 @@ Enables making queries to the ColBERTv2 server for retrieval. Internally, the me
 
 ## AzureCognitiveSearch
 
-### Usage
+### Quickstart
 
 #TODO
 

--- a/docs/teleprompters.md
+++ b/docs/teleprompters.md
@@ -6,33 +6,6 @@ This documentation provides an overview of the DSPy Teleprompters.
 
 ## teleprompt.LabeledFewShot
 
-### Usage
-
-```python
-import dspy
-
-#Assume defined trainset
-class RAG(dspy.Module):
-    def __init__(self, num_passages=3):
-        super().__init__()
-
-        #declare retrieval and predictor modules
-        self.retrieve = dspy.Retrieve(k=num_passages)
-        self.generate_answer = dspy.ChainOfThought(GenerateAnswer)
-    
-    #flow for answering questions using predictor and retrieval modules
-    def forward(self, question):
-        context = self.retrieve(question).passages
-        prediction = self.generate_answer(context=context, question=question)
-        return dspy.Prediction(context=context, answer=prediction.answer)
-
-#Define teleprompter
-teleprompter = LabeledFewShot()
-
-# Compile!
-compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
-```
-
 ### Constructor
 
 The constructor initializes the `LabeledFewShot` class and sets up its attributes, particularly defining `k` number of samples to be used by the predictor.
@@ -59,22 +32,34 @@ This method compiles the `LabeledFewShot` instance by configuring the `student` 
 **Returns:**
 - The compiled `student` predictor with assigned training samples for each predictor or the original `student` if the `trainset` is empty.
 
-## teleprompt.BootstrapFewShot
-
-### Usage
+### Example
 
 ```python
-#Assume defined trainset
-#Assume defined RAG class
-...
+import dspy
 
-#Define teleprompter and include teacher
-teacher = dspy.OpenAI(model='gpt-3.5-turbo', api_key = openai.api_key, api_provider = "openai", model_type = "chat")
-teleprompter = BootstrapFewShot(teacher_settings=dict({'lm': teacher}))
+#Assume defined trainset
+class RAG(dspy.Module):
+    def __init__(self, num_passages=3):
+        super().__init__()
+
+        #declare retrieval and predictor modules
+        self.retrieve = dspy.Retrieve(k=num_passages)
+        self.generate_answer = dspy.ChainOfThought(GenerateAnswer)
+    
+    #flow for answering questions using predictor and retrieval modules
+    def forward(self, question):
+        context = self.retrieve(question).passages
+        prediction = self.generate_answer(context=context, question=question)
+        return dspy.Prediction(context=context, answer=prediction.answer)
+
+#Define teleprompter
+teleprompter = LabeledFewShot()
 
 # Compile!
 compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
 ```
+
+## teleprompt.BootstrapFewShot
 
 ### Constructor
 
@@ -119,9 +104,7 @@ The final stage is performing the bootstrapping iterations.
 **Returns:**
 - The compiled `student` predictor after bootstrapping with refined demonstrations.
 
-## teleprompt.BootstrapFewShotWithRandomSearch
-
-## Usage
+### Example
 
 ```python
 #Assume defined trainset
@@ -130,11 +113,13 @@ The final stage is performing the bootstrapping iterations.
 
 #Define teleprompter and include teacher
 teacher = dspy.OpenAI(model='gpt-3.5-turbo', api_key = openai.api_key, api_provider = "openai", model_type = "chat")
-teleprompter = BootstrapFewShotWithRandomSearch(teacher_settings=dict({'lm': teacher}))
+teleprompter = BootstrapFewShot(teacher_settings=dict({'lm': teacher}))
 
 # Compile!
 compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
 ```
+
+## teleprompt.BootstrapFewShotWithRandomSearch
 
 ### Constructor
 
@@ -175,21 +160,22 @@ class BootstrapFewShotWithRandomSearch(BootstrapFewShot):
 
 Refer to teleprompt.BootstrapFewShot documentation.
 
-## teleprompt.BootstrapFinetune
-
-### Usage
+## Example
 
 ```python
 #Assume defined trainset
 #Assume defined RAG class
 ...
 
-#Define teleprompter
-teleprompter = BootstrapFinetune(teacher_settings=dict({'lm': teacher}))
+#Define teleprompter and include teacher
+teacher = dspy.OpenAI(model='gpt-3.5-turbo', api_key = openai.api_key, api_provider = "openai", model_type = "chat")
+teleprompter = BootstrapFewShotWithRandomSearch(teacher_settings=dict({'lm': teacher}))
 
 # Compile!
-compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset, target='google/flan-t5-base')
+compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
 ```
+
+## teleprompt.BootstrapFinetune
 
 ### Constructor
 
@@ -227,3 +213,17 @@ This method first compiles for bootstrapping with the `BootstrapFewShot` telepro
 
 **Returns:**
 - `compiled2` (_Predict_): A compiled and fine-tuned `Predict` instance.
+
+### Example
+
+```python
+#Assume defined trainset
+#Assume defined RAG class
+...
+
+#Define teleprompter
+teleprompter = BootstrapFinetune(teacher_settings=dict({'lm': teacher}))
+
+# Compile!
+compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset, target='google/flan-t5-base')
+```

--- a/docs/teleprompters.md
+++ b/docs/teleprompters.md
@@ -4,6 +4,15 @@ Teleprompters are powerful optimizers (included in DSPy) that can learn to boots
 
 This documentation provides an overview of the DSPy Teleprompters.
 
+## Teleprompters
+
+| Module | Jump To |
+| --- | --- |
+| LabeledFewShot | [LabeledFewShot Section](#telepromptlabeledfewshot) |
+| BootstrapFewShot | [BootstrapFewShot Section](#telepromptbootstrapfewshot) |
+| BootstrapFewShotWithRandomSearch | [BootstrapFewShotWithRandomSearch Section](#telepromptbootstrapfewshotwithrandomsearch) |
+| BootstrapFinetune | [BootstrapFinetune Section](#telepromptbootstrapfinetune) |
+
 ## teleprompt.LabeledFewShot
 
 ### Constructor
@@ -158,7 +167,7 @@ class BootstrapFewShotWithRandomSearch(BootstrapFewShot):
 
 ### Method
 
-Refer to teleprompt.BootstrapFewShot documentation.
+Refer to [teleprompt.BootstrapFewShot](#telepromptbootstrapfewshot) documentation.
 
 ## Example
 

--- a/docs/teleprompters.md
+++ b/docs/teleprompters.md
@@ -1,38 +1,16 @@
-# dspy.Teleprompters Documentation
+# Teleprompters Documentation
+
+Teleprompters are powerful optimizers (included in DSPy) that can learn to bootstrap and select effective prompts for the modules of any program. (The "tele-" in the name means "at a distance", i.e., automatic prompting at a distance.)
 
 This documentation provides an overview of the DSPy Teleprompters.
 
-## dspy.teleprompt.LabeledFewShot
+## teleprompt.LabeledFewShot
 
-### Constructor
-
-The constructor initializes the `LabeledFewShot` class and sets up its attributes, particularly defining `k` number of samples to be used by the predictor.
+### Usage
 
 ```python
-class LabeledFewShot(Teleprompter):
-    def __init__(self, k=16):
-        self.k = k
-```
+import dspy
 
-**Arguments:**
-- `k` (int): Number of samples to be used for each predictor. Defaults to 16.
-
-### Method
-
-#### `compile(self, student, *, trainset)`
-
-This method compiles the `LabeledFewShot` instance by configuring the `student` predictor. It assigns subsets of the `trainset` in each student's predictor's `demos` attribute. If the `trainset` is empty, the method returns the original `student`.
-
-**Arguments:**
-- `student` (Teleprompter): Student predictor to be compiled.
-- `trainset` (list): Training dataset for compiling with student predictor.
-
-**Returns:**
-- The compiled `student` predictor with assigned training samples for each predictor or the original `student` if the `trainset` is empty.
-
-### Examples
-
-```python
 #Assume defined trainset
 class RAG(dspy.Module):
     def __init__(self, num_passages=3):
@@ -55,7 +33,48 @@ teleprompter = LabeledFewShot()
 compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
 ```
 
-## dspy.teleprompt.BootstrapFewShot
+### Constructor
+
+The constructor initializes the `LabeledFewShot` class and sets up its attributes, particularly defining `k` number of samples to be used by the predictor.
+
+```python
+class LabeledFewShot(Teleprompter):
+    def __init__(self, k=16):
+        self.k = k
+```
+
+**Parameters:**
+- `k` (_int_): Number of samples to be used for each predictor. Defaults to 16.
+
+### Method
+
+#### `compile(self, student, *, trainset)`
+
+This method compiles the `LabeledFewShot` instance by configuring the `student` predictor. It assigns subsets of the `trainset` in each student's predictor's `demos` attribute. If the `trainset` is empty, the method returns the original `student`.
+
+**Parameters:**
+- `student` (_Teleprompter_): Student predictor to be compiled.
+- `trainset` (_list_): Training dataset for compiling with student predictor.
+
+**Returns:**
+- The compiled `student` predictor with assigned training samples for each predictor or the original `student` if the `trainset` is empty.
+
+## teleprompt.BootstrapFewShot
+
+### Usage
+
+```python
+#Assume defined trainset
+#Assume defined RAG class
+...
+
+#Define teleprompter and include teacher
+teacher = dspy.OpenAI(model='gpt-3.5-turbo', api_key = openai.api_key, api_provider = "openai", model_type = "chat")
+teleprompter = BootstrapFewShot(teacher_settings=dict({'lm': teacher}))
+
+# Compile!
+compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
+```
 
 ### Constructor
 
@@ -72,12 +91,12 @@ class BootstrapFewShot(Teleprompter):
         self.max_rounds = max_rounds
 ```
 
-**Arguments:**
-- `metric` (callable, optional): Metric function to evaluate examples during bootstrapping. Defaults to `None`.
-- `teacher_settings` (dict, optional): Settings for teacher predictor. Defaults to empty dictionary.
-- `max_bootstrapped_demos` (int, optional): Maximum number of bootstrapped demonstrations per predictor. Defaults to 4.
-- `max_labeled_demos` (int, optional): Maximum number of labeled demonstrations per predictor. Defaults to 16.
-- `max_rounds` (int, optional): Maximum number of bootstrapping rounds. Defaults to 1.
+**Parameters:**
+- `metric` (_callable_, _optional_): Metric function to evaluate examples during bootstrapping. Defaults to `None`.
+- `teacher_settings` (_dict_, _optional_): Settings for teacher predictor. Defaults to empty dictionary.
+- `max_bootstrapped_demos` (_int_, _optional_): Maximum number of bootstrapped demonstrations per predictor. Defaults to 4.
+- `max_labeled_demos` (_int_, _optional_): Maximum number of labeled demonstrations per predictor. Defaults to 16.
+- `max_rounds` (_int_, _optional_): Maximum number of bootstrapping rounds. Defaults to 1.
 
 ### Method
 
@@ -91,16 +110,18 @@ The next stage involves preparing predictor mappings by validating that both the
 
 The final stage is performing the bootstrapping iterations.
 
-**Arguments:**
-- `student` (Teleprompter): Student predictor to be compiled.
-- `teacher` (Teleprompter, optional): Teacher predictor used for bootstrapping. Defaults to `None`.
-- `trainset` (list): Training dataset used in bootstrapping.
-- `valset` (list, optional): Validation dataset used in compilation. Defaults to `None`.
+**Parameters:**
+- `student` (_Teleprompter_): Student predictor to be compiled.
+- `teacher` (_Teleprompter_, _optional_): Teacher predictor used for bootstrapping. Defaults to `None`.
+- `trainset` (_list_): Training dataset used in bootstrapping.
+- `valset` (_list_, _optional_): Validation dataset used in compilation. Defaults to `None`.
 
 **Returns:**
 - The compiled `student` predictor after bootstrapping with refined demonstrations.
 
-### Examples
+## teleprompt.BootstrapFewShotWithRandomSearch
+
+## Usage
 
 ```python
 #Assume defined trainset
@@ -109,13 +130,11 @@ The final stage is performing the bootstrapping iterations.
 
 #Define teleprompter and include teacher
 teacher = dspy.OpenAI(model='gpt-3.5-turbo', api_key = openai.api_key, api_provider = "openai", model_type = "chat")
-teleprompter = BootstrapFewShot(teacher_settings=dict({'lm': teacher}))
+teleprompter = BootstrapFewShotWithRandomSearch(teacher_settings=dict({'lm': teacher}))
 
 # Compile!
 compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
 ```
-
-## dspy.teleprompt.BootstrapFewShotWithRandomSearch
 
 ### Constructor
 
@@ -143,74 +162,22 @@ class BootstrapFewShotWithRandomSearch(BootstrapFewShot):
         print("Will attempt to train", self.num_candidate_sets, "candidate sets.")
 ```
 
-**Arguments:**
-- `metric` (callable, optional): Metric function to evaluate examples during bootstrapping. Defaults to `None`.
-- `teacher_settings` (dict, optional): Settings for teacher predictor. Defaults to empty dictionary.
-- `max_bootstrapped_demos` (int, optional): Maximum number of bootstrapped demonstrations per predictor. Defaults to 4.
-- `max_labeled_demos` (int, optional): Maximum number of labeled demonstrations per predictor. Defaults to 16.
-- `max_rounds` (int, optional): Maximum number of bootstrapping rounds. Defaults to 1.
-- `num_candidate_programs` (int): Number of candidate programs to generate during random search.
-- `num_threads` (int): Number of threads used for evaluation during random search.
+**Parameters:**
+- `metric` (_callable_, _optional_): Metric function to evaluate examples during bootstrapping. Defaults to `None`.
+- `teacher_settings` (_dict_, _optional_): Settings for teacher predictor. Defaults to empty dictionary.
+- `max_bootstrapped_demos` (_int_, _optional_): Maximum number of bootstrapped demonstrations per predictor. Defaults to 4.
+- `max_labeled_demos` (_int_, _optional_): Maximum number of labeled demonstrations per predictor. Defaults to 16.
+- `max_rounds` (_int_, _optional_): Maximum number of bootstrapping rounds. Defaults to 1.
+- `num_candidate_programs` (_int_): Number of candidate programs to generate during random search.
+- `num_threads` (_int_): Number of threads used for evaluation during random search.
 
 ### Method
 
-Refer to dspy.teleprompt.BootstrapFewShot documentation.
+Refer to teleprompt.BootstrapFewShot documentation.
 
-### Examples
+## teleprompt.BootstrapFinetune
 
-```python
-#Assume defined trainset
-#Assume defined RAG class
-...
-
-#Define teleprompter and include teacher
-teacher = dspy.OpenAI(model='gpt-3.5-turbo', api_key = openai.api_key, api_provider = "openai", model_type = "chat")
-teleprompter = BootstrapFewShotWithRandomSearch(teacher_settings=dict({'lm': teacher}))
-
-# Compile!
-compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset)
-```
-
-## dspy.teleprompt.BootstrapFinetune
-
-### Constructor
-
-### `__init__(self, metric=None, teacher_settings={}, multitask=True)`
-
-The constructor initializes a `BootstrapFinetune` instance and sets up its attributes. It defines the teleprompter as a `BootstrapFewShot` instance for the finetuning compilation.
-
-```python
-class BootstrapFinetune(Teleprompter):
-    def __init__(self, metric=None, teacher_settings={}, multitask=True):
-```
-
-**Arguments:**
-- `metric` (callable, optional): Metric function to evaluate examples during bootstrapping. Defaults to `None`.
-- `teacher_settings` (dict, optional): Settings for teacher predictor. Defaults to empty dictionary.
-- `multitask` (bool, optional): Enable multitask fine-tuning. Defaults to `True`.
-
-### Method
-
-#### `compile(self, student, *, teacher=None, trainset, valset=None, target='t5-large', bsize=12, accumsteps=1, lr=5e-5, epochs=1, bf16=False)`
-
-This method first compiles for bootstrapping with the `BootstrapFewShot` teleprompter. It then prepares fine-tuning data by generating prompt-completion pairs for training and performs finetuning. After compilation, the LMs are set to the finetuned models and the method returns a compiled and fine-tuned predictor.
-
-**Arguments:**
-- `student` (Predict): Student predictor to be fine-tuned.
-- `teacher` (Predict, optional): Teacher predictor to help with fine-tuning. Defaults to `None`.
-- `trainset` (list): Training dataset for fine-tuning.
-- `valset` (list, optional): Validation dataset for fine-tuning. Defaults to `None`.
-- `target` (str, optional): Target model for fine-tuning. Defaults to `'t5-large'`.
-- `bsize` (int, optional): Batch size for training. Defaults to `12`.
-- `accumsteps` (int, optional): Gradient accumulation steps. Defaults to `1`.
-- `lr` (float, optional): Learning rate for fine-tuning. Defaults to `5e-5`.
-- `epochs` (int, optional): Number of training epochs. Defaults to `1`.
-- `bf16` (bool, optional): Enable mixed-precision training with BF16. Defaults to `False`.
-
-**Returns:**
-- `compiled2` (Predict): A compiled and fine-tuned `Predict` instance.
-
-### Examples
+### Usage
 
 ```python
 #Assume defined trainset
@@ -223,3 +190,40 @@ teleprompter = BootstrapFinetune(teacher_settings=dict({'lm': teacher}))
 # Compile!
 compiled_rag = teleprompter.compile(student=RAG(), trainset=trainset, target='google/flan-t5-base')
 ```
+
+### Constructor
+
+### `__init__(self, metric=None, teacher_settings={}, multitask=True)`
+
+The constructor initializes a `BootstrapFinetune` instance and sets up its attributes. It defines the teleprompter as a `BootstrapFewShot` instance for the finetuning compilation.
+
+```python
+class BootstrapFinetune(Teleprompter):
+    def __init__(self, metric=None, teacher_settings={}, multitask=True):
+```
+
+**Parameters:**
+- `metric` (_callable_, _optional_): Metric function to evaluate examples during bootstrapping. Defaults to `None`.
+- `teacher_settings` (_dict_, _optional_): Settings for teacher predictor. Defaults to empty dictionary.
+- `multitask` (_bool_, _optional_): Enable multitask fine-tuning. Defaults to `True`.
+
+### Method
+
+#### `compile(self, student, *, teacher=None, trainset, valset=None, target='t5-large', bsize=12, accumsteps=1, lr=5e-5, epochs=1, bf16=False)`
+
+This method first compiles for bootstrapping with the `BootstrapFewShot` teleprompter. It then prepares fine-tuning data by generating prompt-completion pairs for training and performs finetuning. After compilation, the LMs are set to the finetuned models and the method returns a compiled and fine-tuned predictor.
+
+**Parameters:**
+- `student` (_Predict_): Student predictor to be fine-tuned.
+- `teacher` (_Predict_, _optional_): Teacher predictor to help with fine-tuning. Defaults to `None`.
+- `trainset` (_list_): Training dataset for fine-tuning.
+- `valset` (_list_, _optional_): Validation dataset for fine-tuning. Defaults to `None`.
+- `target` (_str_, _optional_): Target model for fine-tuning. Defaults to `'t5-large'`.
+- `bsize` (_int_, _optional_): Batch size for training. Defaults to `12`.
+- `accumsteps` (_int_, _optional_): Gradient accumulation steps. Defaults to `1`.
+- `lr` (_float_, _optional_): Learning rate for fine-tuning. Defaults to `5e-5`.
+- `epochs` (_int_, _optional_): Number of training epochs. Defaults to `1`.
+- `bf16` (_bool_, _optional_): Enable mixed-precision training with BF16. Defaults to `False`.
+
+**Returns:**
+- `compiled2` (_Predict_): A compiled and fine-tuned `Predict` instance.

--- a/docs/using_local_models.md
+++ b/docs/using_local_models.md
@@ -4,12 +4,12 @@ DSPy supports various methods including `built-in wrappers`, `server integration
 
 ## Local Model Loaders
 
-| Loaders | Link |
+| Loaders | Jump To |
 | --- | --- |
 | HFModel | [HFModel Section](#hfmodel) |
-| Text-Generation-Inference Server | [Text-Generation-Inference Server Section](#text-generation-inference-server) |
-| vLLM Server | [vLLM Server Section](#vllm-server) |
-| MLC LLM | [MLC LLM Section](#mlc-llm) |
+| Cohere | [Cohere Section](#cohere) |
+| TGI | [TGI Section](#tgi) |
+| VLLM | [VLLM Section](#vllm) |
 
 
 # HFModel

--- a/docs/using_local_models.md
+++ b/docs/using_local_models.md
@@ -1,6 +1,16 @@
 # Using local models within DSPy
 
-DSPy supports various methods including built-in wrappers, server integration, and external package integration for model loading. This documentation provides a concise introduction on how to load in models within DSPy extending these capabilities for your specific needs.
+DSPy supports various methods including `built-in wrappers`, `server integration`, and `external package integration` for model loading. This documentation provides a concise introduction on how to load in models within DSPy extending these capabilities for your specific needs.
+
+## Local Model Loaders
+
+| Loaders | Link |
+| --- | --- |
+| HFModel | [HFModel Section](#hfmodel) |
+| Text-Generation-Inference Server | [Text-Generation-Inference Server Section](#text-generation-inference-server) |
+| vLLM Server | [vLLM Server Section](#vllm-server) |
+| MLC LLM | [MLC LLM Section](#mlc-llm) |
+
 
 # HFModel
 


### PR DESCRIPTION
Minor standardization changes:
- Add ToCs for quick navigations
- `Arguments` -> `Parameters`
- parameter type hints are in italic to improve readability
- `GPT3(...)` constructor -> `OpenAI(...)`
- add links to references for quick nav
- define `Quickstart` and `Usage` snippets at the top of doc modules and `Examples` at the end of doc modules. 