### PR TITLE
Small Fix to vLLM Launch Documentation

### DIFF
--- a/docs/guides/language_model_details/launching_vllm.md
+++ b/docs/guides/language_model_details/launching_vllm.md
@@ -11,7 +11,7 @@ Follow these steps to set up the vLLM Server:
 Example command:
 
 ```bash
-   python -m vllm.entrypoints.api_server --model mosaicml/mpt-7b --port 8000
+   python -m vllm.entrypoints.openai.api_server --model mosaicml/mpt-7b --port 8000
 ```
 
 This will launch the vLLM server.

--- a/docs/using_local_models.md
+++ b/docs/using_local_models.md
@@ -92,7 +92,7 @@ Follow these steps to set up the vLLM Server:
 
    Example command:
    ```
-   python -m vllm.entrypoints.api_server --model mosaicml/mpt-7b --port 8000
+   python -m vllm.entrypoints.openai.api_server --model mosaicml/mpt-7b --port 8000
    ```
 
 This will launch the vLLM server.


### PR DESCRIPTION
The current documentation for running vLLM with DSPy suggests that the user start an API server via ```python -m vllm.entrypoints.api_server```. However, this leads to errors since the DSPy code assumes an OpenAI-Compatible API server. So the user should instead launch the server via ```python -m vllm.entrypoints.openai.api_server```.