### PR TITLE
fix: fix groq integration issue

### DIFF
--- a/dsp/modules/groq_client.py
+++ b/dsp/modules/groq_client.py
@@ -64,9 +64,9 @@ class GroqLM(LM):
 
     def log_usage(self, response):
         """Log the total tokens from the Groq API response."""
-        usage_data = response.get("usage")
+        usage_data = response.usage
         if usage_data:
-            total_tokens = usage_data.get("total_tokens")
+            total_tokens = usage_data.total_tokens
             logging.debug(f"Groq Total Tokens Response Usage: {total_tokens}")
 
     def basic_request(self, prompt: str, **kwargs):


### PR DESCRIPTION
fix #867

Previously running groq model will trigger the exception

```
AttributeError: 'ChatCompletion' object has no attribute 'get'
AttributeError: 'Usage' object has no attribute 'get'
```

This pull request uses ChatCompletion attribute instead of `get`