### PR TITLE
Fix _print_signature() for verbose=True

### DIFF
--- a/dspy/teleprompt/signature_opt.py
+++ b/dspy/teleprompt/signature_opt.py
@@ -96,7 +96,7 @@ class SignatureOptimizer(Teleprompter):
             else:
                 signature = predictor.extended_signature1
             print(f"i: {signature.instructions}")
-            print(f"p: {list(signature.fields().values())[-1].json_schema_extra['prefix']}")
+            print(f"p: {list(signature.fields.values())[-1].json_schema_extra['prefix']}")
             print()
 
     


### PR DESCRIPTION
Fix the following error:

```
[/usr/local/lib/python3.10/dist-packages/dspy/teleprompt/signature_opt.py](https://localhost:8080/#) in _print_signature(self, predictor)
     96                 signature = predictor.extended_signature1
     97             # print(f"i: {signature.instructions}")
---> 98             # print(f"p: {list(signature.fields().values())[-1].json_schema_extra['prefix']}")
     99             print()
    100 

TypeError: 'dict' object is not callable
```

for [Signature Optimizer example](https://dspy-docs.vercel.app/docs/deep-dive/teleprompter/signature-optimizer). Also, `compiled_prompt_opt = teleprompter.compile(cot, devset=devset, eval_kwargs=kwargs)` should be changed to `compiled_prompt_opt = teleprompter.compile(cot_baseline, devset=devset, eval_kwargs=kwargs)`