### PR TITLE
Fixed Qdrant integration by adding "k" as an optional argument in Qdrant forward method

### DIFF
--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import List, Union
 import dspy
+from typing import Optional
 
 try:
     from qdrant_client import QdrantClient
@@ -51,7 +52,7 @@ class QdrantRM(dspy.Retrieve):
 
         super().__init__(k=k)
 
-    def forward(self, query_or_queries: Union[str, List[str]]) -> dspy.Prediction:
+    def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int]) -> dspy.Prediction:
         """Search with Qdrant for self.k top passages for query
 
         Args:
@@ -66,9 +67,10 @@ class QdrantRM(dspy.Retrieve):
             else query_or_queries
         )
         queries = [q for q in queries if q]  # Filter empty queries
-
+        
+        k = k if k is not None else self.k
         batch_results = self._qdrant_client.query_batch(
-            self._qdrant_collection_name, query_texts=queries, limit=self.k)
+            self._qdrant_collection_name, query_texts=queries, limit=k)
 
         passages = defaultdict(float)
         for batch in batch_results:
@@ -77,5 +79,5 @@ class QdrantRM(dspy.Retrieve):
                 passages[result.document] += result.score
 
         sorted_passages = sorted(
-            passages.items(), key=lambda x: x[1], reverse=True)[:self.k]
+            passages.items(), key=lambda x: x[1], reverse=True)[:k]
         return dspy.Prediction(passages=[passage for passage, _ in sorted_passages])

--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -22,7 +22,7 @@ class QdrantRM(dspy.Retrieve):
     Args:
         qdrant_collection_name (str): The name of the Qdrant collection.
         qdrant_client (QdrantClient): A QdrantClient instance.
-        k (int, optional): The number of top passages to retrieve. Defaults to 3.
+        k (int, optional): The default number of top passages to retrieve. Defaults to 3.
 
     Examples:
         Below is a code snippet that shows how to use Qdrant as the default retriver:
@@ -57,7 +57,7 @@ class QdrantRM(dspy.Retrieve):
 
         Args:
             query_or_queries (Union[str, List[str]]): The query or queries to search for.
-
+            k (Optional[int]): The number of top passages to retrieve. Defaults to self.k.
         Returns:
             dspy.Prediction: An object containing the retrieved passages.
         """


### PR DESCRIPTION
TL;DR: Fixed Qdrant integration by simply adding a k argument to the forward function QdrantRM class

Currently, the Qdrant integration fails to work, throwing a TypeError when using Qdrant as retriever model.

In dspy/retrieve/retrieve.py, passages are retrieved using a retriever model (in this case Qdrant) with a list of queries, and with the argument `k=self.k`. 
```
    def forward(self, query_or_queries):
        queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
        queries = [query.strip().split('\n')[0].strip() for query in queries]


        # print(queries)
        # TODO: Consider removing any quote-like markers that surround the query too.

        passages = dsp.retrieveEnsemble(queries, k=self.k)
        return Prediction(passages=passages)
  ```
  
 In dspy/retrieve/qdrant_rm.py, the following forward function was implemented previously.
```
    def forward(self, query_or_queries: Union[str, List[str]]) -> dspy.Prediction:
        """Search with Qdrant for self.k top passages for query

        Args:
            query_or_queries (Union[str, List[str]]): The query or queries to search for.

        Returns:
            dspy.Prediction: An object containing the retrieved passages.
        """
        queries = (
            [query_or_queries]
            if isinstance(query_or_queries, str)
            else query_or_queries
        )
        queries = [q for q in queries if q]  # Filter empty queries
        
        batch_results = self._qdrant_client.query_batch(
            self._qdrant_collection_name, query_texts=queries, limit=self.k)

        passages = defaultdict(float)
        for batch in batch_results:
            for result in batch:
                # If a passage is returned multiple times, the score is accumulated.
                passages[result.document] += result.score

        sorted_passages = sorted(
            passages.items(), key=lambda x: x[1], reverse=True)[:self.k]
        return dspy.Prediction(passages=[passage for passage, _ in sorted_passages])
```

As you can see, the arguments in this forward function do not contain k, thus resulting in a TypeError. 

# My contribution

I simply added k to the arguments in the forward method in qdrant_rm, providing optional customisation of top k passages at runtime.

```
   def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int]) -> dspy.Prediction:
        """Search with Qdrant for self.k top passages for query

        Args:
            query_or_queries (Union[str, List[str]]): The query or queries to search for.
            k (Optional[int]): The number of top passages to retrieve. Defaults to self.k.
        Returns:
            dspy.Prediction: An object containing the retrieved passages.
        """
        queries = (
            [query_or_queries]
            if isinstance(query_or_queries, str)
            else query_or_queries
        )
        queries = [q for q in queries if q]  # Filter empty queries
        
        k = k if k is not None else self.k
        batch_results = self._qdrant_client.query_batch(
            self._qdrant_collection_name, query_texts=queries, limit=k)

        passages = defaultdict(float)
        for batch in batch_results:
            for result in batch:
                # If a passage is returned multiple times, the score is accumulated.
                passages[result.document] += result.score

        sorted_passages = sorted(
            passages.items(), key=lambda x: x[1], reverse=True)[:k]
        return dspy.Prediction(passages=[passage for passage, _ in sorted_passages])
```
