### PR TITLE
fix: AttributeError: 'str' object has no attribute 'long_text'

### DIFF
--- a/dspy/retrieve/ragatouille_rm.py
+++ b/dspy/retrieve/ragatouille_rm.py
@@ -59,4 +59,4 @@ class RAGatouilleRM(dspy.Retrieve):
         for query in queries:
             results = self.model.search(query=query, k=k)
             passages.extend(dotdict({"long_text": d["content"]}) for d in results)
-        return dspy.Prediction(passages=passages)
+        return dspy.Prediction(passages=passages).passages


### PR DESCRIPTION
```
.venv/lib/python3.11/site-packages/dsp/primitives/search.py", line 17, in <listcomp>
    passages = [psg.long_text for psg in passages]
                ^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'long_text'
```