### PR TITLE
Allow no-op decorator to take arguments

### DIFF
--- a/dsp/modules/cache_utils.py
+++ b/dsp/modules/cache_utils.py
@@ -10,11 +10,18 @@ from dsp.utils import dotdict
 cache_turn_on = True
 
 
-def noop_decorator(func):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-    return wrapper
+def noop_decorator(arg=None, *noop_args, **noop_kwargs):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    if callable(arg):
+        return decorator(arg)
+    else:
+        return decorator
 
 
 cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), 'cachedir_joblib')


### PR DESCRIPTION
Fixes the error mentioned here https://github.com/stanfordnlp/dspy/issues/181#issuecomment-1776250172

i.e. 
```
  File "<snip>/dspy/dsp/modules/hf_client.py", line 93, in <module>
    @NotebookCacheMemory.cache(ignore=['arg'])
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: noop_decorator() got an unexpected keyword argument 'ignore'

```

Now, if `NotebookCacheMemory.cache` is a `noop_decorator`, it can be called either with or without args/kwargs (i.e. `@NotebookCacheMemory.cache(ignore=["arg"])` or `@NotebookCacheMemory.cache`).
