### PR TITLE
fix structlog dependency when building from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "requests",
     "optuna",
     "pydantic>=2.5.0,<=2.7",
+    "structlog"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
building from a non-poetry environment results in a build error with importing `structlog`. Added to `pyproject.toml` dependencies