### PR TITLE
Fix `long_text` key problem with RMs

### DIFF
--- a/dspy/retrieve/retrieve.py
+++ b/dspy/retrieve/retrieve.py
@@ -36,7 +36,8 @@ class Retrieve(Parameter):
         # print(queries)
         # TODO: Consider removing any quote-like markers that surround the query too.
         k = k if k is not None else self.k
-        passages = dsp.retrieveEnsemble(queries, k=k)
+        passages = dsp.settings.rm(queries=queries, k=k)
+        #passages = dsp.retrieveEnsemble(queries, k=k)
         return Prediction(passages=passages)
 
 # TODO: Consider doing Prediction.from_completions with the individual sets of passages (per query) too.


### PR DESCRIPTION
Draft, started with changing

`dsp.retrieveEnsemble` to `dsp.settings.rm`

in calls to dspy.Retrieve

=== TODO ==

I now need to remove the long_text key from all the RMs

=== RELATED PROJECT TODO (interface metadata with retrieval) ===

I then need to see how the [1], [2] is formatted in the Signatures when passing in the output from Retrieval. I think this should be self-contained in the Signatures.