### PR TITLE
Save kwargs for huggingface TGI model

### DIFF
--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -16,6 +16,9 @@ class HFClientTGI(HFModel):
         self.headers = {"Content-Type": "application/json"}
 
         self.kwargs = {
+            "model": model,
+            "port": port,
+            "url": url,
             "temperature": 0.01,
             "max_tokens": 75,
             "top_p": 0.97,


### PR DESCRIPTION
Previously, using `HFClientTGI` with `BootstrapFewShot` didn't work for `max_rounds` > 1. The culprit was:

```
File "<snip>/lib/python3.10/site-packages/dsp/modules/lm.py", line 84, in copy
    model = kwargs.pop('model')
KeyError: 'model'
```

This PR makes sure the relevant kwargs are saved (all are necessary)

Thanks!