### PR TITLE
fix: AttributeError for Non-Prediction Objects in Retriever

### DIFF
--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -10,6 +10,11 @@ def retrieve(query: str, k: int, **kwargs) -> list[str]:
     if not dsp.settings.rm:
         raise AssertionError("No RM is loaded.")
     passages = dsp.settings.rm(query, k=k, **kwargs)
+
+    # Check if the returned object has a 'passages' attribute (i.e a Prediction object)  
+    # TODO: use a better approach to determine the Prediction object
+    if hasattr(passages, 'passages'):
+        passages = passages.passages
     if not isinstance(passages, Iterable):
         # it's not an iterable yet; make it one.
         # TODO: we should unify the type signatures of dspy.Retriever


### PR DESCRIPTION
Suggestion/Fix for this issue - https://github.com/stanfordnlp/dspy/issues/166

The retrieve function, seems to get the passages (as a Prediction object) during the use of certain retrievers - this breaks the downstream flow.

I have added a check to determine if its a Prediction object (currently I'm doing it by checking the attribute, but i feel there must be a better way - will check!)

Please let me know if there's something I should consider or have missed out.