### PR TITLE
fix(react): `ReAct` doesn't use `instructions` from the given `Signature`

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -28,11 +28,16 @@ class ReAct(Module):
         inputs_ = ", ".join([f"`{k}`" for k in self.input_fields.keys()])
         outputs_ = ", ".join([f"`{k}`" for k in self.output_fields.keys()])
 
-        instr = [
+        instr = []
+        
+        if self.signature.instructions is not None:
+            instr.append(f"{self.signature.instructions}\n")
+        
+        instr.extend([
             f"You will be given {inputs_} and you will respond with {outputs_}.\n",
             "To do this, you will interleave Thought, Action, and Observation steps.\n",
             "Thought can reason about the current situation, and Action can be the following types:\n",
-        ]
+        ])
 
         self.tools["Finish"] = dspy.Example(
             name="Finish",

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -154,3 +154,16 @@ def test_custom_tools():
         "Thought 3: Even more thoughts\n\n"
         "Action 3: Finish[baz]"
     )
+
+
+def test_signature_instructions():
+    class ExampleSignature(dspy.Signature):
+        """You are going to generate output based on input."""
+
+        input = dspy.InputField()
+        output = dspy.OutputField()
+
+    react = dspy.ReAct(ExampleSignature)
+
+    assert react.react[0].signature.instructions is not None
+    assert react.react[0].signature.instructions.startswith("You are going to generate output based on input.")


### PR DESCRIPTION
When I use `ReAct` with `Signature`, I find that the `instructions` field in the given signature is ignored by the `ReAct` class, this behavior is not consistent with `Predict`. This fix provides a workaround for the issue. 