### PR TITLE
Add Template Backend

### DIFF
--- a/dspy/backends/base.py
+++ b/dspy/backends/base.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from dspy.signatures.signature import Signature
 
 
-ReturnValue = t.TypeVar("ReturnValue", bound=dict)
+GeneratedOutput = t.TypeVar("GeneratedOutput", bound=dict)
 
 
 class BaseBackend(BaseModel, ABC):
@@ -16,10 +16,7 @@ class BaseBackend(BaseModel, ABC):
     def __call__(
         self,
         signature: Signature,
-        temperature: float,
-        max_tokens: int,
-        n: int,
         **kwargs,
-    ) -> list[ReturnValue]:
+    ) -> list[GeneratedOutput]:
         """Generates `n` predictions for the signature output."""
         pass

--- a/dspy/backends/lm/base.py
+++ b/dspy/backends/lm/base.py
@@ -18,13 +18,13 @@ MinimalLM = t.Callable[[str, float, int, int], list[Completion]]
 
 
 class BaseLM(BaseModel, ABC):
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.generate_with_cache = _cache_memory.cache(self.generate)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._generate_with_cache = _cache_memory.cache(self.generate)
 
     def __call__(self, prompt: str, **kwargs) -> list[str]:
         """Generates `n` predictions for the signature output."""
-        generator = self.generate_with_cache if dspy.settings.cache else self.generate
+        generator = self._generate_with_cache if dspy.settings.cache else self.generate
         return generator(prompt, **kwargs)
 
     @abstractmethod

--- a/dspy/backends/lm/litellm.py
+++ b/dspy/backends/lm/litellm.py
@@ -7,7 +7,7 @@ from pydantic import Field
 from .base import BaseLM
 
 
-Choice = t.TypeVar("Choice", dict[str, t.Any])
+Choice = t.TypeVar("Choice", bound=dict[str, t.Any])
 
 
 class LiteLM(BaseLM):


### PR DESCRIPTION
Added an initial TemplateBackend, tested with LiteLLM.

At a high level, it would let us do something like this (a minimal example):

```python
class Emotion(Signature):
    """Classify emotion among sadness, joy, love, anger, fear, surprise."""
    sentence = InputField()
    sentiment = OutputField()
    
class Predict(Parameter):
    def __init__(self, signature, **kwargs):
        self.signature = ensure_signature(signature)
    
    def __call__(self, **kwargs):
        return self.forward(**kwargs)
        
    def forward(self, **kwargs):
        
        # Get backend and predict
        backend = dspy.settings.get("backend")
        return backend(signature, **kwargs)
```

We could even abstract that away to some high level primitive function, taking into account any other concerns as well.

### I have a few additional thoughts at a high level:

**1. I changed the signature of the `BaseBackend` to be:**

````python
class TemplateBackend(BaseBackend):
    def __call__(
        self,
        signature: Signature,
        demos: t.List[str] = [],
        **kwargs) -> ...
````

Given that the underlying language model is completely abstracted away from the backend, I wasnt sure why we would specifically call out certain language model specific arguments in the class signature. This sets the signature to only be those additive arguments necessary for templates specifically, with all kwargs being passed directly to the language model as needed.

**2. Small changes to caching**

I like the function changes in the BaseLM. However, due to the way Pydantic manages attributes, we have to set the `generate_with_cache` callable to be a private function (ie. `_generate_with_cache`) to import correctly.

**3. Argument overriding in older methods.**

I noticed some code in the old `Predict` class, I am unsure of moving forward.

```python
class Predict(Parameter):
    ...
    def forward(self, **kwargs):
        ...
        if (temperature is None or temperature <= 0.15) and num_generations > 1:
            config["temperature"] = 0.7
        ...
```

Code like this may, make it harder to track arguments that are actually hitting the Language Models. To make it a bit more transparent, maybe we could put a warning at the Language Model level, which would raise if n > 1 and temperature <= 0.15, which would allow the user to define the temperature themselves.

@CyrusOfEden Let me know what you think, going to do a deeper dive into a few of these internals to identify we have everything managed for on the template side.