### PR TITLE
ops(dspy): adding docs previes to MRs CI/CD action

### DIFF
--- a/.github/workflows/DOCS_PR_PREVIEW.yml
+++ b/.github/workflows/DOCS_PR_PREVIEW.yml
@@ -1,0 +1,60 @@
+name: Deploy PR Pages Preview
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+    paths:
+      - "docs/**"
+      - mkdocs.yml
+  pull_request:
+    branches:
+      - dev
+      - main
+    paths:
+      - "docs/**"
+      - mkdocs.yml
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-pr-preview:
+    runs-on: [self-hosted, Linux, standard]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: "pip"
+
+      - name: Install Python dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          # installing poetry
+          pip install poetry
+          # disable venvs
+          poetry config virtualenvs.create false
+          # assuring we have all extras for testing as well
+          poetry install --only doc --no-interaction
+
+      - name: Install and Build
+        shell: bash
+        run: |
+          mkdocs build
+          echo "DOC GENERATED - OK!"
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/
+          token: ${{ secrets.GITHUB_PAT }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,15 @@ docs = [
     "sphinx-automodapi"
 ]
 
+[tool.poetry.group.doc.dependencies]
+mkdocs = ">=1.5.3"
+mkdocs-material = ">=9.0.6"
+mkdocs-material-extensions = ">=1.3.1"
+mkdocs-gen-files = "^0.5.0"
+mkdocstrings-python = "^1.7.5"
+mkdocstrings = {extras = ["python"], version = ">=0.20.0"}
+mike = ">=2.0.0"
+
 [tool.coverage.run]
 branch = true
 omit = [


### PR DESCRIPTION
Adding automatic docs generation from the new branch (when docs are changed) so we can validate the new documentation before merging the PR.

Warning ⚠️: This requires setting up the repos PAT (personal acess token) in the secrets of the repo.