### PR TITLE
Fix Retry for TypedPredictors

### DIFF
--- a/tests/predict/test_retry.py
+++ b/tests/predict/test_retry.py
@@ -2,6 +2,7 @@ import functools
 import dspy
 from dspy.utils import DummyLM
 from dspy.primitives.assertions import assert_transform_module, backtrack_handler
+import pydantic
 
 
 def test_retry_simple():
@@ -63,4 +64,48 @@ def test_retry_forward_with_feedback():
         "Past Answer: red\n\n"
         "Instructions: Please think harder\n\n"
         "Answer: blue"
+    )
+
+
+def test_retry_forward_with_typed_predictor():
+    # First we make a mistake, then we fix it
+    lm = DummyLM(['{"answer":"red"}', '{"answer":"blue"}'])
+    dspy.settings.configure(lm=lm, trace=[])
+
+    class AnswerQuestion(dspy.Signature):
+        """Answer questions with succint responses."""
+
+        class Input(pydantic.BaseModel):
+            question: str
+
+        class Output(pydantic.BaseModel):
+            answer: str
+
+        input: Input = dspy.InputField()
+        output: Output = dspy.OutputField()
+
+    class QuestionAnswerer(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.answer_question = dspy.TypedPredictor(AnswerQuestion)
+
+        def forward(self, **kwargs):
+            result = self.answer_question(input=AnswerQuestion.Input(**kwargs)).output
+            dspy.Suggest(result.answer == "blue", "Please think harder")
+            return result
+
+    program = QuestionAnswerer()
+    program = assert_transform_module(
+        program.map_named_predictors(dspy.Retry),
+        functools.partial(backtrack_handler, max_backtracks=1),
+    )
+
+    result = program(question="What color is the sky?")
+
+    assert result.answer == "blue"
+    assert lm.get_convo(-1).endswith(
+        'Input: {"question":"What color is the sky?"}\n\n'
+        'Past Output: {"answer":"red"}\n\n'
+        'Instructions: Please think harder\n\n'
+        'Output: {"answer":"blue"}'
     )


### PR DESCRIPTION
This simple PR aims to fix the errors and signature inconsistencies when using Assertions and Suggestions with modules with TypedPredictors.