### PR TITLE
Add `metric_threshold` argument to BootstrapFewShot

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -149,8 +149,12 @@ class BootstrapFewShot(Teleprompter):
                     for name, predictor in teacher.named_predictors():
                         predictor.demos = predictor_cache[name]
                 
-                if self.metric and self.metric_threshold:
-                    success = self.metric(example, prediction, trace) > self.metric_threshold
+                if self.metric:
+                    metric_val = self.metric(example, prediction, trace)
+                    if self.metric_threshold:
+                        success = metric_val > self.metric_threshold
+                    else:
+                        success = metric_val
                 else:
                     success = True
                 # print(success, example, prediction)

--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -34,8 +34,9 @@ from dspy.evaluate.evaluate import Evaluate
 
 
 class BootstrapFewShot(Teleprompter):
-    def __init__(self, metric=None, teacher_settings={}, max_bootstrapped_demos=4, max_labeled_demos=16, max_rounds=1, max_errors=5):
+    def __init__(self, metric=None, metric_threshold=None, teacher_settings={}, max_bootstrapped_demos=4, max_labeled_demos=16, max_rounds=1, max_errors=5):
         self.metric = metric
+        self.metric_threshold = metric_threshold
         self.teacher_settings = teacher_settings
 
         self.max_bootstrapped_demos = max_bootstrapped_demos
@@ -147,8 +148,11 @@ class BootstrapFewShot(Teleprompter):
 
                     for name, predictor in teacher.named_predictors():
                         predictor.demos = predictor_cache[name]
-
-                success = (self.metric is None) or self.metric(example, prediction, trace)
+                
+                if self.metric and self.metric_threshold:
+                    success = self.metric(example, prediction, trace) > self.metric_threshold
+                else:
+                    success = True
                 # print(success, example, prediction)
         except Exception as e:
             success = False

--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -152,7 +152,7 @@ class BootstrapFewShot(Teleprompter):
                 if self.metric:
                     metric_val = self.metric(example, prediction, trace)
                     if self.metric_threshold:
-                        success = metric_val > self.metric_threshold
+                        success = metric_val >= self.metric_threshold
                     else:
                         success = metric_val
                 else:


### PR DESCRIPTION
## How it currently works

In line 151 of `BootstrapFewShot` we currently check examples with:

`success = (self.metric is None) or self.metric(example, prediction, trace)`

If success == True, we then wrap the predictor, inputs, and outputs in an Example object and append it to `name2traces`.

This works great if you have a boolean metric, but maybe we want to extend this with a `metric_threshold` argument for float or int metric return types.

## Metric Threshold

- `metric_threshold` is added as default `None`

Then line 151 is replaced with:

```
if self.metric:
  metric_val = self.metric(example, prediction, trace)
  if self.metric_threshold:
    success = metric_val > self.metric_threshold
  else:
    success = metric_val
else:
  success = True
```

We can now retain the float metrics like LLM rating metrics or what have you, but also add a little more strength to find high quality examples in `BootstrapFewShot`.