### PR TITLE
Adding metric_threshold to BootstrapFewShotWithRandomSearch

### DIFF
--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -24,7 +24,7 @@ from .vanilla import LabeledFewShot
 
 
 class BootstrapFewShotWithRandomSearch(Teleprompter):
-    def __init__(self, metric, teacher_settings={}, max_bootstrapped_demos=4, max_labeled_demos=16, max_rounds=1, num_candidate_programs=16, num_threads=6, max_errors=10, stop_at_score=None):
+    def __init__(self, metric, teacher_settings={}, max_bootstrapped_demos=4, max_labeled_demos=16, max_rounds=1, num_candidate_programs=16, num_threads=6, max_errors=10, stop_at_score=None, metric_threshold=None):
         self.metric = metric
         self.teacher_settings = teacher_settings
         self.max_rounds = max_rounds
@@ -71,7 +71,7 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
             
             elif seed == -1:
                 # unshuffled few-shot
-                program = BootstrapFewShot(metric=self.metric, max_bootstrapped_demos=self.max_num_samples,
+                program = BootstrapFewShot(metric=self.metric, metric_threshold=self.metric_threshold, max_bootstrapped_demos=self.max_num_samples,
                                            max_labeled_demos=self.max_labeled_demos,
                                            teacher_settings=self.teacher_settings, max_rounds=self.max_rounds)
                 program2 = program.compile(student, teacher=teacher, trainset=trainset2)
@@ -82,7 +82,7 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
                 random.Random(seed).shuffle(trainset2)
                 size = random.Random(seed).randint(self.min_num_samples, self.max_num_samples)
 
-                teleprompter = BootstrapFewShot(metric=self.metric, max_bootstrapped_demos=size,
+                teleprompter = BootstrapFewShot(metric=self.metric, metric_threshold=self.metric_threshold, max_bootstrapped_demos=size,
                                                 max_labeled_demos=self.max_labeled_demos,
                                                 teacher_settings=self.teacher_settings,
                                                 max_rounds=self.max_rounds)


### PR DESCRIPTION
*Change:*

- add `metric_threshold` parameter to `BootstrapFewShotWithRandomSearch` with default being `None`

*Reason:*

- when using a custom metric that are not 0 or 1, we need `metric_threshold` in `BootstrapFewShot`; however, when using `BootstrapFewShotWithRandomSearch` we don't have `metric_threshold` that can be passed to  `BootstrapFewShot`

@okhat 