### PR TITLE
Setting the default value of the DatabricksRM.forward  "query_type" 

### DIFF
--- a/dspy/retrieve/databricks_rm.py
+++ b/dspy/retrieve/databricks_rm.py
@@ -87,7 +87,7 @@ class DatabricksRM(dspy.Retrieve):
         self.docs_id_column_name = docs_id_column_name
         self.text_column_name = text_column_name
 
-    def forward(self, query: Union[str, List[float]], query_type: str = 'vector') -> dspy.Prediction:
+    def forward(self, query: Union[str, List[float]], query_type: str = 'text') -> dspy.Prediction:
         """Search with Databricks Vector Search Client for self.k top results for query
 
         Args:


### PR DESCRIPTION
Setting the default value of the DatabricksRM.forward  "query_type" param to "text"

It is recommended to use the fully managed approach for Vector Search which covers getting the embeddings from the of the indexed column during the ingestion and the embeddings of the text query during inference