### PR TITLE
fix/remove n=1 in fallback generate logic when not all fields have been generated

### DIFF
--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -112,7 +112,6 @@ def _generate(template: Template, **kwargs) -> Callable:
             new_kwargs = {
                 **kwargs,
                 max_tokens_key: max_tokens,
-                "n": 1,
                 "temperature": 0.0,
             }
 


### PR DESCRIPTION
Fixes https://github.com/stanfordnlp/dspy/issues/914 and I suspect https://github.com/stanfordnlp/dspy/issues/749

Had to disable pre-commit, linting, and formatting to keep this change atomised to a single line as this file pre-dates changes to the pre-commit settings.

Explaination:

When the required fields are not generated by in any of the completions, [fallback logic](https://github.com/stanfordnlp/dspy/blob/d09d984ecaf17f7262294d50fe46fd8105fbf291/dsp/primitives/predict.py#L95) is entered which `generate` is called recursively until the fields are created:

```python
        # If none of the completions is completed (i.e., none has the final field set).
        if last_field_idx < len(field_names):
            # Pick the first completion that has gone farthest.
            completion = completions[0]
```
However, in this logic, `n` - the number of completions - is set to 1 before `generate` is called again. 

```python
            new_kwargs = {
                **kwargs,
                max_tokens_key: max_tokens,
                "n": 1,
                "temperature": 0.0,
            }

            assert max_depth > 0
            return generate(template, **new_kwargs)(
                completion,
                stage=stage,
                max_depth=max_depth - 1,
                original_example=original_example,
            )
```

This PR removes `"n":1`.

These updates to the kwargs have been in since the initial commit so caution is advised! However, the signature of the function is not affected and based on my understanding of the logic, this should "just work". The temperature being 0 is another thing I would like a maintainer's view upon - as with this fix all the completions would be the same!

I do wonder if the "correct" way to fix this is to recursively continue the completion for all candidate completions as opposed to the one which has got the furthest when the user has set `n` - but that feels like a more extensive change to the logic which would need some additional thought and testing.

There are other parts of `do_generate` which [quietly strip completions](https://github.com/stanfordnlp/dspy/blob/d09d984ecaf17f7262294d50fe46fd8105fbf291/dsp/primitives/predict.py#L95) which could still result in behaviour like #914 even if this change to [`predict.py`]((https://github.com/stanfordnlp/dspy/blob/d09d984ecaf17f7262294d50fe46fd8105fbf291/dsp/primitives/predict.py#L95)) is made. 

```python 

        last_field_idx = 0
        for field_idx, key in enumerate(field_names):
            completions_ = [
                c for c in completions if key in c.keys() and c[key] is not None
            ]

            # Filter out completions that are missing fields that are present in at least one completion.
            if len(completions_):
                completions = completions_
                last_field_idx = field_idx + 1
```

Another option is to update the documentation of `n` to make it clear that it is a limit on the number of returned completions per step in the graph and not a guarantee. For example [here](https://dspy-docs.vercel.app/docs/building-blocks/language_models#tips-and-tricks) in the docs it seems pretty clear that users are meant to treat `n` as a guarantee, not a limit.  

Cheers