### PR TITLE
Bring YouRM .forward signature in-line with Retrieve child class .forward methods (add K kwarg)

### DIFF
--- a/dspy/retrieve/retrieve.py
+++ b/dspy/retrieve/retrieve.py
@@ -1,3 +1,5 @@
+from typing import List, Union, Optional
+
 import dsp
 import random
 
@@ -13,10 +15,10 @@ class Retrieve(Parameter):
     def __init__(self, k=3):
         self.stage = random.randbytes(8).hex()
         self.k = k
-    
+
     def reset(self):
         pass
-    
+
     def dump_state(self):
         state_keys = ["k"]
         return {k: getattr(self, k) for k in state_keys}
@@ -24,20 +26,18 @@ class Retrieve(Parameter):
     def load_state(self, state):
         for name, value in state.items():
             setattr(self, name, value)
-    
+
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
-    
-    def forward(self, query_or_queries):
+
+    def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int] = None) -> Prediction:
         queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
         queries = [query.strip().split('\n')[0].strip() for query in queries]
 
-
         # print(queries)
         # TODO: Consider removing any quote-like markers that surround the query too.
-
-        passages = dsp.retrieveEnsemble(queries, k=self.k)
+        k = k if k is not None else self.k
+        passages = dsp.retrieveEnsemble(queries, k=k)
         return Prediction(passages=passages)
-    
 
 # TODO: Consider doing Prediction.from_completions with the individual sets of passages (per query) too.

--- a/dspy/retrieve/you_rm.py
+++ b/dspy/retrieve/you_rm.py
@@ -2,7 +2,7 @@ import dspy
 import os
 import requests
 
-from typing import Union, List
+from typing import Union, List, Optional
 
 
 class YouRM(dspy.Retrieve):
@@ -15,15 +15,19 @@ class YouRM(dspy.Retrieve):
         else:
             self.ydc_api_key = os.environ["YDC_API_KEY"]
 
-    def forward(self, query_or_queries: Union[str, List[str]]) -> dspy.Prediction:
+    def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int] = None) -> dspy.Prediction:
         """Search with You.com for self.k top passages for query or queries
 
         Args:
             query_or_queries (Union[str, List[str]]): The query or queries to search for.
+            k (Optional[int]): The number of context strings to return, if not already specified in self.k
 
         Returns:
             dspy.Prediction: An object containing the retrieved passages.
         """
+
+        k = k if k is not None else self.k
+
         queries = (
             [query_or_queries]
             if isinstance(query_or_queries, str)
@@ -36,7 +40,7 @@ class YouRM(dspy.Retrieve):
                 f"https://api.ydc-index.io/search?query={query}",
                 headers=headers,
             ).json()
-            for hit in results["hits"][:self.k]:
+            for hit in results["hits"][:k]:
                 for snippet in hit["snippets"]:
                     docs.append(snippet)
         return dspy.Prediction(passages=docs)


### PR DESCRIPTION
The following code (snippet) follow the setup idiom currently used by dspy:

```python

class WebRag(dspy.Module):
    NL_SEP = "\n----------\n"

    def __init__(self):
        super().__init__()
        # uses you_rm as declared below:
        self.you_rm = dspy.Retrieve(k=5)
        self.chain_of_thought = dspy.ChainOfThought(...irrelevant_signature...)

    def forward(self, question: str):
        web_context = self.NL_SEP.join(self.you_rm(question).passages)
        out = self.chain_of_thought(web_context=web_context, question=question)
        return out.answer
...

rm = YouRM(ydc_api_key=settings.YDC_API_KEY.get_secret_value())
lm = dspy.OpenAI(model=settings.LLM_MODEL, api_key=settings.OPENAI_API_KEY.get_secret_value())
dspy.settings.configure(lm=lm, rm=rm)
```

However, invoking this with a question string raises the following error:

```python

web_rag = WebRag()

out = web_rag("What is the meaning of life (according to Douglas Adams)?")

# ERROR:
#  File "/Users/mgb/miniforge3/envs/nlu/lib/python3.9/site-packages/dspy/retrieve/retrieve.py", line 29, in __call__
#    return self.forward(*args, **kwargs)
# TypeError: forward() got an unexpected keyword argument 'k'
```

This is due to `retrieveEnsemble` in `search.py` invoking YouRM's .forward with an additional `k` kwarg. 

Inspecting other modules in dspy/retrieve (e.g. chromadb.py) shows that k is desired as a kwarg to retrieve forward invocations; I therefore added this to YouRM's .forward and also to the parent .forward implementation in retrieve.py.
