### PR TITLE
trace patch

### DIFF
--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -36,7 +36,7 @@ class Settings:
                 force_reuse_cached_compilation=False,
                 compiling=False,
                 skip_logprobs=False,
-                trace=None,
+                trace=[],
                 release=0,
                 log_openai_usage=False,
                 bypass_assert=False,


### PR DESCRIPTION
updated trace to now be configured as `[]` instead of `None` to avoid manual setting to enable assertions. 
Patch per comments from #434 #467. 

@okhat - feel free to confirm this does not break any existing caches/behavior (@Shangyint and I have checked to ensure this already!)