### PR TITLE
fix(colbertv2): Add error handler for server reports error

### DIFF
--- a/dsp/modules/colbertv2.py
+++ b/dsp/modules/colbertv2.py
@@ -43,8 +43,11 @@ def colbertv2_get_request_v2(url: str, query: str, k: int):
 
     payload = {"query": query, "k": k}
     res = requests.get(url, params=payload, timeout=10)
+    res = res.json()
+    if "error" in res and res["error"]:
+        raise(Exception("Server error: " + res["message"]))
 
-    topk = res.json()["topk"][:k]
+    topk = res["topk"][:k]
     topk = [{**d, "long_text": d["text"]} for d in topk]
     return topk[:k]
 


### PR DESCRIPTION
When the ColBERT server returns an error in colbertv2_get_request_v2 the error message is not relayed to the calling function and the line that fails is not helpful for diagnosing the problem.
```
  File "dsp/modules/colbertv2.py", line 50, in colbertv2_get_request_v2
    topk = res.json()["topk"][:k]
           ~~~~~~~~~~^^^^^^^^
KeyError: 'topk'
```
Check for an error flag in the response and raise an exception with the server message instead.
```
  File "dsp/modules/colbertv2.py", line 49, in colbertv2_get_request_v2
    raise(Exception("Server error: " + res["message"]))
Exception: Server error: Exception occurred when connecting to server on port 2172: Cannot connect to host localhost:2172 ssl:default [Connect call failed ('127.0.0.1', 2172)]
```