### PR TITLE
Add `wandb` logging to `BootstrapFewShot`'s `metric_val`

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -49,7 +49,7 @@ class BootstrapFewShot(Teleprompter):
 
         self._prepare_student_and_teacher(student, teacher)
         self._prepare_predictor_mappings()
-        self._bootstrap(wandb_enabled)
+        self._bootstrap(wandb_enabled=wandb_enabled)
 
         self.student = self._train()
         self.student._compiled = True
@@ -94,8 +94,7 @@ class BootstrapFewShot(Teleprompter):
         self.name2predictor = name2predictor
         self.predictor2name = predictor2name
 
-    def _bootstrap(self, *, max_bootstraps=None, wandb_config=None):
-        wandb_enabled = True if wandb_config is not None else False
+    def _bootstrap(self, *, max_bootstraps=None, wandb_enabled=False):
         max_bootstraps = max_bootstraps or self.max_bootstrapped_demos
 
         bootstrapped = {}

--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -150,7 +150,7 @@ class BootstrapFewShot(Teleprompter):
                     metric_val = self.metric(example, prediction, trace)
                     if wandb_enabled:
                         wandb.log({
-                            "metric_val": metric_val
+                            "metric_val": metric_val,
                         })
                     if self.metric_threshold:
                         success = metric_val >= self.metric_threshold


### PR DESCRIPTION
Weights & Biases (wandb) are one of the industry leaders in experiment tracking software for Machine Learning.

I think `runs` and `sweeps` both offer significant value to monitoring DSPy optimization runs.

This PR will add wandb logging to `BootstrapFewShot` to log the values of `metric_val` as the teacher model is bootstrapping traces through the program.

Intended use:

```
# connect to wandb project
wandb.init(
  project: "my-dspy-program",
  config = {
    "program": "Perspective-Guided-STORM",
    "teacherLM": "GPT4"
  }
)

# wandb logging is internal to the `teleprompter.compile` call
# ^ you just add values to the project with wandb.log(...)

compiled_progarm = teleprompter.compile(PG_STORM, trainset=trainset, ...)
```

I think this will be especially effective when say looping through program configurations (in terms of multi-model design or the composition of modules) or teacherLMs.

As a result, DSPy users will have a nice visualization of how effectively the teacher LM is able to bootstrap traces through the program that surpass the `metric_threshold`.

I think this is a nice building block, but generally the wandb integration will be more effective with higher-level optimizers such as `BootstrapFewShotRandomSearch`, `BootstrapFewShotWithOptuna`, or the `BayesianSignatureOptimizer`.