### PR TITLE
FIX: BootstrapFewShotWithRandomSearch.metric_threshold not set

### DIFF
--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -31,6 +31,7 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
 
         self.num_threads = num_threads
         self.stop_at_score = stop_at_score
+        self.metric_threshold = metric_threshold
         self.min_num_samples = 1
         self.max_num_samples = max_bootstrapped_demos
         self.max_errors = max_errors


### PR DESCRIPTION
* will result in AttributeError: 'BootstrapFewShotWithRandomSearch' object has no attribute 'metric_threshold' when execute `compile`
* can be reproduced by executing the following colab's `Compilation With Assertions` part.
** https://colab.research.google.com/github/stanfordnlp/dspy/blob/main/examples/longformqa/longformqa_assertions.ipynb#scrollTo=544FmRbtuzgS

## 📝 Changes Description

This MR/PR contains the following changes:
...

## ✅ Contributor Checklist

- [] Pre-Commit checks are passing (locally and remotely)
- [] Title of your PR / MR corresponds to the required format
- [] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Anything we should be aware of ?
