### PR TITLE
Fix for system-prompt

### DIFF
--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -135,9 +135,10 @@ class AzureOpenAI(LM):
         raw_kwargs = kwargs
 
         kwargs = {**self.kwargs, **kwargs}
+        system_instructions = kwargs.pop("system_instructions", "")
+        
         if self.model_type == "chat":
-            # caching mechanism requires hashable kwargs
-            kwargs["messages"] = [{"role": "user", "content": prompt}]
+            kwargs["messages"] = [{"role": "system", "content": system_instructions}, {"role": "user", "content": prompt}]
             kwargs = {"stringify_request": json.dumps(kwargs)}
             response = chat_request(self.client, **kwargs)
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -84,6 +84,11 @@ class Predict(Parameter):
             missing = [k for k in signature.input_fields if k not in kwargs]
             print(f"WARNING: Not all input fields were provided to module. Present: {present}. Missing: {missing}.")
 
+        system_instructions = getattr(self.signature, 'system_instructions', None)
+        
+        if system_instructions:
+            config["system_instructions"] = system_instructions
+
         # Switch to legacy format for dsp.generate
         template = signature_to_template(signature)
 


### PR DESCRIPTION
This is PR/Fix for differentiating between system prompts and user inputs within the Chat Completions type of scenario. 

How?
By implementing a signature modification in the class's docstring, we enable the passing of optional system instruction prompts, marked by a specific keyword and delimiter. 

Why?

The distinction is critical for improving the model's interaction accuracy and response quality.

Tests?
Initial impact assessment indicates that critical features like chain of thought and program of thought, along with the predict method, can utilize this approach without needing significant modifications. These components will inherently benefit from the ability to include system instructions seamlessly within their operational logic.  


Note:  This update is proposed as a proof of concept (POC) at this stage. I