### PR TITLE
fix(dspy/modules/aws_models): properly copy kwargs so temporary changes don't propagate to base model

### DIFF
--- a/dsp/modules/aws_models.py
+++ b/dsp/modules/aws_models.py
@@ -148,7 +148,7 @@ class AWSMistral(AWSModel):
         return "<s> [INST] Human: " + raw_prompt + " [/INST] Assistant: "
 
     def _create_body(self, prompt: str, **kwargs) -> tuple[int, dict[str, str | float]]:
-        base_args: dict[str, Any] = self.kwargs
+        base_args: dict[str, Any] = self.kwargs.copy()
         for k, v in kwargs.items():
             base_args[k] = v
 
@@ -211,7 +211,7 @@ class AWSAnthropic(AWSModel):
             self.kwargs[k] = v
 
     def _create_body(self, prompt: str, **kwargs) -> tuple[int, dict[str, str | float]]:
-        base_args: dict[str, Any] = self.kwargs
+        base_args: dict[str, Any] = self.kwargs.copy()
         for k, v in kwargs.items():
             base_args[k] = v
 
@@ -275,7 +275,7 @@ class AWSMeta(AWSModel):
         self.kwargs["max_gen_len"] = self.kwargs.pop("max_tokens")
 
     def _create_body(self, prompt: str, **kwargs) -> tuple[int, dict[str, str | float]]:
-        base_args: dict[str, Any] = self.kwargs
+        base_args: dict[str, Any] = self.kwargs.copy()
         for k, v in kwargs.items():
             base_args[k] = v
 


### PR DESCRIPTION
When the kwargs of the model get altered for the body, we don't want the new kwargs saved to the original llm object. This fixes a bug caused by the mutability of kwargs.

In my case, the bug resulted in the max_tokens to repeatedly get cut in half every time i would re-run the model due to following logic in `predict.py` 
```
            max_tokens = min(max(75, max_tokens // 2), max_tokens)
            keys = list(kwargs.keys()) + list(dsp.settings.lm.kwargs.keys()) 
            max_tokens_key = "max_tokens" if "max_tokens" in keys else "max_output_tokens"
            new_kwargs = {
                **kwargs,
                max_tokens_key: max_tokens,
                "n": 1,
                "temperature": 0.0,
            }
```