### PR TITLE
Remove missing keyword argument

### DIFF
--- a/intro.ipynb
+++ b/intro.ipynb
@@ -1497,7 +1497,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "uncompiled_baleen_retrieval_score = evaluate_on_hotpotqa(uncompiled_baleen, metric=gold_passages_retrieved, display=False)"
+    "uncompiled_baleen_retrieval_score = evaluate_on_hotpotqa(uncompiled_baleen, metric=gold_passages_retrieved)"
    ]
   },
   {


### PR DESCRIPTION
I get an error when trying to run this intro notebook. Removing the keyword argument makes the error go away.

Also, when running the setup / install, I get a note that `structlog` is missing. (I'm running this locally in a fresh Python 3.11.8 environment).