### PR TITLE
docs(dspy): fix typo to run tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Then install the package through poetry:
 Note - You may need to install poetry. See [here](https://python-poetry.org/docs/#installing-with-the-official-installer)
 
 ```bash
-poetry install --with test
+poetry install --with dev
 ```
 
 ## Testing


### PR DESCRIPTION
Signed-off-by: hsm207 <hsm207@users.noreply.github.com>

## 📝 Changes Description

This MR/PR contains the following changes:

Fix typo to run tests.

This:

```bash
poetry install --with test
```

gives the following error:

```
Group(s) not found: test (via --with)
```

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Anything we should be aware of ?
No