### PR TITLE
feature(dspy): Copro optimizer prompts are now injectable

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -75,26 +75,31 @@ class COPRO(Teleprompter):
         self.init_temperature = init_temperature
         self.prompt_model = prompt_model
         self.track_stats = track_stats
+        self._additional_instructions = additional_instructions
 
-        self.basic_generate_instruction = (
-            self._get_signature(BasicGenerateInstruction).with_instructions(
-                " ".join([BasicGenerateInstruction.instructions, additional_instructions])
-            )
-            if additional_instructions
-            else BasicGenerateInstruction
-        )
-        self.generate_instruction_given_attempts = (
-            self._get_signature(GenerateInstructionGivenAttempts).with_instructions(
-                " ".join([GenerateInstructionGivenAttempts.instructions, additional_instructions])
-            )
-            if additional_instructions
-            else GenerateInstructionGivenAttempts
-        )
 
         if "verbose" in _kwargs:
             dspy.logger.warning(
                 "DeprecationWarning: 'verbose' has been deprecated. To see all information for debugging, use 'dspy.set_log_level('debug')'. In the future this will raise an error."
             )
+
+    @property
+    def basic_generate_instruction(self):
+        return (self._get_signature(BasicGenerateInstruction).with_instructions(
+                " ".join([BasicGenerateInstruction.instructions, self._additional_instructions])
+            )
+            if self._additional_instructions
+            else BasicGenerateInstruction)
+
+    @property
+    def generate_instruction_given_attempts(self):
+        return (
+            self._get_signature(GenerateInstructionGivenAttempts).with_instructions(
+                " ".join([GenerateInstructionGivenAttempts.instructions, self._additional_instructions])
+            )
+            if self._additional_instructions
+            else GenerateInstructionGivenAttempts
+        )
 
     def _check_candidates_equal(self, candidate1, candidate2):
         for p1, p2 in zip(candidate1["program"].predictors(), candidate2["program"].predictors()):

--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -63,6 +63,8 @@ class COPRO(Teleprompter):
         depth=3,
         init_temperature=1.4,
         track_stats=False,
+        basic_generate_instruction=None,
+        generate_instruction_given_attempts=None,
         **_kwargs,
     ):
         if breadth <= 1:
@@ -73,6 +75,8 @@ class COPRO(Teleprompter):
         self.init_temperature = init_temperature
         self.prompt_model = prompt_model
         self.track_stats = track_stats
+        self.basic_generate_instruction = basic_generate_instruction or BasicGenerateInstruction
+        self.generate_instruction_given_attempts = generate_instruction_given_attempts or GenerateInstructionGivenAttempts
 
         if "verbose" in _kwargs:
             dspy.logger.warning("DeprecationWarning: 'verbose' has been deprecated. To see all information for debugging, use 'dspy.set_log_level('debug')'. In the future this will raise an error.")
@@ -153,13 +157,13 @@ class COPRO(Teleprompter):
             if self.prompt_model:
                 with dspy.settings.context(lm=self.prompt_model):
                     instruct = dspy.Predict(
-                        BasicGenerateInstruction,
+                        self.basic_generate_instruction,
                         n=self.breadth - 1,
                         temperature=self.init_temperature,
                     )(basic_instruction=basic_instruction)
             else:
                 instruct = dspy.Predict(
-                    BasicGenerateInstruction,
+                    self.basic_generate_instruction,
                     n=self.breadth - 1,
                     temperature=self.init_temperature,
                 )(basic_instruction=basic_instruction)
@@ -299,13 +303,13 @@ class COPRO(Teleprompter):
                 if self.prompt_model:
                     with dspy.settings.context(lm=self.prompt_model):
                         instr = dspy.Predict(
-                            GenerateInstructionGivenAttempts,
+                            self.generate_instruction_given_attempts,
                             n=self.breadth,
                             temperature=self.init_temperature,
                         )(attempted_instructions=attempts)
                 else:
                     instr = dspy.Predict(
-                        GenerateInstructionGivenAttempts,
+                        self.generate_instruction_given_attempts,
                         n=self.breadth,
                         temperature=self.init_temperature,
                     )(attempted_instructions=attempts)

--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -29,7 +29,7 @@ Note that this teleprompter takes in the following parameters:
                     * results_latest: The min,max,avg,stddev of newest prompt scores for each predictor at each depth.
                     * total_calls: The total number of calls to the task metric.
                 These statistics will be returned as attributes of the best program.
-* additional_instructions: Instructions appended to the generation signatures. Can be used to provide explicit details on the optimization metric. 
+* additional_instructions: Instructions appended to the generation signatures. Can be used to provide explicit details on the optimization metric.
 """
 
 
@@ -77,26 +77,28 @@ class COPRO(Teleprompter):
         self.track_stats = track_stats
         self._additional_instructions = additional_instructions
 
-
         if "verbose" in _kwargs:
             dspy.logger.warning(
-                "DeprecationWarning: 'verbose' has been deprecated. To see all information for debugging, use 'dspy.set_log_level('debug')'. In the future this will raise an error."
+                "DeprecationWarning: 'verbose' has been deprecated. To see all information for debugging, use 'dspy.set_log_level('debug')'. In the future this will raise an error.",
             )
+
+    def append_instructions(self, base_signature, additional_instructions):
+        return self._get_signature(base_signature).with_instructions(
+            " ".join([base_signature.instructions, additional_instructions]),
+        )
 
     @property
     def basic_generate_instruction(self):
-        return (self._get_signature(BasicGenerateInstruction).with_instructions(
-                " ".join([BasicGenerateInstruction.instructions, self._additional_instructions])
-            )
+        return (
+            self.append_instructions(BasicGenerateInstruction, self._additional_instructions)
             if self._additional_instructions
-            else BasicGenerateInstruction)
+            else BasicGenerateInstruction
+        )
 
     @property
     def generate_instruction_given_attempts(self):
         return (
-            self._get_signature(GenerateInstructionGivenAttempts).with_instructions(
-                " ".join([GenerateInstructionGivenAttempts.instructions, self._additional_instructions])
-            )
+            self.append_instructions(GenerateInstructionGivenAttempts, self._additional_instructions)
             if self._additional_instructions
             else GenerateInstructionGivenAttempts
         )
@@ -336,7 +338,7 @@ class COPRO(Teleprompter):
 
                 if self.prompt_model:
                     dspy.logger.debug(
-                        f"(self.prompt_model.inspect_history(n=1)) {self.prompt_model.inspect_history(n=1)}"
+                        f"(self.prompt_model.inspect_history(n=1)) {self.prompt_model.inspect_history(n=1)}",
                     )
                 # Get candidates for each predictor
                 new_candidates[id(p_base)] = instr.completions

--- a/dspy/teleprompt/mipro_optimizer.py
+++ b/dspy/teleprompt/mipro_optimizer.py
@@ -189,7 +189,7 @@ class MIPRO(Teleprompter):
     def generate_instruction_with_examples_and_observations(self):
         return (
             self.append_instructions(
-                BasicGenerateInstructionWithExamplesAndDataObservations, self._additional_instructions
+                BasicGenerateInstructionWithExamplesAndDataObservations, self._additional_instructions,
             )
             if self._additional_instructions
             else BasicGenerateInstructionWithExamplesAndDataObservations

--- a/dspy/teleprompt/mipro_optimizer.py
+++ b/dspy/teleprompt/mipro_optimizer.py
@@ -154,38 +154,46 @@ class MIPRO(Teleprompter):
         self.track_stats = track_stats
         self.teacher_settings = teacher_settings
         self.view_data_batch_size = view_data_batch_size
+        self._additional_instructions = additional_instructions
 
-        self.basic_generate_instruction = (
-            self._get_signature(BasicGenerateInstruction).with_instructions(
-                " ".join([BasicGenerateInstruction.instructions, additional_instructions])
-            )
-            if additional_instructions
-            else BasicGenerateInstruction
+    @property
+    def basic_generate_instruction(self):
+        return (self._get_signature(BasicGenerateInstruction).with_instructions(
+            " ".join([BasicGenerateInstruction.instructions, self._additional_instructions])
         )
+                if self._additional_instructions
+                else BasicGenerateInstruction)
 
-        self.generate_instruction_with_data_observations = (
+    @property
+    def generate_instruction_with_data_observations(self):
+        return (
             self._get_signature(BasicGenerateInstructionWithDataObservations).with_instructions(
-                " ".join([BasicGenerateInstructionWithDataObservations.instructions, additional_instructions])
+                " ".join([BasicGenerateInstructionWithDataObservations.instructions, self._additional_instructions])
             )
-            if additional_instructions
+            if self._additional_instructions
             else BasicGenerateInstructionWithDataObservations
         )
 
-        self.generate_instruction_with_examples = (
+    @property
+    def generate_instruction_with_examples(self):
+        return (
             self._get_signature(BasicGenerateInstructionWithExamples).with_instructions(
-                " ".join([BasicGenerateInstructionWithExamples.instructions, additional_instructions])
+                " ".join([BasicGenerateInstructionWithExamples.instructions, self._additional_instructions])
             )
-            if additional_instructions
+            if self._additional_instructions
             else BasicGenerateInstructionWithExamples
         )
 
-        self.generate_instruction_with_examples_and_observations = (
+    @property
+    def generate_instruction_with_examples_and_observations(self):
+        return (
             self._get_signature(BasicGenerateInstructionWithExamplesAndDataObservations).with_instructions(
-                " ".join([BasicGenerateInstructionWithExamplesAndDataObservations.instructions, additional_instructions])
+                " ".join([BasicGenerateInstructionWithExamplesAndDataObservations.instructions, self._additional_instructions])
             )
-            if additional_instructions
+            if self._additional_instructions
             else BasicGenerateInstructionWithExamplesAndDataObservations
         )
+
 
     def _print_full_program(self, program):
         for i, predictor in enumerate(program.predictors()):


### PR DESCRIPTION
What:
Allow additional instruction to be added to the signatures used to generate the prompts.

Why:
Generally speaking, it allows the users more freedom regarding the instructions used to generate the prompts.

In our case, It unluck new possibilities to guide the generating prompt. Optimization based on metrics is already a powerful approach. However, being able to add details regarding how the prompt will be evaluated would help generate prompts that fulfill the requirements that must be filled out without relying only on the LLM to understand what is essential from the metrics score.

How:
- Simply added a field to append instructions to the base one in property methods. 
- The changes are backward compatible from the None initialization.