### PR TITLE
feat: add from_parquet to dataloader

### DIFF
--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -62,7 +62,14 @@ class DataLoader(Dataset):
         
         return [dspy.Example({field:row[field] for field in fields}).with_inputs(*input_keys) for row in dataset]
 
+    def from_parquet(self, file_path: str, fields: List[str] = None, input_keys: Tuple[str] = ()) -> List[dspy.Example]:
+        dataset = load_dataset("parquet", data_files=file_path)["train"]
 
+        if not fields:
+            fields = list(dataset.features)
+
+        return [dspy.Example({field: row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
+    
     def sample(
         self,
         dataset: List[dspy.Example],


### PR DESCRIPTION
A parquet file loader would be a convenient addition to the dataloader class. I particularly like that parquet files preserve types better than a csv file.

The primary change is the addition of the from_parquet() function:

```python
def from_parquet(self, file_path: str, fields: list[str] = None, input_keys: tuple[str] = ()) -> list[dspy.Example]:
        dataset = load_dataset("parquet", data_files=file_path)["train"]

        if not fields:
            fields = list(dataset.features)

        return [dspy.Example({field: row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
```

The rest of the changes were caused by the ruff precommit hook.