### PR TITLE
fix(datasets): relax datasets version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "regex~=2023.10.3",
     "ujson~=5.8.0",
     "tqdm~=4.66.1",
-    "datasets~=2.14.6",
+    "datasets~=2.14.6,<3.0.0",
     "requests~=2.31.0",
     "optuna~=3.4.0",
 ]


### PR DESCRIPTION
If you try and add dspy with poetry to an existing project with existing datasets version already installed you may get poetry errors. For example, I tried installing into a project that depended on datasets > 2.15 and so I couldn't install dspy. This was recently fixed for openai version constraint in a similar  [PR](https://github.com/stanfordnlp/dspy/pull/347). Can we do the same for datasets? Im not sure if there was a reason it was pinned to 2.14. A better solution might even be > 2.14 but let me know.


PS: Is there a way to build the environment and run a series of unit tests? I did not see anything about that in the CONTRIBUTING.md. The pre-commit config just does linting/formatting as far a I can tell. 

