### PR TITLE
Fix Google API generate_content usage

### DIFF
--- a/dsp/modules/google.py
+++ b/dsp/modules/google.py
@@ -157,6 +157,6 @@ class Google(LM):
         completions = []
         for i in range(n):
             response = self.request(prompt, **kwargs)
-            completions.append(response.parts[0].text)
+            completions.append(response.candidates[0].content.parts[0].text)
 
         return completions

--- a/dsp/modules/lm.py
+++ b/dsp/modules/lm.py
@@ -83,7 +83,7 @@ class LM(ABC):
             elif provider == "clarifai" or provider == "claude" :
                 text=choices
             elif provider == "google":
-                text = choices[0].parts[0].text
+                text = choices[0].candidates[0].content.parts[0].text
             else:
                 text = choices[0]["text"]
             self.print_green(text, end="")


### PR DESCRIPTION
Per [the docs](https://ai.google.dev/api/rest/v1/GenerateContentResponse) GenerateContentResponse doesn't seem to have a `parts` param any more.

Completions are found under `candidates[i].content.parts[i].text`.