### PR TITLE
Fix a nit for openai azure support.

### DIFF
--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -53,6 +53,7 @@ class GPT3(LM):
     ):
         super().__init__(model)
         self.provider = "openai"
+        openai.api_type = api_provider
 
         default_model_type = (
             "chat"
@@ -67,8 +68,7 @@ class GPT3(LM):
                 "engine" in kwargs or "deployment_id" in kwargs
             ), "Must specify engine or deployment_id for Azure API instead of model."
             assert "api_version" in kwargs, "Must specify api_version for Azure API"
-            assert "api_base" in kwargs, "Must specify api_base for Azure API"
-            openai.api_type = "azure"
+            assert api_base is not None, "Must specify api_base for Azure API"
             if kwargs.get("api_version"):
                 openai.api_version = kwargs["api_version"]
 


### PR DESCRIPTION
Issues:

After the change to support `openai==1.x` (#258), https://github.com/stanfordnlp/dspy/blob/main/dsp/modules/gpt3.py#L70 will always trigger assert when `api_provider == 'azure'`.

Changes:
- Fix this nit.
- Move `openai.api_type = api_provider` to better support switching api providers.

Remaining issues:
- `openai==1.x` suggests using client to manage configurations. It seems that the global configurations do not work for OpenAI Azure service any more. #258 is not fully solved.