### PR TITLE
fix(qdrant_rm): forward can be called without specifying k

### DIFF
--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -53,7 +53,7 @@ class QdrantRM(dspy.Retrieve):
 
         super().__init__(k=k)
 
-    def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int],**kwargs) -> dspy.Prediction:
+    def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int] = None,**kwargs) -> dspy.Prediction:
         """Search with Qdrant for self.k top passages for query
 
         Args:


### PR DESCRIPTION
A bug in QdrantRM.forward signature implementation prevents it to be called without providing the argument `k`.

This was observed while using the `dspy.ReAct` module:
```
         (dspy/predict/react.py:95), in ReAct.act(self, output, hop)
     [92](dspy/predict/react.py:92)     return action_val
     [94](dspy/predict/react.py:94) try:
---> [95](dspy/predict/react.py:95)     output[f"Observation_{hop+1}"] = self.tools[action_name](action_val).passages
     [96](dspy/predict/react.py:96) except AttributeError:
     [97](dspy/predict/react.py:97)     # Handle the case where 'passages' attribute is missing
     [98](dspy/predict/react.py:98)     # TODO: This is a hacky way to handle this. Need to fix this.
     [99](dspy/predict/react.py:99)     output[f"Observation_{hop+1}"] = self.tools[action_name](action_val)

         (dspy/retrieve/retrieve.py:30), in Retrieve.__call__(self, *args, **kwargs)
     [29](dspy/retrieve/retrieve.py:29) def __call__(self, *args, **kwargs):
---> [30](dspy/retrieve/retrieve.py:30)     return self.forward(*args, **kwargs)

TypeError: QdrantRM.forward() missing 1 required positional argument: 'k'

```