### PR TITLE
feature(dspy): return metadata along long_text for ChromaDB retrieval

### DIFF
--- a/docs/api/retrieval_model_clients/ChromadbRM.md
+++ b/docs/api/retrieval_model_clients/ChromadbRM.md
@@ -34,7 +34,7 @@ Search the chromadb collection for the top `k` passages matching the given query
 - `k` (_Optional[int]_, _optional_): The number of results to retrieve. If not specified, defaults to the value set during initialization.
 
 **Returns:**
-- `dspy.Prediction`: Contains the retrieved passages, each represented as a `dotdict` with a `long_text` attribute.
+- `dspy.Prediction`: Contains the retrieved passages, each represented as a `dotdict` with schema `[{"id": str, "score": float, "long_text": str, "metadatas": dict }]`
 
 ### Quickstart with OpenAI Embeddings
 

--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -145,6 +145,10 @@ class ChromadbRM(dspy.Retrieve):
             query_embeddings=embeddings, n_results=k,
         )
 
-        passages = [dotdict({"long_text": x}) for x in results["documents"][0]]
-
-        return passages
+        zipped_results = zip(
+            results["ids"][0], 
+            results["distances"][0], 
+            results["documents"][0], 
+            results["metadatas"][0])
+        results = [dotdict({"id": id, "score": dist, "long_text": doc, "metadatas": meta }) for id, dist, doc, meta in zipped_results]
+        return results


### PR DESCRIPTION
Returning metadata along long_text for ChromaDB.
Fixes #364 for ChromaDB