### PR TITLE
Fix OpenAIVectorizer

### DIFF
--- a/dsp/modules/sentence_vectorizer.py
+++ b/dsp/modules/sentence_vectorizer.py
@@ -198,7 +198,7 @@ class OpenAIVectorizer(BaseSentenceVectorizer):
                 input=cur_batch,
             )
 
-            cur_batch_embeddings = [cur_obj['embedding'] for cur_obj in response['data']]
+            cur_batch_embeddings = [cur_obj.embedding for cur_obj in response.data]
             embeddings_list.extend(cur_batch_embeddings)
 
         embeddings = np.array(embeddings_list, dtype=np.float32)

--- a/tests/retrieve/sentence_vectorizer/test_openai_vectorizer.py
+++ b/tests/retrieve/sentence_vectorizer/test_openai_vectorizer.py
@@ -7,13 +7,12 @@ from dsp import OpenAIVectorizer
 
 @pytest.mark.skipif(os.getenv('OPENAI_API_KEY') is None, reason="Skipping this test because OPENAI_API_KEY is not set")
 def test__call__():
-    # Currently these classes are used to vectorise the input sections of an Example class.
     vectorizer = OpenAIVectorizer()
     input_examples = [
         example.with_inputs('question')
         for example in [
             Example(question="Why?", answer="Who knows?"),
-            Example(question="Why not?", answer="I don't know?"),
+            Example(question="Why not?", answer="I don't know"),
         ]
     ]
     vectorizer(inp_examples=input_examples)
@@ -21,7 +20,5 @@ def test__call__():
 
 @pytest.mark.skipif(os.getenv('OPENAI_API_KEY') is None, reason="Skipping this test because OPENAI_API_KEY is not set")
 def test__call__with_str():
-    # Currently these classes are used to vectorise the input sections of an Example class.
     vectorizer = OpenAIVectorizer()
-    vectorizer("Hello world")
-
+    vectorizer("Hello world!")

--- a/tests/retrieve/sentence_vectorizer/test_openai_vectorizer.py
+++ b/tests/retrieve/sentence_vectorizer/test_openai_vectorizer.py
@@ -1,0 +1,27 @@
+import os
+import pytest
+
+from dspy import Example
+from dsp import OpenAIVectorizer
+
+
+@pytest.mark.skipif(os.getenv('OPENAI_API_KEY') is None, reason="Skipping this test because OPENAI_API_KEY is not set")
+def test__call__():
+    # Currently these classes are used to vectorise the input sections of an Example class.
+    vectorizer = OpenAIVectorizer()
+    input_examples = [
+        example.with_inputs('question')
+        for example in [
+            Example(question="Why?", answer="Who knows?"),
+            Example(question="Why not?", answer="I don't know?"),
+        ]
+    ]
+    vectorizer(inp_examples=input_examples)
+
+
+@pytest.mark.skipif(os.getenv('OPENAI_API_KEY') is None, reason="Skipping this test because OPENAI_API_KEY is not set")
+def test__call__with_str():
+    # Currently these classes are used to vectorise the input sections of an Example class.
+    vectorizer = OpenAIVectorizer()
+    vectorizer("Hello world")
+


### PR DESCRIPTION
Fixes #728 

-[ ] Squash commits, obey commit message guidelines

Currently the use of OpenAIVectorizer fails with recent OpenAI API version(s): 

Versions: 
`openai==1.13.3`
`dspy-ai==2.4.0` (same relevant code on main)

Error: 
```
cur_batch_embeddings = [cur_obj['embedding'] for cur_obj in response['data']]
                                                            ~~~~~~~~^^^^^^^^
TypeError: 'CreateEmbeddingResponse' object is not subscriptable
```

A minimal failing example is given in the tests. The tests commit shows the failure before the fix. **The tests require an API key and are therefore skipped if one isn't set.**

Fix currently tested with Python: (3.11, 3.10) Openai (1.14.3, 1.13.3) on Mac:
```
platform darwin -- Python 3.10.13, pytest-6.2.5, py-1.11.0, pluggy-1.4.0
openai==1.14.3
```

Still need to determine the low end openai version this breaks. 
