### PR TITLE
(dspy/predict): corrected temperature check for bedrock claude models

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -79,7 +79,7 @@ class Predict(Parameter):
         if num_generations is None:
             num_generations = lm.kwargs.get("n", lm.kwargs.get("num_generations", None))
 
-        if (temperature is None or temperature <= 0.15) and num_generations > 1:
+        if (temperature is None or temperature <= 0.15) and num_generations is not None and num_generations > 1:
             config["temperature"] = 0.7
             # print(f"#> Setting temperature to 0.7 since n={num_generations} and prior temperature={temperature}.")
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -77,9 +77,9 @@ class Predict(Parameter):
 
         num_generations = config.get("n")
         if num_generations is None:
-            num_generations = lm.kwargs.get("n", lm.kwargs.get("num_generations", None))
+            num_generations = lm.kwargs.get("n", lm.kwargs.get("num_generations", 1))
 
-        if (temperature is None or temperature <= 0.15) and num_generations is not None and num_generations > 1:
+        if (temperature is None or temperature <= 0.15) and num_generations > 1:
             config["temperature"] = 0.7
             # print(f"#> Setting temperature to 0.7 since n={num_generations} and prior temperature={temperature}.")
 


### PR DESCRIPTION
PR linked to issue described here:
https://github.com/stanfordnlp/dspy/pull/795#issuecomment-2057280084

Using Bedrock and claude3-haiku
```
bedrock = dspy.Bedrock(...)

haiku = dspy.AWSAnthropic(
    aws_provider=bedrock,
    model="anthropic.claude-3-haiku-20240307-v1:0",
)

class BasicQA(dspy.Signature):
    """Answer questions with short factoid answers."""

    question = dspy.InputField()
    answer = dspy.OutputField(desc="often between 1 and 5 words")
    
# Define the predictor. Notice we're just changing the class. The signature BasicQA is unchanged.
generate_answer_with_chain_of_thought = dspy.ChainOfThought(BasicQA)

# Call the predictor on the same input.
pred = generate_answer_with_chain_of_thought(question=dev_example.question)
```
Error: TypeError: '>' not supported between instances of 'NoneType' and 'int'

The error is fixed when the change in the PR is introduced