### PR TITLE
add you retriever module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ checklist.md
 finetuning_ckpts/
 cache/
 * copy*
+.idea

--- a/dspy/retrieve/you_rm.py
+++ b/dspy/retrieve/you_rm.py
@@ -31,7 +31,7 @@ class YouRM(dspy.Retrieve):
         )
         docs = []
         for query in queries:
-            headers = {"X-API-Key": os.environ["YDC_API_KEY"]}
+            headers = {"X-API-Key": self.ydc_api_key}
             results = requests.get(
                 f"https://api.ydc-index.io/search?query={query}",
                 headers=headers,

--- a/dspy/retrieve/you_rm.py
+++ b/dspy/retrieve/you_rm.py
@@ -1,0 +1,42 @@
+import dspy
+import os
+import requests
+
+from typing import Union, List
+
+
+class YouRM(dspy.Retrieve):
+    def __init__(self, ydc_api_key=None, k=3):
+        super().__init__(k=k)
+        if not ydc_api_key and not os.environ.get("YDC_API_KEY"):
+            raise RuntimeError("You must supply ydc_api_key or set environment variable YDC_API_KEY")
+        elif ydc_api_key:
+            self.ydc_api_key = ydc_api_key
+        else:
+            self.ydc_api_key = os.environ["YDC_API_KEY"]
+
+    def forward(self, query_or_queries: Union[str, List[str]]) -> dspy.Prediction:
+        """Search with You.com for self.k top passages for query or queries
+
+        Args:
+            query_or_queries (Union[str, List[str]]): The query or queries to search for.
+
+        Returns:
+            dspy.Prediction: An object containing the retrieved passages.
+        """
+        queries = (
+            [query_or_queries]
+            if isinstance(query_or_queries, str)
+            else query_or_queries
+        )
+        docs = []
+        for query in queries:
+            headers = {"X-API-Key": os.environ["YDC_API_KEY"]}
+            results = requests.get(
+                f"https://api.ydc-index.io/search?query={query}",
+                headers=headers,
+            ).json()
+            for hit in results["hits"][:self.k]:
+                for snippet in hit["snippets"]:
+                    docs.append(snippet)
+        return dspy.Prediction(passages=docs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ regex
 ujson
 tqdm
 datasets
+requests


### PR DESCRIPTION
So I wasn't entirely sure on the difference between the modules in `dsp` vs the retriever module example of pinecone in `dspy`. I went ahead and followed what seemed to be the newer pattern. One thing to note about this implementation is if multiple queries are indeed passed into the new retriever we do not have the ability to rerank the results across queries so we return the passages from query 1 then the passages from query 2. I could also just raise a runtime error if that is a more desirable pattern. Let me know!