### PR TITLE
fix: assertion and chain-of-thought

### DIFF
--- a/dspy/predict/retry.py
+++ b/dspy/predict/retry.py
@@ -10,16 +10,17 @@ class Retry(Predict):
     def __init__(self, module):
         super().__init__(module.signature)
         self.module = module
-        self.original_signature = module.signature
+        self.original_signature = module.extended_signature if isinstance(module, dspy.ChainOfThought) else module.signature
         self.original_forward = module.forward
         self.new_signature = self._create_new_signature(self.original_signature)
 
     def _create_new_signature(self, signature):
         # Add "Past" input fields for each output field
         for key, value in signature.output_fields.items():
+            actual_prefix = value.json_schema_extra["prefix"].split(":")[0] + ":"
             signature = signature.append(f"past_{key}", dspy.InputField(
-                prefix="Past " + value.json_schema_extra["prefix"],
-                desc="past output with errors",
+                prefix="Previous " + actual_prefix,
+                desc=f"past {actual_prefix} with errors",
                 format=value.json_schema_extra.get("format"),
             ))
 

--- a/dspy/primitives/assertions.py
+++ b/dspy/primitives/assertions.py
@@ -105,10 +105,10 @@ class Suggest(Constraint):
             if self.result:
                 return True
             elif dspy.settings.bypass_suggest:
-                dspy.logger.error(f"SuggestionFailed: {self.msg}")
+                dspy.logger.info(f"SuggestionFailed: {self.msg}")
                 return True
             else:
-                dspy.logger.error(f"SuggestionFailed: {self.msg}")
+                dspy.logger.info(f"SuggestionFailed: {self.msg}")
                 raise DSPySuggestionError(
                     id=self.id,
                     msg=self.msg,
@@ -257,8 +257,7 @@ def backtrack_handler(func, bypass_suggest=True, max_backtracks=2):
                             ):
                                 dspy.settings.predictor_feedbacks[dspy.settings.backtrack_to].append(error_msg)
 
-                            # assert isinstance(error_state[0].signature, dspy.Signature)
-                            output_fields = error_state[0].signature.output_fields
+                            output_fields = error_state[0].new_signature.output_fields
                             past_outputs = {}
                             for field_name in output_fields.keys():
                                 past_outputs[field_name] = getattr(


### PR DESCRIPTION
Previously, `ChainOfThought` does not work well with assertions due to an error in handling the `rationale` field of the CoT module. This pr fixes this issue. A future improvement would be implementing unit tests for CoT and Retry in `test_retry.py`.