### PR TITLE
[feat] add from_parquet to dataloader

### DIFF
--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -62,6 +62,13 @@ class DataLoader(Dataset):
         
         return [dspy.Example({field:row[field] for field in fields}).with_inputs(*input_keys) for row in dataset]
 
+    def from_parquet(self, file_path: str, fields: List[str] = None, input_keys: Tuple[str] = ()) -> List[dspy.Example]:
+        dataset = load_dataset("parquet", data_files=file_path)["train"]
+
+        if not fields:
+            fields = list(dataset.features)
+
+        return [dspy.Example({field: row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
 
     def sample(
         self,


### PR DESCRIPTION
A parquet file loader would be a convenient addition to the dataloader class. I particularly like that parquet files preserve types better than a csv file.

Here's the change:

```python
def from_parquet(self, file_path: str, fields: list[str] = None, input_keys: tuple[str] = ()) -> list[dspy.Example]:
        dataset = load_dataset("parquet", data_files=file_path)["train"]

        if not fields:
            fields = list(dataset.features)

        return [dspy.Example({field: row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
```

Note, this PR was originally made in #483, but something with git hooks prevented test from being able to run.