### PR TITLE
[Bug Fix] WeaviateRM Patch, add `long_text` key to `passages`

### DIFF
--- a/dspy/retrieve/weaviate_rm.py
+++ b/dspy/retrieve/weaviate_rm.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import List, Union
 import dspy
+from dsp.utils import dotdict
 from typing import Optional
 
 try:
@@ -78,5 +79,6 @@ class WeaviateRM(dspy.Retrieve):
             results = results["data"]["Get"][self._weaviate_collection_name]
             parsed_results = [result["content"] for result in results]
             passages.extend(parsed_results)
+        passages.extend(dotdict({"long_text": d}) for d in results)
 
         return dspy.Prediction(passages=passages)


### PR DESCRIPTION
This PR adds the `long_text` key to the `passages` returned by the WeaviateRM.

In dsp/primitives/search line 10: `passages = [psg.long_text for psg in passages]` throws an error without this -- maybe worth making a note of removing this. 

Not aware of the full context, but this PR will patch the WeaviateRM for the time being.