### PR TITLE
Increase chances that VSCode dev container will use Poetry venv

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
       ],
       "settings": {
         "git.autofetch": true,
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
         "python.testing.pytestEnabled": true,
         "terminal.integrated.defaultProfile.linux": "zsh"
       }

--- a/.devcontainer/interpreter_warning.py
+++ b/.devcontainer/interpreter_warning.py
@@ -1,0 +1,25 @@
+from rich.console import Console
+from rich.text import Text
+
+text = Text()
+console = Console()
+
+text.append(
+    "Be sure to check that you have the Poetry Python interpreter selected in VSCode otherwise"
+    " your terminal will not include the necessary packages to develop. If you have the correct interpreter"
+    " configured, you'll see an interpreter that looks like this: ",
+    style="bold yellow",
+)
+text.append("3.9.18 ('.venv': Poetry)", style="code")
+text.append(
+    ". If you have previously selected another Python interpreter for the VSCode workspace, you may need to select"
+    " the Poetry Python interpreter.\n\nTo do so, follow the instructions at the following link and choose the Poetry"
+    " virtual environment interpreter.",
+    style="bold yellow",
+)
+
+console.print(text)
+console.print(
+    "VSCode Python Interpreter Documentation\n",
+    style="link https://code.visualstudio.com/docs/python/environments#_working-with-python-interpreters",
+)

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -24,3 +24,5 @@ if [ -f "$personalization_script" ]; then
     chmod +x "$personalization_script"
     $personalization_script
 fi
+
+chmod +x ./.devcontainer/interpreter_warning.py && poetry run python ./.devcontainer/interpreter_warning.py

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -6,6 +6,7 @@ git config --global --add safe.directory /workspaces/dspy
 
 pip install poetry==1.7.1
 poetry config installer.max-workers 4
+poetry config virtualenvs.in-project true
 
 poetry install --with dev
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ To use our dev container:
 3. Within VSCode, install the Remote Development extension (ms-vscode-remote.vscode-remote-extensionpack)
 4. Open the VSCode command palette (cmd / ctrl + shift + p)
 5. Select `Dev Containers: Rebuild and Reopen in container`. A new VSCode window should open up and it should begin setting up your environment. Once it's done, you can open up a new terminal and start running tests or contributing!
+   - Be sure the correct VSCode Python Interpreter is selected. Additional instructions are provided in yellow at the end of the dev container build logs. In short, you need to make sure you have the Poetry interpreter selected or else you'll be using an interpreter without access to the necessary Python packages.
 6. To test that your environment is set up correctly, open a new terminal and run the command `pytest`. You should be able to run all tests and see them pass. Alternatively, you can open up the testing panel, which looks like a beaker, and click the play button to run all of our tests.
 7. After the initial build, you should now be able to leave and re-enter the container any time without needing to rebuild. To do this, open the command palette and select `Dev Containers: Reopen in container`. This will not rebuild the container if you've done it correctly.
 


### PR DESCRIPTION
## 📝 Changes Description

This MR/PR contains the following changes:
* Builds the dev container Poetry venv within the workspace
* Includes VSCode setting to choose the poetry Python interpreter by default
* Includes additional warning about interpreter at the end of the dev container build to provide instructions on how to choose the correct interpreter if it's not already selected
* Updates contributing markdown file with these additional instructions

We got reports that people were not able to run the unit tests after building the dev container. After further investigation, I found that this is not due to the dev container itself but instead in the Python interpreter selected by the user. If the user has the OS default Python interpreter selected, that interpreter will not have access to the packages installed by Poetry. Because poetry creates it's own venv, we need to use the Poetry interpreter rather than any of the other interpreters installed in the dev container. By default, the dev container should find and use this Poetry interpreter but if a user has previously selected a different interpreter for the workspace, it will not attempt to find the Poetry interpreter. 

To resolve this, we're adding additional instructions in the logs of the dev container build as well as in the `contributing.md` file. Additionally, the Poetry venv will now be built within the VSCode workspace rather than outside of it. Because it's inside the workspace, we're now able to add the Poetry interpreter as the default interpreter in the VSCode settings. If a user has selected a different interpreter, this setting will not override that selection but it will make it easier to select the correct interpreter as this makes the Poetry interpreter not only the recommended interpreter but also the default. The instructions to ensure developers are using the correct interpreter should now be hard to miss and the issue should be less likely to occur in the first place. Unfortunately, there's no way to force VSCode to use the Poetry interpreter. The best we can do is set it explicitly as the default.

## ✅ Contributor Checklist

- [] Pre-Commit checks are passing (locally and remotely)
- [] Title of your PR / MR corresponds to the required format
- [] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Anything we should be aware of ?
