### PR TITLE
Update language_models.ipynb Colab link

### DIFF
--- a/docs/guides/language_models.ipynb
+++ b/docs/guides/language_models.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "## Guide: **Language Models**\n",
     "\n",
-    "[<img align=\"center\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" />](https://colab.research.google.com/github/stanfordnlp/dspy/blob/main/docs/guides/signatures.ipynb)"
+    "[<img align=\"center\" src=\"https://colab.research.google.com/assets/colab-badge.svg\" />](https://colab.research.google.com/github/stanfordnlp/dspy/blob/main/docs/guides/language_models.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
Update the notebook. The Colab button is being redirected to signatures.ipynb (on Colab) instead of language_models.ipynb.