### PR TITLE
Lower default `max_labeled_demos` in `BootstrapFewShot`

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -34,7 +34,7 @@ from dspy.evaluate.evaluate import Evaluate
 
 
 class BootstrapFewShot(Teleprompter):
-    def __init__(self, metric=None, teacher_settings={}, max_bootstrapped_demos=4, max_labeled_demos=16, max_rounds=1, max_errors=5):
+    def __init__(self, metric=None, teacher_settings={}, max_bootstrapped_demos=4, max_labeled_demos=8, max_rounds=1, max_errors=5):
         self.metric = metric
         self.teacher_settings = teacher_settings
 


### PR DESCRIPTION
Hey team, I think it would be good to lower the default `max_labeled_demos` from 16 to 8. I have been playing with answering FAQs with 16 and it quickly results in compiling a massive prompt such that I exceed the max token limit. There is probably another way around this -- like ofc setting the argument to 8 or 4 or whatever, but I think this might slightly improve the UX for beginners starting with QA RAG and `GPT-3.5-Turbo` / ~4K input length LLMs.