### PR TITLE
fix(dspy): together client response parsing bug + endpoint

### DIFF
--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -234,7 +234,7 @@ class Together(HFModel):
         on_backoff=backoff_hdlr,
     )
     def _generate(self, prompt, use_chat_api=False, **kwargs):
-        url = f"{self.api_base}"
+        url = f"{self.api_base}/completions"
 
         kwargs = {**self.kwargs, **kwargs}
 
@@ -280,9 +280,9 @@ class Together(HFModel):
             with self.session.post(url, headers=headers, json=body) as resp:
                 resp_json = resp.json()
                 if use_chat_api:
-                    completions = [resp_json['output'].get('choices', [])[0].get('message', {}).get('content', "")]
+                    completions = [resp_json.get('choices', [])[0].get('message', {}).get('content', "")]
                 else:
-                    completions = [resp_json['output'].get('choices', [])[0].get('text', "")]
+                    completions = [resp_json.get('choices', [])[0].get('text', "")]
                 response = {"prompt": prompt, "choices": [{"text": c} for c in completions]}
                 return response
         except Exception as e:


### PR DESCRIPTION
I opened up a related issue just now https://github.com/stanfordnlp/dspy/issues/626

Basically I was getting errors when using the Together client. If I set use_chat_api to true, the response did not have an "output" field. Also, if I set use_chat_api to false, I get a 404. These changes fix these issues.

I've only done a smoke test. probably worth at least a smoke test by whoever is reviewing this as well.