### PR TITLE
Add support for neo4j vector index

### DIFF
--- a/docs/api/retrieval_model_clients/Neo4jRM.md
+++ b/docs/api/retrieval_model_clients/Neo4jRM.md
@@ -28,6 +28,8 @@ You need to define the credentials as environment variables:
 
 - `NEO4J_DATABASE` (_str_, optional): Specifies the name of the database to connect to within the Neo4j instance. If not set, the system defaults to using `"neo4j"` as the database name. This allows for flexibility in connecting to different databases within a single Neo4j server.
 
+- `OPENAI_API_KEY` (_str_): Specifies the API key required for authenticiating with OpenAI's services.
+
 **Parameters:**
 - `index_name` (_str_): Specifies the name of the vector index to be used within Neo4j for organizing and querying data.
 - `text_node_property` (_str_, _optional_): Defines the specific property of nodes that will be returned.
@@ -67,6 +69,7 @@ import os
 os.environ["NEO4J_URI"] = 'bolt://localhost:7687'
 os.environ["NEO4J_USERNAME"] = 'neo4j'
 os.environ["NEO4J_PASSWORD"] = 'password'
+os.environ["OPENAI_API_KEY"] = 'sk-'
 
 retriever_model = Neo4jRM(
     index_name="vector",

--- a/docs/api/retrieval_model_clients/Neo4jRM.md
+++ b/docs/api/retrieval_model_clients/Neo4jRM.md
@@ -1,0 +1,80 @@
+
+# retrieve.neo4j_rm
+
+### Constructor
+
+Initialize an instance of the `Neo4jRM` class.
+
+```python
+Neo4jRM(
+    index_name: str,
+    text_node_property: str,
+    k: int = 5,
+    retrieval_query: str = None,
+    embedding_provider: str = "openai",
+    embedding_model: str = "text-embedding-ada-002",
+)
+```
+
+**Environment Variables:**
+
+You need to define the credentials as environment variables:
+
+- `NEO4J_USERNAME` (_str_): Specifies the username required for authenticating with the Neo4j database. This is a crucial security measure to ensure that only authorized users can access the database.
+
+- `NEO4J_PASSWORD` (_str_): Defines the password associated with the `NEO4J_USERNAME` for authentication purposes. This password should be kept secure to prevent unauthorized access to the database.
+
+- `NEO4J_URI` (_str_): Indicates the Uniform Resource Identifier (URI) used to connect to the Neo4j database. This URI typically includes the protocol, hostname, and port, providing the necessary information to establish a connection to the database.
+
+- `NEO4J_DATABASE` (_str_, optional): Specifies the name of the database to connect to within the Neo4j instance. If not set, the system defaults to using `"neo4j"` as the database name. This allows for flexibility in connecting to different databases within a single Neo4j server.
+
+**Parameters:**
+- `index_name` (_str_): Specifies the name of the vector index to be used within Neo4j for organizing and querying data.
+- `text_node_property` (_str_, _optional_): Defines the specific property of nodes that will be returned.
+- `k` (_int_, _optional_): The number of top results to return from the retrieval operation. It defaults to 5 if not explicitly specified.
+- `retrieval_query` (_str_, _optional_): A custom query string provided for retrieving data. If not provided, a default query tailored to the `text_node_property` will be used.
+- `embedding_provider` (_str_, _optional_): The name of the service provider for generating embeddings. Defaults to "openai" if not specified.
+- `embedding_model` (_str_, _optional_): The specific embedding model to use from the provider. By default, it uses the "text-embedding-ada-002" model from OpenAI.
+
+
+### Methods
+
+#### `forward(self, query: [str], k: Optional[int] = None) -> dspy.Prediction`
+
+Search the neo4j vector index for the top `k` passages matching the given query or queries, using embeddings generated via the specified `embedding_model`.
+
+**Parameters:**
+- `query` (str_): The query.
+- `k` (_Optional[int]_, _optional_): The number of results to retrieve. If not specified, defaults to the value set during initialization.
+
+**Returns:**
+- `dspy.Prediction`: Contains the retrieved passages as a list of string with the prediction signature.
+
+ex:
+```python
+Prediction(
+    passages=['Passage 1 Lorem Ipsum awesome', 'Passage 2 Lorem Ipsum Youppidoo', 'Passage 3 Lorem Ipsum Yassssss']
+)
+```
+
+### Quick Example how to use Neo4j in a local environment. 
+
+
+```python
+from dspy.retrieve.neo4j_rm import Neo4jRM
+import os
+
+os.environ["NEO4J_URI"] = 'bolt://localhost:7687'
+os.environ["NEO4J_USERNAME"] = 'neo4j'
+os.environ["NEO4J_PASSWORD"] = 'password'
+
+retriever_model = Neo4jRM(
+    index_name="vector",
+    text_node_property="text"
+)
+
+results = retriever_model("Explore the significance of quantum computing", k=3)
+
+for passage in results.passages:
+    print("Document:", result, "\n")
+```

--- a/dspy/retrieve/neo4j_rm.py
+++ b/dspy/retrieve/neo4j_rm.py
@@ -94,11 +94,11 @@ class Neo4jRM(dspy.Retrieve):
             query_or_queries = [query_or_queries]
         query_vectors = self.embedder(query_or_queries)
         contents = []
-        retrieval_query = self.retrieval_query or f"RETURN node.{self.text_node_property} AS output"
+        retrieval_query = self.retrieval_query or f"RETURN node.{self.text_node_property} AS text"
         for vector in query_vectors:
             records, _, _ = self.driver.execute_query(
                 DEFAULT_INDEX_QUERY + retrieval_query,
                 {"embedding": vector, "index": self.index_name, "k": k or self.k},
             )
-            contents.extend([dotdict({"long_text": r["output"]}) for r in records])
+            contents.extend([dotdict({"long_text": r["text"]}) for r in records])
         return contents

--- a/dspy/retrieve/neo4j_rm.py
+++ b/dspy/retrieve/neo4j_rm.py
@@ -1,0 +1,104 @@
+import os
+from typing import Any, List, Optional, Union
+
+import backoff
+from openai import (
+    APITimeoutError,
+    InternalServerError,
+    OpenAI,
+    RateLimitError,
+    UnprocessableEntityError,
+)
+
+import dspy
+from dsp.utils import dotdict
+
+try:
+    from neo4j import GraphDatabase
+    from neo4j.exceptions import (
+        AuthError,
+        ServiceUnavailable,
+    )
+except ImportError:
+    raise ImportError(
+        "Please install the neo4j package by running `pip install dspy-ai[neo4j]`",
+    )
+
+
+class Embedder:
+    def __init__(self, provider: str, model: str):
+        if provider == "openai":
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise ValueError("Environment variable OPENAI_API_KEY must be set")
+            self.client = OpenAI()
+            self.model = model
+
+    @backoff.on_exception(
+        backoff.expo,
+        (
+            APITimeoutError,
+            InternalServerError,
+            RateLimitError,
+            UnprocessableEntityError,
+        ),
+        max_time=15,
+    )
+    def __call__(self, queries) -> Any:
+        embedding = self.client.embeddings.create(input=queries, model=self.model)
+        return [result.embedding for result in embedding.data]
+
+
+DEFAULT_INDEX_QUERY = "CALL db.index.vector.queryNodes($index, $k, $embedding) YIELD node, score "
+
+
+class Neo4jRM(dspy.Retrieve):
+    def __init__(
+        self,
+        index_name: str,
+        text_node_property: str,
+        k: int = 5,
+        retrieval_query: str = None,
+        embedding_provider: str = "openai",
+        embedding_model: str = "text-embedding-ada-002",
+    ):
+        super().__init__(k=k)
+        self.index_name = index_name
+        self.username = os.getenv("NEO4J_USERNAME")
+        self.password = os.getenv("NEO4J_PASSWORD")
+        self.uri = os.getenv("NEO4J_URI")
+        self.database = os.getenv("NEO4J_DATABASE")
+        self.k = k
+        self.retrieval_query = retrieval_query
+        self.text_node_property = text_node_property
+        if not self.username:
+            raise ValueError("Environment variable NEO4J_USERNAME must be set")
+        if not self.password:
+            raise ValueError("Environment variable NEO4J_PASSWORD must be set")
+        if not self.uri:
+            raise ValueError("Environment variable NEO4J_URI must be set")
+        try:
+            self.driver = GraphDatabase.driver(self.uri, auth=(self.username, self.password))
+            self.driver.verify_connectivity()
+
+        except (
+            ServiceUnavailable,
+            AuthError,
+        ) as e:
+            raise ConnectionError("Failed to connect to Neo4j database") from e
+
+        self.embedder = Embedder(provider=embedding_provider, model=embedding_model)
+
+    def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int]) -> dspy.Prediction:
+        if not isinstance(query_or_queries, list):
+            query_or_queries = [query_or_queries]
+        query_vectors = self.embedder(query_or_queries)
+        contents = []
+        retrieval_query = self.retrieval_query or f"RETURN node.{self.text_node_property} AS output"
+        for vector in query_vectors:
+            records, _, _ = self.driver.execute_query(
+                DEFAULT_INDEX_QUERY + retrieval_query,
+                {"embedding": vector, "index": self.index_name, "k": k or self.k},
+            )
+            contents.extend([dotdict({"long_text": r["output"]}) for r in records])
+        return contents


### PR DESCRIPTION
Neo4j has a vector index that can be used for vector retrieval in RAG in other applications. It can be expanded with retrieval query, so that it can traverse through the graph after the initial vector search if needed.