### PR TITLE
fix(evaluate): `Evaluate` should not error when `display_table=True`

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -218,12 +218,12 @@ class Evaluate:
         result_df = result_df.rename(columns={"correct": metric_name})
 
         if display_table:
-            if isinstance(display_table, int):
-                df_to_display = result_df.head(display_table).copy()
-                truncated_rows = len(result_df) - display_table
-            else:
+            if isinstance(display_table, bool):
                 df_to_display = result_df.copy()
                 truncated_rows = 0
+            else:
+                df_to_display = result_df.head(display_table).copy()
+                truncated_rows = len(result_df) - display_table
 
             styled_df = configure_dataframe_display(df_to_display, metric_name)
 

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -112,11 +112,17 @@ def test_evaluate_call_bad():
     assert score == 0.0
 
 
-def test_evaluate_display_table():
+@pytest.mark.parametrize(
+    "display_table", [True, False, 1]
+)
+def test_evaluate_display_table(display_table):
     devset = [new_example("What is 1+1?", "2")]
+    program = Predict("question -> answer")
     ev = Evaluate(
         devset=devset,
         metric=answer_exact_match,
-        display_table=True,
+        display_table=display_table,
     )
-    assert ev.display_table == True
+    assert ev.display_table == display_table
+
+    ev(program)


### PR DESCRIPTION
Obtained an error when `display_table=True` is provided for `Evaluate`. 
See simple reproducible example below:

```py
from dspy.evaluate.evaluate import Evaluate
from dspy.evaluate.metrics import answer_exact_match
from dspy.predict import Predict

def new_example(question, answer):
    """Helper function to create a new example."""
    return dspy.Example(
        question=question,
        answer=answer,
    ).with_inputs("question")

devset = [new_example("What is 1+1?", "2")]

program = Predict("question -> answer")

ev = Evaluate(
    devset=devset,
    metric=answer_exact_match,
    display_table=True,
)
ev(program)  # TypeError: cannot do positional indexing on RangeIndex with these indexers [True] of type bool
```

This stems from `isinstance(True, int) == True`. 

This PR contains a proposed fix with updated unit tests. Feel free to re-structure the unit tests as you see fit.