### PR TITLE
Easier api for transforming modules with assertions

### DIFF
--- a/dspy/primitives/assertions.py
+++ b/dspy/primitives/assertions.py
@@ -336,9 +336,9 @@ def assert_transform_module(
         module
     )
 
-    if all(map(lambda p: isinstance(p, dspy.retry.Retry), module.named_predictors())):
+    if all(map(lambda p: isinstance(p[1], dspy.retry.Retry), module.named_predictors())):
         pass # we already applied the Retry mapping outside
-    elif all(map(lambda p: not isinstance(p, dspy.retry.Retry), module.named_predictors())):
+    elif all(map(lambda p: not isinstance(p[1], dspy.retry.Retry), module.named_predictors())):
         module.map_named_predictors(dspy.retry.Retry)
     else:
         raise RuntimeError("Module has mixed predictors, can't apply Retry mapping.")

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -54,6 +54,14 @@ class Module(BaseModule, metaclass=ProgramMeta):
         for name, predictor in self.named_predictors():
             set_attribute_by_name(self, name, func(predictor))
         return self
+    
+    def activate_assertions(self, handler=backtrack_handler, **handler_args):
+        """
+        Activates assertions for the module.
+        The default handler is the backtrack_handler.
+        """
+        assert_transform_module(self, handler, **handler_args)
+        return self
 
     # def __deepcopy__(self, memo):
     #     # memo is a dict of id's to copies already made during the current call


### PR DESCRIPTION
Now, it is possible to write `assert_transform_module(module)` to transform a module to handle suggestions and assertions. The default behavior is implemented by the `backtrack_handler`, which automatically backtracks for failing assertions and suggestions.