### PR TITLE
fix #841, the issue with the api documentation.

### DIFF
--- a/docs/api/modules/ChainOfThought.md
+++ b/docs/api/modules/ChainOfThought.md
@@ -26,7 +26,7 @@ class ChainOfThought(Predict):
 
 **Parameters:**
 - `signature` (_Any_): Signature of predictive model.
-- `rationale_type` (_dsp.OutputField_, _optional_): Rationale type for reasoning steps. Defaults to `None`.
+- `rationale_type` (_dspy.OutputField_, _optional_): Rationale type for reasoning steps. Defaults to `None`.
 - `activated` (_bool_, _optional_): Flag for activated chain of thought processing. Defaults to `True`.
 - `**config` (_dict_): Additional configuration parameters for model.
 
@@ -62,7 +62,7 @@ print(f"Question: {question}")
 print(f"Predicted Answer: {pred.answer}")
 ```
 
-The following example shows how to specify your custom rationale.
+The following example shows how to specify your custom rationale. Here `answer` corresponds to the last key to produce, it may be different in your case. 
 
 ```python
 #define a custom rationale

--- a/docs/api/modules/ChainOfThoughtWithHint.md
+++ b/docs/api/modules/ChainOfThoughtWithHint.md
@@ -24,7 +24,7 @@ class ChainOfThoughtWithHint(Predict):
 
 **Parameters:**
 - `signature` (_Any_): Signature of predictive model.
-- `rationale_type` (_dsp.OutputField_, _optional_): Rationale type for reasoning steps. Defaults to `None`.
+- `rationale_type` (_dspy.OutputField_, _optional_): Rationale type for reasoning steps. Defaults to `None`.
 - `activated` (_bool_, _optional_): Flag for activated chain of thought processing. Defaults to `True`.
 - `**config` (_dict_): Additional configuration parameters for model.
 

--- a/docs/api/modules/ChainOfThoughtWithHint.md
+++ b/docs/api/modules/ChainOfThoughtWithHint.md
@@ -8,32 +8,23 @@ The constructor initializes the `ChainOfThoughtWithHint` class and sets up its a
 class ChainOfThoughtWithHint(Predict):
     def __init__(self, signature, rationale_type=None, activated=True, **config):
         super().__init__(signature, **config)
-
         self.activated = activated
-
         signature = self.signature
-        *keys, last_key = signature.kwargs.keys()
 
-        DEFAULT_HINT_TYPE = dsp.Type(prefix="Hint:", desc="${hint}")
+        *keys, last_key = signature.fields.keys()
+        rationale_type = rationale_type or dspy.OutputField(
+            prefix="Reasoning: Let's think step by step in order to",
+            desc="${produce the " + last_key + "}. We ...",
+        )
+        self.extended_signature1 = self.signature.insert(-2, "rationale", rationale_type, type_=str)
 
-        DEFAULT_RATIONALE_TYPE = dsp.Type(prefix="Reasoning: Let's think step by step in order to",
-                                          desc="${produce the " + last_key + "}. We ...")
-
-        rationale_type = rationale_type or DEFAULT_RATIONALE_TYPE
-        
-        extended_kwargs1 = {key: signature.kwargs[key] for key in keys}
-        extended_kwargs1.update({'rationale': rationale_type, last_key: signature.kwargs[last_key]})
-
-        extended_kwargs2 = {key: signature.kwargs[key] for key in keys}
-        extended_kwargs2.update({'hint': DEFAULT_HINT_TYPE, 'rationale': rationale_type, last_key: signature.kwargs[last_key]})
-        
-        self.extended_signature1 = dsp.Template(signature.instructions, **extended_kwargs1)
-        self.extended_signature2 = dsp.Template(signature.instructions, **extended_kwargs2)
+        DEFAULT_HINT_TYPE = dspy.OutputField()
+        self.extended_signature2 = self.extended_signature1.insert(-2, "hint", DEFAULT_HINT_TYPE, type_=str)
 ```
 
 **Parameters:**
 - `signature` (_Any_): Signature of predictive model.
-- `rationale_type` (_dsp.Type_, _optional_): Rationale type for reasoning steps. Defaults to `None`.
+- `rationale_type` (_dsp.OutputField_, _optional_): Rationale type for reasoning steps. Defaults to `None`.
 - `activated` (_bool_, _optional_): Flag for activated chain of thought processing. Defaults to `True`.
 - `**config` (_dict_): Additional configuration parameters for model.
 


### PR DESCRIPTION
This PR addresses issue #841.

- Modify API documentation for class ChainOfThought to reflect the correct rationale_type according to the up-to-date source.
  - Provide a simple example to show how to specify a custom rationale
- Modify API documentation for class ChainOfThoughtWithHint to reflect correct rationale_type according to the up-to-date source.

Also please note that `git subtree pull` command provided in `docs/README.md` does NOT work, raising `fatal: refusing to merge unrelated histories`.