### PR TITLE
fix(dspy): added `copy` to `OllamaLocal` to propagate `model`, `model_type`, `base_url` and `timeout_s`.

### DIFF
--- a/dsp/modules/ollama.py
+++ b/dsp/modules/ollama.py
@@ -180,3 +180,15 @@ class OllamaLocal(LM):
         completions = [self._get_choice_text(c) for c in choices]
 
         return completions
+    
+    def copy(self, **kwargs):
+        """Returns a copy of the language model with the same parameters."""
+        kwargs = {**self.kwargs, **kwargs}
+
+        return self.__class__(
+            model=self.model_name,
+            model_type=self.model_type,
+            base_url=self.base_url,
+            timeout_s=self.timeout_s,
+            **kwargs,
+        )


### PR DESCRIPTION
This problem is very similar to #769. `OllamaLocal.copy` uses `LM.copy`. However, `OllamaLocal`'s `kwargs` dict doesn't have `model` key, which means `model = kwargs.pop("model")` will create a `KeyError`. This fix added a `copy` method to `OllamaLocal` class so that it's own attributes like `model`, `model_type`, `base_url` and `timeout_s` can be copied.