### PR TITLE
Add Custom Rationale Type option in TypedChainOfThought Module

### DIFF
--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -62,7 +62,7 @@ def TypedChainOfThought(signature, instructions=None, rationale_type=None, *, ma
         prefix="Rationale: Let's think step by step in order to",
         desc="${produce the " + output_keys + "}. We ...",
     )
-    rationale_type = DEFAULT_RATIONALE or rationale_type
+    rationale_type = rationale_type or DEFAULT_RATIONALE
 
     return TypedPredictor(
         signature.prepend(

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -59,7 +59,7 @@ def TypedChainOfThought(signature, instructions=None, rationale_type=None, *, ma
     output_keys = ", ".join(signature.output_fields.keys())
 
     DEFAULT_RATIONALE = dspy.OutputField(
-        prefix="Rationale: Let's think step by step in order to",
+        prefix="Reasoning: Let's think step by step in order to",
         desc="${produce the " + output_keys + "}. We ...",
     )
     rationale_type = rationale_type or DEFAULT_RATIONALE

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -53,7 +53,7 @@ class FunctionalModule(dspy.Module):
                 self.__dict__[name] = attr.copy()
 
 
-def TypedChainOfThought(signature, instructions=None, rationale_type=None, *, max_retries=3) -> dspy.Module:  # noqa: N802
+def TypedChainOfThought(signature, instructions=None, reasoning=None, *, max_retries=3) -> dspy.Module:  # noqa: N802
     """Just like TypedPredictor, but adds a ChainOfThought OutputField."""
     signature = ensure_signature(signature, instructions)
     output_keys = ", ".join(signature.output_fields.keys())
@@ -62,12 +62,12 @@ def TypedChainOfThought(signature, instructions=None, rationale_type=None, *, ma
         prefix="Reasoning: Let's think step by step in order to",
         desc="${produce the " + output_keys + "}. We ...",
     )
-    rationale_type = rationale_type or DEFAULT_RATIONALE
+    reasoning = reasoning or DEFAULT_RATIONALE
 
     return TypedPredictor(
         signature.prepend(
             "reasoning",
-            rationale_type,
+            reasoning,
         ),
         max_retries=max_retries,
     )

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -53,17 +53,21 @@ class FunctionalModule(dspy.Module):
                 self.__dict__[name] = attr.copy()
 
 
-def TypedChainOfThought(signature, instructions=None, *, max_retries=3) -> dspy.Module:  # noqa: N802
+def TypedChainOfThought(signature, instructions=None, rationale_type=None, *, max_retries=3) -> dspy.Module:  # noqa: N802
     """Just like TypedPredictor, but adds a ChainOfThought OutputField."""
     signature = ensure_signature(signature, instructions)
     output_keys = ", ".join(signature.output_fields.keys())
+
+    DEFAULT_RATIONALE = dspy.OutputField(
+        prefix="Rationale: Let's think step by step in order to",
+        desc="${produce the " + output_keys + "}. We ...",
+    )
+    rationale_type = rationale_type or DEFAULT_RATIONALE
+
     return TypedPredictor(
         signature.prepend(
             "reasoning",
-            dspy.OutputField(
-                prefix="Reasoning: Let's think step by step in order to",
-                desc="${produce the " + output_keys + "}. We ...",
-            ),
+            rationale_type,
         ),
         max_retries=max_retries,
     )

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -62,7 +62,7 @@ def TypedChainOfThought(signature, instructions=None, rationale_type=None, *, ma
         prefix="Rationale: Let's think step by step in order to",
         desc="${produce the " + output_keys + "}. We ...",
     )
-    rationale_type = rationale_type or DEFAULT_RATIONALE
+    rationale_type = DEFAULT_RATIONALE or rationale_type
 
     return TypedPredictor(
         signature.prepend(

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -619,7 +619,7 @@ def test_list_input2():
         Proposed Signature: Output""")
 
 
-def test_custom_rationale_type():
+def test_custom_reasoning_field():
     class Question(pydantic.BaseModel):
         value: str
 
@@ -627,12 +627,12 @@ def test_custom_rationale_type():
         topic: str = dspy.InputField()
         question: Question = dspy.OutputField()
 
-    rationale_type = dspy.OutputField(
+    reasoning = dspy.OutputField(
         prefix="Custom Reasoning: Let's break this down. To generate a question about",
         desc="${topic}, we should ...",
     )
 
-    program = TypedChainOfThought(QuestionSignature, rationale_type=rationale_type)
+    program = TypedChainOfThought(QuestionSignature, reasoning=reasoning)
 
     expected = "What is the speed of light?"
     lm = DummyLM(["Thoughts", f'{{"value": "{expected}"}}'])


### PR DESCRIPTION
Add an argument for custom rationale type like:

```python
        rationale_type = dsp.Type(
            prefix="Take a deep breath and let's think step by step in order...",
            desc="Based on the context...",
        )

        self.task = dspy.TypedChainOfThought(SomeTask, rationale_type=rationale_type)
```