### PR TITLE
Remove --- between examples in KNN few-shot prompts

### DIFF
--- a/dsp/templates/template_v2.py
+++ b/dsp/templates/template_v2.py
@@ -259,6 +259,7 @@ class TemplateV2:
                 query = self.query(example)
 
         rdemos = "\n\n".join(rdemos)
+        ademos = "\n\n".join(ademos)
         if len(rdemos) >= 1 and len(ademos) == 0 and not long_query:
             rdemos_and_query = "\n\n".join([rdemos, query])
             parts = [
@@ -270,7 +271,7 @@ class TemplateV2:
             parts = [
                 self.instructions,
                 self.guidelines(show_guidelines),
-                *ademos,
+                ademos,
                 query,
             ]
         else:
@@ -278,7 +279,7 @@ class TemplateV2:
                 self.instructions,
                 rdemos,
                 self.guidelines(show_guidelines),
-                *ademos,
+                ademos,
                 query,
             ]
 


### PR DESCRIPTION
This change removes the `---` that are added between every KNN example in a prompt. These dashes were not present in prompts generated by DSP programs implementing KNN few shot, but are present in prompts generated by DSPy programs implementing KNN few shot.

Previously with DSP (and with this change), KNN fewshot demos would (and will) look like:
```
Answer questions with short factoid answers.

---

Follow the following format.

Question: ${question}
Answer: often between 1 and 5 words

---

Question: On the coast of what ocean is the birthplace of Diogal Sakho?
Answer: Atlantic Ocean

Question: Which is taller, the Empire State Building or the Bank of America Tower?
Answer: Empire State Building

Question: Samantha Cristoforetti and Mark Shuttleworth are both best known for being first in their field to go where?
Answer: Space

Question: Which Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 will be in the ICC World Twenty20?
Answer: Aleem Dar

Question: What is the code name for the German offensive that started this Second World War engagement on the Eastern Front (a few hundred kilometers from Moscow) between Soviet and German forces, which included 102nd Infantry Division?
Answer: Operation Citadel

Question: Which of these publications was most recently published, Who Put the Bomp or Self?
Answer: Self

Question: Which magazine has published articles by Scott Shaw, Tae Kwon Do Times or Southwest Art?
Answer: Tae Kwon Do Times

---

Question: Are both Cangzhou and Qionghai in the Hebei province of China?
Answer: No
```

With DSPy, KNN examples are formatted like:
```
Answer questions with short factoid answers.

---

Follow the following format.

Question: ${question}
Answer: often between 1 and 5 words

---

Question: On the coast of what ocean is the birthplace of Diogal Sakho?
Answer: Atlantic Ocean

---

Question: Which is taller, the Empire State Building or the Bank of America Tower?
Answer: Empire State Building

---

Question: Samantha Cristoforetti and Mark Shuttleworth are both best known for being first in their field to go where?
Answer: Space

---

Question: Which Pakistani cricket umpire who won 3 consecutive ICC umpire of the year awards in 2009, 2010, and 2011 will be in the ICC World Twenty20?
Answer: Aleem Dar

---

Question: What is the code name for the German offensive that started this Second World War engagement on the Eastern Front (a few hundred kilometers from Moscow) between Soviet and German forces, which included 102nd Infantry Division?
Answer: Operation Citadel

---

Question: Which of these publications was most recently published, Who Put the Bomp or Self?
Answer: Self

---

Question: Which magazine has published articles by Scott Shaw, Tae Kwon Do Times or Southwest Art?
Answer: Tae Kwon Do Times

---

Question: Are both Cangzhou and Qionghai in the Hebei province of China?
Answer: No

```