### PR TITLE
[Suggestion] Add token counting to BaseLM

### DIFF
--- a/dspy/backends/lm/base.py
+++ b/dspy/backends/lm/base.py
@@ -15,3 +15,8 @@ class BaseLM(BaseModel, ABC):
     ) -> list[str]:
         """Generates `n` predictions for the signature output."""
         ...
+
+    @abstractmethod
+    def count_tokens(self, prompt: str) -> int:
+        """Counts the number of tokens for a specific prompt."""
+        ...

--- a/dspy/backends/lm/litellm.py
+++ b/dspy/backends/lm/litellm.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from litellm import completion
+from litellm import completion, token_counter
 from pydantic import Field
 
 
@@ -8,7 +8,7 @@ from .base import BaseLM
 
 
 class LiteLLM(BaseLM):
-    STANDARD_PARAMS = {
+    STANDARD_PARAMS: t.Dict[str, t.Union[float, int]] = {
         "temperature": 0.0,
         "max_tokens": 150,
         "top_p": 1,
@@ -33,3 +33,9 @@ class LiteLLM(BaseLM):
         )
         choices = [c for c in response["choices"] if c["finish_reason"] != "length"]
         return [c["message"]["content"] for c in choices]
+
+    def count_tokens(self, prompt: str) -> int:
+        """Counts the number of tokens for a specific prompt."""
+        return token_counter(
+            model=self.model, messages=[{"role": "user", "content": prompt}]
+        )


### PR DESCRIPTION
With a few projects discussed including Optimization Dry Runs #397 , and Token Budgeting. I thought we may want to add token counting functionality directly in at the BaseLM level within the refactor.

This change includes two small changes, changes to the abstract methods at the BaseLM, and token counting implementation for LiteLLM.

```python
class BaseLM(BaseModel, ABC):
    ...
    
    @abstractmethod
    def count_tokens(self, prompt: str) -> int:
        """counts the number of tokens for a specific prompt."""
        ...
````

The good news is LiteLLM makes this super simple, and no additional attributes are needed to make this work.

```python
from dspy.backends.lm.litellm import LiteLLM

lm = LiteLLM(model="gpt-3.5-turbo")

# returns 13, the number of tokens in a string.
lm.count_tokens("hello this is a small test")

````

If there is another place, token counting would be preferred, I am happy to move this functionality over, just thought I would give us an easy starting point.