### PR TITLE
Fix do_generate looking for max_tokens when using Google LM

### DIFF
--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -98,11 +98,20 @@ def _generate(template: Template, **kwargs) -> Callable:
             completion[field_names[last_field_idx]] = ""
 
             # Recurse with greedy decoding and a shorter length.
-            max_tokens = kwargs.get("max_tokens", dsp.settings.lm.kwargs["max_tokens"])
+            max_tokens = (kwargs.get("max_tokens") or 
+                        kwargs.get("max_output_tokens") or
+                        dsp.settings.lm.kwargs.get("max_tokens") or 
+                        dsp.settings.lm.kwargs.get('max_output_tokens'))
+
+
+            if max_tokens is None:
+                raise ValueError("Required 'max_tokens' or 'max_output_tokens' not specified in settings.")
             max_tokens = min(max(75, max_tokens // 2), max_tokens)
+            keys = list(kwargs.keys()) + list(dsp.settings.lm.kwargs.keys()) 
+            max_tokens_key = "max_tokens" if "max_tokens" in keys else "max_output_tokens"
             new_kwargs = {
                 **kwargs,
-                "max_tokens": max_tokens,
+                max_tokens_key: max_tokens,
                 "n": 1,
                 "temperature": 0.0,
             }


### PR DESCRIPTION
The google LM module has "max_output_tokens" in its kwargs dict, rather than "max_tokens". This causes `do_generate` to sometimes fail when trying to adjust the max tokens in the retry logic.

I considered updating the Google kwargs dict to also contain "max_tokens", but then the generation config object complains about extra keys, so it gets kind of annoying to keep track of as you switch back and forth.

It probably won't matter soon anyway, since I think the plan is to migrate to LiteLLM.