### PR TITLE
Update langchain.py for old field types

### DIFF
--- a/dspy/predict/langchain.py
+++ b/dspy/predict/langchain.py
@@ -9,7 +9,7 @@ import dspy
 from dspy.predict.parameter import Parameter
 from dspy.predict.predict import Predict
 from dspy.primitives.prediction import Prediction
-from dspy.signatures.field import InputField, OutputField
+from dspy.signatures.field import OldInputField as InputField, OldOutputField as OutputField
 from dspy.signatures.signature import infer_prefix
 
 # TODO: This class is currently hard to test, because it hardcodes gpt-4 usage:


### PR DESCRIPTION
in langchain.py import Old Fields as Fields

This is a short-term fix until langchain.py can be migrated to the new Pydantic fields