### PR TITLE
docs(dspy): add toy invocation of model to minimal-example

### DIFF
--- a/docs/docs/quick-start/minimal-example.mdx
+++ b/docs/docs/quick-start/minimal-example.mdx
@@ -85,6 +85,8 @@ This example showcases how to set up your environment, define a custom module, c
 
 Feel free to adapt and expand upon this example to suit your specific use case while exploring the extensive capabilities of DSPy.
 
+If you want to try what you just built, run `optimized_cot.forward('Your Question Here')`.
+
 ***
 
 <AuthorDetails name="Herumb Shandilya"/>


### PR DESCRIPTION
The new docs are awesome, and this is a 1 line change that I propose to improve `minimal-example`