### PR TITLE
Add missing gold_passages_retrieved function

### DIFF
--- a/docs/docs/tutorials/simplified-baleen.md
+++ b/docs/docs/tutorials/simplified-baleen.md
@@ -193,6 +193,14 @@ Let's now define our evaluation function and compare the performance of the unco
 ```python
 from dspy.evaluate.evaluate import Evaluate
 
+# Define metric to check if we retrieved the correct documents
+def gold_passages_retrieved(example, pred, trace=None):
+    gold_titles = set(map(dspy.evaluate.normalize_text, example["gold_titles"]))
+    found_titles = set(
+        map(dspy.evaluate.normalize_text, [c.split(" | ")[0] for c in pred.context])
+    )
+    return gold_titles.issubset(found_titles)
+
 # Set up the `evaluate_on_hotpotqa` function. We'll use this many times below.
 evaluate_on_hotpotqa = Evaluate(devset=devset, num_threads=1, display_progress=True, display_table=5)
 


### PR DESCRIPTION
The function gold_passages_retrieved is currently missing, without it the tutorial doesn't work. 
I copied the function from https://github.com/stanfordnlp/dspy/blob/eab1324d45aa1a723e187b2523e4d20bfc75356d/tests/examples/test_baleen.py#L98

I tested the code with this new function and I get similar numbers as in the tutorial