### PR TITLE
BootstrapFewShot failing due to lm.copy for AzureOpenAI, #521

### DIFF
--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -107,6 +107,9 @@ class AzureOpenAI(LM):
             kwargs["model"] = model
 
         self.kwargs = {
+            "api_base": api_base,
+            "api_version": api_version,
+            "api_key": api_key,
             "temperature": 0.0,
             "max_tokens": 150,
             "top_p": 1,

--- a/dsp/modules/lm.py
+++ b/dsp/modules/lm.py
@@ -101,4 +101,4 @@ class LM(ABC):
         kwargs = {**self.kwargs, **kwargs}
         model = kwargs.pop('model')
 
-        return self.__class__(model, **kwargs)
+        return self.__class__(model=model, **kwargs)


### PR DESCRIPTION
BootstrapFewShot failing due to lm.copy for AzureOpenAI, likely due to positional argument issue from recent changes.

- Issue: https://github.com/stanfordnlp/dspy/issues/521

### Environment
- code: 98304a2eb9d1dddaaa846e30258cd5d8fc6b5d8d
- model azure openai

### Error message
- during `BootstrapFewShot` run, code errored out due to missing arguments, `api_version`

```
>[dspy/dsp/modules/lm.py](https://file+.vscode-resource.vscode-cdn.net/Users/insop/Projects/Github/NLP/dspy/dsp/modules/lm.py)(106)copy()
    102         model = kwargs.pop('model')
    105
--> 106         return self.__class__(model, **kwargs)
```

### Changes

AzureOpenAI expects positional arguments, so it is failing. I am putting my change for review if that will impact other models.

```
class AzureOpenAI(LM):
...

    def __init__(
        self,
        api_base: str,
        api_version: str,
        model: str = "gpt-3.5-turbo-instruct",
        api_key: Optional[str] = None,
        model_type: Literal["chat", "text"] = "chat",
        **kwargs,
    ):