### PR TITLE
Allow to set LM and RM per module on constructors and forward func

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -38,7 +38,7 @@ class Predict(Parameter):
 
             self.signature = dsp.Template(instructions, **inputs, **outputs)
 
-        self.lm = config.get("lm")
+        self.lm = config.pop("lm", None)
 
     def reset(self):
         self.lm = None

--- a/dspy/retrieve/retrieve.py
+++ b/dspy/retrieve/retrieve.py
@@ -15,7 +15,7 @@ class Retrieve(Parameter):
         self.k = k
         self.reset()
 
-        self.rm = config.get("rm")
+        self.rm = config.pop("rm", None)
 
     def reset(self):
         self.rm = None

--- a/dspy/retrieve/retrieve.py
+++ b/dspy/retrieve/retrieve.py
@@ -10,34 +10,42 @@ class Retrieve(Parameter):
     input_variable = "query"
     desc = "takes a search query and returns one or more potentially relevant passages from a corpus"
 
-    def __init__(self, k=3):
+    def __init__(self, k=3, **config):
         self.stage = random.randbytes(8).hex()
         self.k = k
-    
+        self.reset()
+
+        self.rm = config.get("rm")
+
     def reset(self):
-        pass
-    
+        self.rm = None
+
     def dump_state(self):
-        state_keys = ["k"]
+        state_keys = ["k", "rm"]
         return {k: getattr(self, k) for k in state_keys}
 
     def load_state(self, state):
         for name, value in state.items():
             setattr(self, name, value)
-    
+
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
-    
-    def forward(self, query_or_queries):
+
+    def forward(self, query_or_queries, **kwargs):
         queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
         queries = [query.strip().split('\n')[0].strip() for query in queries]
 
+        # Get the right RM to use.
+        rm = kwargs.pop("rm", None) or self.rm or dsp.settings.rm
 
         # print(queries)
         # TODO: Consider removing any quote-like markers that surround the query too.
 
-        passages = dsp.retrieveEnsemble(queries, k=self.k)
+        with dsp.settings.context(rm=rm):
+            passages = dsp.retrieveEnsemble(queries, k=self.k)
+
         return Prediction(passages=passages)
-    
+
+
 
 # TODO: Consider doing Prediction.from_completions with the individual sets of passages (per query) too.


### PR DESCRIPTION
This PR allows to set LM and RM per module on their constructors or dynamically when calling them.

Note that I removed the `query_only=True` parameter on the existent `with dsp.settings.context` in the predictor `forward` because I checked and that parameter is only used on `dsp.TemplateV2` but dspy is using `dsp.TemplateV3`.