### PR TITLE
[BUG FIX] Switching trial.suggest_int --> trial.suggest_categorical

### DIFF
--- a/dspy/teleprompt/signature_opt_bayesian.py
+++ b/dspy/teleprompt/signature_opt_bayesian.py
@@ -303,8 +303,8 @@ class BayesianSignatureOptimizer(Teleprompter):
                     p_demo_candidates = demo_candidates[id(p_old)]
 
                     # Suggest the index of the instruction candidate to use in our trial
-                    instruction_idx = trial.suggest_int(f"{id(p_old)}_predictor_instruction",low=0, high=len(p_instruction_candidates)-1)
-                    demos_idx = trial.suggest_int(f"{id(p_old)}_predictor_demos",low=0, high=len(p_demo_candidates)-1)
+                    instruction_idx = trial.suggest_categorical(f"{id(p_old)}_predictor_instruction",range(len(p_instruction_candidates)))
+                    demos_idx = trial.suggest_categorical(f"{id(p_old)}_predictor_demos",range(len(p_demo_candidates)))
                     trial_logs[trial_num][f"{id(p_old)}_predictor_instruction"] = instruction_idx
                     trial_logs[trial_num][f"{id(p_old)}_predictor_demos"] = demos_idx
 


### PR DESCRIPTION
BUG FIX: Switching suggest_int --> suggest_categorical for suggesting the indices to use for our instruction / demo set in each optuna trial. This is because Optuna's suggest_int assumes that the performance of each selected number is related, which is not the case in our application. suggest_categorical does not have this built in assumption, which is what our application requires.