### PR TITLE
Remove common indentations in signature according to Python Docstring convention

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 import re
 import types
 import typing
@@ -88,7 +89,7 @@ class SignatureMeta(type(BaseModel)):
 
     @property
     def instructions(cls) -> str:
-        return getattr(cls, "__doc__", "")
+        return inspect.cleandoc(getattr(cls, "__doc__", ""))
 
     def with_instructions(cls, instructions: str) -> Type["Signature"]:
         return Signature(cls.fields, instructions)
@@ -217,9 +218,9 @@ def ensure_signature(signature: Union[str, Type[Signature]], instructions=None) 
 
 
 def make_signature(
-    signature: Union[str, Dict[str, Tuple[type, FieldInfo]]],
-    instructions: str = None,
-    signature_name: str = "StringSignature",
+        signature: Union[str, Dict[str, Tuple[type, FieldInfo]]],
+        instructions: str = None,
+        signature_name: str = "StringSignature",
 ) -> Type[Signature]:
     """Create a new Signature type with the given fields and instructions.
 

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -183,7 +183,8 @@ def test_insantiating2():
 def test_multiline_instructions():
     class MySignature(Signature):
         """First line
-        Second line"""
+        Second line
+            Third line"""
 
         output = OutputField()
 
@@ -195,7 +196,8 @@ def test_multiline_instructions():
 
     assert lm.get_convo(-1) == textwrap.dedent("""\
         First line
-                Second line
+        Second line
+            Third line
         
         ---
         


### PR DESCRIPTION
* Remove common indentations like it is done in docstring tools
* Fixes https://github.com/stanfordnlp/dspy/issues/986