### PR TITLE
feat: Add support for additional Anthropic models

### DIFF
--- a/dsp/modules/anthropic.py
+++ b/dsp/modules/anthropic.py
@@ -45,15 +45,26 @@ class Claude(LM):
     ):
         super().__init__(model)
 
+
         try:
             from anthropic import Anthropic
         except ImportError as err:
             raise ImportError("Claude requires `pip install anthropic`.") from err
+        supported_models = [
+        "claude-instant-1.2",
+        "claude-2.0",
+        "claude-2.1",
+        "claude-3-opus-20240229",
+        "claude-3-haiku-20240307",
+        "claude-3-sonnet-20240229",
+    ]
+    
+        if model not in supported_models:
+            raise ValueError(f"Unsupported model: {model}. Supported models are: {', '.join(supported_models)}")
 
         self.provider = "anthropic"
         self.api_key = api_key = os.environ.get("ANTHROPIC_API_KEY") if api_key is None else api_key
         self.api_base = BASE_URL if api_base is None else api_base
-
         self.kwargs = {
             "temperature": kwargs.get("temperature", 0.0),
             "max_tokens": min(kwargs.get("max_tokens", 4096), 4096),

--- a/dsp/modules/anthropic.py
+++ b/dsp/modules/anthropic.py
@@ -1,7 +1,9 @@
 import logging
 import os
 from typing import Any, Optional
+
 import backoff
+
 from dsp.modules.lm import LM
 
 try:


### PR DESCRIPTION
This commit updates the `Claude` class to support additional models provided by the Anthropic API:

- claude-2.0
- claude-2.1
- claude-3-opus-20240229
- claude-3-haiku-20240307
- claude-3-sonnet-20240229

The `__init__` method of the `Claude` class has been modified to include a list of supported models. When creating an instance of the `Claude` class, the `model` parameter can be set to any of the supported model names. If an unsupported model is provided, a `ValueError` is raised with a message indicating the supported models.

This change allows users to utilize the newly added models for generating completions using the Anthropic API.