### PR TITLE
Further Update YouRM to return an Iterable of Predictions

### DIFF
--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -1,4 +1,7 @@
+from collections.abc import Iterable
+
 import numpy as np
+
 import dsp
 
 
@@ -7,6 +10,10 @@ def retrieve(query: str, k: int, **kwargs) -> list[str]:
     if not dsp.settings.rm:
         raise AssertionError("No RM is loaded.")
     passages = dsp.settings.rm(query, k=k, **kwargs)
+    if not isinstance(passages, Iterable):
+        # it's not an iterable yet; make it one.
+        # TODO: we should unify the type signatures of dspy.Retriever
+        passages = [passages]
     passages = [psg.long_text for psg in passages]
     
     if dsp.settings.reranker:

--- a/dspy/retrieve/you_rm.py
+++ b/dspy/retrieve/you_rm.py
@@ -1,6 +1,7 @@
 import dspy
 import os
 import requests
+from dsp.utils import dotdict
 
 from typing import Union, List, Optional
 
@@ -43,4 +44,4 @@ class YouRM(dspy.Retrieve):
             for hit in results["hits"][:k]:
                 for snippet in hit["snippets"]:
                     docs.append(snippet)
-        return dspy.Prediction(passages=docs)
+        return [dotdict({"long_text": document}) for document in docs]


### PR DESCRIPTION
This brings it in line with the behavior of other retriever implementations in `/retrieve`.

Related - we probably want to make dspy.Retrieve a Protocol or AbstractMethod so Pycharm and co can highlight/catch these errors ahead of time. 