### PR TITLE
docs(dspy): Fixed docstring for OpenAI having wrong default model

### DIFF
--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -44,7 +44,7 @@ class AzureOpenAI(LM):
     Args:
         api_base (str): Azure URL endpoint for model calling, often called 'azure_endpoint'.
         api_version (str): Version identifier for API.
-        model (str, optional): OpenAI or Azure supported LLM model to use. Defaults to "text-davinci-002".
+        model (str, optional): OpenAI or Azure supported LLM model to use. Defaults to "gpt-3.5-turbo-instruct".
         api_key (Optional[str], optional): API provider Authentication token. use Defaults to None.
         model_type (Literal["chat", "text"], optional): The type of model that was specified. Mainly to decide the optimal prompting strategy. Defaults to "chat".
         **kwargs: Additional arguments to pass to the API provider.

--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -40,7 +40,7 @@ class GPT3(LM):
     """Wrapper around OpenAI's GPT API.
 
     Args:
-        model (str, optional): OpenAI supported LLM model to use. Defaults to "text-davinci-002".
+        model (str, optional): OpenAI supported LLM model to use. Defaults to "gpt-3.5-turbo-instruct".
         api_key (Optional[str], optional): API provider Authentication token. use Defaults to None.
         api_provider (Literal["openai"], optional): The API provider to use. Defaults to "openai".
         model_type (Literal["chat", "text"], optional): The type of model that was specified. Mainly to decide the optimal prompting strategy. Defaults to "text".


### PR DESCRIPTION
## 📝 Changes Description

I noticed that the docstring for `OpenAI` says that the default model value is davinci. However, the default value of the parameter in code is GT3 turbo instruct, which looks more reasonable.
I suspect the default changed a while ago and someone forgot to change the docstring.

This MR/PR contains the following changes:
* New docstring value for the model property of `OpenAI` and `AzureOpenAI` classes

## ⚠️ Warnings

Exactly because of these things (changing the parameter default value and forgetting to update the docs), I would consider not writing the default value in the docs at all. The IDE (I checked VS Code) anyway shows the available parameters and their default values, in addition to the docstring. So best case - it's written twice. Worst case - it's written twice AND one is incorrect.
