### PR TITLE
Add vllm chat completion endpoints and fix inspect_history

### DIFF
--- a/dsp/modules/lm.py
+++ b/dsp/modules/lm.py
@@ -63,13 +63,11 @@ class LM(ABC):
             if len(printed) >= n:
                 break
 
-        for idx, (prompt, choices) in enumerate(reversed(printed)):
-            printing_value = ""
-
+        for idx, (prompt, choices) in enumerate(printed):
             # skip the first `skip` prompts
-            if (n - idx - 1) < skip:
+            if (n - idx - 1) > skip:
                 continue
-
+            printing_value = ""
             printing_value += "\n\n\n"
             printing_value += prompt
 

--- a/dsp/modules/lm.py
+++ b/dsp/modules/lm.py
@@ -63,11 +63,11 @@ class LM(ABC):
             if len(printed) >= n:
                 break
 
-        for idx, (prompt, choices) in enumerate(printed):
+        printing_value = ""
+        for idx, (prompt, choices) in enumerate(reversed(printed)):
             # skip the first `skip` prompts
-            if (n - idx - 1) > skip:
+            if (n - idx - 1) < skip:
                 continue
-            printing_value = ""
             printing_value += "\n\n\n"
             printing_value += prompt
 


### PR DESCRIPTION
Related to issue #778 #784 

- added vllm chat completion endpoints (support system_prompt)
- fixed an issue with .copy() with vllm client module. (need to include model, url, port into kwargs)
- fix inspect_histrory not respecting n/skip as mentioned in #784 