### PR TITLE
Added saving/loading instructions to Predict and Chain_Of_Thought

### DIFF
--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -66,6 +66,27 @@ class ChainOfThought(Predict):
         return super().forward(signature=signature, **kwargs)
 
 
+    def dump_state(self):
+        state = super().dump_state()
+
+        # Cache the signature instructions and the last field's name.
+        state["extended_signature_instructions"] = self.extended_signature.instructions
+        state["extended_signature_prefix"] = self.extended_signature.fields[-1].name
+
+        return state
+
+    def load_state(self, state):
+        super().load_state(state)
+        
+        # Reconstruct the signature.
+        if "extended_signature_instructions" in state:
+            instructions = state["extended_signature_instructions"]
+            self.extended_signature.instructions = instructions
+        
+        if "extended_signature_prefix" in state:
+            prefix = state["extended_signature_prefix"]
+            self.extended_signature.fields[-1] = self.extended_signature.fields[-1]._replace(name=prefix)
+
 """
 TODO: In principle, we can update the field's prefix during forward too to fill any thing based on the input args.
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -47,14 +47,26 @@ class Predict(Parameter):
 
     def dump_state(self):
         state_keys = ["lm", "traces", "train", "demos"]
-        return {k: getattr(self, k) for k in state_keys}
+        state = {k: getattr(self, k) for k in state_keys}
+
+        # Cache the signature instructions and the last field's name.
+        state["signature_instructions"] = self.signature.instructions
+        state["signature_prefix"] = self.signature.fields[-1].name
+
+        return state
 
     def load_state(self, state):
         for name, value in state.items():
             setattr(self, name, value)
-
-        import dspy
-        self.demos = [dspy.Example(**x) for x in self.demos]
+        
+        # Reconstruct the signature.
+        if "signature_instructions" in state:
+            instructions = state["signature_instructions"]
+            self.signature.instructions = instructions
+        
+        if "signature_prefix" in state:
+            prefix = state["signature_prefix"]
+            self.signature.fields[-1] = self.signature.fields[-1]._replace(name=prefix)
     
     def __call__(self, **kwargs):
         return self.forward(**kwargs)


### PR DESCRIPTION
After the optimizers change the instruction we need to be able to save/load the optimized instructions.  Currently the original (unoptimized) instructions are loaded and only the demos are saved.

This is a quick fix that adds this change for Predict and Chain of Thought.  If more modules are added for instruction optimization then this fix will need to be added to those modules as well.

Thanks to @klopsahlong for help with testing/validating the changes!