### PR TITLE
Add Weights & Biases logging to BootstrapFewShot

### DIFF
--- a/docs/docs/building-blocks/6-optimizers.md
+++ b/docs/docs/building-blocks/6-optimizers.md
@@ -38,7 +38,7 @@ All of these can be accessed via `from dspy.teleprompt import *`.
 
 1. **`LabeledFewShot`**: Simply constructs few-shot examples from provided labeled Q/A pairs.
 
-2. **`BootstrapFewShot`**: Uses your program to self-generate complete demonstrations for every stage of your program. Will simply use the generated demonstrations (if they pass the metric) without any further optimization. Advanced: Supports using a teacher program (a different DSPy program that has compatible structure) and a teacher LM, for harder tasks.
+2. **`BootstrapFewShot`**: Uses your program to self-generate complete demonstrations for every stage of your program. Will simply use the generated demonstrations (if they pass the metric) without any further optimization. You can use weights & biases logging of the metric values per bootstrapped examples with the `wandb_enabled` flag in calls to `compile`. Advanced: Supports using a teacher program (a different DSPy program that has compatible structure) and a teacher LM, for harder tasks.
 
 3. **`BootstrapFewShotWithRandomSearch`**: Applies `BootstrapFewShot` several times with random search over generated demonstrations, and selects the best program.
 


### PR DESCRIPTION
# `wandb_enabled` to `BootstrapFewShot`

Here is a minimal first step to adding Weights & Biases optimization logging to DSPy.

This can be used for monitoring runs to `BootstrapFewShot` in order to see the `metric_val` returned for each bootstrapped example. To motivate the use case, you may have a rating on a scale of 1 to 5 for answers and you only want to use examples that achieve a 5 in your prompt.

There are definitely more directions to take with DSPy <> Weights & Biases logging, hopefully this is a nice first step. I've found this to be pretty interesting particularly when you are testing multiple teacher models for bootstrapping.

### Docs

Note, this contains a quick note in `6-optimizers.md`. I think it would be a premature refactoring, but I think it's likely we see a lot of the "callback" style logging of PyTorch / Keras carry over.