### PR TITLE
allow passing of kwargs to typed predictor decorators

### DIFF
--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -14,18 +14,32 @@ from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import ensure_signature, make_signature
 
 
-def predictor(func) -> dspy.Module:
-    """Decorator that creates a predictor module based on the provided function."""
-    signature = _func_to_signature(func)
-    *_, output_key = signature.output_fields.keys()
-    return _StripOutput(TypedPredictor(signature), output_key)
+def predictor(*args, **kwargs):
+    def _predictor(func) -> dspy.Module:
+        """Decorator that creates a predictor module based on the provided function."""
+        signature = _func_to_signature(func)
+        *_, output_key = signature.output_fields.keys()
+        return _StripOutput(TypedPredictor(signature, **kwargs), output_key)
+
+    # if we have only a single callable argument, the decorator was invoked with no key word arguments
+    #  so we just return the wrapped function 
+    if len(args) == 1 and callable(args[0]) and len(kwargs) == 0:
+        return _predictor(args[0])
+    return _predictor
 
 
-def cot(func) -> dspy.Module:
-    """Decorator that creates a chain of thought module based on the provided function."""
-    signature = _func_to_signature(func)
-    *_, output_key = signature.output_fields.keys()
-    return _StripOutput(TypedChainOfThought(signature), output_key)
+def cot(*args, **kwargs):
+    def _cot(func) -> dspy.Module:
+        """Decorator that creates a chain of thought module based on the provided function."""
+        signature = _func_to_signature(func)
+        *_, output_key = signature.output_fields.keys()
+        return _StripOutput(TypedChainOfThought(signature, **kwargs), output_key)
+
+    # if we have only a single callable argument, the decorator was invoked with no key word arguments
+    #  so we just return the wrapped function 
+    if len(args) == 1 and callable(args[0]) and len(kwargs) == 0:
+        return _cot(args[0])
+    return _cot
 
 
 class _StripOutput(dspy.Module):


### PR DESCRIPTION
This change allows you to pass key word arguments such as the max_retries argument to the typed predictors while using the decorator method to construct them. Example:
```py
class MyModule(dspy.Module):
    @dspy.cot(max_retries=5, explain_errors=True)
    def my_cool_function(self, input: Input) -> Output:
        """Does some incredibly cool stuff up to five times with an explanation for errors"""
        pass

    ... rest of module implementation
```

The arguments are optional, so `@dspy.cot` and `@dspy.cot(max_retries=1)` will both work under this patch.