### PR TITLE
add condition to prevent comparing Example with non-Example object

### DIFF
--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -54,7 +54,7 @@ class Example:
         return self.__repr__()
     
     def __eq__(self, other):
-        return self._store == other._store
+        return isinstance(other, Example) and self._store == other._store
     
     def __hash__(self):
         return hash(tuple(self._store.items()))

--- a/tests/primitives/test_example.py
+++ b/tests/primitives/test_example.py
@@ -59,6 +59,7 @@ def test_example_eq():
     example1 = Example(a=1, b=2)
     example2 = Example(a=1, b=2)
     assert example1 == example2
+    assert example1 != ""
 
 
 def test_example_hash():


### PR DESCRIPTION
This simple condition should fix #568  and #557 and prevents further class mismatch assuming only Example object will be compared to each other.