### PR TITLE
ops(dspy): setting-up base actions and files for Semantic Release

### DIFF
--- a/.github/templates/Python/poetry_build/action.yml
+++ b/.github/templates/Python/poetry_build/action.yml
@@ -1,0 +1,50 @@
+name: Building and deploying python Package
+description: Building And Deploying python package using poetry and twine.
+
+inputs:
+  PYTHON_VERSION:
+    description: "Python version to use for this action. Default is 3.9"
+    required: false
+    default: 3.9
+  SEMANTIC_VERSION:
+    description: "Semantic Realsede version to use for teh package build"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "${{ inputs.PYTHON_VERSION }}"
+
+    - name: Install package dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+
+        # installing poetry
+        pip install poetry
+
+        # assuring we have all extras for testing as well
+        poetry install --all-extras --no-interaction
+
+        # incrementing package version based on semantic release
+        poetry version ${{ inputs.SEMANTIC_VERSION }}
+
+    - name: Display Publish Config List
+      shell: bash
+      run: |
+        echo 'Display Publish Config List'
+        poetry config --list
+
+    - name: Poetry Build and Publish
+      shell: bash
+      run: |
+        # building and publishing the package
+        poetry publish \
+        -r jfrog \
+        -u ${{ secrets.URL }} \
+        -p ${{ secrets.TOKEN }} \
+        --build
+        echo "ALL DONE !"

--- a/.github/templates/Python/unittests/action.yml
+++ b/.github/templates/Python/unittests/action.yml
@@ -1,0 +1,56 @@
+name: Python run pytests
+description: Installing dependencies and running unit-tests
+
+inputs:
+  pkg_folder:
+    description: "Folder of Python application"
+    required: false
+    default: src
+  PYTHON_VERSION:
+    description: "Python version to use for unit tests. Default is 3.9"
+    required: false
+    default: 3.9
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "${{ inputs.PYTHON_VERSION }}"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # installing poetry
+        pip install poetry
+        # assuring we have all extras for testing as well
+        poetry install --all-extras --no-interaction
+      shell: bash
+    - name: Test with pytest
+      shell: bash
+      run: |
+        pip install flake8 pytest pytest-cov
+        echo "Running unit-tests!"
+        # preparing tests config file
+        if [ -f "pytest.ini" ];
+        then
+          echo "pytest.ini exists."
+        else
+          touch pytest.ini
+          echo "[pytest]" >> pytest.ini
+          echo "pythonpath = . ${{ inputs.pkg_folder }}" >> pytest.ini
+        fi
+        # running tests
+        poetry run pytest --junitxml=pytest.xml --cov=${{ inputs.pkg_folder }}/ | tee pytest-coverage.txt
+        echo "TEST OK!"
+    - name: Pytest coverage comment
+      id: coverageComment
+      uses: MishaKav/pytest-coverage-comment@main
+      with:
+        pytest-coverage-path: pytest-coverage.txt
+        junitxml-path: pytest.xml
+      # - name: Update Readme with Coverage Html
+      #   # if: ${{ github.ref == 'refs/heads/main' }}
+      #   run: |
+      #     sed -i '/<!-- Pytest Coverage Comment:Begin -->/,/<!-- Pytest Coverage Comment:End -->/c\<!-- Pytest Coverage Comment:Begin -->\n\${{ steps.coverageComment.outputs.coverageHtml }}\n<!-- Pytest Coverage Comment:End -->' ./README.md

--- a/.github/templates/github/semantic_release/.releaserc.json.template
+++ b/.github/templates/github/semantic_release/.releaserc.json.template
@@ -1,0 +1,57 @@
+{
+  "branches": "main",
+  "tagFormat": "${PROJECT_NAME_LOWER}.${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github",
+    "@semantic-release/changelog",
+    ["@semantic-release/git", {
+        "assets": ["CHANGELOG.md"]
+      }]
+  ],
+  "preset": "conventionalcommits",
+  "presetConfig": {
+    "types": [
+      {"type": "break", "hidden": false, "section": ":boom: Breaking Changes"},
+      {"type": "feat", "hidden": false, "section": ":gift: Features"},
+      {"type": "init", "hidden": false, "section": ":gift: Features"},
+      {"type": "enh", "hidden": false, "section": ":gift: Features"},
+      {"type": "refactor", "hidden": false, "section": ":tools: Maintenance"},
+      {"type": "style", "hidden": false, "section": ":tools: Maintenance"},
+      {"type": "maint", "hidden": false, "section": ":tools: Maintenance"},
+      {"type": "perf", "hidden": false, "section": ":tools: Maintenance"},
+      {"type": "ci", "hidden": false, "section": ":hotsprings: Infra"},
+      {"type": "ops", "hidden": false, "section": ":hotsprings: Infra"},
+      {"type": "build", "hidden": true, "section": ":hotsprings: Infra"},
+      {"type": "test", "hidden": true, "section": ":hotsprings: Infra"},
+      {"type": "hotfix", "hidden": false, "section": ":fire: Hotfixes"},
+      {"type": "fix", "hidden": false, "section": ":beetle: Bug Fixes"},
+      {"type": "revert", "hidden": false, "section": ":track_previous: Reverts"},
+      {"type": "docs", "hidden": true, "section": ":books: Documentation"}
+    ]
+  },
+  "parserOpts": {
+    "revertPattern": "^Revert\\s(\\w*:\\s{0,1}\\[${PROJECT_NAME_LOWER}|${PROJECT_NAME_UPPER}.*\\]*\\ .*).\\s*This reverts commit (\\w*)?",
+    "headerPattern": "^(\\w*)(?:\\((?:${PROJECT_NAME_LOWER}|${PROJECT_NAME_UPPER}).*\\):|:\\s{0,1}\\[(?:${PROJECT_NAME_LOWER}|${PROJECT_NAME_UPPER}).*\\]) (?:.*)$"
+
+  },
+  "releaseRules": [
+    {"type": "break", "release": "major"},
+    {"type": "feat", "release": "minor"},
+    {"type": "init", "release": "minor"},
+    {"type": "ci", "release": "minor"},
+    {"type": "ops", "release": "minor"},
+    {"type": "test", "release": "patch"},
+    {"type": "enh", "release": "patch"},
+    {"type": "refactor", "release": "patch"},
+    {"type": "style", "release": "patch"},
+    {"type": "maint", "release": "patch"},
+    {"type": "perf", "release": "patch"},
+    {"type": "build", "release": "patch"},
+    {"type": "hotfix", "release": "patch"},
+    {"type": "fix", "release": "patch"},
+    {"type": "revert", "release": "patch"},
+    {"type": "docs", "release": "patch"}
+  ]
+}

--- a/.github/templates/github/semantic_release/action.yml
+++ b/.github/templates/github/semantic_release/action.yml
@@ -1,0 +1,114 @@
+name: "Semantic Release for Projects"
+description: "Custom implementation of Semantic Release able to handle per project releases"
+
+inputs:
+  PROJECT_NAME:
+    description: "Name of the project to release"
+    required: true
+  PROJECT_DIRECTORY:
+    description: "Folder patht to the project directory"
+    required: true
+  BRANCHES:
+    description: "List of branches for semantic release"
+    required: false
+    default: main
+  GITHUB_TOKEN:
+    description: "Token to use for Github"
+    required: true
+  TEMPLATE_FILE:
+    description: "Semantic release template file"
+    required: false
+    default: .github/templates/github/semantic_release/.releaserc.json.template
+  DRY_RUN:
+    description: "Should we execute in a dry run mode?"
+    required: false
+    default: true
+
+outputs:
+  new_release_version:
+    description: "New TAG attached to the Semantic Release version"
+    value: ${{ steps.semantic-release.outputs.new_release_version }}
+  new_release_notes:
+    description: "Release notes for Semantic Release"
+    value: ${{ env.new_release_notes }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Creating Project Related Template"
+      id: semantic-release-template
+      shell: bash
+      run: |
+        # creating project name variables
+        export PROJECT_NAME_UPPER=$(echo ${{ inputs.PROJECT_NAME }} | tr 'a-z' 'A-Z')
+        export PROJECT_NAME_LOWER=$(echo ${{ inputs.PROJECT_NAME }} | tr 'A-Z' 'a-z')
+        # populating project specific template for the semantic release
+        envsubst '${PROJECT_NAME_UPPER} ${PROJECT_NAME_LOWER}' < ${{ inputs.TEMPLATE_FILE }} > ${{ inputs.PROJECT_DIRECTORY }}/.releaserc.json
+
+    - name: "Setup Node"
+      uses: actions/setup-node@v3
+      with:
+        node-version: 14
+
+    - name: "Configure Git user"
+      shell: bash
+      run: |
+        git config user.email "actions@github.com"
+        git config user.name "GitHub Actions"
+
+    - name: "Semantic Release"
+      id: semantic-release
+      uses: cycjimmy/semantic-release-action@v3.4.1
+      env:
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+      with:
+        branches: ${{ inputs.BRANCHES }}
+        dry_run: ${{ inputs.DRY_RUN }}
+        working_directory: ${{ inputs.PROJECT_DIRECTORY }}
+        extra_plugins: |
+          @semantic-release/commit-analyzer
+          @semantic-release/release-notes-generator
+          @semantic-release/changelog
+          @semantic-release/github
+          @semantic-release/git
+          conventional-changelog-conventionalcommits@5.0.0
+
+    - name: "export released version"
+      id: export-released-version
+      shell: bash
+      run: |
+        if [ "${{ steps.semantic-release.outputs.new_release_version }}" != "" ] ;
+          then echo "new_release_version=${{ steps.semantic-release.outputs.new_release_version }}" >> $GITHUB_OUTPUT ;
+          else if [ "${{ steps.semantic-release.outputs.new_release_version }}" != "" ] ;
+            then echo "new_release_version=${{ steps.semantic-release.outputs.new_release_version }}" >> $GITHUB_OUTPUT ;
+          fi ;
+        fi
+
+    - name: "export release notes"
+      id: export-released-notes
+      shell: bash
+      run: |
+        if [ "${{ steps.semantic-release.outputs.new_release_notes }}" != "" ] ; then
+          RELEASE_NOTES="${{ steps.semantic-release.outputs.new_release_notes }}"
+          RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
+          RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
+          RELEASE_NOTES="$(echo "$RELEASE_NOTES" | sed -z 's/\n/\\n/g')"
+          echo "new_release_notes=${RELEASE_NOTES}" >> $GITHUB_OUTPUT ;
+        else if [ "${{ steps.semantic-release.outputs.new_release_notes }}" != "" ] ; then
+          RELEASE_NOTES="${{ steps.semantic-release.outputs.new_release_notes }}"
+          RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
+          RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
+          RELEASE_NOTES="$(echo "$RELEASE_NOTES" | sed -z 's/\n/\\n/g')"
+          echo "new_release_notes=${RELEASE_NOTES}" >> $GITHUB_OUTPUT ;
+          fi ;
+        fi
+
+    - name: "Do something else when a new release published"
+      if: steps.semantic-release.outputs.new_release_published == 'true'
+      shell: bash
+      run: |
+        echo ${{ steps.semantic-release.outputs.new_release_version }}
+        echo ${{ steps.semantic-release.outputs.new_release_major_version }}
+        echo ${{ steps.semantic-release.outputs.new_release_minor_version }}
+        echo ${{ steps.semantic-release.outputs.new_release_patch_version }}
+        echo ${{ steps.semantic-release.outputs.new_release_patch_version }}


### PR DESCRIPTION
- adding semantic release action
- adding semantic release configuration (to automatically bump up the version based on the commits in the repo and their label)
- adding python package release action template
- adding python unit-test template

(this PR won't have any functional impact as the final flow needs to be adjusted: adding docs build + versioning etc, and only brings base of the functionality)

Warning: this will require setting up some secrets (to be able to publish to pypi)
