### PR TITLE
dspy assertions

### DIFF
--- a/assert_gsm8k.py
+++ b/assert_gsm8k.py
@@ -1,0 +1,99 @@
+import re
+import dspy
+from dspy import Example
+from dspy.teleprompt import LabeledFewShot, BootstrapFewShotWithRandomSearch
+
+import datasets
+
+from tool import calculator, prefix_calculator
+
+# pipeline configs
+turbo = dspy.OpenAI(model="gpt-3.5-turbo-16k")
+dspy.settings.configure(lm=turbo)
+
+
+# load up the gsm8k dataset from hub into a dspy-compatible format
+dataset = datasets.load_dataset("gsm8k", 'main')
+training_data = dataset["train"].shuffle(seed=42).select(range(10))
+dev_data = dataset["train"].shuffle(seed=42).select(range(10, 15))
+
+trainset = [Example(x).with_inputs("question") for x in training_data]
+devset = [Example(x).with_inputs("question") for x in dev_data]
+testset = [Example(x).with_inputs("question") for x in dataset["test"]]
+
+# validation function
+def gsm8k_accuracy(example, pred, trace=None):
+    ANS_RE = re.compile(r"#### (\-?[0-9\.\,]+)")
+    INVALID_ANS = "[invalid]"
+    
+    def extract_answer(completion):
+        match = ANS_RE.search(completion)
+        if match:
+            match_str = match.group(1).strip()
+            match_str = match_str.replace(",", "")
+            return match_str
+        else:
+            return INVALID_ANS
+
+    gt_answer = extract_answer(example.answer)
+    assert gt_answer != INVALID_ANS
+    
+    pred_answer = extract_answer(pred.answer)
+    
+    return pred_answer == gt_answer
+
+
+class GenerateAnswer(dspy.Signature):
+    """Answer questions with a single numeric value."""
+    question = dspy.InputField()
+    answer = dspy.OutputField(desc="#### ${answer}")
+    
+
+########## PROGRAMS ##########
+
+class Vanilla(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.predict = dspy.Predict(GenerateAnswer)
+    
+    def forward(self, question):
+        return self.predict(question=question)
+
+
+class CoT(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.predict = dspy.ChainOfThought(GenerateAnswer)
+    
+    def forward(self, question):
+        return self.predict(question=question)
+
+
+class ThoughtReflection(dspy.Module):
+    def __init__(self, num_attempts):
+        super().__init__()
+
+        self.predict = dspy.ChainOfThought(GenerateAnswer, n=num_attempts)
+        self.compare = dspy.MultiChainComparison(GenerateAnswer, M=num_attempts)
+        
+    def forward(self, question):
+        completions = self.predict(question=question).completions        
+        answer = self.compare(question=question, completions=completions)
+        return answer
+
+########## COMPILATION (w/ random hyperparameter search) ##########
+
+prog = Vanilla()
+# prog = CoT()
+# prog = ThoughtReflection(num_attempts=5)
+
+teleprompter = BootstrapFewShotWithRandomSearch(metric=gsm8k_accuracy)
+compiled_prog = teleprompter.compile(prog, trainset=trainset, valset=devset)
+
+########## EVALUATION ##########
+
+my_question = testset[0].question
+pred = compiled_prog(my_question)
+
+print("Question:", my_question)
+turbo.inspect_history(n=1)

--- a/assert_hotpotqa.py
+++ b/assert_hotpotqa.py
@@ -1,0 +1,138 @@
+import dspy
+from dsp.utils import deduplicate
+from dspy.datasets import HotPotQA
+from dspy.teleprompt import BootstrapFewShot
+
+# pipeline configs
+turbo = dspy.OpenAI(model="gpt-3.5-turbo")
+colbertv2_wiki17_abstracts = dspy.ColBERTv2(
+    url="http://20.102.90.50:2017/wiki17_abstracts"
+)
+dspy.settings.configure(lm=turbo, rm=colbertv2_wiki17_abstracts)
+
+
+# load dataset
+dataset = HotPotQA(
+    train_seed=1, train_size=20, eval_seed=2023, dev_size=50, test_size=0
+)
+trainset = [x.with_inputs("question") for x in dataset.train]
+devset = [x.with_inputs("question") for x in dataset.dev]
+
+
+# signatures of dspy modules
+class GenerateAnswer(dspy.Signature):
+    """Answer questions with short factoid answers."""
+
+    context = dspy.InputField(desc="may contain relevant facts")
+    question = dspy.InputField()
+    answer = dspy.OutputField(desc="often between 1 and 5 words")
+
+
+class GenerateSearchQuery(dspy.Signature):
+    """Write a simple search query that will help answer a complex question."""
+
+    context = dspy.InputField(desc="may contain relevant facts")
+    question = dspy.InputField()
+    query = dspy.OutputField()
+
+
+failure_counts = {
+    "answer_exact_match": 0,
+    "answer_passage_match": 0,
+    "max_hop_length_exceeded": 0,
+    "hop_query_similarity_exceeded": 0,
+    "failed_prog_assertions": 0,
+}
+
+
+def validate_context_and_answer_and_hops(example, pred, trace=None):
+    global failure_counts
+
+    try:
+        if not dspy.evaluate.answer_exact_match(example, pred):
+            failure_counts["answer_exact_match"] += 1
+            return False
+
+        if not dspy.evaluate.answer_passage_match(example, pred):
+            failure_counts["answer_passage_match"] += 1
+            return False
+
+        hops = [example.question] + [
+            outputs.query for *_, outputs in trace if "query" in outputs
+        ]
+
+        if max([len(h) for h in hops]) > 100:
+            failure_counts["max_hop_length_exceeded"] += 1
+            return False
+
+        if any(
+            dspy.evaluate.answer_exact_match_str(hops[idx], hops[:idx], frac=0.8)
+            for idx in range(2, len(hops))
+        ):
+            failure_counts["hop_query_similarity_exceeded"] += 1
+            return False
+    except:
+        failure_counts["failed_prog_assertions"] += 1
+        print("failed prog assertions:", example.question)
+        return False
+
+    return True
+
+
+def validate_query_distinction_local(previous_queries, query):
+    if previous_queries == []:
+        return True
+    if dspy.evaluate.answer_exact_match_str(query, previous_queries, frac=0.8):
+        return False
+    return True
+
+
+# declaration of dspy program
+class SimplifiedBaleen(dspy.Module):
+    def __init__(self, passages_per_hop=2, max_hops=2):
+        super().__init__()
+
+        self.generate_query = [
+            dspy.ChainOfThought(GenerateSearchQuery) for _ in range(max_hops)
+        ]
+        self.retrieve = dspy.Retrieve(k=passages_per_hop)
+        self.generate_answer = dspy.ChainOfThought(GenerateAnswer)
+        self.max_hops = max_hops
+
+    def forward(self, question):
+        context = []
+        prev_queries = [question]
+
+        for hop in range(self.max_hops):
+            query = self.generate_query[hop](context=context, question=question).query
+
+            dspy.Assert(
+                len(query) <= 100,
+                msg="Query should be short and less than 100 characters",
+            )
+
+            dspy.Assert(
+                validate_query_distinction_local(prev_queries, query),
+                msg="Query should not be the following: "
+                + "; ".join(
+                    f"{idx+1}) {query}" for idx, query in enumerate(prev_queries)
+                ),
+            )
+
+            prev_queries.append(query)
+            passages = self.retrieve(query).passages
+            context = deduplicate(context + passages)
+
+        pred = self.generate_answer(context=context, question=question)
+
+        return dspy.Prediction(context=context, answer=pred.answer)
+
+
+teleprompter = BootstrapFewShot(metric=validate_context_and_answer_and_hops)
+compiled_baleen = teleprompter.compile(
+    SimplifiedBaleen(), teacher=SimplifiedBaleen(passages_per_hop=2), trainset=trainset
+)
+
+print("=" * 50, "Validation Failures", "=" * 50)
+for failure_type, count in failure_counts.items():
+    print(f"{failure_type}: {count}")

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -106,6 +106,12 @@ class Predict(Parameter):
 
         return pred
 
+    def update_config(self, **kwargs):
+        self.config = {**self.config, **kwargs}
+    
+    def get_config(self):
+        return self.config
+
     def __repr__(self):
         return f"{self.__class__.__name__}({self.signature})"
 

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -1,4 +1,5 @@
 from .example import *
 from .program import *
 from .prediction import *
+from .assertions import *
 from .python_interpreter import *

--- a/dspy/primitives/assertions.py
+++ b/dspy/primitives/assertions.py
@@ -1,0 +1,148 @@
+from typing import Any, Callable
+import dsp
+import dspy
+
+
+class DSPyAssertionError(AssertionError):
+    """Custom exception raised when a DSPy `Assert` fails.
+    """
+
+    def __init__(self, msg: str, state: Any = None) -> None:
+        super().__init__(msg)
+        self.msg = msg
+        self.state = state
+
+
+class Assert:
+    """DSPy Assertion"""
+
+    def __init__(self, assert_fun_res: bool, **kwargs):
+        self.assert_fun_res = assert_fun_res
+
+        if "msg" in kwargs:
+            self.msg = kwargs["msg"]
+            del kwargs["msg"]
+        else:
+            self.msg = ""
+
+        self.kwargs = kwargs
+        self.__call__()
+
+    def __call__(self) -> bool:
+        if isinstance(self.assert_fun_res, bool):
+            if self.assert_fun_res:
+                return True
+            else:
+                raise DSPyAssertionError(msg=self.msg, state=dsp.settings.trace)
+        else:
+            raise ValueError("Assertion function should always return [bool]")
+
+
+def assert_backtrack_policy(max_backtracks=2):
+    """Decorator that defines the backtracking policy for assertions.
+    
+    current policy: re-run the latest predictor up to `max_backtracks` times,
+    with updated signature if assertion fails. updated signature adds a new 
+    input field to the signature, which is the feedback.
+    """
+
+    def wrapper(func):
+        def inner(*args, **kwargs):
+            backtrack_to = None
+            error_msg = None
+            result = None
+            extended_predictors_to_original_forward = {}
+
+            def _extend_predictor_signature(predictor, **kwargs):
+                """Update the signature of a predictor instance with specified fields."""
+                old_signature = predictor.extended_signature
+                new_signature_kwargs = {
+                    k: v
+                    for (k, v) in old_signature.kwargs.items()
+                    if isinstance(v, dspy.InputField)
+                }
+                new_signature_kwargs.update(kwargs)
+                new_signature_kwargs.update(
+                    {
+                        k: v
+                        for (k, v) in old_signature.kwargs.items()
+                        if isinstance(v, (dsp.Type, dspy.OutputField))
+                    }
+                )
+
+                new_signature = dsp.Template(
+                    old_signature.instructions, **new_signature_kwargs
+                )
+
+                predictor.extended_signature = new_signature
+
+            def _revert_predictor_signature(predictor, *args):
+                """Revert the signature of a predictor by removing specified fields."""
+                old_signature_kwargs = predictor.extended_signature.kwargs
+                for key in args:
+                    old_signature_kwargs.pop(key, None)
+                new_signature = dsp.Template(
+                    predictor.extended_signature.instructions, **old_signature_kwargs
+                )
+                predictor.extended_signature = new_signature
+
+            def _wrap_forward_with_set_fields(predictor, default_args):
+                """Wrap the forward method of a predictor instance to enforce default arguments."""
+                original_forward = predictor.forward
+
+                def new_forward(**kwargs):
+                    for arg, value in default_args.items():
+                        kwargs.setdefault(arg, value)
+
+                    return original_forward(**kwargs)
+
+                predictor.forward = new_forward
+
+            for i in range(max_backtracks + 1):
+                if i > 0 and backtrack_to is not None:
+                    # create a new feedback field
+                    feedback = dspy.InputField(
+                        prefix="Instruction:", desc="Some instructions you must satisfy"
+                    )
+
+                    # save the original forward function to revert back to
+                    extended_predictors_to_original_forward[
+                        backtrack_to
+                    ] = backtrack_to.forward
+
+                    # extend signature with feedback field
+                    _extend_predictor_signature(backtrack_to, feedback=feedback)
+
+                    # set feedback field as a default kwarg to the predictor's forward function
+                    _wrap_forward_with_set_fields(
+                        backtrack_to, default_args={"feedback": error_msg}
+                    )
+
+                try:
+                    result = func(*args, **kwargs)
+                    break
+                except DSPyAssertionError as e:
+                    print(f"AssertionError: {e.msg}")
+                    error_msg = e.msg
+
+                    if dsp.settings.trace:
+                        backtrack_to = dsp.settings.trace[-1][0]
+                    else:
+                        print(
+                            "UNREACHABLE: No trace available, this should not happen. Is this run time?"
+                        )
+
+            # revert any extended predictors to their originals
+            if extended_predictors_to_original_forward:
+                for (
+                    predictor,
+                    original_forward,
+                ) in extended_predictors_to_original_forward.items():
+                    _revert_predictor_signature(predictor, "feedback")
+                    predictor.forward = original_forward
+
+            return result
+
+        return inner
+
+    return wrapper

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -1,13 +1,14 @@
 import copy
 
 from dspy.primitives.module import BaseModule
+from dspy.primitives.assertions import *
 
 
 class ProgramMeta(type):
     pass
     # def __call__(cls, *args, **kwargs):
     #     obj = super(ProgramMeta, cls).__call__(*args, **kwargs)
-        
+
     #     if issubclass(cls, Program) and not getattr(obj, "_program_init_called", False):
     #         obj._base_init()
     #         obj._program_init_called = True
@@ -22,23 +23,29 @@ class Module(BaseModule, metaclass=ProgramMeta):
         self._compiled = False
 
     def __call__(self, *args, **kwargs):
-        return self.forward(*args, **kwargs)
-    
+        if getattr(self, "forward", False) and not getattr(
+            self.forward, "_decorated", False
+        ):
+            wrapped_forward = assert_backtrack_policy()(self.forward)
+            return wrapped_forward(*args, **kwargs)
+        else:
+            return self.forward(*args, **kwargs)
+
     def named_predictors(self):
         from dspy.predict.predict import Predict
-        
+
         named_parameters = self.named_parameters()
         return [(name, param) for name, param in named_parameters if isinstance(param, Predict)]
 
     def predictors(self):
         return [param for _, param in self.named_predictors()]
-    
+
     def __repr__(self):
         s = []
 
         for name, param in self.named_predictors():
             s.append(f"{name} = {param}")
-        
+
         return '\n'.join(s)
 
     # def __deepcopy__(self, memo):
@@ -46,7 +53,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
     #     # Check if the object is already copied
     #     if id(self) in memo:
     #         return memo[id(self)]
-        
+
     #     print(f"Deep copying {self.__class__.__name__}...")
 
     #     new_copy = copy.copy(self)

--- a/logs.log
+++ b/logs.log
@@ -1,0 +1,197 @@
+
+Before adding any assertions:
+================================================== Validation Failures ==================================================
+answer_exact_match: 8               
+answer_passage_match: 0
+max_hop_length_exceeded: 5          
+hop_query_similarity_exceeded: 1 
+---------------------------------
+Total: 14
+---------------------------------
+
+
+
+With query length and similarity assertion:
+================================================== Validation Failures ==================================================
+answer_exact_match: 4                   # need new assertions to fix these?
+answer_passage_match: 0
+max_hop_length_exceeded: 5              # most are question is too long :/
+hop_query_similarity_exceeded: 0
+---------------------------------
+failed_prog_assertions: 5               # 4/8 exact_answer_match and 1/1 hop_query_similarity_exceeded caught earlier
+---------------------------------
+Total: 14
+---------------------------------
+
+
+--- logs ---
+
+question is  At My Window was released by which American singer-songwriter?
+query is  "At My Window" American singer-songwriter
+query is  "At My Window" album 1987 American singer-songwriter
+AssertionError: Query should not be the following: 1) At My Window was released by which American singer-songwriter?; 2) "At My Window" American singer-songwriter
+rewinding to 139971175300544
+
+question is  At My Window was released by which American singer-songwriter?
+query is  "At My Window" American singer-songwriter
+query is  "At My Window" album American singer-songwriter
+AssertionError: Query should not be the following: 1) At My Window was released by which American singer-songwriter?; 2) "At My Window" American singer-songwriter
+rewinding to 139971175300544
+
+question is  At My Window was released by which American singer-songwriter?
+query is  "At My Window" American singer-songwriter
+query is  "At My Window" album American singer-songwriter
+AssertionError: Query should not be the following: 1) At My Window was released by which American singer-songwriter?; 2) "At My Window" American singer-songwriter
+reverting predictor 139971175300544
+failed prog assertions: At My Window was released by which American singer-songwriter?
+
+question is  which  American actor was Candace Kita  guest starred with 
+query is  "Candace Kita guest starred with American actor"
+AssertionError: Query should not be the following: 1) which  American actor was Candace Kita  guest starred with 
+rewinding to 139971175300496
+
+question is  which  American actor was Candace Kita  guest starred with 
+query is  "Candace Kita guest starred with American actor"
+AssertionError: Query should not be the following: 1) which  American actor was Candace Kita  guest starred with 
+rewinding to 139971175300496
+
+question is  which  American actor was Candace Kita  guest starred with 
+query is  "Candace Kita guest starred with American actor"
+AssertionError: Query should not be the following: 1) which  American actor was Candace Kita  guest starred with 
+reverting predictor 139971175300496
+failed prog assertions: which  American actor was Candace Kita  guest starred with 
+
+question is  Which of these publications was most recently published, Who Put the Bomp or Self?
+query is  "publication date of Who Put the Bomp" OR "publication date of Self"
+query is  "Publication date of 'Who Put the Bomp'" AND "Publication date of 'Self'"
+AssertionError: Query should not be the following: 1) Which of these publications was most recently published, Who Put the Bomp or Self?; 2) "publication date of Who Put the Bomp" OR "publication date of Self"
+rewinding to 139971175300544
+
+question is  Which of these publications was most recently published, Who Put the Bomp or Self?
+query is  "publication date of Who Put the Bomp" OR "publication date of Self"
+query is  "publication date of Who Put the Bomp" AND "publication date of Self"
+AssertionError: Query should not be the following: 1) Which of these publications was most recently published, Who Put the Bomp or Self?; 2) "publication date of Who Put the Bomp" OR "publication date of Self"
+rewinding to 139971175300544
+
+question is  Which of these publications was most recently published, Who Put the Bomp or Self?
+query is  "publication date of Who Put the Bomp" OR "publication date of Self"
+query is  "publication date of Who Put the Bomp" AND "publication date of Self"
+AssertionError: Query should not be the following: 1) Which of these publications was most recently published, Who Put the Bomp or Self?; 2) "publication date of Who Put the Bomp" OR "publication date of Self"
+reverting predictor 139971175300544
+failed prog assertions: Which of these publications was most recently published, Who Put the Bomp or Self?
+
+question is  The Victorians - Their Story In Pictures is a documentary series written by an author born in what year?
+query is  "The Victorians - Their Story In Pictures" documentary series author birth year
+query is  Jeremy Paxman birth year
+
+question is  Which magazine has published articles by Scott Shaw, Tae Kwon Do Times or Southwest Art?
+query is  "Scott Shaw" site:tkdtimes.com OR site:southwestart.com
+query is  "Scott Shaw articles published Tae Kwon Do Times" OR "Scott Shaw articles published Southwest Art"
+
+question is  In what year was the club founded that played Manchester City in the 1972 FA Charity Shield
+query is  "History of FA Charity Shield 1972"
+query is  "Aston Villa founding year"
+
+question is  Which is taller, the Empire State Building or the Bank of America Tower?
+query is  "height of Empire State Building" OR "height of Bank of America Tower"
+query is  "Convert 312 meters to feet"
+
+question is  Which American actress who made their film debut in the 1995 teen drama "Kids" was the co-founder of Voto Latino?
+query is  "Kids 1995 cast" + "Voto Latino co-founder"
+query is  American actress film debut 1995 "Kids" co-founder Voto Latino
+
+question is  Tombstone stared an actor born May 17, 1955 known as who?
+query is  "Tombstone movie cast"
+query is  "Actor who starred in Tombstone"
+
+question is  What is the code name for the German offensive that started this Second World War engagement on the Eastern Front (a few hundred kilometers from Moscow) between Soviet and German forces, which included 102nd Infantry Division?
+query is  "German offensive code name Eastern Front Second World War Moscow"
+query is  German offensive code name Eastern Front Second World War a few hundred kilometers from Moscow 102nd Infantry Division.
+AssertionError: Query should be short and less than 100 characters
+rewinding to 139971175300544
+
+question is  What is the code name for the German offensive that started this Second World War engagement on the Eastern Front (a few hundred kilometers from Moscow) between Soviet and German forces, which included 102nd Infantry Division?
+query is  "German offensive code name Eastern Front Second World War Moscow"
+query is  German offensive Eastern Front code name 102nd Infantry Division
+reverting predictor 139971175300544
+
+question is  Who acted in the shot film The Shore and is also the youngest actress ever to play Ophelia in a Royal Shakespeare Company production of "Hamlet." ?
+query is  "The Shore" cast + youngest actress to play Ophelia in Royal Shakespeare Company "Hamlet" production.
+AssertionError: Query should be short and less than 100 characters
+rewinding to 139971175300496
+
+question is  Who acted in the shot film The Shore and is also the youngest actress ever to play Ophelia in a Royal Shakespeare Company production of "Hamlet." ?
+query is  "actress The Shore youngest Ophelia RSC Hamlet"
+query is  "actress who played Ophelia in Royal Shakespeare Company production of Hamlet" "actress in the short film The Shore"
+AssertionError: Query should be short and less than 100 characters
+rewinding to 139971175300544
+
+question is  Who acted in the shot film The Shore and is also the youngest actress ever to play Ophelia in a Royal Shakespeare Company production of "Hamlet." ?
+query is  "actress The Shore youngest Ophelia RSC Hamlet"
+query is  "actress The Shore Ophelia Royal Shakespeare Company"
+reverting predictor 139971175300496
+reverting predictor 139971175300544
+
+question is  Which company distributed this 1977 American animated film produced by Walt Disney Productions for which Sherman Brothers wrote songs?
+query is  "1977 American animated film produced by Walt Disney Productions Sherman Brothers songs distribution company"
+AssertionError: Query should be short and less than 100 characters
+rewinding to 139971175300496
+
+question is  Which company distributed this 1977 American animated film produced by Walt Disney Productions for which Sherman Brothers wrote songs?
+query is  "1977 animated film Walt Disney Sherman Brothers distribution company"
+query is  "1977 American animated film produced by Walt Disney Productions distribution company"
+reverting predictor 139971175300496
+
+question is  Samantha Cristoforetti and Mark Shuttleworth are both best known for being first in their field to go where? 
+query is  "Samantha Cristoforetti first in her field" AND "Mark Shuttleworth first in his field"
+query is  "Samantha Cristoforetti and Mark Shuttleworth achievements"
+
+question is  Having the combination of excellent foot speed and bat speed helped Eric Davis, create what kind of outfield for the Los Angeles Dodgers? 
+query is  "Eric Davis outfield performance Los Angeles Dodgers"
+query is  "Eric Davis impact on Los Angeles Dodgers outfield"
+
+question is  Which Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 will be in the ICC World Twenty20?
+query is  "Pakistani cricket umpire ICC World Twenty20"
+query is  "Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 in ICC World Twenty20"
+AssertionError: Query should be short and less than 100 characters
+rewinding to 139971175300544
+
+question is  Which Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 will be in the ICC World Twenty20?
+query is  "Pakistani cricket umpire ICC World Twenty20"
+query is  "Pakistani cricket umpire ICC World Twenty20"
+AssertionError: Query should not be the following: 1) Which Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 will be in the ICC World Twenty20?; 2) "Pakistani cricket umpire ICC World Twenty20"
+rewinding to 139971175300544
+
+question is  Which Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 will be in the ICC World Twenty20?
+query is  "Pakistani cricket umpire ICC World Twenty20"
+query is  "Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 ICC World Twenty20"
+AssertionError: Query should be short and less than 100 characters
+reverting predictor 139971175300544
+failed prog assertions: Which Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 will be in the ICC World Twenty20?
+
+question is  The Organisation that allows a community to influence their operation or use and to enjoy the benefits arisingwas founded in what year?
+query is  "Organization that allows community to influence operation and benefits arising"
+query is  "founding year" OR "established year" + [name of the organization]
+
+question is  "Everything Has Changed" is a song from an album released under which record label ?
+query is  "Everything Has Changed" record label
+query is  "Everything Has Changed" record label
+AssertionError: Query should not be the following: 1) "Everything Has Changed" is a song from an album released under which record label ?; 2) "Everything Has Changed" record label
+rewinding to 139971175300544
+
+question is  "Everything Has Changed" is a song from an album released under which record label ?
+query is  "Everything Has Changed" record label
+query is  "Everything Has Changed" album record label
+AssertionError: Query should not be the following: 1) "Everything Has Changed" is a song from an album released under which record label ?; 2) "Everything Has Changed" record label
+rewinding to 139971175300544
+
+question is  "Everything Has Changed" is a song from an album released under which record label ?
+query is  "Everything Has Changed" record label
+query is  "Everything Has Changed" album record label
+AssertionError: Query should not be the following: 1) "Everything Has Changed" is a song from an album released under which record label ?; 2) "Everything Has Changed" record label
+reverting predictor 139971175300544
+failed prog assertions: "Everything Has Changed" is a song from an album released under which record label ?
+
+question is  Who is older, Aleksandr Danilovich Aleksandrov or Anatoly Fomenko?
+query is  "Birth date Aleksandr Danilovich Aleksandrov" "Birth date Anatoly Fomenko"
+query is  "Anatoly Fomenko birthdate"

--- a/tool.py
+++ b/tool.py
@@ -1,0 +1,45 @@
+def calculator(expr):
+    return eval(expr)
+
+def prefix_calculator(expr):
+    """
+    Evaluate a prefix arithmetic expression.
+    """
+    stack = []
+    for token in reversed(expr.split()):
+        if token.isdigit():
+            stack.append(int(token))
+        else:
+            op1 = stack.pop()
+            op2 = stack.pop()
+            if token == '+':
+                stack.append(op1 + op2)
+            elif token == '-':
+                stack.append(op1 - op2)
+            elif token == '*':
+                stack.append(op1 * op2)
+            elif token == '/':
+                stack.append(op1 / op2)
+    return stack.pop()
+
+
+def test_calculator():
+    expr1 = "1 + 2"
+    assert calculator(expr1) == 3, f"Expected 3, got {calculator(expr1)}"
+    expr2 = "1 + 2 * 3"
+    assert calculator(expr2) == 7, f"Expected 7, got {calculator(expr2)}"
+    expr3 = "(1 + 2) * 3"
+    assert calculator(expr3) == 9, f"Expected 9, got {calculator(expr3)}"
+
+def test_prefix_calculator():
+    expr1 = "+ 1 2"
+    assert prefix_calculator(expr1) == 3, f"Expected 3, got {prefix_calculator(expr1)}"
+    expr2 = "+ 1 * 2 3"
+    assert prefix_calculator(expr2) == 7, f"Expected 7, got {prefix_calculator(expr2)}"
+    expr3 = "* + 1 2 3"
+    assert prefix_calculator(expr3) == 9, f"Expected 9, got {prefix_calculator(expr3)}"
+
+if __name__ == '__main__':
+    test_calculator()
+    test_prefix_calculator()
+    print("All tests passed!")


### PR DESCRIPTION
Adds assertions as first-class primitives in dspy.

Syntax: `dspy.Assert(fn(args), msg="feedback message")`

Semantics: On using `dspy.Assert` in a program, the compiler promises that, during inference, either _the compiler figures out how to simulate the DSPy program up to that step in a way that passes the assertion_ or it raises a DSPyAssertionError exception. For the latter, the compiler will use the assertion as a hint, trying on a best-effort basis to make it pass. If it fails, a warning is logged, but execution will continue.

TODOs:

- [x] simplify syntax from `dspy.Assert(fn, *args, msg="...")` ==> dspy.Assert(fn(args), msg="...")
- [ ] simplify syntax to make msg a non keyword argument
