### PR TITLE
fix: default collection embedding function attribute in ChromadbRM constructor

### DIFF
--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -70,11 +70,11 @@ class ChromadbRM(dspy.Retrieve):
         persist_directory: str,
         embedding_function: Optional[
             EmbeddingFunction[Embeddable]
-        ] = None,
+        ] = ef.DefaultEmbeddingFunction(),
         k: int = 7,
     ):
         self._init_chromadb(collection_name, persist_directory)
-        self.ef = embedding_function or self._chromadb_collection._embedding_function
+        self.ef = embedding_function
 
         super().__init__(k=k)
 

--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -74,7 +74,7 @@ class ChromadbRM(dspy.Retrieve):
         k: int = 7,
     ):
         self._init_chromadb(collection_name, persist_directory)
-        self.ef = embedding_function or self._chromadb_collection.embedding_function
+        self.ef = embedding_function or self._chromadb_collection._embedding_function
 
         super().__init__(k=k)
 


### PR DESCRIPTION
The recent PR #449 opened by @smwitkowski  refactored ChromadbRM constructor to use collection default embedding function with the syntax "self._chromadb_collection.embedding_function". But ChromaDB collection object has no such attribute and raises attribute error if no embedding function is passed to the constructor. 

This PR modifies the constructor to use Chromadb collection's protected attribute "self._chromadb_collection._embedding_function" and the module now works as expected.

I could be wrong in my assumptions as I am relatively new to dspy and am open to possible better resolution. 