### PR TITLE
ops(dspy): adding pre-commit + contrib.md initialization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,68 @@
+default_language_version:
+  python: python3.11
+
+default_stages: [commit]
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.11
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        args:
+          [
+            "--profile=black",
+            "--py=311",
+            "--line-length=120",
+            "--multi-line=3",
+            "--trailing-comma",
+            "--force-grid-wrap=0",
+            "--use-parentheses",
+            "--ensure-newline-before-comments",
+            "--project=CORE,src,config,preprocess,train,transform,main,model",
+          ]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-yaml
+        args: ["--allow-multiple-documents", "--unsafe"]
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-docstring-first
+      - id: check-toml
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: requirements-txt-fixer
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: pretty-format-json
+        args:
+          - "--autofix"
+          - "--indent=2"
+  - repo: local
+    hooks:
+      - id: validate-commit-msg
+        name: Commit Message is Valid
+        language: pygrep
+        entry: ^(break|build|ci|docs|feat|fix|perf|refactor|style|test|ops|hotfix|release|maint|init|enh|revert)\([\w,\.,\-,\(,\),\/]+\)(!?)(:)\s{1}([\w,\W,:]+)
+        stages: [commit-msg]
+        args: [--negate]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.3
+    hooks:
+      - id: prettier
+        additional_dependencies:
+          - prettier@2.1.2
+          - "@prettier/plugin-xml@0.12.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Setting-up
+
+## Crete new envirinment
+
+```
+conda create --name dspy python=3.11
+```
+
+or
+
+```
+python3 -m venv dspy
+```
+
+## Pre-commit hook
+
+Before using pre-commit hook you need to install it in your python environment.
+
+```
+conda install -c conda-forge pre-commit
+```
+
+go to the root folder and then activate it as follows (it will first download all required dependencies):
+
+```
+pre-commit install
+```
+
+> Pre-commit hooks will attept to fix all your files and so you will need to (add + commit) them once the fixes are done !
+
+#### Optional:
+
+Generally the pre-commit will run automatically before each of your commit,
+but you can also manually trigger it, as follows:
+
+```
+pre-commit run --all-files
+```
+
+## Commit Message format:
+
+Commit message format must be respected, with the followint regex:
+
+```
+^(break|build|ci|docs|feat|fix|perf|refactor|style|test|ops|hotfix|release|maint|init|enh|revert)\([a-z,A-Z,0-9,\-,\_,\/,:]+\)(:)\s{1}([\w\s]+)
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,3 +117,143 @@ docs = [
     "sphinx-reredirects",
     "sphinx-automodapi"
 ]
+
+[tool.coverage.run]
+branch = true
+omit = [
+  "*/__init__.py",
+  "*/test_*.py",
+  "*/tests/*.py",
+  "*/conftest.py",
+  "*/venv/*",
+  "*/virtualenv/*",
+  "*/.venv/*",
+  "*/.virtualenv/*",
+  "*/env/*",
+  "*/.env/*",
+  "*/setup.py"
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self.debug:",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if __name__ == '__main__':",
+    "logger",
+    "try",
+    "except",
+    "^\\s*self\\.\\w+(:\\s*[^=]+)?\\s*=.*$",
+    "continue",
+]
+
+[tool.ruff]
+line-length = 120
+indent-width = 4
+target-version = "py311"
+extend-unsafe-fixes = ["D"]
+
+[tool.ruff.lint]
+# List of rules: https://docs.astral.sh/ruff/rules
+select = [
+    # flake8-builtins
+    "A",
+    # flake8-commas
+    "COM812",
+    # flake8-comprehensions
+    "C4",
+    # pydocstyle
+    "D",
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # flake8-implicit-str-concat
+    "ISC",
+    # pep8-naming
+    "N",
+    # flake8-annotations
+    "ANN",
+    # flake8-async
+    "ASYNC",
+    # flake8-bandid selected
+    "S",
+    # flake8-print
+    "T20",
+    # flake8-return
+    "RET",
+    # flake8-simplify
+    "SIM",
+    # flake8-unused-arguments
+    "ARG",
+    # flake8-use-pathlib
+    "PTH",
+    # eradicate
+    "ERA",
+    # pandas-vet
+    "PD",
+]
+ignore = [
+    "D100",
+    "D101",
+    "D104",
+    "D106",
+    # missing-type-self
+    "ANN101",
+    # missing-type-cls
+    "ANN102",
+    # missing-type-kwargs
+    "ANN003",
+    # utf-8 encoding skip
+    "UP009",
+    # First argument of a method should be named `self`
+    "N805",
+    # 1 blank line required between summary line and description
+    "D205",
+    # Missing return type annotation for special method `__init__`
+    "ANN204",
+    # Avoid using the generic variable name `df` for DataFrames
+    "PD901",
+    # Unnecessary assignment to `df` before `return` statement
+    "RET504",
+    # commented code
+    "ERA001",
+    # Star-arg unpacking after a keyword argument is strongly discouraged
+    "B026",
+    # Missing type annotation for function argument `self`
+    "ANN001",
+    # Dynamically typed expressions (typing.Any) are disallowed in `wrapper`
+    "ANN401",
+    # Unnecessary `elif` after `return` statement
+    "RET505",
+    # Within an `except` clause, raise exceptions with `raise
+    "B904",
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.format]
+docstring-code-format = true
+quote-style = "double"
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.per-file-ignores]
+"**/{test,docs}/*" = ["ALL"]


### PR DESCRIPTION
- Adding base configurationfor the new advanced pre-commit hook (.toml + pre-commit.yaml)
- Adding base config for pytests coverage reporting (.toml)
- Adding `CONTRIBUTE.md` to start explaining the basic process for setting up the pre-commit hook
