### PR TITLE
feature(dsp) Add context to details

### DIFF
--- a/dspy/datasets/hotpotqa.py
+++ b/dspy/datasets/hotpotqa.py
@@ -18,7 +18,7 @@ class HotPotQA(Dataset):
         for raw_example in hf_official_train:
             if raw_example['level'] == 'hard':
                 if keep_details is True:
-                    keys = ['id', 'question', 'answer', 'type', 'supporting_facts']
+                    keys = ['id', 'question', 'answer', 'type', 'supporting_facts', 'context']
                 elif keep_details == 'dev_titles':
                     keys = ['question', 'answer', 'supporting_facts']
                 else:


### PR DESCRIPTION
Add context to details to make it easier to run evaluations.
We want want to make it easier to retrieve context outside of dspy retriever