### PR TITLE
hotfix(dsp): In HFClientVLLM get the model from the kwargs attached by the parent class

### DIFF
--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -128,13 +128,14 @@ class HFClientVLLM(HFModel):
         
         self.headers = {"Content-Type": "application/json"}
         self.kwargs = kwargs
+        self.model = model
 
 
     def _generate(self, prompt, **kwargs):
         kwargs = {**self.kwargs, **kwargs}
 
         payload = {
-            "model": self.model,
+            "model": self.kwargs["model"],
             "prompt": prompt,
             **kwargs,
         }

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -127,8 +127,7 @@ class HFClientVLLM(HFModel):
             raise ValueError(f"The url provided to `HFClientVLLM` is neither a string nor a list of strings. It is of type {type(url)}.")
         
         self.headers = {"Content-Type": "application/json"}
-        self.kwargs = kwargs
-        self.model = model
+        self.kwargs |= kwargs
 
 
     def _generate(self, prompt, **kwargs):


### PR DESCRIPTION
In HFClientVLLM attach the model string directly to instance

Fixes an error in https://github.com/stanfordnlp/dspy/pull/719

Closes #764 