### PR TITLE
fix(dspy): add `copy` to AzureOpenAI to propagate `api_(key|version|...)`

### DIFF
--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -108,6 +108,10 @@ class AzureOpenAI(LM):
             **kwargs,
         }  # TODO: add kwargs above for </s>
 
+        self.api_base = api_base
+        self.api_version = api_version
+        self.api_key = api_key
+
         self.history: list[dict[str, Any]] = []
 
     def _openai_client(self):
@@ -219,6 +223,19 @@ class AzureOpenAI(LM):
             completions = [c for _, c in scored_completions]
 
         return completions
+    
+    def copy(self, **kwargs):
+        """Returns a copy of the language model with the same parameters."""
+        kwargs = {**self.kwargs, **kwargs}
+        model = kwargs.pop("model")
+
+        return self.__class__(
+            model=model, 
+            api_key=self.api_key, 
+            api_version=self.api_version, 
+            api_base=self.api_base, 
+            **kwargs,
+        )
 
 
 @CacheMemory.cache


### PR DESCRIPTION
Fixes issue #591 without re-creating issue #543

The problem was that `AzureOpenAI.copy` used `LM.copy`, but because `api_key` etc. aren't in the `AzureOpenAI.kwargs`, and `LM.copy` per default only propagates `self.__class__.kwargs`.

I now gave `AzureOpenAI` its own `copy`-method. This isn't really beautiful, but it seems to work pretty well.