### PR TITLE
CoT fix + move torch dependeny when using vllm

### DIFF
--- a/dsp/modules/hf.py
+++ b/dsp/modules/hf.py
@@ -40,19 +40,20 @@ class HFModel(LM):
             hf_device_map (str, optional): HF config strategy to load the model. 
                 Recommeded to use "auto", which will help loading large models using accelerate. Defaults to "auto".
         """
-        try:
-            from transformers import AutoModelForSeq2SeqLM, AutoModelForCausalLM, AutoTokenizer, AutoConfig
-            import torch
-        except ImportError as exc:
-            raise ModuleNotFoundError(
-                "You need to install Hugging Face transformers library to use HF models."
-            ) from exc
+
         super().__init__(model)
         self.provider = "hf"
         self.is_client = is_client
         self.device_map = hf_device_map
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         if not self.is_client:
+            try:
+                from transformers import AutoModelForSeq2SeqLM, AutoModelForCausalLM, AutoTokenizer, AutoConfig
+                import torch
+            except ImportError as exc:
+                raise ModuleNotFoundError(
+                    "You need to install Hugging Face transformers library to use HF models."
+                ) from exc
+            self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             try:
                 architecture = AutoConfig.from_pretrained(model).__dict__["architectures"][0]
                 self.encoder_decoder_model = ("ConditionalGeneration" in architecture) or ("T5WithLMHeadModel" in architecture)

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -62,7 +62,7 @@ class ChainOfThought(Predict):
             else:
                 signature = self.signature
         else:
-            signature = dsp.Template(signature.instructions, **new_signature)
+            signature = dsp.Template(self.signature.instructions, **new_signature)
         return super().forward(signature=signature, **kwargs)
 
 


### PR DESCRIPTION
Very cool project 💯 

This PR fixes a typo introduced in [#333](https://github.com/stanfordnlp/dspy/pull/333). The signature is undefined in this context.

Additionally, I moved the torch dependency to only be required when running the model locally through hf and not when a vllm endpoint is called.