### PR TITLE
fix(ollama): added model to kwargs

### DIFF
--- a/dsp/modules/ollama.py
+++ b/dsp/modules/ollama.py
@@ -53,6 +53,7 @@ class OllamaLocal(LM):
         self.timeout_s = timeout_s
 
         self.kwargs = {
+            "model": model,
             "temperature": temperature,
             "max_tokens": max_tokens,
             "top_p": top_p,


### PR DESCRIPTION
Failed to run or to evaluate example Example({'message_thread': 'human: how to make a milkshake\n', 'doc_context': 'No Context Found', 'answer': "I would be happy to answer that question! Here's the answer etc..."}) (input_keys={'message_thread', 'doc_context'}) with <function validate_context_and_answer at 0x12a942e80> due to 'model'. [dspy.teleprompt.bootstrap] filename=bootstrap.py lineno=179

this happens because "model" isn't passed to self.kwargs