### PR TITLE
Refactored ChromadbRM to use generic EmbeddingFunction

### DIFF
--- a/docs/retrieval_models_client.md
+++ b/docs/retrieval_models_client.md
@@ -8,6 +8,7 @@ This documentation provides an overview of the DSPy Retrieval Model Clients.
 | --- | --- |
 | ColBERTv2 | [ColBERTv2 Section](#ColBERTv2) |
 | AzureCognitiveSearch | [AzureCognitiveSearch Section](#AzureCognitiveSearch) |
+| ChromadbRM | [ChromadbRM Section](#ChromadbRM) |
 
 ## ColBERTv2
 
@@ -92,3 +93,65 @@ class AzureCognitiveSearch:
 Refer to [ColBERTv2](#ColBERTv2) documentation. Keep in mind there is no `simplify` flag for AzureCognitiveSearch.
 
 AzureCognitiveSearch supports sending queries and processing the received results, mapping content and scores to a correct format for the Azure Cognitive Search server.
+
+## ChromadbRM
+
+### Quickstart with OpenAI Embeddings
+
+ChromadbRM have the flexibility from a variety of embedding functions as outlined in the [chromadb embeddings documentation](https://docs.trychroma.com/embeddings). While different options are available, this example demonstrates how to utilize OpenAI embeddings specifically.
+
+```python
+from dspy.retrieve import ChromadbRM
+import os
+import openai
+from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
+
+embedding_function = OpenAIEmbeddingFunction(
+    api_key=os.environ.get('OPENAI_API_KEY'),
+    model_name="text-embedding-ada-002"
+)
+
+retriever_model = ChromadbRM(
+    'your_collection_name',
+    '/path/to/your/db',
+    embedding_function=embedding_function,
+    k=5
+)
+
+results = retriever_model("Explore the significance of quantum computing", k=5)
+
+for result in results:
+    print("Document:", result.long_text, "\n")
+```
+
+### Constructor
+
+Initialize an instance of the `ChromadbRM` class, with the option to use OpenAI's embeddings or any alternative supported by chromadb, as detailed in the official [chromadb embeddings documentation](https://docs.trychroma.com/embeddings).
+
+```python
+ChromadbRM(
+    collection_name: str,
+    persist_directory: str,
+    embedding_function: Optional[EmbeddingFunction[Embeddable]] = OpenAIEmbeddingFunction(),
+    k: int = 7,
+)
+```
+
+**Parameters:**
+- `collection_name` (_str_): The name of the chromadb collection.
+- `persist_directory` (_str_): Path to the directory where chromadb data is persisted.
+- `embedding_function` (_Optional[EmbeddingFunction[Embeddable]]_, _optional_): The function used for embedding documents and queries. Defaults to `DefaultEmbeddingFunction()` if not specified.
+- `k` (_int_, _optional_): The number of top passages to retrieve. Defaults to 7.
+
+### Methods
+
+#### `forward(self, query_or_queries: Union[str, List[str]], k: Optional[int] = None) -> dspy.Prediction`
+
+Search the chromadb collection for the top `k` passages matching the given query or queries, using embeddings generated via the specified `embedding_function`.
+
+**Parameters:**
+- `query_or_queries` (_Union[str, List[str]]_): The query or list of queries to search for.
+- `k` (_Optional[int]_, _optional_): The number of results to retrieve. If not specified, defaults to the value set during initialization.
+
+**Returns:**
+- `dspy.Prediction`: Contains the retrieved passages, each represented as a `dotdict` with a `long_text` attribute.

--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -42,10 +42,8 @@ class ChromadbRM(dspy.Retrieve):
     Args:
         collection_name (str): chromadb collection name
         persist_directory (str): chromadb persist directory
-        openai_embed_model (str, optional): The OpenAI embedding model to use. Defaults to "text-embedding-ada-002".
-        openai_api_key (str, optional): The API key for OpenAI. Defaults to None.
-        openai_org (str, optional): The organization for OpenAI. Defaults to None.
-        k (int, optional): The number of top passages to retrieve. Defaults to 3.
+        embedding_function (Optional[EmbeddingFunction[Embeddable]]): Optional function to use to embed documents. Defaults to DefaultEmbeddingFunction.
+        k (int, optional): The number of top passages to retrieve. Defaults to 7.
 
     Returns:
         dspy.Prediction: An object containing the retrieved passages.


### PR DESCRIPTION
I've updated the ChromadbRM retriever to be more flexible and fix a bug:

- **Flexibility with Embeddings**: Removed the direct dependency on OpenAI, allowing for the use of various embedding functions from [Chroma](https://docs.trychroma.com/embeddings). This change makes the retriever more adaptable to different needs.

- **Bug Fix**: Fixed issue #389 where `_get_embeddings` threw a TypeError due to an unexpected keyword argument 'engine'. This ensures smoother functionality.

This revision enhances ChromadbRM by introducing flexibility in embedding selection and resolving a critical error.