### PR TITLE
fix(dsp): in `HFClientVLLM`, actually use `kwargs` in the payload instead of discarding them

### DIFF
--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -136,6 +136,7 @@ class HFClientVLLM(HFModel):
         payload = {
             "model": self.model,
             "prompt": prompt,
+            **kwargs,
         }
 
         

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -134,11 +134,12 @@ class HFClientVLLM(HFModel):
         kwargs = {**self.kwargs, **kwargs}
 
         payload = {
-            "model": kwargs["model"],
+            "model": self.model,
             "prompt": prompt,
             "max_tokens": kwargs["max_tokens"],
             "temperature": kwargs["temperature"],
         }
+
         
         # Round robin the urls.
         url = self.urls.pop(0)

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -127,6 +127,8 @@ class HFClientVLLM(HFModel):
             raise ValueError(f"The url provided to `HFClientVLLM` is neither a string nor a list of strings. It is of type {type(url)}.")
         
         self.headers = {"Content-Type": "application/json"}
+        self.kwargs = kwargs
+
 
     def _generate(self, prompt, **kwargs):
         kwargs = {**self.kwargs, **kwargs}

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -136,8 +136,6 @@ class HFClientVLLM(HFModel):
         payload = {
             "model": self.model,
             "prompt": prompt,
-            "max_tokens": kwargs["max_tokens"],
-            "temperature": kwargs["temperature"],
         }
 
         


### PR DESCRIPTION
in `dsp.modules.HFClientVLLM` class the `kwargs` are supposed to be passed to the vllm openai endpoint (cf. the docs) but are discarded instead. This is related to the issue here : https://github.com/stanfordnlp/dspy/issues/718

In this PR, there are some modifications to the `dsp.modules.HFClientVLLM` class:

1.  In the `__init__` the `kwargs` were actually unused. In this PR those are attached to `self.` instead of being discarded.
2. The model of the payload was provided by the `kwargs` of `_generate` method, disregarding the value initialized in the `__init__`. This is fixed in this PR.
3. Two optional parameters were made mandatory (`temperature` and `max_tokens`) in the `_generate` method. Those were made mandatory because it was a direct `kwargs["<parameter>"]`, which would raise `KeyError`. In this PR, those two dictionary access have been deleted.
4. Finally, still in the `_generate` method, the kwargs were never actually passed to the vllm endpoint. In this PR we fix this by unpacking the `kwargs` into the payload so that the extra arguments.