### PR TITLE
Langchain integration bug fixed

### DIFF
--- a/dspy/predict/langchain.py
+++ b/dspy/predict/langchain.py
@@ -9,7 +9,7 @@ import dspy
 from dspy.predict.parameter import Parameter
 from dspy.predict.predict import Predict
 from dspy.primitives.prediction import Prediction
-from dspy.signatures.field import InputField, OutputField
+from dspy.signatures.field import OldInputField, OldOutputField
 from dspy.signatures.signature import infer_prefix
 
 # TODO: This class is currently hard to test, because it hardcodes gpt-4 usage:
@@ -73,8 +73,8 @@ class LangChainPredict(Predict, Runnable): #, RunnableBinding):
 
         with dspy.context(lm=gpt4T): parts = dspy.Predict(Template2Signature)(template=template)
 
-        inputs = {k.strip(): InputField() for k in parts.input_keys.split(',')}
-        outputs = {k.strip(): OutputField() for k in parts.output_key.split(',')}
+        inputs = {k.strip(): OldInputField() for k in parts.input_keys.split(',')}
+        outputs = {k.strip(): OldOutputField() for k in parts.output_key.split(',')}
 
         for k, v in inputs.items():
             v.finalize(k, infer_prefix(k))  # TODO: Generate from the template at dspy.Predict(Template2Signature)


### PR DESCRIPTION
When running the [example](https://github.com/stanfordnlp/dspy/blob/main/examples/tweets/compiling_langchain.ipynb) I face this error:

```
{
	"name": "AttributeError",
	"message": "'FieldInfo' object has no attribute 'finalize'",
	"stack": "---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[5], line 6
      2 from dspy.predict.langchain import LangChainPredict, LangChainModule
      4 # This is how to wrap it so it behaves like a DSPy program.
      5 # Just Replace every pattern like `prompt | llm` with `LangChainPredict(prompt, llm)`.
----> 6 zeroshot_chain = RunnablePassthrough.assign(context=retrieve) | LangChainPredict(prompt, llm) | StrOutputParser()
      7 zeroshot_chain = LangChainModule(zeroshot_chain)  # then wrap the chain in a DSPy module.

File ~/anaconda3/envs/survey_buddy/lib/python3.12/site-packages/dspy/predict/langchain.py:47, in LangChainPredict.__init__(self, prompt, llm, **config)
     44 except AttributeError: langchain_template = prompt.template
     46 self.stage = random.randbytes(8).hex()
---> 47 self.signature, self.output_field_key = self._build_signature(langchain_template)
     48 self.config = config
     49 self.reset()

File ~/anaconda3/envs/survey_buddy/lib/python3.12/site-packages/dspy/predict/langchain.py:80, in LangChainPredict._build_signature(self, template)
     77 outputs = {k.strip(): OutputField() for k in parts.output_key.split(',')}
     79 for k, v in inputs.items():
---> 80     v.finalize(k, infer_prefix(k))  # TODO: Generate from the template at dspy.Predict(Template2Signature)
     82 for k, v in outputs.items():
     83     output_field_key = k

AttributeError: 'FieldInfo' object has no attribute 'finalize'"
}
```

I fixed this error by simply replacing `Fields` to `OldFields`