### PR TITLE
Add AWS Bedrock Claude v3 support

### DIFF
--- a/dsp/modules/bedrock.py
+++ b/dsp/modules/bedrock.py
@@ -36,7 +36,7 @@ class Bedrock(AWSLM):
             batch_n=True,  # Bedrock does not support the `n` parameter
         )
         self._validate_model(model)
-        self.provider = "claude" if "claude" in model.lower() else "bedrock"
+        self.provider = "bedrock-claude" if "claude" in model.lower() else "bedrock"
 
     def _validate_model(self, model: str) -> None:
         if "claude" not in model.lower():

--- a/dsp/modules/lm.py
+++ b/dsp/modules/lm.py
@@ -46,7 +46,7 @@ class LM(ABC):
             prompt = x["prompt"]
 
             if prompt != last_prompt:
-                if provider == "clarifai" or provider == "google":
+                if provider == "clarifai" or provider == "google" or provider == "bedrock-claude":
                     printed.append((prompt, x["response"]))
                 elif provider == "anthropic":
                     blocks = [{"text": block.text} for block in x["response"].content if block.type == "text"]
@@ -78,7 +78,7 @@ class LM(ABC):
                 text = choices
             elif provider == "openai" or provider == "ollama":
                 text = " " + self._get_choice_text(choices[0]).strip()
-            elif provider == "clarifai":
+            elif provider == "clarifai" or provider == "bedrock-claude":
                 text = choices
             elif provider == "google":
                 text = choices[0].parts[0].text


### PR DESCRIPTION
This commit introduces changes to the BedrockClaudeV3 class, extending the Bedrock base class. It specifically tailors the _create_body method to handle request body parameters unique to the AWS Bedrock Claude V3 model. This includes the mandatory inclusion of the 'anthropic_version' parameter and structuring the 'messages' parameter to accept prompts as text. Additionally, updates to the _call_model method ensure proper parsing and return of the text outputs from the model responses. The _format_prompt method remains unchanged."

It also includes the commit from https://github.com/stanfordnlp/dspy/pull/745 to ensure the inspect history API can run properly for AWS Bedrock Claude V2 & V3 models. 



