### PR TITLE
feat: Exploring global caching for LM calls

### DIFF
--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -42,7 +42,8 @@ class Settings(object):
                 bypass_suggest=False,
                 assert_failures=0,
                 suggest_failures=0,
-                langchain_history=[]
+                langchain_history=[],
+                cache=True,
             )
             cls._instance.__append(config)
 

--- a/dspy/backends/lm/base.py
+++ b/dspy/backends/lm/base.py
@@ -6,11 +6,10 @@ from abc import ABC, abstractmethod
 
 from pydantic import BaseModel
 from joblib import Memory
-from dsp.modules.cache_utils import cachedir
 
 
-cachedir = os.environ.get("DSP_CACHEDIR") or os.path.join(Path.home(), ".joblib_cache")
-_cache_memory = Memory(cachedir, verbose=0)
+_cachedir = os.environ.get("DSP_CACHEDIR") or os.path.join(Path.home(), ".joblib_cache")
+_cache_memory = Memory(_cachedir, verbose=0)
 
 
 class BaseLM(BaseModel, ABC):

--- a/dspy/backends/lm/base.py
+++ b/dspy/backends/lm/base.py
@@ -1,16 +1,26 @@
 from abc import ABC, abstractmethod
 
 from pydantic import BaseModel
+from joblib import Memory
+from dsp.modules.cache_utils import cachedir
+
+
+_cache_memory = Memory(cachedir, verbose=0)
 
 
 class BaseLM(BaseModel, ABC):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cached = _cache_memory.cache(self._call)
+
+    def __call__(self, prompt: str, **kwargs) -> list[str]:
+        """Generates `n` predictions for the signature output."""
+        return self._cached(prompt, **kwargs)
+
     @abstractmethod
-    def __call__(
+    def _call(
         self,
         prompt: str,
-        temperature: float,
-        max_tokens: int,
-        n: int,
         **kwargs,
     ) -> list[str]:
         """Generates `n` predictions for the signature output."""

--- a/dspy/backends/lm/base.py
+++ b/dspy/backends/lm/base.py
@@ -1,3 +1,7 @@
+import dspy
+import os
+from pathlib import Path
+import typing as t
 from abc import ABC, abstractmethod
 
 from pydantic import BaseModel
@@ -5,6 +9,7 @@ from joblib import Memory
 from dsp.modules.cache_utils import cachedir
 
 
+cachedir = os.environ.get("DSP_CACHEDIR") or os.path.join(Path.home(), ".joblib_cache")
 _cache_memory = Memory(cachedir, verbose=0)
 
 
@@ -15,14 +20,17 @@ class BaseLM(BaseModel, ABC):
 
     def __call__(self, prompt: str, **kwargs) -> list[str]:
         """Generates `n` predictions for the signature output."""
-        return self._cached(prompt, **kwargs)
+        if dspy.settings.cache:
+            return self._cached(prompt, **kwargs)
+        else:
+            return self._call(prompt, **kwargs)
 
     @abstractmethod
     def _call(
         self,
         prompt: str,
         **kwargs,
-    ) -> list[str]:
+    ) -> list[dict[str, t.Any]]:
         """Generates `n` predictions for the signature output."""
         ...
 

--- a/dspy/backends/lm/litellm.py
+++ b/dspy/backends/lm/litellm.py
@@ -19,7 +19,7 @@ class LiteLLM(BaseLM):
     model: str
     default_params: dict[str, t.Any] = Field(default_factory=dict)
 
-    def __call__(
+    def _call(
         self,
         prompt: str,
         **kwargs,


### PR DESCRIPTION
I took a look into how we can integrate global joblib Memory caching into the `BaseLM` class.

It takes a little bit of misdirection, but the below `BaseLM` class will provide for global caching for all sub-classes that implement `BaseLM`.

```python
_cache_memory = Memory(cachedir, verbose=0)


class BaseLM(BaseModel, ABC):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        self._cached = _cache_memory.cache(self._call)

    def __call__(self, prompt: str, **kwargs) -> list[str]:
        """Generates `n` predictions for the signature output."""
        return self._cached(prompt, **kwargs)

    @abstractmethod
    def _call(
        self,
        prompt: str,
        **kwargs,
    ) -> list[str]:
        """Generates `n` predictions for the signature output."""
        ...

    @abstractmethod
    def count_tokens(self, prompt: str) -> int:
        """Counts the number of tokens for a specific prompt."""
        ...

```

The only change to downstream LM implementations, is now the abstract method is called `_call` as opposed to `__call__`. Additionally, with this scenario the cache is based on both LM attributes and function arguments. This is essential in the LiteLLM case, as the model name is essential for appropriate hashing, but each subsequent modification in the class itself, in which attributes are added/removed, will use a new cache. To combat this, the `_cache_memory.cache` does have an `ignore` parameter, which we can use to isolate exactly what is necessary for cache hashing.

This also is grabbing the same cache_utils, we are using in the current version of dspy, and I have a few questions on that generally:

1. Would we be okay with just global `joblib.Memory`  for all caching needs?
    - I noticed the current version is using nested caching for what appears to be Notebook first, then global caching. I am unsure exactly what benefit this is providing for.

2. Small note, but can we hide this cachedir behind a hidden folder?
    - Currently, the cachedir is stored at 'Path.home() / cachedir_joblib' can we change this to 'Path.home() / .cachedir_job' with this refactor, so all new LiteLLM caching calls are not cluttering up the visible files in the home directory.
    
Let me know what you think @CyrusOfEden, @okhat, I know cache misses are an important point for some folks.