### PR TITLE
fix: update imports to allow global dspy.Google

### DIFF
--- a/dsp/modules/__init__.py
+++ b/dsp/modules/__init__.py
@@ -9,6 +9,7 @@ from .pyserini import *
 from .ollama import *
 from .clarifai import *
 from .bedrock import *
+from .google import *
 
 
 from .hf_client import HFClientTGI

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -21,6 +21,7 @@ Cohere = dsp.Cohere
 ColBERTv2 = dsp.ColBERTv2
 Pyserini = dsp.PyseriniRetriever
 Clarifai = dsp.ClarifaiLLM
+Google = dsp.Google
 
 HFClientTGI = dsp.HFClientTGI
 HFClientVLLM = HFClientVLLM


### PR DESCRIPTION
Currently, the new Google LM class, does not have consistent imports with the remainder of the LMs.

ie. dspy.Cohere works, but dspy.Google does not.

This PR makes small import changes to ensure consistency.