### PR TITLE
Update evaluate.py

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -3,7 +3,11 @@ import tqdm
 import threading
 import pandas as pd
 
-from IPython.display import display as ipython_display, HTML
+try:
+    from IPython.display import display as ipython_display, HTML
+except ImportError:
+    ipython_display = print
+    HTML = lambda x: x
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from dsp.utils import EM


### PR DESCRIPTION
This modification replaces the IPython import with a try-except block. If IPython is not available, it sets ipython_display to the built-in print function and defines a dummy HTML lambda function.