### PR TITLE
fix 502 openai error

### DIFF
--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -106,7 +106,7 @@ class GPT3(LM):
 
     @backoff.on_exception(
         backoff.expo,
-        (openai.error.RateLimitError, openai.error.ServiceUnavailableError),
+        (openai.error.RateLimitError, openai.error.ServiceUnavailableError, openai.error.APIError),
         max_time=1000,
         on_backoff=backoff_hdlr,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 backoff
 joblib
 jupyter
-openai
+openai==0.28.1
 pandas
 spacy
 regex


### PR DESCRIPTION
Have had this happen for multiple 3.5 trials where openai just craps out for a couple requests. Thought this may help. 

```
80     self._interpret_response_line(
81   File "/home/dakisho/.pyenv/versions/3.11.6/lib/python3.11/site-packages/openai/api_requestor.py", line 775, in _interpret_response_line
82     raise self.handle_error_response(
83 openai.error.APIError: Bad gateway. {"error":{"code":502,"message":"Bad gateway.","param":null,"type":"cf_bad_gateway"}} 502 {'error': {'code': 502, 'message': 'Bad gateway.', 'param': None, 'type': 'cf_bad_gateway'}} {'Date': 'Wed, 01 Nov 2023 09:23:59 GMT', 'Content-Type': 'application/json', 'Content-Length': '84', 'Connection': 'keep-alive', 'X-Frame-Options': 'SAMEORIGIN', 'Referrer-Policy': 'same-origin', 'Cache-Control': 'private, max-age=0, no-store, no-cache, must-revalidate, post-check=0, pre-check=0', 'Expires': 'Thu, 01 Jan 1970 00:00:01 GMT', 'Server': 'cloudflare', 'CF-RAY': '81f306648c6ab0ed-ATL', 'alt-svc': 'h3=":443"; ma=86400'}
```