### PR TITLE
Fix the bug of lm in predict

### DIFF
--- a/dsp/templates/template_v2.py
+++ b/dsp/templates/template_v2.py
@@ -199,9 +199,6 @@ class TemplateV2:
     def __call__(self, example, show_guidelines=True) -> str:
         example = dsp.Example(example)
 
-        if hasattr(dsp.settings, "query_only") and dsp.settings.query_only:
-            return self.query(example)
-
         # The training data should not contain the output variable
         if self.fields[-1].input_variable in example:
             del example[self.fields[-1].input_variable]

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -99,7 +99,8 @@ class Predict(Parameter):
         # Switch to legacy format for dsp.generate
         template = signature_to_template(signature)
 
-        x, C = dsp.generate(template, **config)(x, stage=self.stage)
+        with dsp.settings.context(lm=lm):
+            x, C = dsp.generate(template, **config)(x, stage=self.stage)
         assert self.stage in x, "The generated (input, output) example was not stored"
 
         completions = []

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -99,14 +99,7 @@ class Predict(Parameter):
         # Switch to legacy format for dsp.generate
         template = signature_to_template(signature)
 
-        if self.lm is None:
-            x, C = dsp.generate(template, **config)(x, stage=self.stage)
-        else:
-            # Note: query_only=True means the instructions and examples are not included.
-            # I'm not really sure why we'd want to do that, but it's there.
-            with dsp.settings.context(lm=self.lm, query_only=True):
-                x, C = dsp.generate(template, **config)(x, stage=self.stage)
-
+        x, C = dsp.generate(template, **config)(x, stage=self.stage)
         assert self.stage in x, "The generated (input, output) example was not stored"
 
         completions = []


### PR DESCRIPTION
In l71 of predict.py, there is a logic to use the lm from the kwargs: `lm = kwargs.pop("lm", self.lm) or dsp.settings.lm`, but the `generate` call does not use it. This PR fixes the bug by using the lm as the context.

Also, the previous comment stated that it's unclear why `query_only` should ever be used, and this is the only place the `query_only` option is used. So it sounds like a good choice to just get rid of this option and simplify the code logic.

Reference:

1. [self.lm in generate](https://github.com/stanfordnlp/dspy/commit/bc23a70f8f051903a9034b41a2a7837536cc3837) was introduced on 08/24/2023
2. [lm kwargs](https://github.com/stanfordnlp/dspy/commit/9cf152317f53db76c879ba9a6870479cf78f440c) was introduced on 10/11/2023