### PR TITLE
added proper error handling within evaluate and bootstrap

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -28,6 +28,8 @@ class Evaluate:
         self.display_table = display_table
         self.display = display
         self.max_errors = max_errors
+        self.error_count = 0
+        self.error_lock = threading.Lock()
 
     def _execute_single_thread(self, wrapped_program, devset, display_progress):
         ncorrect = 0
@@ -95,6 +97,11 @@ class Evaluate:
                 score = metric(example, prediction)  # FIXME: TODO: What's the right order? Maybe force name-based kwargs!
                 return example_idx, example, prediction, score
             except Exception as e:
+                with self.error_lock:
+                    self.error_count += 1
+                    current_error_count = self.error_count
+                if current_error_count >= self.max_errors:
+                    raise e
                 print(f"Error for example in dev set: \t\t {e}")
                 return example_idx, example, dict(), 0.0
             finally:


### PR DESCRIPTION
-permits up to 5 errors during 1) evaluation and 2) bootstrapping and then raises actual error, halting program for user to fix the error 