### PR TITLE
WIP fix: cache for the baleen test and add notebook cache to everywhere.

### DIFF
--- a/dsp/modules/cache_utils.py
+++ b/dsp/modules/cache_utils.py
@@ -27,7 +27,8 @@ def noop_decorator(arg=None, *noop_args, **noop_kwargs):
 cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), 'cachedir_joblib')
 CacheMemory = Memory(location=cachedir, verbose=0)
 
-cachedir2 = os.environ.get('DSP_NOTEBOOK_CACHEDIR')
+project_home = Path(__file__).resolve().parent.parent.parent
+cachedir2 = os.environ.get('DSP_NOTEBOOK_CACHEDIR') or os.path.join(project_home, 'cache')
 NotebookCacheMemory = dotdict()
 NotebookCacheMemory.cache = noop_decorator
 

--- a/tests/examples/test_baleen.py
+++ b/tests/examples/test_baleen.py
@@ -1,4 +1,6 @@
 import pytest
+import os
+from dsp.modules.cache_utils import *
 from dsp.utils import deduplicate
 import dspy.evaluate
 import dspy
@@ -87,8 +89,8 @@ def validate_context_and_answer_and_hops(example, pred, trace=None):
     if max([len(h) for h in hops]) > 100:
         return False
     if any(
-        dspy.evaluate.answer_exact_match_str(hops[idx], hops[:idx], frac=0.8)
-        for idx in range(2, len(hops))
+            dspy.evaluate.answer_exact_match_str(hops[idx], hops[:idx], frac=0.8)
+            for idx in range(2, len(hops))
     ):
         return False
 
@@ -106,7 +108,7 @@ def gold_passages_retrieved(example, pred, trace=None):
 
 # @pytest.mark.slow_test
 # TODO: Find a way to make this test run without the slow hotpotqa dataset
-def _test_compiled_baleen():
+def test_compiled_baleen():
     trainset, devset = load_hotpotqa()
     lm = dspy.OpenAI(model="gpt-3.5-turbo")
     rm = dspy.ColBERTv2(url="http://20.102.90.50:2017/wiki17_abstracts")


### PR DESCRIPTION
What is change?
- making the notebook cache available everywhere.

Why the change is important?
- we want to in baleen_test be able to use notebook cache

Why not putting it in actual test or decorator?
- because cached are used globally so it needs a huge change if we want to do that.

How to test?
- Running unit tests.
- Running the notebooks.