### PR TITLE
Introduce dspy.Template

### DIFF
--- a/dspy/backends/template.py
+++ b/dspy/backends/template.py
@@ -40,9 +40,6 @@ class TemplateBackend(BaseBackend):
         pred = self.lm(template(example), **kwargs)
 
         # This returns a list of Examples
-        for prediction in pred:
-            print(prediction.message.content)
-
         extracted = [
             template.extract(example, prediction.message.content) for prediction in pred
         ]

--- a/dspy/backends/template.py
+++ b/dspy/backends/template.py
@@ -1,5 +1,6 @@
 from dspy.signatures.signature import Signature, signature_to_template
 from dspy.primitives.example import Example
+from dspy.primitives.template import Template
 
 import typing as t
 from .base import BaseBackend, GeneratedOutput
@@ -30,7 +31,7 @@ class TemplateBackend(BaseBackend):
         example = Example(demos=demos, **kwargs)
 
         # Generate Template
-        template = signature_to_template(signature)
+        template = Template(signature)
 
         # Clean Up Kwargs Before Sending Through Language Model
         for input in signature.input_fields:
@@ -39,6 +40,9 @@ class TemplateBackend(BaseBackend):
         pred = self.lm(template(example), **kwargs)
 
         # This returns a list of Examples
+        for prediction in pred:
+            print(prediction.message.content)
+
         extracted = [
             template.extract(example, prediction.message.content) for prediction in pred
         ]

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -3,3 +3,4 @@ from .program import *
 from .prediction import *
 from .assertions import *
 from .python_interpreter import *
+from .template import *

--- a/dspy/primitives/template.py
+++ b/dspy/primitives/template.py
@@ -108,6 +108,9 @@ class Template:
 
         """
 
+        # We have to deepcopy, so that the values dont continously overwrite each other.
+        example = example.copy()
+
         full_text = self.__call__(example) + raw_pred
 
         if not full_text.endswith("\n\n---"):

--- a/dspy/primitives/template.py
+++ b/dspy/primitives/template.py
@@ -1,0 +1,119 @@
+import typing as t
+from dspy.signatures.signature import Signature
+from dspy.primitives.example import Example
+
+
+def passages_to_text(passages: t.Iterable[str]) -> str:
+    assert len(passages) > 0
+
+    return "\n".join([f"[{idx + 1}] <<{text}>>" for idx, text in enumerate(passages)])
+
+
+def format_answers(answers: t.Iterable[str]) -> str:
+    assert len(answers) > 0
+    return (answers[0]).strip()
+
+
+def default_format_handler(x: str) -> str:
+    assert type(x) == str
+    return " ".join(x.split())
+
+
+class Template:
+    def __init__(self, signature: Signature, **kwargs):
+        self.signature = signature
+        self.kwargs = kwargs
+
+        self.format_handlers: dict[str, t.Callable] = {
+            "context": passages_to_text,
+            "passages": passages_to_text,
+            "answers": format_answers,
+        }
+
+        for key, field in signature.fields.items():
+            format = field.json_schema_extra.get("format")
+            if format:
+                self.format_handlers[key] = format
+
+    def query(self, example: Example, is_demo: bool = False) -> str:
+        result = []
+
+        # Fill in Output Variable Values in Example and ensure all params are provided
+        if not is_demo:
+            for field in self.signature.fields:
+                if field not in example:
+                    example[field] = ""
+                    break
+
+        # Iterate through Fields
+        for name, field in self.signature.fields.items():
+            if name in self.format_handlers:
+                format_handler = self.format_handlers[name]
+            else:
+                format_handler = default_format_handler
+
+            formatted_value = format_handler(example[name])
+
+            result.append(f"{name.capitalize()}: {formatted_value}")
+
+        return "\n".join(result)
+
+    def guidelines(self) -> str:
+        """Returns the task guidelines as described in the lm prompt"""
+        result = "Follow the following format.\n\n"
+
+        example = Example()
+        field_strings = []
+        for name, field in self.signature.fields.items():
+            field_strings.append(
+                f"{name.capitalize()}: {field.json_schema_extra['desc']}"
+            )
+
+        return result + "\n".join(field_strings)
+
+    def extract(self, example: Example, raw_pred: str) -> Example:
+        """Extracts the answer from the LM raw prediction using the template structure
+
+        Args:
+            example (Example): Contains the input variables that raw_pred was completed on.
+            raw_pred (str): LM generated field_strings
+
+        Returns:
+            Example: The example with the output variables filled in
+
+        """
+
+        output_fields = [
+            (name, field)
+            for name, field in self.signature.fields.items()
+            if field.json_schema_extra["__dspy_field_type"] == "output"
+        ]
+
+        example[output_fields[0][0]] = raw_pred
+
+        return example
+
+    def __call__(self, example: Example, show_guidelines: bool = True) -> str:
+        prompt_spans = []
+
+        # Start by getting the instructions
+        prompt_spans.append(self.signature.instructions)
+
+        # Generate the Guidelines
+        prompt_spans.append(self.guidelines())
+
+        # Generate Spans for Each Demo
+        field_names = list(self.signature.fields.keys())
+        for demo in example.demos:
+            demo_example = Example()
+            for idx, variable in enumerate(demo):
+                print(idx, variable, field_names)
+                name = field_names[idx]
+                demo_example[name] = variable
+
+            prompt_spans.append(self.query(demo_example))
+
+        # Generate Empty Demo for Generation
+        prompt_spans.append(self.query(example))
+
+        return "\n\n---\n\n".join([span.strip() for span in prompt_spans])

--- a/dspy/primitives/template.py
+++ b/dspy/primitives/template.py
@@ -120,7 +120,7 @@ class Template:
             if len(search_strings) > 0:
                 search_strings[-1] += f"{field.json_schema_extra['prefix']}"
 
-            target_str = f"(?s){field.json_schema_extra['prefix']}\\s(.+?)"
+            target_str = f"(?s){field.json_schema_extra['prefix']}\\s?(.+?)"
             if idx != len(self.signature.output_fields) - 1:
                 target_str += "\\n\\n"
             else:
@@ -139,18 +139,10 @@ class Template:
                 example[output_fields[0]] = matches[-1]
 
         else:
-            count = None
             for idx, field in enumerate(output_fields):
-                matches = regex.findall(search_strings[idx], raw_pred)
-                if count is not None and len(matches) != count:
-                    break
-
-                count = len(matches)
-
-                print(matches)
+                matches = regex.findall(search_strings[idx], full_text)
 
                 if len(matches) > 0:
-                    print(matches[-1])
                     example[field] = matches[-1]
 
         return example

--- a/tests/primitives/test_template.py
+++ b/tests/primitives/test_template.py
@@ -1,0 +1,45 @@
+import pytest
+from dspy import Example, Signature, InputField, OutputField
+from dspy.primitives import Template
+
+
+class Emotion(Signature):
+    """Classify emotion among sadness, joy, love, anger, fear, surprise."""
+
+    sentence = InputField()
+    sentiment = OutputField()
+
+
+EXAMPLE_TEMPLATE_PROMPTS = [
+    (
+        Emotion,
+        [],
+        "This is a positive test sentence.",
+        "Joy",
+        "Joy",
+        "Classify emotion among sadness, joy, love, anger, fear, surprise.\n\n---\n\nFollow the following format.\n\nSentence: ${sentence}\nSentiment: ${sentiment}\n\n---\n\nSentence: This is a positive test sentence.\nSentiment:",
+    )
+]
+
+
+def test_example_initialization():
+    for signature, demos, sentence, _, _, prompt in EXAMPLE_TEMPLATE_PROMPTS:
+        template = Template(signature)
+        example = Example(sentence=sentence, demos=demos)
+        assert template(example) == prompt
+
+
+def test_template_extraction():
+    for (
+        signature,
+        demos,
+        sentence,
+        sentiment,
+        output,
+        _,
+    ) in EXAMPLE_TEMPLATE_PROMPTS:
+        template = Template(signature)
+        example = Example(sentence=sentence, demos=demos)
+        assert template.extract(example, output) == Example(
+            sentence=sentence, demos=demos, sentiment=sentiment
+        )

--- a/tests/primitives/test_template.py
+++ b/tests/primitives/test_template.py
@@ -26,7 +26,7 @@ class COTCheckCitationFaithfulness(Signature):
     context = InputField(desc="facts here are assumed to be true")
     text = InputField()
     rationale = OutputField(
-        desc="${produce the faithfulness}. We ...",
+        desc="Think step by step in order to generate the faithfulness.",
     )
     faithfulness = OutputField(
         desc="True/False indicating if text is faithful to context"
@@ -34,29 +34,29 @@ class COTCheckCitationFaithfulness(Signature):
 
 
 TEMPLATE_SCENARIOS = [
-    # {
-    #     "signature": Emotion,
-    #     "output": "Joy",
-    #     "input_kwargs": {
-    #         "sentence": "This is a positive test sentence.",
-    #     },
-    #     "output_kwargs": {"sentiment": "Joy"},
-    #     "prompt": "Classify emotion among sadness, joy, love, anger, fear, surprise.\n\n---\n\nFollow the following format.\n\nSentence: ${sentence}\nSentiment: ${sentiment}\n\n---\n\nSentence: This is a positive test sentence.\nSentiment:",
-    # },
-    # {
-    #     "signature": CheckCitationFaithfulness,
-    #     "output": "False",
-    #     "input_kwargs": {
-    #         "context": [
-    #             "The 21-year-old made seven appearances for the Hammers and netted his only goal for them in a Europa League qualification round match against Andorran side FC Lustrains last season. Lee had two loan spells in League One last term, with Blackpool and then Colchester United. He scored twice for the U's but was unable to save them from relegation. The length of Lee's contract with the promoted Tykes has not been revealed. Find all the latest football transfers on our dedicated page."
-    #         ],
-    #         "text": "Lee scored 3 goals for Colchester United.",
-    #     },
-    #     "output_kwargs": {
-    #         "faithfulness": "False",
-    #     },
-    #     "prompt": "Verify that the text is based on the provided context.\n\n---\n\nFollow the following format.\n\nContext: facts here are assumed to be true\nText: ${text}\nFaithfulness: True/False indicating if text is faithful to context\n\n---\n\nContext: The 21-year-old made seven appearances for the Hammers and netted his only goal for them in a Europa League qualification round match against Andorran side FC Lustrains last season. Lee had two loan spells in League One last term, with Blackpool and then Colchester United. He scored twice for the U's but was unable to save them from relegation. The length of Lee's contract with the promoted Tykes has not been revealed. Find all the latest football transfers on our dedicated page.\nText: Lee scored 3 goals for Colchester United.\nFaithfulness:",
-    # },
+    {
+        "signature": Emotion,
+        "output": "Joy",
+        "input_kwargs": {
+            "sentence": "This is a positive test sentence.",
+        },
+        "output_kwargs": {"sentiment": "Joy"},
+        "prompt": "Classify emotion among sadness, joy, love, anger, fear, surprise.\n\n---\n\nFollow the following format.\n\nSentence: ${sentence}\n\nSentiment: ${sentiment}\n\n---\n\nSentence: This is a positive test sentence.\n\nSentiment:",
+    },
+    {
+        "signature": CheckCitationFaithfulness,
+        "output": "False",
+        "input_kwargs": {
+            "context": [
+                "The 21-year-old made seven appearances for the Hammers and netted his only goal for them in a Europa League qualification round match against Andorran side FC Lustrains last season. Lee had two loan spells in League One last term, with Blackpool and then Colchester United. He scored twice for the U's but was unable to save them from relegation. The length of Lee's contract with the promoted Tykes has not been revealed. Find all the latest football transfers on our dedicated page."
+            ],
+            "text": "Lee scored 3 goals for Colchester United.",
+        },
+        "output_kwargs": {
+            "faithfulness": "False",
+        },
+        "prompt": "Verify that the text is based on the provided context.\n\n---\n\nFollow the following format.\n\nContext: facts here are assumed to be true\n\nText: ${text}\n\nFaithfulness: True/False indicating if text is faithful to context\n\n---\n\nContext: The 21-year-old made seven appearances for the Hammers and netted his only goal for them in a Europa League qualification round match against Andorran side FC Lustrains last season. Lee had two loan spells in League One last term, with Blackpool and then Colchester United. He scored twice for the U's but was unable to save them from relegation. The length of Lee's contract with the promoted Tykes has not been revealed. Find all the latest football transfers on our dedicated page.\n\nText: Lee scored 3 goals for Colchester United.\n\nFaithfulness:",
+    },
     {
         "signature": COTCheckCitationFaithfulness,
         "output": "Faithfulness: False",
@@ -71,7 +71,7 @@ TEMPLATE_SCENARIOS = [
             "rationale": "produce the faithfulness. We know that Lee had two loan spells in League One last term, with Blackpool and then Colchester United. He scored twice for the U's but was unable to save them from relegation. However, there is no mention of him scoring three goals for Colchester United.",
             "faithfulness": "False",
         },
-        "prompt": "Verify that the text is based on the provided context.\n\n---\n\nFollow the following format.\n\nContext: facts here are assumed to be true\n\nText: ${text}\n\nRationale: Let's think step by step in order to ${produce the faithfulness}. We ...\n\nFaithfulness: True/False indicating if text is faithful to context\n\n---\n\nContext: The 21-year-old made seven appearances for the Hammers and netted his only goal for them in a Europa League qualification round match against Andorran side FC Lustrains last season. Lee had two loan spells in League One last term, with Blackpool and then Colchester United. He scored twice for the U's but was unable to save them from relegation. The length of Lee's contract with the promoted Tykes has not been revealed. Find all the latest football transfers on our dedicated page.\n\nText: Lee scored 3 goals for Colchester United.\n\nRationale: Let's think step by step in order to",
+        "prompt": "Verify that the text is based on the provided context.\n\n---\n\nFollow the following format.\n\nContext: facts here are assumed to be true\n\nText: ${text}\n\nRationale: Think step by step in order to generate the faithfulness.\n\nFaithfulness: True/False indicating if text is faithful to context\n\n---\n\nContext: The 21-year-old made seven appearances for the Hammers and netted his only goal for them in a Europa League qualification round match against Andorran side FC Lustrains last season. Lee had two loan spells in League One last term, with Blackpool and then Colchester United. He scored twice for the U's but was unable to save them from relegation. The length of Lee's contract with the promoted Tykes has not been revealed. Find all the latest football transfers on our dedicated page.\n\nText: Lee scored 3 goals for Colchester United.\n\nRationale:",
     },
 ]
 


### PR DESCRIPTION
The original implementation of `TemplateBackend` relied upon the `signature_to_template` function. This would take in a `dspy.Signature` and return a `dsp.Template`. However, we would pass `dspy.Example` into the `dsp.Template` and the extract function would return `dsp.Example` a different type. Leaving us with two different types of `Example` within a single prediction. To combat this, a new `Template` primitive was introduced into `dspy` to mirror and replace the original `dsp.Template`.

I do not expect this current PR to achieve feature parity with the original class, but initial tests have been introduced to mock and mirror the current prompt structure used in `dsp`.

Let me know what you think @CyrusOfEden, the last piece I believe to start using the `TemplateBackend` is to fully explore the `do_generate` function dealing with incomplete or inaccurate completions.