### PR TITLE
fix/Extend generation for all candidate completions

### DIFF
--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -63,13 +63,9 @@ def _generate(template: Template, **kwargs) -> Callable:
 
     def extend_generation(completion: Example, field_names: list[str], stage:str, max_depth: int, original_example:Example):
         """If the required fields are not present in the completion, extend the generation."""
+
         # remove content of last field to avoid half-completed content
-        for field_idx, key in enumerate(field_names):
-            if key not in completion:
-                break
-            if completion[key] is None or completion[key] == "":
-                break
-        completion[field_names[field_idx]] = ""
+        completion[get_last_field(completion, field_names)] = ""
 
         # Recurse with greedy decoding and a shorter length.
         max_tokens = (kwargs.get("max_tokens") or 
@@ -165,6 +161,12 @@ def _generate(template: Template, **kwargs) -> Callable:
 
     return do_generate
 
+def get_last_field(completion, field_names):
+    for key in field_names:
+        if key not in completion:
+            return key
+        if completion[key] is None or completion[key] == "":
+            return key
 
 def generate_sc(
     example, prompt, normalize=True, extract=None, prediction_field=None, **kwargs,

--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -112,7 +112,6 @@ def _generate(template: Template, **kwargs) -> Callable:
             new_kwargs = {
                 **kwargs,
                 max_tokens_key: max_tokens,
-                "n": 1,
                 "temperature": 0.0,
             }
 

--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -65,7 +65,7 @@ def _generate(template: Template, **kwargs) -> Callable:
         """If the required fields are not present in the completion, extend the generation."""
         # remove content of last field to avoid half-completed content
         for field_name in get_all_fields_following_missing_field(completion, field_names):
-            completion[field_name] = ""
+            completion.pop(field_name, None)
 
         # Recurse with greedy decoding and a shorter length.
         max_tokens = (kwargs.get("max_tokens") or 

--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -61,6 +61,45 @@ def _generate(template: Template, **kwargs) -> Callable:
 
     generator = dsp.settings.lm
 
+    def extend_generation(completion: Example, field_names: list[str], stage:str, max_depth: int, original_example:Example):
+        """If the required fields are not present in the completion, extend the generation."""
+        # remove content of last field to avoid half-completed content
+        for field_idx, key in enumerate(field_names):
+            if key not in completion:
+                break
+            if completion[key] is None or completion[key] == "":
+                break
+        completion[field_names[field_idx]] = ""
+
+        # Recurse with greedy decoding and a shorter length.
+        max_tokens = (kwargs.get("max_tokens") or 
+                    kwargs.get("max_output_tokens") or
+                    dsp.settings.lm.kwargs.get("max_tokens") or 
+                    dsp.settings.lm.kwargs.get('max_output_tokens'))
+
+
+        if max_tokens is None:
+            raise ValueError("Required 'max_tokens' or 'max_output_tokens' not specified in settings.")
+        max_tokens = min(max(75, max_tokens // 2), max_tokens)
+        keys = list(kwargs.keys()) + list(dsp.settings.lm.kwargs.keys()) 
+        max_tokens_key = "max_tokens" if "max_tokens" in keys else "max_output_tokens"
+        new_kwargs = {
+            **kwargs,
+            max_tokens_key: max_tokens,
+            "n": 1,
+            "temperature": 0.0,
+        }
+
+        assert max_depth > 0, "Max depth exceeded - failed to complete in one pass - increase max_tokens"
+        _, finished_completion = generate(template, **new_kwargs)(
+            completion,
+            stage=stage,
+            max_depth=max_depth - 1,
+            original_example=original_example,
+        )
+        return finished_completion.data[0]
+        
+
     def do_generate(
         example: Example, stage: str, max_depth: int = 2, original_example=None,
     ):
@@ -77,53 +116,19 @@ def _generate(template: Template, **kwargs) -> Callable:
         completions: list[dict[str, Any]] = generator(prompt, **kwargs)
         completions: list[Example] = [template.extract(example, p) for p in completions]
 
-        # Find the completions that are most complete.
+        # Find the completions that are unfinished.
         field_names: list[str] = [field.input_variable for field in template.fields]
 
-        last_field_idx = 0
-        for field_idx, key in enumerate(field_names):
-            completions_ = [
-                c for c in completions if key in c.keys() and c[key] is not None
-            ]
-
-            # Filter out completions that are missing fields that are present in at least one completion.
-            if len(completions_):
-                completions = completions_
-                last_field_idx = field_idx + 1
-
-        # If none of the completions is completed (i.e., none has the final field set).
-        if last_field_idx < len(field_names):
-            # Pick the first completion that has gone farthest.
-            completion = completions[0]
-            completion[field_names[last_field_idx]] = ""
-
-            # Recurse with greedy decoding and a shorter length.
-            max_tokens = (kwargs.get("max_tokens") or 
-                        kwargs.get("max_output_tokens") or
-                        dsp.settings.lm.kwargs.get("max_tokens") or 
-                        dsp.settings.lm.kwargs.get('max_output_tokens'))
-
-
-            if max_tokens is None:
-                raise ValueError("Required 'max_tokens' or 'max_output_tokens' not specified in settings.")
-            max_tokens = min(max(75, max_tokens // 2), max_tokens)
-            keys = list(kwargs.keys()) + list(dsp.settings.lm.kwargs.keys()) 
-            max_tokens_key = "max_tokens" if "max_tokens" in keys else "max_output_tokens"
-            new_kwargs = {
-                **kwargs,
-                max_tokens_key: max_tokens,
-                "temperature": 0.0,
-            }
-
-            assert max_depth > 0
-            return generate(template, **new_kwargs)(
-                completion,
-                stage=stage,
-                max_depth=max_depth - 1,
-                original_example=original_example,
+        finished_completions = []
+        for completion in completions:
+            if all(key in completion for key in field_names):
+                finished_completions.append(completion)
+                continue
+            finished_completions.append(
+                extend_generation(completion, field_names, stage, max_depth, original_example)
             )
 
-        completions = Completions(completions, template=template)
+        completions = Completions(finished_completions, template=template)
         example = example.copy(completions=completions)
 
         if len(completions) == 1:

--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -161,7 +161,7 @@ def _generate(template: Template, **kwargs) -> Callable:
 
     return do_generate
 
-def get_last_field(completion, field_names):
+def get_last_field(completion: Example, field_names: list[str]):
     for key in field_names:
         if key not in completion:
             return key

--- a/dsp/primitives/predict.py
+++ b/dsp/primitives/predict.py
@@ -121,7 +121,7 @@ def _generate(template: Template, **kwargs) -> Callable:
                 finished_completions.append(completion)
                 continue
             finished_completions.append(
-                extend_generation(completion, field_names, stage, max_depth, original_example)
+                extend_generation(completion, field_names, stage, max_depth, original_example),
             )
 
         completions = Completions(finished_completions, template=template)


### PR DESCRIPTION
Following from https://github.com/stanfordnlp/dspy/pull/918 - This PR attempts a fuller implementation of the fix suggested there such that every candidate completion is extended until it contains valid content for every field in the template. 

Fixes https://github.com/stanfordnlp/dspy/issues/914 and I suspect https://github.com/stanfordnlp/dspy/issues/749 and some other raised issues.

The current, unpatched, behaviour also seems to be replicated in the [backend-refactor](https://github.com/stanfordnlp/dspy/tree/backend-refactor) branch.

This PR makes the following changes to the logic of `do_generate` in `dsp/primitives/predict.py`:
- Differentiates between `completions` and `finished_completions` where `finished_completions` have entries for every field in the template.
- Introduces the function`extend_generation` to `dsp/primitives/predict.py`, in the ns of `_generate` which ensures (up to two levels of recursion) that every template field has valid content for all `n` completions requested.
- Introduces `get_last_field` to acquire the last valid field of an Example.
- Maintains overwriting of temperature in extended completions.

Further suggestions:
- Should this method raise warnings suggesting that `max_tokens` should be increased? This implementation could slow down forward passes significantly.