### PR TITLE
Reformatted all the code with ruff

### DIFF
--- a/dsp/evaluation/utils.py
+++ b/dsp/evaluation/utils.py
@@ -7,7 +7,7 @@ try:
     from IPython.display import display as ipython_display
 except ImportError:
     ipython_display = print
-from dsp.utils import EM, F1, HotPotF1
+from dsp.utils import EM
 
 
 def evaluateRetrieval(fn, dev, metric=None):

--- a/dsp/modules/aws_lm.py
+++ b/dsp/modules/aws_lm.py
@@ -81,7 +81,7 @@ class AWSLM(LM):
 
     @abstractmethod
     def _extract_input_parameters(
-        self, body: dict[Any, Any]
+        self, body: dict[Any, Any],
     ) -> dict[str, str | float | int]:
         pass
 
@@ -94,7 +94,7 @@ class AWSLM(LM):
         else:
             llm_out = [generated.replace(formatted_prompt, "") for generated in llm_out]
         self.history.append(
-            {"prompt": formatted_prompt, "response": llm_out, "kwargs": body}
+            {"prompt": formatted_prompt, "response": llm_out, "kwargs": body},
         )
         return llm_out
 
@@ -107,20 +107,20 @@ class AWSLM(LM):
             truncated_prompt: str = self._truncate_prompt(prompt)
             formatted_prompt = self._format_prompt(truncated_prompt)
         else:
-            formatted_prompt = self._format_prompt((prompt))
+            formatted_prompt = self._format_prompt(prompt)
 
         llm_out: str | list[str]
         if "n" in kwargs.keys():
             if self._batch_n:
                 llm_out = self._simple_api_call(
-                    formatted_prompt=formatted_prompt, **kwargs
+                    formatted_prompt=formatted_prompt, **kwargs,
                 )
             else:
                 del kwargs["n"]
                 llm_out = []
                 for _ in range(0, kwargs["n"]):
                     generated: str | list[str] = self._simple_api_call(
-                        formatted_prompt=formatted_prompt, **kwargs
+                        formatted_prompt=formatted_prompt, **kwargs,
                     )
                     if isinstance(generated, str):
                         llm_out.append(generated)

--- a/dsp/modules/azurecognitivesearch.py
+++ b/dsp/modules/azurecognitivesearch.py
@@ -1,14 +1,14 @@
-from typing import Optional, Union, Any
+from typing import Union, Any
 
 from dsp.utils import dotdict
 try:
     from azure.core.credentials import AzureKeyCredential
     from azure.search.documents import SearchClient
     from azure.search.documents._paging import SearchItemPaged
-except ImportError as e:
+except ImportError:
     raise ImportError(
         "You need to install azure-search-documents library"
-        "Please use the command: pip install azure-search-documents"
+        "Please use the command: pip install azure-search-documents",
     )
 
 class AzureCognitiveSearch:

--- a/dsp/modules/bedrock.py
+++ b/dsp/modules/bedrock.py
@@ -47,7 +47,7 @@ class Bedrock(AWSLM):
         query_args: dict[str, Any] = self._sanitize_kwargs(base_args)
         query_args["prompt"] = prompt
         # AWS Bedrock forbids these keys
-        if "max_tokens" in query_args.keys():
+        if "max_tokens" in query_args:
             max_tokens: int = query_args["max_tokens"]
             input_tokens: int = self._estimate_tokens(prompt)
             max_tokens_to_sample: int = max_tokens - input_tokens
@@ -67,7 +67,7 @@ class Bedrock(AWSLM):
         return completion
 
     def _extract_input_parameters(
-        self, body: dict[Any, Any]
+        self, body: dict[Any, Any],
     ) -> dict[str, str | float | int]:
         return body
 

--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -17,7 +17,7 @@ def backoff_hdlr(details):
     print(
         "Backing off {wait:0.1f} seconds after {tries} tries "
         "calling function {target} with kwargs "
-        "{kwargs}".format(**details)
+        "{kwargs}".format(**details),
     )
 
 
@@ -39,7 +39,7 @@ class Cohere(LM):
         model: str = "command-nightly",
         api_key: Optional[str] = None,
         stop_sequences: list[str] = [],
-        **kwargs
+        **kwargs,
     ):
         """
         Parameters
@@ -66,7 +66,7 @@ class Cohere(LM):
             "frequency_penalty": 0,
             "presence_penalty": 0,
             "num_generations": 1,
-            **kwargs
+            **kwargs,
         }
         self.stop_sequences = stop_sequences
         self.max_num_generations = 5
@@ -109,7 +109,7 @@ class Cohere(LM):
         prompt: str,
         only_completed: bool = True,
         return_sorted: bool = False,
-        **kwargs
+        **kwargs,
     ):
         assert only_completed, "for now"
         assert return_sorted is False, "for now"

--- a/dsp/modules/colbertv2.py
+++ b/dsp/modules/colbertv2.py
@@ -22,7 +22,7 @@ class ColBERTv2:
         self.url = f"{url}:{port}" if port else url
 
     def __call__(
-        self, query: str, k: int = 10, simplify: bool = False
+        self, query: str, k: int = 10, simplify: bool = False,
     ) -> Union[list[str], list[dotdict]]:
         if self.post_requests:
             topk: list[dict[str, Any]] = colbertv2_post_request(self.url, query, k)
@@ -49,7 +49,7 @@ def colbertv2_get_request_v2(url: str, query: str, k: int):
     return topk[:k]
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 @NotebookCacheMemory.cache
 def colbertv2_get_request_v2_wrapped(*args, **kwargs):
     return colbertv2_get_request_v2(*args, **kwargs)
@@ -67,7 +67,7 @@ def colbertv2_post_request_v2(url: str, query: str, k: int):
     return res.json()["topk"][:k]
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 @NotebookCacheMemory.cache
 def colbertv2_post_request_v2_wrapped(*args, **kwargs):
     return colbertv2_post_request_v2(*args, **kwargs)

--- a/dsp/modules/databricks.py
+++ b/dsp/modules/databricks.py
@@ -1,21 +1,18 @@
 import logging
-from logging.handlers import RotatingFileHandler
 
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(message)s',
     handlers=[
-        logging.FileHandler('openai_usage.log')
-    ]
+        logging.FileHandler('openai_usage.log'),
+    ],
 )
 
 import functools
 import json
-from typing import Any, Literal, Optional, cast
+from typing import Literal, Optional
 
-import dsp
-import backoff
 import openai
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
@@ -35,7 +32,7 @@ def backoff_hdlr(details):
     print(
         "Backing off {wait:0.1f} seconds after {tries} tries "
         "calling function {target} with kwargs "
-        "{kwargs}".format(**details)
+        "{kwargs}".format(**details),
     )
 
 class Databricks(GPT3):

--- a/dsp/modules/finetuning/finetune_hf.py
+++ b/dsp/modules/finetuning/finetune_hf.py
@@ -5,7 +5,6 @@ import json
 import copy
 import glob
 import torch
-import random
 import warnings
 import evaluate
 import numpy as np
@@ -247,7 +246,7 @@ def smart_tokenizer_and_embedding_resize(special_tokens_dict, tokenizer, model):
 
 
 @dataclass
-class DataCollatorForSupervisedDataset(object):
+class DataCollatorForSupervisedDataset:
     """
     Collate examples for supervised fine-tuning.
     """
@@ -316,7 +315,7 @@ def finetune_hf(data_path, target, config):
         # training completed, load best model
         ckpts = glob.glob(f'{output_dir}/checkpoint*')
         final_ckpt = sorted(ckpts, key=lambda x: int(x.split('-')[-1]))[-1]
-        with open(os.path.join(final_ckpt, 'trainer_state.json'), 'r') as f:
+        with open(os.path.join(final_ckpt, 'trainer_state.json')) as f:
             state = json.load(f)
         best_model_checkpoint = state['best_model_checkpoint']
 
@@ -331,8 +330,8 @@ def finetune_hf(data_path, target, config):
         encoder_decoder_model = ("ConditionalGeneration" in architecture) or ("T5WithLMHeadModel" in architecture)
         decoder_only_model = ("CausalLM" in architecture) or ("GPT2LMHeadModel" in architecture)
         assert encoder_decoder_model or decoder_only_model, f"Unknown HuggingFace model class: {target}"
-        assert not config['fid'] or encoder_decoder_model, f"Model must be encoder-decoder for Fusion in Decoder"
-        assert not config['fid'] or not config['peft'], f"FiD and PEFT can't be trained together"
+        assert not config['fid'] or encoder_decoder_model, "Model must be encoder-decoder for Fusion in Decoder"
+        assert not config['fid'] or not config['peft'], "FiD and PEFT can't be trained together"
 
         # load model
         AutoModelClass = AutoModelForSeq2SeqLM if encoder_decoder_model else AutoModelForCausalLM

--- a/dsp/modules/google.py
+++ b/dsp/modules/google.py
@@ -1,5 +1,6 @@
 import os
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
+from collections.abc import Iterable
 import backoff
 
 from dsp.modules.lm import LM
@@ -18,7 +19,7 @@ def backoff_hdlr(details):
     print(
         "Backing off {wait:0.1f} seconds after {tries} tries "
         "calling function {target} with kwargs "
-        "{kwargs}".format(**details)
+        "{kwargs}".format(**details),
     )
 
 
@@ -32,19 +33,19 @@ def giveup_hdlr(details):
 BLOCK_ONLY_HIGH = [
   {
     "category": "HARM_CATEGORY_HARASSMENT",
-    "threshold": "BLOCK_ONLY_HIGH"
+    "threshold": "BLOCK_ONLY_HIGH",
   },
   {
     "category": "HARM_CATEGORY_HATE_SPEECH",
-    "threshold": "BLOCK_ONLY_HIGH"
+    "threshold": "BLOCK_ONLY_HIGH",
   },
   {
     "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-    "threshold": "BLOCK_ONLY_HIGH"
+    "threshold": "BLOCK_ONLY_HIGH",
   },
   {
     "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
-    "threshold": "BLOCK_ONLY_HIGH"
+    "threshold": "BLOCK_ONLY_HIGH",
   },
 ]
 
@@ -60,7 +61,7 @@ class Google(LM):
         model: str = "models/gemini-1.0-pro",
         api_key: Optional[str] = None,
         safety_settings: Optional[Iterable] = BLOCK_ONLY_HIGH,
-        **kwargs
+        **kwargs,
     ):
         """
         Parameters
@@ -89,7 +90,7 @@ class Google(LM):
             "max_output_tokens": 2048,
             "top_p": 1,
             "top_k": 1,
-            **kwargs
+            **kwargs,
         }
 
         self.config = genai.GenerationConfig(**kwargs)
@@ -145,7 +146,7 @@ class Google(LM):
         prompt: str,
         only_completed: bool = True,
         return_sorted: bool = False,
-        **kwargs
+        **kwargs,
     ):
         assert only_completed, "for now"
         assert return_sorted is False, "for now"

--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -1,5 +1,4 @@
 import logging
-from logging.handlers import RotatingFileHandler
 
 # Configure logging
 logging.basicConfig(
@@ -43,7 +42,7 @@ def backoff_hdlr(details):
     print(
         "Backing off {wait:0.1f} seconds after {tries} tries "
         "calling function {target} with kwargs "
-        "{kwargs}".format(**details)
+        "{kwargs}".format(**details),
     )
 
 

--- a/dsp/modules/hf.py
+++ b/dsp/modules/hf.py
@@ -1,13 +1,9 @@
-import os
-import json
 # from peft import PeftConfig, PeftModel
 # from transformers import AutoModelForSeq2SeqLM, AutoModelForCausalLM, AutoTokenizer, AutoConfig
 from typing import Optional, Literal
 
 from dsp.modules.lm import LM
 # from dsp.modules.finetuning.finetune_hf import preprocess_prompt
-from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
-import functools
 
 def openai_to_hf(**kwargs):
     hf_kwargs = {}
@@ -51,7 +47,7 @@ class HFModel(LM):
                 import torch
             except ImportError as exc:
                 raise ModuleNotFoundError(
-                    "You need to install Hugging Face transformers library to use HF models."
+                    "You need to install Hugging Face transformers library to use HF models.",
                 ) from exc
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             try:
@@ -85,7 +81,7 @@ class HFModel(LM):
             except ValueError:
                 self.model = AutoModelForCausalLM.from_pretrained(
                     model if checkpoint is None else checkpoint,
-                    device_map=self.device_map
+                    device_map=self.device_map,
                 )
                 self.drop_prompt_from_output = True
                 self.tokenizer = AutoTokenizer.from_pretrained(model)

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -1,14 +1,11 @@
-import functools
 import os
 import random
 import requests
 from dsp.modules.hf import HFModel, openai_to_hf
-from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
-import os
+from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory
 import subprocess
 import re
 import shutil
-import time
 
 # from dsp.modules.adapter import TurboAdapter, DavinciAdapter, LlamaAdapter
 
@@ -21,7 +18,7 @@ def backoff_hdlr(details):
     print(
         "Backing off {wait:0.1f} seconds after {tries} tries "
         "calling function {target} with kwargs "
-        "{kwargs}".format(**details)
+        "{kwargs}".format(**details),
     )
 
 class HFClientTGI(HFModel):
@@ -57,13 +54,13 @@ class HFClientTGI(HFModel):
             # "max_new_tokens": kwargs.get('max_tokens', kwargs.get('max_new_tokens', 75)),
             # "stop": ["\n", "\n\n"],
             **kwargs,
-            }
+            },
         }
 
         payload["parameters"] = openai_to_hf(**payload["parameters"])
 
         payload["parameters"]["temperature"] = max(
-            0.1, payload["parameters"]["temperature"]
+            0.1, payload["parameters"]["temperature"],
         )
 
         # print(payload['parameters'])
@@ -96,7 +93,7 @@ class HFClientTGI(HFModel):
 
             response = {"prompt": prompt, "choices": [{"text": c} for c in completions]}
             return response
-        except Exception as e:
+        except Exception:
             print("Failed to parse JSON response:", response.text)
             raise Exception("Received invalid JSON response from server")
 
@@ -147,7 +144,7 @@ class HFClientVLLM(HFModel):
             }
             return response
 
-        except Exception as e:
+        except Exception:
             print("Failed to parse JSON response:", response.text)
             raise Exception("Received invalid JSON response from server")
 
@@ -227,7 +224,7 @@ class Together(HFModel):
             "repetition_penalty": 1,
             "n": 1,
             "stop": stop_default if "stop" not in kwargs else kwargs["stop"],
-            **kwargs
+            **kwargs,
         }
 
     @backoff.on_exception(
@@ -253,7 +250,7 @@ class Together(HFModel):
             url = f"{self.api_base}/chat/completions"
             messages = [
                 {"role": "system", "content": "You are a helpful assistant. You must continue the user text directly without *any* additional interjections."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ]
             body = {
                 "model": self.model,
@@ -305,7 +302,7 @@ class Anyscale(HFModel):
         self.kwargs = {
             "temperature": 0.0,
             "n": 1,
-            **kwargs
+            **kwargs,
         }
 
     def _generate(self, prompt, use_chat_api=False, **kwargs):
@@ -320,20 +317,20 @@ class Anyscale(HFModel):
             url = f"{self.api_base}/chat/completions"
             messages = [
                 {"role": "system", "content": "You are a helpful assistant. You must continue the user text directly without *any* additional interjections."},
-                {"role": "user", "content": prompt}
+                {"role": "user", "content": prompt},
             ]
             body = {
                 "model": self.model,
                 "messages": messages,
                 "temperature": temperature,
-                "max_tokens": max_tokens
+                "max_tokens": max_tokens,
             }
         else:
             body = {
                 "model": self.model,
                 "prompt": f"[INST]{prompt}[/INST]",
                 "temperature": temperature,
-                "max_tokens": max_tokens
+                "max_tokens": max_tokens,
             }
 
         headers = {"Authorization": f"Bearer {self.token}"}
@@ -362,7 +359,7 @@ class ChatModuleClient(HFModel):
         from mlc_chat import ChatConfig
 
         self.cm = ChatModule(
-            model=model, lib_path=model_path, chat_config=ChatConfig(conv_template="LM")
+            model=model, lib_path=model_path, chat_config=ChatConfig(conv_template="LM"),
         )
 
     def _generate(self, prompt, **kwargs):
@@ -373,7 +370,7 @@ class ChatModuleClient(HFModel):
             completions = [{"text": output}]
             response = {"prompt": prompt, "choices": completions}
             return response
-        except Exception as e:
+        except Exception:
             print("Failed to parse output:", response.text)
             raise Exception("Received invalid output")
 
@@ -417,7 +414,7 @@ class HFClientSGLang(HFModel):
             }
             return response
 
-        except Exception as e:
+        except Exception:
             print("Failed to parse JSON response:", response.text)
             raise Exception("Received invalid JSON response from server")
 

--- a/dsp/modules/lm.py
+++ b/dsp/modules/lm.py
@@ -50,8 +50,8 @@ class LM(ABC):
                     printed.append(
                         (
                             prompt,
-                            x['response']
-                        )
+                            x['response'],
+                        ),
                     )
                 else:
                     printed.append(
@@ -60,7 +60,7 @@ class LM(ABC):
                             x["response"].generations
                             if provider == "cohere"
                             else x["response"]["choices"],
-                        )
+                        ),
                     )
 
             last_prompt = prompt

--- a/dsp/modules/ollama.py
+++ b/dsp/modules/ollama.py
@@ -1,10 +1,10 @@
 from dsp.modules.lm import LM
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
-import os, multiprocessing, datetime, hashlib
+import datetime
+import hashlib
 import requests
 
-import json
 
 
 def post_request_metadata(model_name, prompt):
@@ -116,7 +116,7 @@ class OllamaLocal(LM):
                         "content": "".join(text),
                     },
                     "finish_reason": "stop",
-                }
+                },
             )
             tot_eval_tokens += response_json.get("eval_count")
         request_info["additional_kwargs"] = {k: v for k, v in response_json.items() if k not in ["response"]}

--- a/dsp/modules/sbert.py
+++ b/dsp/modules/sbert.py
@@ -2,13 +2,13 @@ class SentenceTransformersCrossEncoder:
     """Wrapper for sentence-transformers cross-encoder model.
     """
     def __init__(
-        self, model_name_or_path: str = "cross-encoder/ms-marco-MiniLM-L-12-v2"
+        self, model_name_or_path: str = "cross-encoder/ms-marco-MiniLM-L-12-v2",
     ):
         try:
             from sentence_transformers.cross_encoder import CrossEncoder
         except ImportError:
             raise ModuleNotFoundError(
-                "You need to install sentence-transformers library to use SentenceTransformersCrossEncoder."
+                "You need to install sentence-transformers library to use SentenceTransformersCrossEncoder.",
             )
         self.model = CrossEncoder(model_name_or_path)
 

--- a/dsp/modules/sentence_vectorizer.py
+++ b/dsp/modules/sentence_vectorizer.py
@@ -40,7 +40,7 @@ class SentenceTransformersVectorizer(BaseSentenceVectorizer):
         model_name_or_path: str = 'all-MiniLM-L6-v2',
         vectorize_bs: int = 256,
         max_gpu_devices: int = 1,
-        normalize_embeddings: bool = False
+        normalize_embeddings: bool = False,
     ):
         # this isn't a good practice, but with top-level import the whole DSP
         # module import will be slow (>5 sec), because SentenceTransformer is doing
@@ -48,11 +48,11 @@ class SentenceTransformersVectorizer(BaseSentenceVectorizer):
         
         try:
             from sentence_transformers import SentenceTransformer
-        except ImportError as e:
+        except ImportError:
             raise ImportError(
                 "You need to install sentence_transformers library to use pretrained embedders. "
                 "Please check the official doc https://www.sbert.net/ "
-                "or simply run `pip install sentence-transformers"
+                "or simply run `pip install sentence-transformers",
             )
         from dsp.utils.ann_utils import determine_devices
         
@@ -75,7 +75,7 @@ class SentenceTransformersVectorizer(BaseSentenceVectorizer):
             emb = self.model.encode_multi_process(
                 sentences=text_to_vectorize,
                 pool=pool,
-                batch_size=self.vectorize_bs
+                batch_size=self.vectorize_bs,
             )
             self.model.stop_multi_process_pool(pool)
             # for some reason, multi-GPU setup doesn't accept normalize_embeddings parameter
@@ -87,7 +87,7 @@ class SentenceTransformersVectorizer(BaseSentenceVectorizer):
             emb = self.model.encode(
                 sentences=text_to_vectorize,
                 batch_size=self.vectorize_bs,
-                normalize_embeddings=self.normalize_embeddings
+                normalize_embeddings=self.normalize_embeddings,
             )
             return emb
 
@@ -121,7 +121,7 @@ class CohereVectorizer(BaseSentenceVectorizer):
         api_key: str,
         model: str = 'embed-english-v3.0',
         embed_batch_size: int = 96,
-        embedding_type: str = 'search_document'  # for details check Cohere embed docs
+        embedding_type: str = 'search_document',  # for details check Cohere embed docs
     ):
         self.model = model
         self.embed_batch_size = embed_batch_size
@@ -144,7 +144,7 @@ class CohereVectorizer(BaseSentenceVectorizer):
             response = self.client.embed(
                 texts=cur_batch,
                 model=self.model,
-                input_type=self.embedding_type
+                input_type=self.embedding_type,
             )
 
             embeddings_list.extend(response.embeddings)
@@ -169,7 +169,7 @@ class OpenAIVectorizer(BaseSentenceVectorizer):
         self,
         model: str = 'text-embedding-ada-002',
         embed_batch_size: int = 1024,
-        api_key: Optional[str] = None
+        api_key: Optional[str] = None,
     ):
         self.model = model
         self.embed_batch_size = embed_batch_size
@@ -195,7 +195,7 @@ class OpenAIVectorizer(BaseSentenceVectorizer):
             # OpenAI API call:
             response = self.Embedding.create(
                 model=self.model,
-                input=cur_batch
+                input=cur_batch,
             )
 
             cur_batch_embeddings = [cur_obj['embedding'] for cur_obj in response['data']]

--- a/dsp/primitives/demonstrate.py
+++ b/dsp/primitives/demonstrate.py
@@ -148,7 +148,7 @@ def cast_naive_get_question_and_answer(inp_example: Example) -> Example:
 def knn(
     train: list[Example],
     cast: Callable[[Example], Example] = cast_naive_get_only_question_text,
-    **knn_args
+    **knn_args,
 ) -> Callable[[Example, int], list[Example]]:
     """
     A function that vectorizes train data using `dsm.settings.vectorizer`, then build an ANN/KNN
@@ -171,7 +171,7 @@ def knn(
     all_vectors = vectorizer(train_casted_to_vectorize).astype(np.float32)
 
     index = create_faiss_index(
-        emb_dim=all_vectors.shape[1], n_objects=len(train), **knn_args
+        emb_dim=all_vectors.shape[1], n_objects=len(train), **knn_args,
     )
     index.train(all_vectors)
     index.add(all_vectors)

--- a/dsp/primitives/inspect.py
+++ b/dsp/primitives/inspect.py
@@ -41,9 +41,7 @@ class FuncInspector:
     if isinstance(obj, dict):
       to_delete = []
       for key in obj:
-        if delete_empty and not obj[key]:
-          to_delete.append(key)
-        elif key == "completions":
+        if delete_empty and not obj[key] or key == "completions":
           to_delete.append(key)
         else:
           self.parse(obj[key], delete_empty)

--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -3,7 +3,6 @@ from typing import Callable, Any, Optional
 
 import dsp
 from dsp.utils import zipstar, normalize_text
-from dsp.primitives.inspect import FuncInspector
 from dsp.utils.utils import dotdict
 from dsp.templates.template_v3 import Template
 from dsp.primitives.demonstrate import Example
@@ -63,7 +62,7 @@ def _generate(template: Template, **kwargs) -> Callable:
     generator = dsp.settings.lm
 
     def do_generate(
-        example: Example, stage: str, max_depth: int = 2, original_example=None
+        example: Example, stage: str, max_depth: int = 2, original_example=None,
     ):
         if not dsp.settings.lm:
             raise AssertionError("No LM is loaded.")
@@ -143,7 +142,7 @@ def _generate(template: Template, **kwargs) -> Callable:
                         "template": template,
                         "inputs": inputs,
                         "outputs": outputs,
-                    }
+                    },
                 )
         else:
             # assert not dsp.settings.compiling, "TODO: At this point, cannot compile n>1 generations"
@@ -155,7 +154,7 @@ def _generate(template: Template, **kwargs) -> Callable:
 
 
 def generate_sc(
-    example, prompt, normalize=True, extract=None, prediction_field=None, **kwargs
+    example, prompt, normalize=True, extract=None, prediction_field=None, **kwargs,
 ):
     if not dsp.settings.lm:
         raise AssertionError("No LM is loaded.")
@@ -164,7 +163,7 @@ def generate_sc(
     completions = dsp.settings.lm(prompt, **kwargs)
     completions = extract_final_answer(example, completions, extract=extract)
     return majority_vote_(
-        completions, normalize=normalize, prediction_field=prediction_field
+        completions, normalize=normalize, prediction_field=prediction_field,
     )
 
 
@@ -180,14 +179,14 @@ def extract_final_answer(example, completions, extract=None):
 
     # TODO: make thread-safe?
     dsp.settings.lm.history.append(
-        {**dsp.settings.lm.history[-1], "completions": completions}
+        {**dsp.settings.lm.history[-1], "completions": completions},
     )
 
     return completions
 
 
 def majority(
-    completions: Completions, normalize: bool = True, field: Optional[str] = None
+    completions: Completions, normalize: bool = True, field: Optional[str] = None,
 ):
     """Returns the most common completion for the target field or the last field in the template."""
     field = completions.template.fields[-1].output_variable if field is None else field
@@ -231,7 +230,7 @@ def majority_vote_(completions: Completions, normalize: bool, prediction_field: 
         pred = normalized_to_original[pred]
 
     dsp.settings.lm.history.append(
-        {**dsp.settings.lm.history[-1], "topk": topk, "completions": [pred]}
+        {**dsp.settings.lm.history[-1], "topk": topk, "completions": [pred]},
     )
 
     return [pred]

--- a/dsp/primitives/primitives.py
+++ b/dsp/primitives/primitives.py
@@ -1,5 +1,4 @@
 import dsp
-import copy
 from functools import wraps
 
 # applied right to left (innermost first, like function calls)

--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -35,7 +35,7 @@ def retrieveRerankEnsemble(queries: list[str], k: int) -> list[str]:
         for idx in np.argsort(passages_cs_scores)[::-1]:
             psg = retrieved_passages[idx]
             passages[psg.long_text] = passages.get(psg.long_text, []) + [
-                passages_cs_scores[idx]
+                passages_cs_scores[idx],
             ]
 
     passages = [(np.average(score), text) for text, score in passages.items()]

--- a/dsp/templates/template_v2.py
+++ b/dsp/templates/template_v2.py
@@ -44,7 +44,7 @@ class TemplateV2:
                     variable = match.group(3)
                     description = None
                 else:
-                    raise ValueError(f"Could not parse template")
+                    raise ValueError("Could not parse template")
 
             var_match = re.match("(.*) -> (.*)", variable)
             if var_match is not None:
@@ -61,7 +61,7 @@ class TemplateV2:
                     input_variable=input_variable,
                     output_variable=output_variable,
                     description=description,
-                )
+                ),
             )
 
             template = template[len(match.group(0)) :].strip()
@@ -99,7 +99,7 @@ class TemplateV2:
                 separator = '\n' if field.separator == ' ' and '\n' in formatted_value else field.separator
 
                 result.append(
-                    f"{field.name}{separator}{formatted_value}"
+                    f"{field.name}{separator}{formatted_value}",
                 )
 
         if self._has_augmented_guidelines() and (example.get('augmented', False)):
@@ -130,7 +130,7 @@ class TemplateV2:
         )
 
     def extract(
-        self, example: Union[Example, dict[str, Any]], raw_pred: str
+        self, example: Union[Example, dict[str, Any]], raw_pred: str,
     ) -> Example:
         """Extracts the answer from the LM raw prediction using the template structure
 

--- a/dsp/utils/ann_utils.py
+++ b/dsp/utils/ann_utils.py
@@ -3,10 +3,10 @@ from typing import Tuple
 try:
     import faiss
     from faiss import Index
-except ImportError as e:
+except ImportError:
     raise ImportError(
         "You need to install FAISS library to perform ANN/KNN. Please check the official doc: "
-        "https://github.com/facebookresearch/faiss/blob/main/INSTALL.md"
+        "https://github.com/facebookresearch/faiss/blob/main/INSTALL.md",
     )
 
 
@@ -48,7 +48,7 @@ def _get_ivf_index(
     n_objects: int,
     in_list_dist_type: str,
     centroid_dist_type: str,
-    encode_residuals: bool
+    encode_residuals: bool,
 ) -> Index:
     # according to the FAISS doc, this should be OK
     n_list = int(4 * (n_objects ** 0.5))
@@ -73,7 +73,7 @@ def _get_ivf_index(
         n_list,
         faiss.ScalarQuantizer.QT_fp16,  # TODO: should be optional?
         centroid_metric,
-        encode_residuals
+        encode_residuals,
     )
     return index
 
@@ -85,7 +85,7 @@ def create_faiss_index(
     max_gpu_devices: int = 0,
     encode_residuals: bool = True,
     in_list_dist_type: str = 'L2',
-    centroid_dist_type: str = 'L2'
+    centroid_dist_type: str = 'L2',
 ) -> Index:
     """
     Create IVF index (with IP or L2 dist), without adding data and training
@@ -118,7 +118,7 @@ def create_faiss_index(
             n_objects=n_objects,
             in_list_dist_type=in_list_dist_type,
             centroid_dist_type=centroid_dist_type,
-            encode_residuals=encode_residuals
+            encode_residuals=encode_residuals,
         )
 
     index.nprobe = n_probe

--- a/dsp/utils/dpr.py
+++ b/dsp/utils/dpr.py
@@ -8,7 +8,7 @@ import regex
 import unicodedata
 
 
-class Tokens(object):
+class Tokens:
     """A class to represent a list of tokenized text."""
     TEXT = 0
     TEXT_WS = 1
@@ -125,7 +125,7 @@ class Tokens(object):
         return groups
 
 
-class Tokenizer(object):
+class Tokenizer:
     """Base tokenizer class.
     Tokenizers implement tokenize, which should return a Tokens class.
     """
@@ -151,7 +151,7 @@ class SimpleTokenizer(Tokenizer):
         """
         self._regexp = regex.compile(
             '(%s)|(%s)' % (self.ALPHA_NUM, self.NON_WS),
-            flags=regex.IGNORECASE + regex.UNICODE + regex.MULTILINE
+            flags=regex.IGNORECASE + regex.UNICODE + regex.MULTILINE,
         )
         if len(kwargs.get('annotators', {})) > 0:
             logger.warning('%s only tokenizes! Skipping annotators: %s' %

--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -3,7 +3,7 @@ from dsp.utils.utils import dotdict
 import threading
 
 
-class Settings(object):
+class Settings:
     """DSP configuration settings."""
 
     _instance = None
@@ -42,7 +42,7 @@ class Settings(object):
                 bypass_suggest=False,
                 assert_failures=0,
                 suggest_failures=0,
-                langchain_history=[]
+                langchain_history=[],
             )
             cls._instance.__append(config)
 

--- a/dsp/utils/utils.py
+++ b/dsp/utils/utils.py
@@ -27,7 +27,7 @@ def file_tqdm(file):
     print(f"#> Reading {file.name}")
 
     with tqdm.tqdm(
-        total=os.path.getsize(file.name) / 1024.0 / 1024.0, unit="MiB"
+        total=os.path.getsize(file.name) / 1024.0 / 1024.0, unit="MiB",
     ) as pbar:
         for line in file:
             yield line
@@ -214,7 +214,7 @@ def lengths2offsets(lengths):
 
 
 # see https://stackoverflow.com/a/45187287
-class NullContextManager(object):
+class NullContextManager:
     def __init__(self, dummy_resource=None):
         self.dummy_resource = dummy_resource
 

--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -3,7 +3,8 @@ import random
 from dspy.datasets import Dataset
 
 from datasets import load_dataset
-from typing import Union, List, Mapping, Tuple
+from typing import Union, List, Tuple
+from collections.abc import Mapping
 
 class DataLoader(Dataset):
     def __init__(self,):
@@ -15,13 +16,13 @@ class DataLoader(Dataset):
         *args,
         input_keys: Tuple[str] = (),
         fields: Tuple[str] = None,
-        **kwargs
+        **kwargs,
     ) -> Union[Mapping[str, List[dspy.Example]], List[dspy.Example]]:
         if fields and not isinstance(fields, tuple):
-            raise ValueError(f"Invalid fields provided. Please provide a tuple of fields.")
+            raise ValueError("Invalid fields provided. Please provide a tuple of fields.")
 
         if not isinstance(input_keys, tuple):
-            raise ValueError(f"Invalid input keys provided. Please provide a tuple of input keys.")
+            raise ValueError("Invalid input keys provided. Please provide a tuple of input keys.")
 
         dataset = load_dataset(dataset_name, *args, **kwargs)
         
@@ -65,7 +66,7 @@ class DataLoader(Dataset):
         dataset: List[dspy.Example],
         n: int,
         *args,
-        **kwargs
+        **kwargs,
     ) -> List[dspy.Example]:
         if not isinstance(dataset, list):
             raise ValueError(f"Invalid dataset provided of type {type(dataset)}. Please provide a list of examples.")
@@ -77,7 +78,7 @@ class DataLoader(Dataset):
         dataset: List[dspy.Example],
         train_size: Union[int, float] = 0.75,
         test_size: Union[int, float] = None,
-        random_state: int = None
+        random_state: int = None,
     ) -> Mapping[str, List[dspy.Example]]:
         if random_state is not None:
             random.seed(random_state)

--- a/dspy/datasets/gsm8k.py
+++ b/dspy/datasets/gsm8k.py
@@ -2,7 +2,6 @@ import tqdm
 import random
 
 from datasets import load_dataset
-from dspy.datasets.dataset import Dataset
 
 class GSM8K:
     def __init__(self) -> None:

--- a/dspy/evaluate/__init__.py
+++ b/dspy/evaluate/__init__.py
@@ -1,3 +1,4 @@
 from .evaluate import Evaluate
 from .metrics import *
 from .auto_evaluation import *
+from dsp.utils import EM, normalize_text

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -11,7 +11,6 @@ except ImportError:
     HTML = lambda x: x
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from dsp.utils import EM
 from dsp.evaluation.utils import *
 
 """
@@ -219,12 +218,12 @@ def configure_dataframe_display(df, metric_name):
     # Return styled DataFrame
     return df.style.set_table_styles([
         {'selector': 'th', 'props': [('text-align', 'left')]},
-        {'selector': 'td', 'props': [('text-align', 'left')]}
+        {'selector': 'td', 'props': [('text-align', 'left')]},
     ]).set_properties(**{
         'text-align': 'left',
         'white-space': 'pre-wrap',
         'word-wrap': 'break-word',
-        'max-width': '400px'
+        'max-width': '400px',
     })
 
 # FIXME: TODO: The merge_dicts stuff above is way too quick and dirty.

--- a/dspy/evaluate/metrics.py
+++ b/dspy/evaluate/metrics.py
@@ -1,7 +1,6 @@
 # TODO: This should move internally. Same for passage_match. dspy.metrics.answer_exact_match, dspy.metrics.answer_passage_match
 
 import dsp
-from dsp.utils import EM, normalize_text
 
 def answer_exact_match(example, pred, trace=None, frac=1.0):
     assert(type(example.answer) is str or type(example.answer) is list)

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -1,6 +1,10 @@
-import inspect, os, openai, dspy, typing, pydantic
-from typing import Annotated, List, Tuple
+import inspect
+import os
+import openai
+import dspy
 import typing
+import pydantic
+from typing import Annotated, List, Tuple
 from dsp.templates import passages2text
 import json
 
@@ -58,7 +62,7 @@ def TypedChainOfThought(signature):
                 prefix="Reasoning: Let's think step by step in order to",
                 desc="${produce the " + output_keys + "}. We ...",
             ),
-        )
+        ),
     )
 
 
@@ -78,7 +82,7 @@ class TypedPredictor(dspy.Module):
             dspy.Signature(
                 "json_schema -> json_object",
                 "Make a very succinct json object that validates with the following schema",
-            )
+            ),
         )(json_schema=json.dumps(type_.model_json_schema())).json_object
         # We use the model_validate_json method to make sure the example is valid
         try:
@@ -120,7 +124,7 @@ class TypedPredictor(dspy.Module):
                         name,
                         desc=field.json_schema_extra.get("desc", "")
                         + (
-                            f". Respond with a single JSON object. JSON Schema: "
+                            ". Respond with a single JSON object. JSON Schema: "
                             + json.dumps(type_.model_json_schema())
                         ),
                         format=lambda x: (x if isinstance(x, str) else wrap(x).model_dump_json()),
@@ -164,7 +168,7 @@ class TypedPredictor(dspy.Module):
                     if try_i + 1 < MAX_RETRIES and prefix not in current_desc:
                         if example := self._make_example(field.annotation):
                             signature = signature.with_updated_fields(
-                                name, desc=current_desc + "\n" + prefix + example + "\n" + suffix
+                                name, desc=current_desc + "\n" + prefix + example + "\n" + suffix,
                             )
             if errors:
                 # Add new fields for each error
@@ -173,7 +177,7 @@ class TypedPredictor(dspy.Module):
                     signature = signature.append(
                         f"error_{name}_{try_i}",
                         dspy.InputField(
-                            prefix=f"Past Error " + (f"({name}):" if try_i == 0 else f"({name}, {try_i+1}):"),
+                            prefix="Past Error " + (f"({name}):" if try_i == 0 else f"({name}, {try_i+1}):"),
                             desc="An error to avoid in the future",
                         ),
                     )
@@ -183,7 +187,7 @@ class TypedPredictor(dspy.Module):
                     setattr(result, name, value)
                 return result
         raise ValueError(
-            "Too many retries trying to get the correct output format. " + "Try simplifying the requirements.", errors
+            "Too many retries trying to get the correct output format. " + "Try simplifying the requirements.", errors,
         )
 
 

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -104,7 +104,7 @@ class TypedPredictor(dspy.Module):
                     signature = signature.with_updated_fields(
                         name,
                         desc=field.json_schema_extra.get("desc", "")
-                        + (f". Respond with a single {type_.__name__} value"),
+                        + (f" (Respond with a single {type_.__name__} value)" if type_ != str else ""),
                         format=lambda x: x if isinstance(x, str) else str(x),
                         parser=type_,
                     )
@@ -195,7 +195,7 @@ def _format_error(error: Exception):
             errors.append(f"{e['msg']}: {fields} (error type: {e['type']})")
         return "; ".join(errors)
     else:
-        return str(error)
+        return repr(error)
 
 
 def _func_to_signature(func):

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -4,7 +4,7 @@ import openai
 import dspy
 import typing
 import pydantic
-from typing import Annotated, List, Tuple
+from typing import Annotated, List, Tuple  # noqa: UP035
 from dsp.templates import passages2text
 import json
 
@@ -14,13 +14,15 @@ from dspy.signatures.signature import ensure_signature
 MAX_RETRIES = 3
 
 
-def predictor(func):
+def predictor(func) -> dspy.Module:
+    """Decorator that creates a predictor module based on the provided function."""
     signature = _func_to_signature(func)
     *_, output_key = signature.output_fields.keys()
     return _StripOutput(TypedPredictor(signature), output_key)
 
 
-def cot(func):
+def cot(func) -> dspy.Module:
+    """Decorator that creates a chain of thought module based on the provided function."""
     signature = _func_to_signature(func)
     *_, output_key = signature.output_fields.keys()
     return _StripOutput(TypedChainOfThought(signature), output_key)
@@ -51,7 +53,7 @@ class FunctionalModule(dspy.Module):
                 self.__dict__[name] = attr.copy()
 
 
-def TypedChainOfThought(signature):
+def TypedChainOfThought(signature) -> dspy.Module:  # noqa: N802
     """Just like TypedPredictor, but adds a ChainOfThought OutputField."""
     signature = ensure_signature(signature)
     output_keys = ", ".join(signature.output_fields.keys())
@@ -72,11 +74,11 @@ class TypedPredictor(dspy.Module):
         self.signature = signature
         self.predictor = dspy.Predict(signature)
 
-    def copy(self):
+    def copy(self) -> "TypedPredictor":
         return TypedPredictor(self.signature)
 
     @staticmethod
-    def _make_example(type_):
+    def _make_example(type_) -> str:
         # Note: DSPy will cache this call so we only pay the first time TypedPredictor is called.
         json_object = dspy.Predict(
             dspy.Signature(
@@ -96,9 +98,10 @@ class TypedPredictor(dspy.Module):
         # TODO: Instead of using a language model to create the example, we can also just use a
         # library like https://pypi.org/project/polyfactory/ that's made exactly to do this.
 
-    def _prepare_signature(self):
+    def _prepare_signature(self) -> dspy.Signature:
         """Add formats and parsers to the signature fields, based on the type
-        annotations of the fields."""
+        annotations of the fields.
+        """
         signature = self.signature
         for name, field in self.signature.fields.items():
             is_output = field.json_schema_extra["__dspy_field_type"] == "output"
@@ -114,12 +117,12 @@ class TypedPredictor(dspy.Module):
                     )
                 else:
                     # Anything else we wrap in a pydantic object
-                    unwrap = lambda x: x
-                    wrap = lambda x: x
+                    to_json = lambda x: x.model_dump_json()
+                    from_json = lambda x, type_=type_: type_.model_validate_json(x)
                     if not (inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel)):
                         type_ = pydantic.create_model("Output", value=(type_, ...), __base__=pydantic.BaseModel)
-                        wrap = lambda x: type_(value=x)
-                        unwrap = lambda x: x.value
+                        to_json = lambda x, type_=type_: type_(value=x).model_dump_json()
+                        from_json = lambda x, type_=type_: type_.model_validate_json(x).value
                     signature = signature.with_updated_fields(
                         name,
                         desc=field.json_schema_extra.get("desc", "")
@@ -127,21 +130,21 @@ class TypedPredictor(dspy.Module):
                             ". Respond with a single JSON object. JSON Schema: "
                             + json.dumps(type_.model_json_schema())
                         ),
-                        format=lambda x: (x if isinstance(x, str) else wrap(x).model_dump_json()),
-                        parser=lambda x: unwrap(type_.model_validate_json(_unwrap_json(x))),
+                        format=lambda x, to_json=to_json: (x if isinstance(x, str) else to_json(x)),
+                        parser=lambda x, from_json=from_json: from_json(_unwrap_json(x)),
                         type_=type_,
                     )
             else:  # If input field
-                format = lambda x: x if isinstance(x, str) else str(x)
+                format_ = lambda x: x if isinstance(x, str) else str(x)
                 if type_ in (List[str], list[str], Tuple[str], tuple[str]):
-                    format = passages2text
+                    format_ = passages2text
                 elif inspect.isclass(type_) and issubclass(type_, pydantic.BaseModel):
-                    format = lambda x: x if isinstance(x, str) else x.model_dump_json()
-                signature = signature.with_updated_fields(name, format=format)
+                    format_ = lambda x: x if isinstance(x, str) else x.model_dump_json()
+                signature = signature.with_updated_fields(name, format=format_)
 
         return signature
 
-    def forward(self, **kwargs):
+    def forward(self, **kwargs) -> dspy.Prediction:
         modified_kwargs = kwargs.copy()
         # We have to re-prepare the signature on every forward call, because the base
         # signature might have been modified by an optimizer or something like that.
@@ -165,11 +168,12 @@ class TypedPredictor(dspy.Module):
                         continue  # Only add examples to JSON objects
                     suffix, current_desc = current_desc[i:], current_desc[:i]
                     prefix = "You MUST use this format: "
-                    if try_i + 1 < MAX_RETRIES and prefix not in current_desc:
-                        if example := self._make_example(field.annotation):
-                            signature = signature.with_updated_fields(
-                                name, desc=current_desc + "\n" + prefix + example + "\n" + suffix,
-                            )
+                    if try_i + 1 < MAX_RETRIES \
+                            and prefix not in current_desc \
+                            and (example := self._make_example(field.annotation)):
+                        signature = signature.with_updated_fields(
+                            name, desc=current_desc + "\n" + prefix + example + "\n" + suffix,
+                        )
             if errors:
                 # Add new fields for each error
                 for name, error in errors.items():
@@ -249,7 +253,7 @@ def _unwrap_json(output):
 ################################################################################
 
 
-def main():
+def main() -> None:
     class Answer(pydantic.BaseModel):
         value: float
         certainty: float
@@ -277,8 +281,8 @@ def main():
         question, answer = qa(topic="Physics")
         # lm.inspect_history(n=5)
 
-        print("Question:", question)
-        print("Answer:", answer)
+        print("Question:", question)  # noqa: T201
+        print("Answer:", answer)  # noqa: T201
 
 
 ################################################################################
@@ -286,7 +290,7 @@ def main():
 ################################################################################
 
 
-def validate_context_and_answer_and_hops(example, pred, trace=None):
+def validate_context_and_answer_and_hops(example, pred, trace=None) -> bool:
     if not dspy.evaluate.answer_exact_match(example, pred):
         return False
     if not dspy.evaluate.answer_passage_match(example, pred):
@@ -302,25 +306,25 @@ def validate_context_and_answer_and_hops(example, pred, trace=None):
     return True
 
 
-def gold_passages_retrieved(example, pred, trace=None):
+def gold_passages_retrieved(example, pred, _trace=None) -> bool:
     gold_titles = set(map(dspy.evaluate.normalize_text, example["gold_titles"]))
     found_titles = set(map(dspy.evaluate.normalize_text, [c.split(" | ")[0] for c in pred.context]))
 
     return gold_titles.issubset(found_titles)
 
 
-def hotpot():
+def hotpot() -> None:
     from dsp.utils import deduplicate
     import dspy.evaluate
     from dspy.datasets import HotPotQA
     from dspy.evaluate.evaluate import Evaluate
     from dspy.teleprompt.bootstrap import BootstrapFewShot
 
-    print("Load the dataset.")
+    print("Load the dataset.")  # noqa: T201
     dataset = HotPotQA(train_seed=1, train_size=20, eval_seed=2023, dev_size=50, test_size=0)
     trainset = [x.with_inputs("question") for x in dataset.train]
     devset = [x.with_inputs("question") for x in dataset.dev]
-    print("Done")
+    print("Done")  # noqa: T201
 
     class SimplifiedBaleen(FunctionalModule):
         def __init__(self, passages_per_hop=3, max_hops=1):
@@ -341,7 +345,7 @@ def hotpot():
         def forward(self, question):
             context = []
 
-            for hop in range(self.max_hops):
+            for _ in range(self.max_hops):
                 query = self.generate_query(context=context, question=question)
                 passages = self.retrieve(query).passages
                 context = deduplicate(context + passages)
@@ -358,7 +362,7 @@ def hotpot():
 
     # uncompiled (i.e., zero-shot) program
     uncompiled_baleen = SimplifiedBaleen()
-    print(
+    print(  # noqa: T201
         "Uncompiled Baleen retrieval score:",
         evaluate_on_hotpotqa(uncompiled_baleen, metric=gold_passages_retrieved),
     )
@@ -369,7 +373,7 @@ def hotpot():
         teacher=SimplifiedBaleen(passages_per_hop=2),
         trainset=trainset,
     )
-    print(
+    print(  # noqa: T201
         "Compiled Baleen retrieval score:",
         evaluate_on_hotpotqa(compiled_baleen, metric=gold_passages_retrieved),
     )

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -1,7 +1,8 @@
-import dsp, dspy
+import dsp
+import dspy
 from dspy.signatures.signature import ensure_signature
 
-from .predict import Predict, signature_to_template
+from .predict import Predict
 
 
 # TODO: FIXME: Insert this right before the *first* output field. Also rewrite this to use the new signature system.

--- a/dspy/predict/chain_of_thought_with_hint.py
+++ b/dspy/predict/chain_of_thought_with_hint.py
@@ -1,4 +1,5 @@
-import dsp, dspy
+import dsp
+import dspy
 
 from .predict import Predict
 

--- a/dspy/predict/multi_chain_comparison.py
+++ b/dspy/predict/multi_chain_comparison.py
@@ -3,7 +3,6 @@ from dspy.signatures.signature import ensure_signature
 from .predict import Predict
 from ..primitives.program import Module
 
-import dsp
 
 
 class MultiChainComparison(Module):
@@ -19,7 +18,7 @@ class MultiChainComparison(Module):
             signature = signature.append(
                 f"reasoning_attempt_{idx+1}",
                 dspy.InputField(
-                    prefix=f"Student Attempt #{idx+1}:", desc="${reasoning attempt}"
+                    prefix=f"Student Attempt #{idx+1}:", desc="${reasoning attempt}",
                 ),
             )
 
@@ -40,7 +39,7 @@ class MultiChainComparison(Module):
             rationale = c.rationale.strip().split("\n")[0].strip()
             answer = c[self.last_key].strip().split("\n")[0].strip()
             attempts.append(
-                f"«I'm trying to {rationale} I'm not sure but my prediction is {answer}»"
+                f"«I'm trying to {rationale} I'm not sure but my prediction is {answer}»",
             )
 
         assert len(attempts) == self.M, len(attempts)

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -60,10 +60,10 @@ class Predict(Parameter):
         assert lm is not None, "No LM is loaded."
 
         # If temperature is 0.0 but its n > 1, set temperature to 0.7.
-        temperature = config.get("temperature", None)
+        temperature = config.get("temperature")
         temperature = lm.kwargs["temperature"] if temperature is None else temperature
 
-        num_generations = config.get("n", None)
+        num_generations = config.get("n")
         if num_generations is None:
             num_generations = lm.kwargs.get("n", lm.kwargs.get("num_generations", None))
 
@@ -103,7 +103,7 @@ class Predict(Parameter):
             for field in template.fields:
                 if field.output_variable not in kwargs.keys():
                     completions[-1][field.output_variable] = getattr(
-                        c, field.output_variable
+                        c, field.output_variable,
                     )
 
         pred = Prediction.from_completions(completions, signature=signature)

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -1,4 +1,3 @@
-import dsp
 import dspy
 from dspy.signatures.signature import ensure_signature
 from ..primitives.program import Module
@@ -16,23 +15,23 @@ class ProgramOfThought(Module):
         self.output_fields = signature.output_fields
 
         inputs_ = ", ".join(
-            [f"`{field_name}`" for field_name in self.input_fields.keys()]
+            [f"`{field_name}`" for field_name in self.input_fields.keys()],
         )
         outputs_ = ", ".join(
-            [f"`{field_name}`" for field_name in self.output_fields.keys()]
+            [f"`{field_name}`" for field_name in self.output_fields.keys()],
         )
 
         assert len(self.output_fields) == 1, "PoT only supports one output field."
 
         instr = []
         instr.append(
-            f"You will be given {inputs_} and you will respond with {outputs_}."
+            f"You will be given {inputs_} and you will respond with {outputs_}.",
         )
         instr.append(
-            f"Generating executable Python code that programmatically computes the correct {outputs_}."
+            f"Generating executable Python code that programmatically computes the correct {outputs_}.",
         )
         instr.append(
-            f"After you're done with the computation, make sure the last line in your code evaluates to the correct value for {outputs_}."
+            f"After you're done with the computation, make sure the last line in your code evaluates to the correct value for {outputs_}.",
         )
         instr = "\n".join(instr)
 
@@ -40,19 +39,19 @@ class ProgramOfThought(Module):
             dspy.Signature(
                 self._generate_signature("generate").fields,
                 self._generate_instruction("generate"),
-            )
+            ),
         )
         self.code_regenerate = dspy.ChainOfThought(
             dspy.Signature(
                 self._generate_signature("regenerate").fields,
                 self._generate_instruction("regenerate"),
-            )
+            ),
         )
         self.generate_answer = dspy.ChainOfThought(
             dspy.Signature(
                 self._generate_signature("answer").fields,
                 self._generate_instruction("answer"),
-            )
+            ),
         )
 
     def _generate_signature(self, mode):
@@ -63,7 +62,7 @@ class ProgramOfThought(Module):
                     prefix="Code:",
                     desc="python code that answers the question",
                     format=str,
-                )
+                ),
             },
             "regenerate": {
                 "previous_code": dspy.InputField(
@@ -102,13 +101,13 @@ class ProgramOfThought(Module):
             [
                 f"`{field_name}`"
                 for field_name in self._generate_signature(mode).input_fields
-            ]
+            ],
         )
         mode_outputs = ", ".join(
             [
                 f"`{field_name}`"
                 for field_name in self._generate_signature(mode).output_fields
-            ]
+            ],
         )
         if mode == "generate":
             instr = [
@@ -123,7 +122,7 @@ class ProgramOfThought(Module):
             ]
         else:  # mode == 'answer'
             instr = [
-                f"Given the final code {mode_inputs}, provide the final {mode_outputs}."
+                f"Given the final code {mode_inputs}, provide the final {mode_outputs}.",
             ]
 
         return "\n".join(instr)
@@ -144,10 +143,10 @@ class ProgramOfThought(Module):
             code_block += "\n" + last_line_match.group(1)
         else:
             code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)(?=[a-zA-Z_]\w* *=)", r"\1\n", code_block
+                r"([a-zA-Z_]\w* *=.*?)(?=[a-zA-Z_]\w* *=)", r"\1\n", code_block,
             )
             code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)([a-zA-Z_]\w*)$", r"\1\n\2", code_block
+                r"([a-zA-Z_]\w* *=.*?)([a-zA-Z_]\w*)$", r"\1\n\2", code_block,
             )
         return code_block, None
 
@@ -171,7 +170,7 @@ class ProgramOfThought(Module):
         while hop < self.max_iters and error:
             print("Error in code execution")
             code_data = self.code_regenerate(
-                question=kwargs["question"], previous_code=code, error=error
+                question=kwargs["question"], previous_code=code, error=error,
             )
             parsed_code, error = self.parse_code(code_data)
             # FIXME: Don't try to execute the code if it didn't parse
@@ -181,6 +180,6 @@ class ProgramOfThought(Module):
                 print("Max hops reached. Error persists.")
                 return None
         answer_gen_result = self.generate_answer(
-            question=kwargs["question"], final_generated_code=code, code_output=output
+            question=kwargs["question"], final_generated_code=code, code_output=output,
         )
         return answer_gen_result

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -40,7 +40,7 @@ class ReAct(Module):
         for idx, tool in enumerate(self.tools):
             tool = self.tools[tool]
             instr.append(
-                f"({idx+1}) {tool.name}[{tool.input_variable}], which {tool.desc}"
+                f"({idx+1}) {tool.name}[{tool.input_variable}], which {tool.desc}",
             )
 
         instr = "\n".join(instr)
@@ -65,7 +65,7 @@ class ReAct(Module):
                     f"{tool.name}[{tool.input_variable}]"
                     for tool in self.tools.values()
                     if tool.name != "Finish"
-                ]
+                ],
             )
             signature_dict[f"Action_{j}"] = dspy.OutputField(
                 prefix=f"Action {j}:",

--- a/dspy/primitives/assertions.py
+++ b/dspy/primitives/assertions.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Callable
+from typing import Any
 import dsp
 import dspy
 import logging
@@ -16,7 +16,7 @@ def setup_logger():
     fileHandler.setLevel(logging.DEBUG)
 
     formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
     fileHandler.setFormatter(formatter)
 
@@ -80,7 +80,7 @@ class DSPySuggestionError(AssertionError):
 class Constraint:
 
     def __init__(
-        self, result: bool, msg: str = "", target_module=None, is_metric: bool = False
+        self, result: bool, msg: str = "", target_module=None, is_metric: bool = False,
     ):
         self.id = str(uuid.uuid4())
         self.result = result
@@ -187,7 +187,7 @@ def assert_no_except_handler(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except DSPyAssertionError as e:
+        except DSPyAssertionError:
             return None
 
     return wrapper
@@ -216,7 +216,7 @@ def backtrack_handler(func, bypass_suggest=True, max_backtracks=2):
                 if i > 0 and dspy.settings.backtrack_to is not None:
                     # generate values for new fields
                     feedback_msg = _build_error_msg(
-                        dspy.settings.predictor_feedbacks[dspy.settings.backtrack_to]
+                        dspy.settings.predictor_feedbacks[dspy.settings.backtrack_to],
                     )
 
                     dspy.settings.backtrack_to_args = {
@@ -274,7 +274,7 @@ def backtrack_handler(func, bypass_suggest=True, max_backtracks=2):
                             if (
                                 error_msg
                                 not in dspy.settings.predictor_feedbacks.setdefault(
-                                    dspy.settings.backtrack_to, []
+                                    dspy.settings.backtrack_to, [],
                                 )
                             ):
                                 dspy.settings.predictor_feedbacks[
@@ -286,7 +286,7 @@ def backtrack_handler(func, bypass_suggest=True, max_backtracks=2):
                             past_outputs = {}
                             for field_name in output_fields.keys():
                                 past_outputs[field_name] = getattr(
-                                    error_state[2], field_name, None
+                                    error_state[2], field_name, None,
                                 )
 
                             # save latest failure trace for predictor per suggestion
@@ -297,7 +297,7 @@ def backtrack_handler(func, bypass_suggest=True, max_backtracks=2):
 
                         else:
                             logger.error(
-                                f"UNREACHABLE: No trace available, this should not happen. Is this run time?"
+                                "UNREACHABLE: No trace available, this should not happen. Is this run time?",
                             )
 
             return result
@@ -323,37 +323,37 @@ default_assertion_handler = backtrack_handler
 
 
 def assert_transform_module(
-    module, assertion_handler=default_assertion_handler, **handler_args
+    module, assertion_handler=default_assertion_handler, **handler_args,
 ):
     """
     Transform a module to handle assertions.
     """
     if not getattr(module, "forward", False):
         raise ValueError(
-            "Module must have a forward method to have assertions handled."
+            "Module must have a forward method to have assertions handled.",
         )
     if getattr(module, "_forward", False):
         logger.info(
-            f"Module {module.__class__.__name__} already has a _forward method. Skipping..."
+            f"Module {module.__class__.__name__} already has a _forward method. Skipping...",
         )
         pass  # TODO warning: might be overwriting a previous _forward method
 
     module._forward = module.forward
     module.forward = handle_assert_forward(assertion_handler, **handler_args).__get__(
-        module
+        module,
     )
 
     if all(
-        map(lambda p: isinstance(p[1], dspy.retry.Retry), module.named_predictors())
+        map(lambda p: isinstance(p[1], dspy.retry.Retry), module.named_predictors()),
     ):
         pass  # we already applied the Retry mapping outside
     elif all(
-        map(lambda p: not isinstance(p[1], dspy.retry.Retry), module.named_predictors())
+        map(lambda p: not isinstance(p[1], dspy.retry.Retry), module.named_predictors()),
     ):
         module.map_named_predictors(dspy.retry.Retry)
     else:
         raise RuntimeError("Module has mixed predictors, can't apply Retry mapping.")
 
-    setattr(module, "_assert_transformed", True)
+    module._assert_transformed = True
 
     return module

--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -1,4 +1,3 @@
-import copy
 
 class Example:
     def __init__(self, base=None, **kwargs):

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -67,5 +67,5 @@ class BaseModule:
             f.write(ujson.dumps(self.dump_state(), indent=2))
     
     def load(self, path):
-        with open(path, "r") as f:
+        with open(path) as f:
             self.load_state(ujson.loads(f.read()))

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -1,5 +1,3 @@
-import copy
-import inspect
 
 from dspy.primitives.module import BaseModule
 from dspy.primitives.assertions import *

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -16,19 +16,15 @@ import difflib
 import importlib
 import re
 import typing
-import inspect
 from typing import (
     Any,
-    Callable,
     Dict,
-    Mapping,
     List,
     Optional,
     Set,
     Tuple,
-    TypeVar,
-    Union,
 )
+from collections.abc import Mapping
 import builtins
 
 
@@ -40,7 +36,7 @@ class InterpreterError(ValueError):
     pass
 
 
-class PythonInterpreter():
+class PythonInterpreter:
     r"""A customized python interpreter to control the execution of
     LLM-generated codes. The interpreter makes sure the code can only execute
     functions given in action space and import white list. It also supports
@@ -572,7 +568,7 @@ class CodePrompt(TextPrompt):
 
     def execute(
         self, interpreter: Optional[PythonInterpreter] = None,
-        user_variable: Optional[Dict[str, Any]] = None
+        user_variable: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Any, PythonInterpreter]:
         r"""Executes the code string by a given python interpreter.
 

--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -20,7 +20,7 @@ try:
     from chromadb.utils import embedding_functions
     from chromadb.api.types import (
         Embeddable,
-        EmbeddingFunction
+        EmbeddingFunction,
     )
     import chromadb.utils.embedding_functions as ef
 except ImportError:
@@ -28,7 +28,7 @@ except ImportError:
 
 if chromadb is None:
     raise ImportError(
-        "The chromadb library is required to use ChromadbRM. Install it with `pip install dspy-ai[chromadb]`"
+        "The chromadb library is required to use ChromadbRM. Install it with `pip install dspy-ai[chromadb]`",
     )
 
 
@@ -97,7 +97,7 @@ class ChromadbRM(dspy.Retrieve):
             Settings(
                 persist_directory=persist_directory,
                 is_persistent=True,
-            )
+            ),
         )
         self._chromadb_collection = self._chromadb_client.get_or_create_collection(
             name=collection_name,
@@ -120,7 +120,7 @@ class ChromadbRM(dspy.Retrieve):
         return self.ef(queries)
 
     def forward(
-        self, query_or_queries: Union[str, List[str]], k: Optional[int] = None
+        self, query_or_queries: Union[str, List[str]], k: Optional[int] = None,
     ) -> dspy.Prediction:
         """Search with db for self.k top passages for query
 
@@ -140,7 +140,7 @@ class ChromadbRM(dspy.Retrieve):
 
         k = self.k if k is None else k
         results = self._chromadb_collection.query(
-            query_embeddings=embeddings, n_results=k
+            query_embeddings=embeddings, n_results=k,
         )
 
         passages = [dotdict({"long_text": x}) for x in results["documents"][0]]

--- a/dspy/retrieve/clarifai_rm.py
+++ b/dspy/retrieve/clarifai_rm.py
@@ -12,7 +12,7 @@ try:
     from clarifai.client.search import Search
 except ImportError as err:
     raise ImportError(
-        "Clarifai is not installed. Install it using `pip install clarifai`"
+        "Clarifai is not installed. Install it using `pip install clarifai`",
     ) from err
 
 
@@ -45,7 +45,7 @@ class ClarifaiRM(dspy.Retrieve):
         )
         self.k = k
         self.clarifai_search = Search(
-            user_id=self.user_id, app_id=self.app_id, top_k=k, pat=self.pat
+            user_id=self.user_id, app_id=self.app_id, top_k=k, pat=self.pat,
         )
         super().__init__(k=k)
 
@@ -57,7 +57,7 @@ class ClarifaiRM(dspy.Retrieve):
         return requested_text
 
     def forward(
-        self, query_or_queries: Union[str, List[str]], k: Optional[int] = None
+        self, query_or_queries: Union[str, List[str]], k: Optional[int] = None,
     ) -> dspy.Prediction:
         """Uses clarifai-python SDK search function and retrieves top_k similar passages for given query,
         Args:

--- a/dspy/retrieve/databricks_rm.py
+++ b/dspy/retrieve/databricks_rm.py
@@ -1,7 +1,7 @@
 import dspy
 import os
 import requests
-from typing import Union, List, Optional
+from typing import Union, List
 from collections import defaultdict
 from dspy.primitives.prediction import Prediction
 
@@ -91,11 +91,11 @@ class DatabricksRM(dspy.Retrieve):
         """
         headers = {
             "Authorization": f"Bearer {self.databricks_token}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
         payload = {
             "columns": self.columns,
-            "num_results": self.k
+            "num_results": self.k,
         }
         if query_type == 'vector':
             if not isinstance(query, list):
@@ -112,7 +112,7 @@ class DatabricksRM(dspy.Retrieve):
         response = requests.post(
             f"{self.databricks_endpoint}/api/2.0/vector-search/indexes/{self.databricks_index_name}/query",
             json=payload,
-            headers=headers
+            headers=headers,
         )
         results = response.json()
 

--- a/dspy/retrieve/deeplake_rm.py
+++ b/dspy/retrieve/deeplake_rm.py
@@ -2,7 +2,7 @@
 Retriever model for deeplake
 """
 
-from typing import Optional, List, Union, Type
+from typing import Optional, List, Union
 import openai
 import dspy
 from collections import defaultdict
@@ -59,7 +59,7 @@ class DeeplakeRM(dspy.Retrieve):
           from deeplake import VectorStore
         except ImportError:
           raise ImportError(
-              "The 'deeplake' extra is required to use DeepLakeRM. Install it with `pip install dspy-ai[deeplake]`"
+              "The 'deeplake' extra is required to use DeepLakeRM. Install it with `pip install dspy-ai[deeplake]`",
           )
         self._deeplake_vectorstore_name = deeplake_vectorstore_name
         self._deeplake_client = deeplake_client
@@ -77,7 +77,7 @@ class DeeplakeRM(dspy.Retrieve):
         ]
 
     def forward(
-        self, query_or_queries: Union[str, List[str]], k: Optional[int]
+        self, query_or_queries: Union[str, List[str]], k: Optional[int],
     ) -> dspy.Prediction:
         
         """Search with DeepLake for self.k top passages for query
@@ -103,7 +103,7 @@ class DeeplakeRM(dspy.Retrieve):
         for query in queries:
             results = self._deeplake_client(
             path=self._deeplake_vectorstore_name,
-            embedding_function=self.embedding_function
+            embedding_function=self.embedding_function,
             ).search(query, k=k)
 
             for score,text in zip(results.get('score',0.0),results.get('text',"")):

--- a/dspy/retrieve/marqo_rm.py
+++ b/dspy/retrieve/marqo_rm.py
@@ -7,7 +7,7 @@ try:
     import marqo
 except ImportError:
     raise ImportError(
-        "The 'marqo' extra is required to use MarqoRM. Install it with `pip install dspy-ai[marqo]`"
+        "The 'marqo' extra is required to use MarqoRM. Install it with `pip install dspy-ai[marqo]`",
     )
 
 class MarqoRM(dspy.Retrieve):
@@ -48,7 +48,7 @@ class MarqoRM(dspy.Retrieve):
         marqo_client: marqo.client.Client,
         k: int = 3,
         page_content: str = 'document',
-        filter_string: str = None
+        filter_string: str = None,
     ):
         self._marqo_index_name = marqo_index_name
         self._marqo_client = marqo_client
@@ -80,7 +80,7 @@ class MarqoRM(dspy.Retrieve):
                 q=query,
                 limit=limit,
                 filter_string=self.filter_string,
-                **kwargs
+                **kwargs,
             )
             all_query_results.append(_result)
 

--- a/dspy/retrieve/mongodb_atlas_rm.py
+++ b/dspy/retrieve/mongodb_atlas_rm.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union, Any
+from typing import List, Any
 import dspy
 import os
 from openai import (
@@ -21,12 +21,12 @@ try:
     )
 except ImportError:
     raise ImportError(
-        "Please install the pymongo package by running `pip install dspy-ai[mongodb]`"
+        "Please install the pymongo package by running `pip install dspy-ai[mongodb]`",
     )
 
 
 def build_vector_search_pipeline(
-    index_name: str, query_vector: List[float], num_candidates: int, limit: int
+    index_name: str, query_vector: List[float], num_candidates: int, limit: int,
 ) -> List[dict[str, Any]]:
     return [
         {
@@ -36,7 +36,7 @@ def build_vector_search_pipeline(
                 "queryVector": query_vector,
                 "numCandidates": num_candidates,
                 "limit": limit,
-            }
+            },
         },
         {"$project": {"_id": 0, "text": 1, "score": {"$meta": "vectorSearchScore"}}},
     ]
@@ -92,7 +92,7 @@ class MongoDBAtlasRM(dspy.Retrieve):
         try:
             self.client = MongoClient(
                 f"mongodb+srv://{self.username}:{self.password}@{self.cluster_url}/{self.db_name}"
-                "?retryWrites=true&w=majority"
+                "?retryWrites=true&w=majority",
             )
         except (
             InvalidURI,

--- a/dspy/retrieve/pgvector_rm.py
+++ b/dspy/retrieve/pgvector_rm.py
@@ -1,6 +1,6 @@
 import dspy
 import openai
-from typing import List, Union, Optional
+from typing import List, Optional
 
 try:
     from pgvector.psycopg2 import register_vector
@@ -8,7 +8,7 @@ try:
     from psycopg2 import sql
 except ImportError:
     raise ImportError(
-        "The 'pgvector' extra is required to use PgVectorRM. Install it with `pip install dspy-ai[pgvector]`"
+        "The 'pgvector' extra is required to use PgVectorRM. Install it with `pip install dspy-ai[pgvector]`",
     )
 
 
@@ -61,7 +61,7 @@ class PgVectorRM(dspy.Retrieve):
             openai_client: openai.OpenAI,
             k: Optional[int]=20,
             embedding_field: str = "embedding",
-            fields: List[str] = ['text']
+            fields: List[str] = ['text'],
     ):
         """
         k = 20 is the number of paragraphs to retrieve
@@ -89,7 +89,7 @@ class PgVectorRM(dspy.Retrieve):
         query_embedding = self.openai_client.embeddings.create(
             model="text-embedding-ada-002",
             input=query,
-            encoding_format="float"
+            encoding_format="float",
         ).data[0].embedding
 
         related_paragraphs = []
@@ -101,7 +101,7 @@ class PgVectorRM(dspy.Retrieve):
                 for f in self.fields
             ]),
             table=sql.Identifier(self.pg_table_name),
-            embedding_field=sql.Identifier(self.embedding_field)
+            embedding_field=sql.Identifier(self.embedding_field),
         )
 
         with self.conn as conn:

--- a/dspy/retrieve/pinecone_rm.py
+++ b/dspy/retrieve/pinecone_rm.py
@@ -15,7 +15,7 @@ except ImportError:
 
 if pinecone is None:
     raise ImportError(
-        "The pinecone library is required to use PineconeRM. Install it with `pip install dspy-ai[pinecone]`"
+        "The pinecone library is required to use PineconeRM. Install it with `pip install dspy-ai[pinecone]`",
     )
 
 import openai
@@ -81,7 +81,7 @@ class PineconeRM(dspy.Retrieve):
                 from transformers import AutoModel, AutoTokenizer
             except ImportError as exc:
                 raise ModuleNotFoundError(
-                "You need to install Hugging Face transformers library to use a local embedding model with PineconeRM."
+                "You need to install Hugging Face transformers library to use a local embedding model with PineconeRM.",
             ) from exc
 
             self._local_embed_model = AutoModel.from_pretrained(local_embed_model)
@@ -90,7 +90,7 @@ class PineconeRM(dspy.Retrieve):
             self.device = torch.device(
                 'cuda:0' if torch.cuda.is_available() else
                 'mps' if torch.backends.mps.is_available()
-                else 'cpu'
+                else 'cpu',
             )
         elif openai_embed_model is not None:
             self._openai_embed_model = openai_embed_model
@@ -102,11 +102,11 @@ class PineconeRM(dspy.Retrieve):
                 openai.organization = openai_org
         else:
             raise ValueError(
-                "Either local_embed_model or openai_embed_model must be provided."
+                "Either local_embed_model or openai_embed_model must be provided.",
             )
 
         self._pinecone_index = self._init_pinecone(
-            pinecone_index_name, pinecone_api_key, pinecone_env
+            pinecone_index_name, pinecone_api_key, pinecone_env,
         )
 
         super().__init__(k=k)
@@ -145,7 +145,7 @@ class PineconeRM(dspy.Retrieve):
         if index_name not in active_indexes:
             if dimension is None and distance_metric is None:
                 raise ValueError(
-                    "dimension and distance_metric must be provided since the index provided does not exist."
+                    "dimension and distance_metric must be provided since the index provided does not exist.",
                 )
 
             pinecone.create_index(
@@ -159,13 +159,13 @@ class PineconeRM(dspy.Retrieve):
     def _mean_pooling(
             self, 
             model_output, 
-            attention_mask
+            attention_mask,
         ):
         try:
             import torch
         except ImportError as exc:
             raise ModuleNotFoundError(
-                "You need to install torch to use a local embedding model with PineconeRM."
+                "You need to install torch to use a local embedding model with PineconeRM.",
             ) from exc
 
         token_embeddings = model_output[0] # First element of model_output contains all token embeddings
@@ -179,7 +179,7 @@ class PineconeRM(dspy.Retrieve):
     )
     def _get_embeddings(
         self, 
-        queries: List[str]
+        queries: List[str],
     ) -> List[List[float]]:
         """Return query vector after creating embedding using OpenAI
 
@@ -193,17 +193,17 @@ class PineconeRM(dspy.Retrieve):
             import torch
         except ImportError as exc:
             raise ModuleNotFoundError(
-                "You need to install torch to use a local embedding model with PineconeRM."
+                "You need to install torch to use a local embedding model with PineconeRM.",
             ) from exc
         
         if not self.use_local_model:
             if OPENAI_LEGACY:
                 embedding = openai.Embedding.create(
-                    input=queries, model=self._openai_embed_model
+                    input=queries, model=self._openai_embed_model,
                 )
             else:
                 embedding = openai.embeddings.create(
-                    input=queries, model=self._openai_embed_model
+                    input=queries, model=self._openai_embed_model,
                 ).model_dump()
             return [embedding["embedding"] for embedding in embedding["data"]]
         
@@ -239,12 +239,12 @@ class PineconeRM(dspy.Retrieve):
         # For single query, just look up the top k passages
         if len(queries) == 1:
             results_dict = self._pinecone_index.query(
-                embeddings[0], top_k=self.k, include_metadata=True
+                embeddings[0], top_k=self.k, include_metadata=True,
             )
 
             # Sort results by score
             sorted_results = sorted(
-                results_dict["matches"], key=lambda x: x.get("scores", 0.0), reverse=True
+                results_dict["matches"], key=lambda x: x.get("scores", 0.0), reverse=True,
             )
             passages = [result["metadata"]["text"] for result in sorted_results]
             passages = [dotdict({"long_text": passage for passage in passages})]
@@ -255,7 +255,7 @@ class PineconeRM(dspy.Retrieve):
         passage_scores = {}
         for embedding in embeddings:
             results_dict = self._pinecone_index.query(
-                embedding, top_k=self.k * 3, include_metadata=True
+                embedding, top_k=self.k * 3, include_metadata=True,
             )
             for result in results_dict["matches"]:
                 passage_scores[result["metadata"]["text"]] = (
@@ -264,6 +264,6 @@ class PineconeRM(dspy.Retrieve):
                 )
 
         sorted_passages = sorted(
-            passage_scores.items(), key=lambda x: x[1], reverse=True
+            passage_scores.items(), key=lambda x: x[1], reverse=True,
         )[: self.k]
         return dspy.Prediction(passages=[dotdict({"long_text": passage}) for passage, _ in sorted_passages])

--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -8,7 +8,7 @@ try:
     import fastembed
 except ImportError:
     raise ImportError(
-        "The 'qdrant' extra is required to use QdrantRM. Install it with `pip install dspy-ai[qdrant]`"
+        "The 'qdrant' extra is required to use QdrantRM. Install it with `pip install dspy-ai[qdrant]`",
     )
 
 

--- a/dspy/retrieve/vectara_rm.py
+++ b/dspy/retrieve/vectara_rm.py
@@ -76,7 +76,7 @@ class VectaraRM(dspy.Retrieve):
         corpus_key = {
             "customerId": self._vectara_customer_id,
             "corpusId": self._vectara_corpus_id,
-            "lexicalInterpolationConfig": {"lambda": 0.025 }
+            "lexicalInterpolationConfig": {"lambda": 0.025 },
         }
 
         data = {
@@ -92,8 +92,8 @@ class VectaraRM(dspy.Retrieve):
                         "endTag": END_SNIPPET,
                     },
                     "corpusKey": [corpus_key],
-                }
-            ]
+                },
+            ],
         }
 
         headers = {
@@ -124,7 +124,7 @@ class VectaraRM(dspy.Retrieve):
         res = [
             {
                 "text": remove_snippet(x["text"]),
-                "score": x["score"]
+                "score": x["score"],
             } for x in responses
         ]
         return res

--- a/dspy/retrieve/weaviate_rm.py
+++ b/dspy/retrieve/weaviate_rm.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import List, Union
 import dspy
 from dsp.utils import dotdict
@@ -8,7 +7,7 @@ try:
     import weaviate
 except ImportError:
     raise ImportError(
-        "The 'weaviate' extra is required to use WeaviateRM. Install it with `pip install dspy-ai[weaviate]`"
+        "The 'weaviate' extra is required to use WeaviateRM. Install it with `pip install dspy-ai[weaviate]`",
     )
 
 
@@ -47,7 +46,7 @@ class WeaviateRM(dspy.Retrieve):
                  weaviate_collection_name: str, 
                  weaviate_client: weaviate.Client, 
                  k: int = 3,
-                 weaviate_collection_text_key: Optional[str] = "content"
+                 weaviate_collection_text_key: Optional[str] = "content",
         ):
         self._weaviate_collection_name = weaviate_collection_name
         self._weaviate_client = weaviate_client

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -56,7 +56,7 @@ class SignatureMeta(type(BaseModel)):
             field_type = extra.get("__dspy_field_type")
             if field_type not in ["input", "output"]:
                 raise TypeError(
-                    f"Field '{name}' in '{cls.__name__}' must be declared with InputField or OutputField."
+                    f"Field '{name}' in '{cls.__name__}' must be declared with InputField or OutputField.",
                 )
 
     @property
@@ -179,14 +179,14 @@ class SignatureMeta(type(BaseModel)):
         fixed_fields = {}
         for name, type_field in fields.items():
             assert isinstance(
-                name, str
+                name, str,
             ), f"Field names must be strings, not {type(name)}"
             if isinstance(type_field, FieldInfo):
                 type_ = type_field.annotation
                 field = type_field
             else:
                 assert isinstance(
-                    type_field, tuple
+                    type_field, tuple,
                 ), f"Field values must be tuples, not {type(type_field)}"
                 type_, field = type_field
             # It might be better to be explicit about the type, but it currently would break
@@ -194,10 +194,10 @@ class SignatureMeta(type(BaseModel)):
             if type_ is None:
                 type_ = str
             assert isinstance(type_, type) or isinstance(
-                typing.get_origin(type_), type
+                typing.get_origin(type_), type,
             ), f"Field types must be types, not {type(type_)}"
             assert isinstance(
-                field, FieldInfo
+                field, FieldInfo,
             ), f"Field values must be Field instances, not {type(field)}"
             fixed_fields[name] = (type_, field)
 
@@ -266,10 +266,10 @@ def infer_prefix(attribute_name: str) -> str:
 
     # Insert underscores around numbers to ensure spaces in the final output
     with_underscores_around_numbers = re.sub(
-        r"([a-zA-Z])(\d)", r"\1_\2", intermediate_name
+        r"([a-zA-Z])(\d)", r"\1_\2", intermediate_name,
     )
     with_underscores_around_numbers = re.sub(
-        r"(\d)([a-zA-Z])", r"\1_\2", with_underscores_around_numbers
+        r"(\d)([a-zA-Z])", r"\1_\2", with_underscores_around_numbers,
     )
 
     # Convert snake_case to 'Proper Title Case', but ensure acronyms are uppercased

--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -4,14 +4,12 @@ import random
 import threading
 
 import dspy
-from dspy.predict.retry import Retry
 
 from dspy.primitives import Example
 
 from .teleprompt import Teleprompter
 from .vanilla import LabeledFewShot
 
-from dspy.evaluate.evaluate import Evaluate
 
 # TODO: metrics should return an object with __bool__ basically, but fine if they're more complex.
 # They can also be sortable.
@@ -58,8 +56,8 @@ class BootstrapFewShot(Teleprompter):
         self.student._compiled = True
 
         # set assert_failures and suggest_failures as attributes of student w/ value 0
-        setattr(self.student, '_assert_failures', 0)
-        setattr(self.student, '_suggest_failures', 0)
+        self.student._assert_failures = 0
+        self.student._suggest_failures = 0
 
         return self.student
     
@@ -204,7 +202,6 @@ class BootstrapFewShot(Teleprompter):
 
             raw_demos = rng.sample(raw_demos, sample_size)
             
-            import dspy
             if dspy.settings.release >= 20230928:
                 predictor.demos = raw_demos + augmented_demos
             else:

--- a/dspy/teleprompt/ensemble.py
+++ b/dspy/teleprompt/ensemble.py
@@ -1,5 +1,3 @@
-import dsp
-import tqdm
 import random
 
 from dspy.teleprompt.teleprompt import Teleprompter

--- a/dspy/teleprompt/finetune.py
+++ b/dspy/teleprompt/finetune.py
@@ -1,7 +1,6 @@
 import os
 import time
 import dsp
-import tqdm
 import random
 
 import ujson
@@ -130,7 +129,7 @@ class BootstrapFinetune(Teleprompter):
             'batch_size': bsize,
             'epochs': epochs,
             'gradient_accumulation_steps': accumsteps, # 2,
-            'lr': lr
+            'lr': lr,
         }
 
         compiler_config['save'] = os.path.join(path_prefix, compiler_config['save']) if path_prefix else compiler_config['save']

--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -1,5 +1,3 @@
-import dsp
-import tqdm
 import random
 
 from dspy.teleprompt.teleprompt import Teleprompter

--- a/dspy/teleprompt/signature_opt.py
+++ b/dspy/teleprompt/signature_opt.py
@@ -60,11 +60,11 @@ class SignatureOptimizer(Teleprompter):
 
     def _check_candidates_equal(self, candidate1, candidate2):
         for p1, p2 in zip(candidate1["program"].predictors(), candidate2["program"].predictors()):
-            if not p1.extended_signature.instructions == p2.extended_signature.instructions:
+            if p1.extended_signature.instructions != p2.extended_signature.instructions:
                 return False
             *_, p1_last_field = p1.extended_signature.fields.values()
             *_, p2_last_field = p2.extended_signature.fields.values()
-            if not p1_last_field == p2_last_field:
+            if p1_last_field != p2_last_field:
                 return False
         return True
 
@@ -177,7 +177,7 @@ class SignatureOptimizer(Teleprompter):
                             .with_updated_fields(last_key, prefix=prefix)
 
                     # Score the instruction / prefix 
-                    if self.verbose: print(f"----------------")
+                    if self.verbose: print("----------------")
                     for i,predictor in enumerate(module_clone.predictors()):
                         if self.verbose: print(f"Predictor {i}")
                         self._print_signature(predictor)
@@ -185,7 +185,7 @@ class SignatureOptimizer(Teleprompter):
                     score = evaluate(module_clone, devset=devset, **eval_kwargs)
                     if self.verbose and self.prompt_model: print(f"prompt_model.inspect_history(n=1) {self.prompt_model.inspect_history(n=1)}")
                     total_calls += 1
-                    if self.verbose: print(f"----------------")
+                    if self.verbose: print("----------------")
 
                     replace_entry = True
                     if self.verbose: print(f"(instruction, prefix) {(instruction, prefix)}")
@@ -202,7 +202,7 @@ class SignatureOptimizer(Teleprompter):
                             "program": module_clone.deepcopy(),
                             "instruction": instruction,
                             "prefix": prefix,
-                            "depth": d
+                            "depth": d,
                         }
                     
                     if (len(candidates_)-self.breadth <= c_i):
@@ -233,7 +233,7 @@ class SignatureOptimizer(Teleprompter):
                         .with_instructions(best_candidate["instruction"]) \
                         .with_updated_fields(last_key2, prefix=best_candidate["prefix"])
                 if self.verbose: print(f"Updating Predictor {id(p_old)} to:\ni: {best_candidate['instruction']}\np: {best_candidate['prefix']}")
-                if self.verbose: print(f"Full predictor with update: ")
+                if self.verbose: print("Full predictor with update: ")
                 for i,predictor in enumerate(module_clone.predictors()):
                     if self.verbose: print(f"Predictor {i}")
                     self._print_signature(predictor)

--- a/dspy/teleprompt/signature_opt_bayesian.py
+++ b/dspy/teleprompt/signature_opt_bayesian.py
@@ -7,7 +7,6 @@ from dspy.evaluate.evaluate import Evaluate
 from collections import defaultdict
 import random
 from dspy.teleprompt import BootstrapFewShot
-import numpy as np
 import optuna
 import math
 
@@ -221,11 +220,11 @@ class BayesianSignatureOptimizer(Teleprompter):
                         new_instruct = dspy.Predict(
                             BasicGenerateInstructionWithExamplesAndDataObservations,
                             n=1,
-                            temperature=self.init_temperature
+                            temperature=self.init_temperature,
                         )(
                             basic_instruction=basic_instruction,
                             observations=self.observations,
-                            examples=example_sets[id(predictor)][i]
+                            examples=example_sets[id(predictor)][i],
                         )
                         if not instruct:
                             instruct = new_instruct
@@ -242,10 +241,10 @@ class BayesianSignatureOptimizer(Teleprompter):
                         new_instruct = dspy.Predict(
                             BasicGenerateInstructionWithExamples,
                             n=1,
-                            temperature=self.init_temperature
+                            temperature=self.init_temperature,
                         )(
                             basic_instruction=basic_instruction,
-                            examples=example_sets[id(predictor)][i]
+                            examples=example_sets[id(predictor)][i],
                         )
                         if not instruct:
                             instruct = new_instruct
@@ -279,7 +278,7 @@ class BayesianSignatureOptimizer(Teleprompter):
         for i in range(self.n):
             if i == 0: # Story empty set of demos as default for index 0
                 for module_p in module.predictors():
-                    if id(module_p) not in demo_candidates.keys():
+                    if id(module_p) not in demo_candidates:
                         demo_candidates[id(module_p)] = []
                     demo_candidates[id(module_p)].append([])
             else:
@@ -294,7 +293,7 @@ class BayesianSignatureOptimizer(Teleprompter):
 
                 # Store the candidate demos
                 for module_p, candidate_p in zip(module.predictors(), candidate_program.predictors()):
-                    if id(module_p) not in demo_candidates.keys():
+                    if id(module_p) not in demo_candidates:
                         demo_candidates[id(module_p)] = []
                     demo_candidates[id(module_p)].append(candidate_p.demos)
 
@@ -374,7 +373,7 @@ class BayesianSignatureOptimizer(Teleprompter):
 
                     # Handle pruning based on the intermediate value.
                     if trial.should_prune():
-                        if self.verbose: print(f"Optuna decided to prune!")
+                        if self.verbose: print("Optuna decided to prune!")
                         trial_logs[trial_num]["score"] = curr_weighted_avg_score
                         trial_logs[trial_num]["pruned"] = True
                         trial_num += 1 

--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -1,8 +1,4 @@
-import tqdm
-import random
-import dsp
 
-from dspy.evaluate.evaluate import Evaluate
 
 
 class Teleprompter:

--- a/dspy/teleprompt/teleprompt_optuna.py
+++ b/dspy/teleprompt/teleprompt_optuna.py
@@ -1,12 +1,8 @@
-import dsp
-import tqdm
-import random
 import optuna
 
 from dspy.teleprompt.teleprompt import Teleprompter
 
 from .bootstrap import BootstrapFewShot
-from .vanilla import LabeledFewShot
 
 from dspy.evaluate.evaluate import Evaluate
 

--- a/dspy/teleprompt/vanilla.py
+++ b/dspy/teleprompt/vanilla.py
@@ -1,4 +1,3 @@
-import dsp
 import random
 
 from .teleprompt import Teleprompter

--- a/examples/functional/repl.py
+++ b/examples/functional/repl.py
@@ -14,7 +14,7 @@ class PythonREPL:
     def run(self, command: str, timeout=5, globals={}, locals=None) -> Optional[str]:
         queue: multiprocessing.Queue = multiprocessing.Queue()
         p = multiprocessing.Process(
-            target=self.worker, args=(command, globals, locals, queue)
+            target=self.worker, args=(command, globals, locals, queue),
         )
         p.start()
         p.join(timeout)

--- a/examples/longformqa/longformqa_assertions.ipynb
+++ b/examples/longformqa/longformqa_assertions.ipynb
@@ -47,6 +47,12 @@
     "import os\n",
     "repo_clone_path = '/content/DSPy_LongFormQA_Cache'\n",
     "\n",
+    "# Check if '/content' is writable\n",
+    "if not os.access('/content', os.W_OK):\n",
+    "    # If '/content' is not writable, choose an alternative directory\n",
+    "    # Example: using a directory relative to the current working directory\n",
+    "    repo_clone_path = os.path.join(os.getcwd(), 'DSPy_LongFormQA_Cache')\n",
+    "\n",
     "# Set up the cache for this notebook\n",
     "os.environ[\"DSP_NOTEBOOK_CACHEDIR\"] = repo_clone_path"
    ]

--- a/examples/longformqa/utils.py
+++ b/examples/longformqa/utils.py
@@ -1,5 +1,4 @@
 import regex as re
-import os
 import nltk
 nltk.download('punkt')
 from nltk.tokenize import sent_tokenize

--- a/examples/quiz/quiz_assertions.ipynb
+++ b/examples/quiz/quiz_assertions.ipynb
@@ -37,6 +37,12 @@
     "import os\n",
     "repo_clone_path = '/content/DSPy_QuizGen_Cache'\n",
     "\n",
+    "# Check if '/content' is writable\n",
+    "if not os.access('/content', os.W_OK):\n",
+    "    # If '/content' is not writable, choose an alternative directory\n",
+    "    # Example: using a directory relative to the current working directory\n",
+    "    repo_clone_path = os.path.join(os.getcwd(), 'DSPy_QuizGen_Cache')\n",
+    "\n",
     "# Set up the cache for this notebook\n",
     "os.environ[\"DSP_NOTEBOOK_CACHEDIR\"] = repo_clone_path"
    ]

--- a/examples/tweets/tweet_metric.py
+++ b/examples/tweets/tweet_metric.py
@@ -38,7 +38,7 @@ def metric(gold, pred, trace=None):
         correct =  dspy.Predict(Assess)(context='N/A', assessed_text=tweet, assessment_question=correct)
         engaging = dspy.Predict(Assess)(context='N/A', assessed_text=tweet, assessment_question=engaging)
 
-    correct, engaging, faithful = [m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful]]
+    correct, engaging, faithful = (m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful])
     score = (correct + engaging + faithful) if correct and (len(tweet) <= 280) else 0
 
     if METRIC is not None:

--- a/examples/tweets/tweets_assertions.ipynb
+++ b/examples/tweets/tweets_assertions.ipynb
@@ -37,6 +37,12 @@
     "import os\n",
     "repo_clone_path = '/content/DSPy_TweetGen_Cache'\n",
     "\n",
+    "# Check if '/content' is writable\n",
+    "if not os.access('/content', os.W_OK):\n",
+    "    # If '/content' is not writable, choose an alternative directory\n",
+    "    # Example: using a directory relative to the current working directory\n",
+    "    repo_clone_path = os.path.join(os.getcwd(), 'DSPy_TweetGen_Cache')\n",
+    "\n",
     "# Set up the cache for this notebook\n",
     "os.environ[\"DSP_NOTEBOOK_CACHEDIR\"] = repo_clone_path"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -274,4 +274,5 @@ line-ending = "auto"
 convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
-"**/{test,docs}/*" = ["ALL"]
+"**/{tests,docs}/*" = ["ALL"]
+"**__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,6 +254,15 @@ ignore = [
     "RET505",
     # Within an `except` clause, raise exceptions with `raise
     "B904",
+    # We don't need docstrings for every method
+    "ANN202",
+    "D107",
+    "D102",
+    "D103",
+    # Inline lambdas
+    "E731",
+    # Sometimes we need List and Tuple
+    "UP006",
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 from setuptools import setup, find_packages	
 
 # Read the content of the README file	
-with open('README.md', 'r', encoding='utf-8') as f:	
+with open('README.md', encoding='utf-8') as f:	
     long_description = f.read()	
 
 # Read the content of the requirements.txt file	
-with open('requirements.txt', 'r', encoding='utf-8') as f:	
+with open('requirements.txt', encoding='utf-8') as f:	
     requirements = f.read().splitlines()	
 
 setup(	

--- a/testing/optimizer_tester.py
+++ b/testing/optimizer_tester.py
@@ -142,7 +142,7 @@ class OptimizerTester:
                 'view_data': False,
                 'optimizer_log_dir': 'NA',
                 'additional_notes': '',
-                'misc': ''
+                'misc': '',
             })
 
     def test_optimizer_default(self, optimizer_function, datasets=datasets, test_name="default"):
@@ -195,7 +195,7 @@ class OptimizerTester:
                 'view_data': False,
                 'optimizer_log_dir': log_dir,
                 'additional_notes': '',
-                'misc': ''
+                'misc': '',
             }
 
             output.update(output_dict)

--- a/testing/tasks/biodex.py
+++ b/testing/tasks/biodex.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 from .base_task import BaseTask
-import sys
 import dspy
 from dspy.evaluate import Evaluate
 from dsp.utils import deduplicate
 import tqdm
 import datasets
-import sys
 import math
 from functools import lru_cache
 import os
@@ -80,19 +78,19 @@ class Node(BaseModel):
     level: Level
     count: int = 0
 
-    parent: 'Node' = None
-    children: Dict[str, 'Node'] = {}
+    parent: Node = None
+    children: Dict[str, Node] = {}
 
     # maps for efficient nested children lookups
     # typically only used for the root node
-    id_to_nodes: Optional[DefaultDict[str, List['Node']]] = None
-    term_to_nodes: Optional[DefaultDict[str, List['Node']]] = None
+    id_to_nodes: Optional[DefaultDict[str, List[Node]]] = None
+    term_to_nodes: Optional[DefaultDict[str, List[Node]]] = None
 
     # text normalizer to build lookup tables
     # typically only used for the root node
     normalizer: function = lambda x: x
 
-    def get_parent_at_level(self, target_level: Level) -> Union['Node', None]:
+    def get_parent_at_level(self, target_level: Level) -> Union[Node, None]:
         # check if current node is deeper than target_level
         level_diff = target_level - self.level
         if level_diff > 0:
@@ -103,10 +101,10 @@ class Node(BaseModel):
                 node = node.parent
             return node
 
-    def get_children_at_level(self, target_level: Level) -> List['Node']:
+    def get_children_at_level(self, target_level: Level) -> List[Node]:
         raise NotImplementedError
 
-    def lookup_id(self, id: str) -> Union[List['Node'], None]:
+    def lookup_id(self, id: str) -> Union[List[Node], None]:
         # create lookup tables if they do not exists
         if self.id_to_nodes == None:
             self.set_lookup_tables()
@@ -117,7 +115,7 @@ class Node(BaseModel):
         else:
             return None
 
-    def lookup_term(self, term: str) -> Union[List['Node'], None]:
+    def lookup_term(self, term: str) -> Union[List[Node], None]:
         # create lookup tables if they do not exists
         if self.term_to_nodes == None:
             raise RuntimeError("First set the lookup tables using 'set_lookup_tables'.")
@@ -198,9 +196,9 @@ class Node(BaseModel):
             # add candidate's children to candidate list
             if candidate.children:
                 candidates.extend(candidate.children.values())
-        return None
+        return
 
-    def is_equivalent_node(self, other: 'Node') -> bool:
+    def is_equivalent_node(self, other: Node) -> bool:
         # return true if two nodes are the same, siblings or in a parent-child relation
         return (
             (self == other)
@@ -229,7 +227,7 @@ class Node(BaseModel):
     def __hash__(self):
         return hash(self.__key())
 
-    def __eq__(self, other: 'Node') -> bool:
+    def __eq__(self, other: Node) -> bool:
         # undeep equals operator, does not check children
         return self.__key() == other.__key()
 
@@ -258,7 +256,7 @@ class Match(BaseModel):
     query: str
 
 def _create_child_if_not_exists(
-    parent: Node, child_id: str, child_term: str, term_to_count: dict
+    parent: Node, child_id: str, child_term: str, term_to_count: dict,
 ):
     parent_level = parent.level
     # get child level if still appropriate
@@ -276,7 +274,7 @@ def _create_child_if_not_exists(
         else:
             count = 0
         child = Node(
-            id=child_id, term=child_term, level=child_level, parent=parent, count=count
+            id=child_id, term=child_term, level=child_level, parent=parent, count=count,
         )
         parent.children.update({child_id: child})
     return child
@@ -297,7 +295,7 @@ def parse_mdhier(data_dir):
 
     # get data
     lines = []
-    with open(file, "r") as fp:
+    with open(file) as fp:
         lines = fp.readlines()
     text = "\n".join(lines)
 
@@ -306,7 +304,7 @@ def parse_mdhier(data_dir):
     print(f"Read {len(lines)} lines.")
     if len(lines) != len(matches):
         raise RuntimeError(
-            f"Error parsing mdhier.asc. Expected number of matches to match number of lines."
+            "Error parsing mdhier.asc. Expected number of matches to match number of lines.",
         )
 
     # load counts
@@ -562,7 +560,7 @@ def extract_reactions_from_strings(reactions):
     return reactions
 
 class PredictReactions(dspy.Signature):
-    __doc__ = f"""Given a snippet from a medical article, identify the adverse drug reactions affecting the patient. If none are mentioned in the snippet, say N/A."""
+    __doc__ = """Given a snippet from a medical article, identify the adverse drug reactions affecting the patient. If none are mentioned in the snippet, say N/A."""
 
     title = dspy.InputField()
     context = dspy.InputField()

--- a/testing/tasks/scone.py
+++ b/testing/tasks/scone.py
@@ -27,7 +27,7 @@ def load_scone(dirname):
             "context": row['sentence1' + suffix],
             "question": question,
             "answer": label,
-            "category": row['category']
+            "category": row['category'],
         }).with_inputs("context", "question")
 
     return list(data_df.apply(as_example, axis=1).values)

--- a/testing/tasks/tweet.py
+++ b/testing/tasks/tweet.py
@@ -1,7 +1,6 @@
 import dspy
 from dspy.datasets import HotPotQA
 from .base_task import BaseTask
-from dspy.evaluate import Evaluate
 from functools import lru_cache
 import openai
 from dotenv import load_dotenv
@@ -45,7 +44,7 @@ class Assess(dspy.Signature):
     assessment_question = dspy.InputField()
     assessment_answer = dspy.OutputField(desc="Yes or No")
 
-@lru_cache()
+@lru_cache
 def load_models():
     load_dotenv()  # This will load the .env file's variables
 
@@ -74,7 +73,7 @@ def metric(gold, pred, trace=None):
         correct =  dspy.Predict(Assess)(context='N/A', assessed_text=tweet, assessment_question=correct)
         engaging = dspy.Predict(Assess)(context='N/A', assessed_text=tweet, assessment_question=engaging)
 
-    correct, engaging, faithful = [m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful]]
+    correct, engaging, faithful = (m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful])
     score = (correct + engaging + faithful) if correct and (len(tweet) <= 280) else 0
 
     if METRIC is not None:

--- a/testing/tasks/tweet_metric.py
+++ b/testing/tasks/tweet_metric.py
@@ -1,7 +1,6 @@
 import dspy
 from dspy.datasets import HotPotQA
 from .base_task import BaseTask
-from dspy.evaluate import Evaluate
 from dspy import Example
 from functools import lru_cache
 import openai
@@ -48,7 +47,7 @@ class Assess(dspy.Signature):
     assessment_question = dspy.InputField()
     assessment_answer = dspy.OutputField(desc="Yes or No")
 
-@lru_cache()
+@lru_cache
 def load_models():
     load_dotenv()  # This will load the .env file's variables
 
@@ -76,7 +75,7 @@ def metric(gold, pred, trace=None):
         correct =  dspy.Predict(Assess)(context='N/A', assessed_text=tweet, assessment_question=correct)
         engaging = dspy.Predict(Assess)(context='N/A', assessed_text=tweet, assessment_question=engaging)
 
-    correct, engaging, faithful = [m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful]]
+    correct, engaging, faithful = (m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful])
     score = (correct + engaging + faithful) if correct and (len(tweet) <= 280) else 0
 
     return 1 - abs(score - score_pred) # We want a score we can maximize, so take the negative L1 norm and add 1
@@ -98,7 +97,7 @@ class TweetMetric(dspy.Module):
         correct =  self.correct(context='N/A', assessed_text=tweet, assessment_question=correct)
         engaging = self.engaging(context='N/A', assessed_text=tweet, assessment_question=engaging)
 
-        correct, engaging, faithful = [m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful]]
+        correct, engaging, faithful = (m.assessment_answer.split()[0].lower() == 'yes' for m in [correct, engaging, faithful])
         score = (correct + engaging + faithful) if correct and (len(tweet) <= 280) else 0
 
         return dspy.Prediction(score= score/3.0)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -259,7 +259,7 @@ def test_bootstrap_effectiveness():
         Follow the following format.
 
         Input: ${input}
-        Output: ${output}. Respond with a single str value
+        Output: ${output}
 
         ---
 


### PR DESCRIPTION
As per our discussions, I ran `ruff . --fix` on the entire code base.
I had to change a few things to get the tests to still run:
```
[tool.ruff.lint.per-file-ignores]
"**/{tests,docs}/*" = ["ALL"]
"**__init__.py" = ["F401"]
```
The first line just disables linting/error fixing on the tests.
This was necessary, because some tests do stuff like importing `List` rather than using `list`, because it wants to be backwards compatible.
The line `"**__init__.py" = ["F401"]` prevents `ruff` from removing unused imports in `__init__.py` files, which are used to make those modules publicly available.