### PR TITLE
ops(dspy): activating pre-commit global check (and aligning to py3.9)

### DIFF
--- a/.github/workflows/precommits_check.yml
+++ b/.github/workflows/precommits_check.yml
@@ -15,7 +15,6 @@ on:
 
 jobs:
   pre-commit-checks:
-    runs-on: [self-hosted, Linux, standard]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/precommits_check.yml
+++ b/.github/workflows/precommits_check.yml
@@ -1,0 +1,47 @@
+name: Pre-commit checks
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+  workflow_dispatch:
+    branches:
+      - dev
+      - main
+
+jobs:
+  pre-commit-checks:
+    runs-on: [self-hosted, Linux, standard]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - name: Check Pull Request Title
+        uses: Slashgear/action-check-pr-title@main
+        with:
+          regexp: '(break|build|ci|docs|feat|fix|perf|refactor|style|test|ops|hotfix|release|maint|init|enh|revert)\([a-z,A-Z,0-9,\-,\_,\/,:]+\)(:)\s{1}([\w\s]+)' # Regex the title should match.
+      - name: Getting changed files list
+        id: files
+        uses: jitterbit/get-changed-files@master
+      - name: Checking changed files
+        shell: bash
+        run: |
+          echo "Changed files"
+          echo ${{ steps.files.outputs.all }}
+          echo "Github Client version"
+          echo $(gh --version)
+      - name: Pre-Commit Checks
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+          echo "Running pre-commit scans:"
+          # adding log display in case of pre-commit errors
+          pre-commit run -v --files ${{ steps.files.outputs.all }}
+        shell: bash

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.9
 
 default_stages: [commit]
 default_install_hook_types: [pre-commit, commit-msg]
@@ -22,7 +22,7 @@ repos:
         args:
           [
             "--profile=black",
-            "--py=311",
+            "--py=39",
             "--line-length=120",
             "--multi-line=3",
             "--trailing-comma",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ exclude_lines = [
 [tool.ruff]
 line-length = 120
 indent-width = 4
-target-version = "py311"
+target-version = "py39"
 extend-unsafe-fixes = ["D"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
- aligning pre-commit version to py3.9 (do we need this version or can we start with >=3.10, which is x10 faster) and has lot's of nice features for typing etc
- activating pre-commit checks in the repo (you shall not pass principle)