### PR TITLE
feature: add dl.from_json to support native json dataset formats

### DIFF
--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -45,6 +45,15 @@ class DataLoader(Dataset):
         
         return [dspy.Example({field:row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
 
+    def from_json(self, file_path:str, fields: List[str] = None, input_keys: Tuple[str] = ()) -> List[dspy.Example]:
+        dataset = load_dataset("json", data_files=file_path)["train"]
+        
+        if not fields:
+            fields = list(dataset.features)
+        
+        return [dspy.Example({field:row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
+
+
     def sample(
         self,
         dataset: List[dspy.Example],


### PR DESCRIPTION
```
from dspy.datasets import DataLoader
dl = DataLoader()
json_dataset = dl.from_json("/home/path-to/sample_responses.json", fields=["question", "answer", "context"])
# joy ensues...
```