### PR TITLE
add missing kwargs when invoking retrieveRerankEnsemble

### DIFF
--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -49,7 +49,7 @@ def retrieveEnsemble(queries: list[str], k: int, by_prob: bool = True,**kwargs) 
     if not dsp.settings.rm:
         raise AssertionError("No RM is loaded.")
     if dsp.settings.reranker:
-        return retrieveRerankEnsemble(queries, k)
+        return retrieveRerankEnsemble(queries, k, **kwargs)
     
     queries = [q for q in queries if q]
 


### PR DESCRIPTION
When invoking `retrieveRerankEnsemble` in  https://github.com/stanfordnlp/dspy/blob/d7dace6b51e1c0899fd798c575262310939f6deb/dsp/primitives/search.py#L52, it's missing `kwargs` 