### PR TITLE
feat: Add Qdrant support for retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ For the optional Pinecone retrieval integration, include the `pinecone` extra:
 pip install dspy-ai[pinecone]
 ```
 
+For the optional Qdrant retrieval integration, include the `qdrant` extra:
+
+```
+pip install dspy-ai[qdrant]
+```
+
 ## 2) Syntax: You're in charge of the workflow—it's free-form Python code!
 
 **DSPy** hides tedious prompt engineering, but it cleanly exposes the important decisions you need to make: **[1]** what's your system design going to look like? **[2]** what are the important constraints on the behavior of your program?

--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -1,0 +1,81 @@
+from collections import defaultdict
+from typing import List, Union
+import dspy
+
+try:
+    from qdrant_client import QdrantClient
+    import fastembed
+except ImportError:
+    raise ImportError(
+        "The 'qdrant' extra is required to use QdrantRM. Install it with `pip install dspy-ai[qdrant]`"
+    )
+
+
+class QdrantRM(dspy.Retrieve):
+    """
+    A retrieval module that uses Qdrant to return the top passages for a given query.
+
+    Assumes that a Qdrant collection has been created and populated with the following payload:
+        - document: The text of the passage
+
+    Args:
+        qdrant_collection_name (str): The name of the Qdrant collection.
+        qdrant_client (QdrantClient): A QdrantClient instance.
+        k (int, optional): The number of top passages to retrieve. Defaults to 3.
+
+    Examples:
+        Below is a code snippet that shows how to use Qdrant as the default retriver:
+        ```python
+        from qdrant_client import QdrantClient
+
+        llm = dspy.OpenAI(model="gpt-3.5-turbo")
+        qdrant_client = QdrantClient()
+        retriever_model = QdrantRM("my_collection_name", qdrant_client=qdrant_client)
+        dspy.settings.configure(lm=llm, rm=retriever_model)
+        ```
+
+        Below is a code snippet that shows how to use Qdrant in the forward() function of a module
+        ```python
+        self.retrieve = QdrantRM("my_collection_name", qdrant_client=qdrant_client, k=num_passages)
+        ```
+    """
+
+    def __init__(
+        self,
+        qdrant_collection_name: str,
+        qdrant_client: QdrantClient,
+        k: int = 3,
+    ):
+        self._qdrant_collection_name = qdrant_collection_name
+        self._qdrant_client = qdrant_client
+
+        super().__init__(k=k)
+
+    def forward(self, query_or_queries: Union[str, List[str]]) -> dspy.Prediction:
+        """Search with Qdrant for self.k top passages for query
+
+        Args:
+            query_or_queries (Union[str, List[str]]): The query or queries to search for.
+
+        Returns:
+            dspy.Prediction: An object containing the retrieved passages.
+        """
+        queries = (
+            [query_or_queries]
+            if isinstance(query_or_queries, str)
+            else query_or_queries
+        )
+        queries = [q for q in queries if q]  # Filter empty queries
+
+        batch_results = self._qdrant_client.query_batch(
+            self._qdrant_collection_name, query_texts=queries, limit=self.k)
+
+        passages = defaultdict(float)
+        for batch in batch_results:
+            for result in batch:
+                # If a passage is returned multiple times, the score is accumulated.
+                passages[result.document] += result.score
+
+        sorted_passages = sorted(
+            passages.items(), key=lambda x: x[1], reverse=True)[:self.k]
+        return dspy.Prediction(passages=[passage for passage, _ in sorted_passages])

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     python_requires='>=3.9',
     install_requires=requirements,
     extras_require={
-        "pinecone": ["pinecone-client~=2.2.4"]
+        "pinecone": ["pinecone-client~=2.2.4"],
+        "qdrant": ["qdrant-client~=1.6.2", "fastembed~=0.1.0"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This PR intends to add Qdrant as a supported retrieval mechanism.

[Qdrant](https://qdrant.tech/) is a high-performance vector database & vector similarity search engine.

The [Qdrant client library](https://github.com/qdrant/qdrant-client) has built in support for generating sentence embeddings using [FastEmbed](https://github.com/qdrant/fastembed). 

This implementation uses the `query_batch` mechanism to perform similarity searches in a batch and return the relevant docs.