### PR TITLE
Remove unused kwargs passed to requests sent through `AzureOpenAI`

### DIFF
--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -107,9 +107,6 @@ class AzureOpenAI(LM):
             kwargs["model"] = model
 
         self.kwargs = {
-            "api_base": api_base,
-            "api_version": api_version,
-            "api_key": api_key,
             "temperature": 0.0,
             "max_tokens": 150,
             "top_p": 1,


### PR DESCRIPTION
This commit is to remove unused kwargs that we include in the requests sent through `AzureOpenAI` class.

This seems to fix this issue: https://github.com/stanfordnlp/dspy/issues/543