### PR TITLE
fixing issue in DatabricksRM preventing indexed text from being returned

### DIFF
--- a/dspy/retrieve/databricks_rm.py
+++ b/dspy/retrieve/databricks_rm.py
@@ -136,6 +136,8 @@ class DatabricksRM(dspy.Retrieve):
                     else:
                         doc_ids.append(str(val))
                     text = val
+                if col["name"] == self.text_column_name:   
+                    text = val   
                 if col["name"] == 'score':
                     score = val
             docs[text] += score


### PR DESCRIPTION
- There were two missing code lines that prevented the "text" column from being returned when the "froward" method was executed