### PR TITLE
README tweak, update order of links out to references

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,12 +380,16 @@ If you use DSPy or DSP in a research paper, please cite our work as follows:
 }
 ```
 
-
 You can also read more about the evolution of the framework from Demonstrate-Search-Predict to DSPy:
-* [**Demonstrate-Search-Predict: Composing retrieval and language models for knowledge-intensive NLP**](https://arxiv.org/abs/2212.14024.pdf) (Academic Paper, Dec 2022)
-* [**Introducing DSP**](https://twitter.com/lateinteraction/status/1617953413576425472)  (Twitter Thread, Jan 2023)
-* [**Releasing the DSP Compiler (v0.1)**](https://twitter.com/lateinteraction/status/1625231662849073160)  (Twitter Thread, Feb 2023)
-* [**Releasing DSPy, the latest iteration of the framework**](https://twitter.com/lateinteraction/status/1694748401374490946) (Twitter Thread, Aug 2023)
 * [**DSPy: Compiling Declarative Language Model Calls into Self-Improving Pipelines**](https://arxiv.org/abs/2310.03714) (Academic Paper, Oct 2023)
+* [**Releasing DSPy, the latest iteration of the framework**](https://twitter.com/lateinteraction/status/1694748401374490946) (Twitter Thread, Aug 2023)
+* [**Releasing the DSP Compiler (v0.1)**](https://twitter.com/lateinteraction/status/1625231662849073160)  (Twitter Thread, Feb 2023)
+* [**Introducing DSP**](https://twitter.com/lateinteraction/status/1617953413576425472)  (Twitter Thread, Jan 2023)
+* [**Demonstrate-Search-Predict: Composing retrieval and language models for knowledge-intensive NLP**](https://arxiv.org/abs/2212.14024.pdf) (Academic Paper, Dec 2022)
+
+
+
+
+
 
 


### PR DESCRIPTION
This is a trivial change– I just reversed the chronological order of the list of links to references. Previously, it was: oldest -> newest, and I just swapped it: newest -> oldest.

Reason: people often click the first link in a list to read more something. So it probably makes sense to have the thing we'd actually want folks to read listed first (the most recent preprint).