### PR TITLE
Remove top_p default value

### DIFF
--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -87,7 +87,6 @@ class GPT3(LM):
         self.kwargs = {
             "temperature": 0.0,
             "max_tokens": 150,
-            "top_p": 1,
             "frequency_penalty": 0,
             "presence_penalty": 0,
             "n": 1,


### PR DESCRIPTION
Pratically, we should not use top_p and temperture at the same time, however, we may override  temperture in some cases, but since DSPy predefine `top_p = 1`, it's impossible to leave `top_p` as blank.

this weired behavior is due to there are very diffrent results from direct openai call V.S. DSPy. 