### PR TITLE
feature(dsp) Remove default max token param from OpenAI

### DIFF
--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -82,7 +82,6 @@ class GPT3(LM):
 
         self.kwargs = {
             "temperature": 0.0,
-            "max_tokens": 150,
             "top_p": 1,
             "frequency_penalty": 0,
             "presence_penalty": 0,


### PR DESCRIPTION
For sending data to models with large context, this causes an artificial limit of outbound text and limits to max 8000 tokens.
You are unable to set a large max_token value due to inherent limitations, and with a small value, it is hard to get more complex prompts to work for knowledge graph generation.

OpenAI sets it to infinite, which is optimal.