### PR TITLE
[CohereAPIKey patch] Solve problem with importing cohere

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 backoff
 joblib<=1.3.2
 openai>=0.28.1,<2.0.0
+cohere>=5.3.0
 pandas
 regex
 ujson


### PR DESCRIPTION
Cohere recently deprecated `CohereAPIKey` in favor of `errors.UnauthorizedError`.

I'm not sure how the poetry system is setup, here is one potential workaround.

Resolves issue discussed on Discord.