### PR TITLE
Deprecate old logging

### DIFF
--- a/dsp/modules/anthropic.py
+++ b/dsp/modules/anthropic.py
@@ -8,12 +8,14 @@ from dsp.modules.lm import LM
 
 try:
     import anthropic
+
     anthropic_rate_limit = anthropic.RateLimitError
 except ImportError:
     anthropic_rate_limit = Exception
 
 logger = logging.getLogger(__name__)
 BASE_URL = "https://api.anthropic.com/v1/messages"
+
 
 def backoff_hdlr(details):
     """Handler from https://pypi.org/project/backoff/."""
@@ -23,14 +25,17 @@ def backoff_hdlr(details):
         "{kwargs}".format(**details),
     )
 
+
 def giveup_hdlr(details):
     """Wrapper function that decides when to give up on retry."""
     if "rate limits" in details.message:
         return False
     return True
 
+
 class Claude(LM):
     """Wrapper around anthropic's API. Supports both the Anthropic and Azure APIs."""
+
     def __init__(
         self,
         model: str = "claude-3-opus-20240229",
@@ -64,7 +69,7 @@ class Claude(LM):
         usage_data = response.usage
         if usage_data:
             total_tokens = usage_data.input_tokens + usage_data.output_tokens
-            logger.info(f'{total_tokens}')
+            logger.info(f"{total_tokens}")
 
     def basic_request(self, prompt: str, **kwargs):
         raw_kwargs = kwargs
@@ -114,9 +119,7 @@ class Claude(LM):
         completions = []
         for _ in range(n):
             response = self.request(prompt, **kwargs)
-            # TODO: Log llm usage instead of hardcoded openai usage
-            # if dsp.settings.log_openai_usage:
-            #     self.log_usage(response)
+            self.log_usage(response)
             if only_completed and response.stop_reason == "max_tokens":
                 continue
             completions = [c.text for c in response.content]

--- a/dsp/modules/anthropic.py
+++ b/dsp/modules/anthropic.py
@@ -69,7 +69,7 @@ class Claude(LM):
         usage_data = response.usage
         if usage_data:
             total_tokens = usage_data.input_tokens + usage_data.output_tokens
-            logger.info(f"{total_tokens}")
+            logger.debug(f"Anthropic Total Token Response Usage: {total_tokens}")
 
     def basic_request(self, prompt: str, **kwargs):
         raw_kwargs = kwargs

--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -6,7 +6,6 @@ from typing import Any, Literal, Optional, cast
 import backoff
 import openai
 
-import dsp
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
 from dsp.modules.lm import LM
 
@@ -192,8 +191,7 @@ class AzureOpenAI(LM):
 
         response = self.request(prompt, **kwargs)
 
-        if dsp.settings.log_openai_usage:
-            self.log_usage(response)
+        self.log_usage(response)
 
         choices = response["choices"]
 
@@ -223,17 +221,17 @@ class AzureOpenAI(LM):
             completions = [c for _, c in scored_completions]
 
         return completions
-    
+
     def copy(self, **kwargs):
         """Returns a copy of the language model with the same parameters."""
         kwargs = {**self.kwargs, **kwargs}
         model = kwargs.pop("model")
 
         return self.__class__(
-            model=model, 
-            api_key=self.api_key, 
-            api_version=self.api_version, 
-            api_base=self.api_base, 
+            model=model,
+            api_key=self.api_key,
+            api_version=self.api_version,
+            api_base=self.api_base,
             **kwargs,
         )
 

--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -124,7 +124,7 @@ class AzureOpenAI(LM):
         usage_data = response.get("usage")
         if usage_data:
             total_tokens = usage_data.get("total_tokens")
-            logging.info(f"{total_tokens}")
+            logging.debug(f"Azure OpenAI Total Token Usage: {total_tokens}")
 
     def basic_request(self, prompt: str, **kwargs):
         raw_kwargs = kwargs

--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -6,7 +6,6 @@ from typing import Any, Literal, Optional, cast
 import backoff
 import openai
 
-import dsp
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
 from dsp.modules.lm import LM
 
@@ -19,9 +18,7 @@ try:
     import openai.error
     from openai.openai_object import OpenAIObject
 
-    ERRORS = (
-        openai.error.RateLimitError,
-    )
+    ERRORS = (openai.error.RateLimitError,)
 except Exception:
     ERRORS = (openai.RateLimitError,)
     OpenAIObject = dict
@@ -69,8 +66,7 @@ class GPT3(LM):
 
         default_model_type = (
             "chat"
-            if ("gpt-3.5" in model or "turbo" in model or "gpt-4" in model)
-            and ("instruct" not in model)
+            if ("gpt-3.5" in model or "turbo" in model or "gpt-4" in model) and ("instruct" not in model)
             else "text"
         )
         self.model_type = model_type if model_type else default_model_type
@@ -181,9 +177,7 @@ class GPT3(LM):
 
         response = self.request(prompt, **kwargs)
 
-        if dsp.settings.log_openai_usage:
-            self.log_usage(response)
-
+        self.log_usage(response)
         choices = response["choices"]
 
         completed_choices = [c for c in choices if c["finish_reason"] != "length"]

--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -101,7 +101,7 @@ class GPT3(LM):
         usage_data = response.get("usage")
         if usage_data:
             total_tokens = usage_data.get("total_tokens")
-            logging.info(f"{total_tokens}")
+            logging.debug(f"OpenAI Response Token Usage: {total_tokens}")
 
     def basic_request(self, prompt: str, **kwargs):
         raw_kwargs = kwargs

--- a/dsp/modules/groq_client.py
+++ b/dsp/modules/groq_client.py
@@ -12,7 +12,6 @@ except ImportError:
     groq_api_error = Exception
 
 
-import dsp
 from dsp.modules.lm import LM
 
 
@@ -132,8 +131,7 @@ class GroqLM(LM):
         assert return_sorted is False, "for now"
         response = self.request(prompt, **kwargs)
 
-        if dsp.settings.log_openai_usage:
-            self.log_usage(response)
+        self.log_usage(response)
 
         choices = response.choices
 

--- a/dsp/modules/groq_client.py
+++ b/dsp/modules/groq_client.py
@@ -67,7 +67,7 @@ class GroqLM(LM):
         usage_data = response.get("usage")
         if usage_data:
             total_tokens = usage_data.get("total_tokens")
-            logging.info(f"{total_tokens}")
+            logging.debug(f"Groq Total Tokens Response Usage: {total_tokens}")
 
     def basic_request(self, prompt: str, **kwargs):
         raw_kwargs = kwargs

--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -20,9 +20,7 @@ class Settings:
             cls._instance.main_tid = threading.get_ident()
             cls._instance.main_stack = []
             cls._instance.stack_by_thread = {}
-            cls._instance.stack_by_thread[
-                threading.get_ident()
-            ] = cls._instance.main_stack
+            cls._instance.stack_by_thread[threading.get_ident()] = cls._instance.main_stack
 
             #  TODO: remove first-class support for re-ranker and potentially combine with RM to form a pipeline of sorts
             #  eg: RetrieveThenRerankPipeline(RetrievalModel, Reranker)
@@ -38,7 +36,6 @@ class Settings:
                 skip_logprobs=False,
                 trace=[],
                 release=0,
-                log_openai_usage=False,
                 bypass_assert=False,
                 bypass_suggest=False,
                 assert_failures=0,

--- a/dspy/utils/logging.py
+++ b/dspy/utils/logging.py
@@ -42,7 +42,10 @@ class LogSettings:
         )
 
     def set_log_output(
-        self, method: t.Optional[str] = None, file_name: t.Optional[str] = None, output_type: t.Optional[str] = None,
+        self,
+        method: t.Optional[str] = None,
+        file_name: t.Optional[str] = None,
+        output_type: t.Optional[str] = None,
     ):
         if method is not None and method not in ["console", "file"]:
             raise ValueError("method provided can only be 'console', 'file'")
@@ -78,12 +81,14 @@ class LogSettings:
 
 level = os.environ.get("LOG_LEVEL", "info").upper()
 
+
 # Set Defaults
-logging.basicConfig(
-    format="%(message)s",
-    stream=sys.stdout,
-    level=level,
-)
+def show_logging(level: str = level) -> None:
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stdout,
+        level=level,
+    )
 
 
 settings = LogSettings(output_type="str", method="console", file_name=None)

--- a/dspy/utils/logging.py
+++ b/dspy/utils/logging.py
@@ -90,6 +90,11 @@ def show_logging(level: str = level) -> None:
         level=level,
     )
 
+    # 'backoff' is used by OpenAI, and defaults their log level to INFO.
+    # this can clobber up dspy relevant logging for users
+    # this silences there logs.
+    logging.getLogger("backoff").setLevel(logging.WARNING)
+
 
 settings = LogSettings(output_type="str", method="console", file_name=None)
 set_log_output = settings.set_log_output


### PR DESCRIPTION
Deprecate the 'log_openai_usage' configuration option.
As we are now moving to proper logging, we now log all usage by default, and allow the user to specify how they want to handle the logs themselves.

This removes the setting, and all mentions of this settings across gpt3/anthropic/azure_openai/groq.