### PR TITLE
Change the name of the GPT3 class to just GPT?

### DIFF
--- a/dsp/modules/__init__.py
+++ b/dsp/modules/__init__.py
@@ -1,5 +1,5 @@
 from .cache_utils import *
-from .gpt3 import *
+from .gpt import *
 from .hf import HFModel
 from .colbertv2 import ColBERTv2
 from .sentence_vectorizer import *

--- a/dsp/modules/gpt.py
+++ b/dsp/modules/gpt.py
@@ -20,7 +20,7 @@ def backoff_hdlr(details):
     )
 
 
-class GPT3(LM):
+class GPT(LM):
     """Wrapper around OpenAI's GPT API. Supports both the OpenAI and Azure APIs.
 
     Args:

--- a/dsp/primitives/compiler.py
+++ b/dsp/primitives/compiler.py
@@ -155,7 +155,7 @@ def finetune(training_data, target):
     jobname, ft = openai_finetune(name, target)
     print(ft)
 
-    ft = dsp.GPT3(model=ft, stop=" </s>")
+    ft = dsp.GPT(model=ft, stop=" </s>")
     return ft
 
 # 4. Return updated program.

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -15,7 +15,7 @@ import dsp
 
 settings = dsp.settings
 
-OpenAI = dsp.GPT3
+OpenAI = dsp.GPT
 ColBERTv2 = dsp.ColBERTv2
 Pyserini = dsp.PyseriniRetriever
 

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -49,7 +49,7 @@ class ChainOfThought(Predict):
     def forward(self, **kwargs):
         signature = self.signature
 
-        if self.activated is True or (self.activated is None and isinstance(dsp.settings.lm, dsp.GPT3)):
+        if self.activated is True or (self.activated is None and isinstance(dsp.settings.lm, dsp.GPT)):
             signature = self.extended_signature
         
         return super().forward(signature=signature, **kwargs)

--- a/dspy/predict/chain_of_thought_with_hint.py
+++ b/dspy/predict/chain_of_thought_with_hint.py
@@ -34,7 +34,7 @@ class ChainOfThoughtWithHint(Predict):
     def forward(self, **kwargs):
         signature = self.signature
 
-        if self.activated is True or (self.activated is None and isinstance(dsp.settings.lm, dsp.GPT3)):
+        if self.activated is True or (self.activated is None and isinstance(dsp.settings.lm, dsp.GPT)):
             if 'hint' in kwargs and kwargs['hint']:
                 signature = self.extended_signature2
             else:


### PR DESCRIPTION
Self explanatory. The classname GPT3 resulted in confusing errors like this. A DSPy newbie like me might wonder why gpt-3 was being invoked when I was attempting to use GPT-4:

![error_code_references_wrong_llm](https://github.com/stanfordnlp/dspy/assets/13938372/e5996722-ecbd-496a-ac2b-22b50dea50b2)

Open to feedback on other ways to improve this! 