### PR TITLE
Refactor ChromadbRM to use collection's default embedding function

### DIFF
--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -70,12 +70,11 @@ class ChromadbRM(dspy.Retrieve):
         persist_directory: str,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = ef.DefaultEmbeddingFunction(),
+        ] = None,
         k: int = 7,
     ):
         self._init_chromadb(collection_name, persist_directory)
-
-        self.ef = embedding_function
+        self.ef = embedding_function or self._chromadb_collection.embedding_function
 
         super().__init__(k=k)
 


### PR DESCRIPTION
The previous PR #400 opened by @animtel set `chromadb.utils.embedding_functions.DefaultEmbeddingFunction` as the default query embedding function. This calls `ONNXMiniLM_L6_V2` , which uses `all-MiniLM-L6-v2` as the base embedding model.

This introduced unintended behavior where queries could be embedded using a different model than documents unless the embedding function was explicitly provided. If a model other than `all-MiniLM-L6-v2` embeds queries, and the embedding function is not specified, the query and document embeddings will use different models. While this may be desired in some cases, this should not be the default behavior.

This PR changes the default query embedding method to use the collection's embedding function, accessed via the class. Users can still provide a custom embedding model.