### PR TITLE
Add logprobs hfclientvllm

### DIFF
--- a/dsp/modules/hf.py
+++ b/dsp/modules/hf.py
@@ -188,7 +188,7 @@ class HFModel(LM):
             kwargs["do_sample"] = True
 
         response = self.request(prompt, **kwargs)
-        return [c["text"] for c in response["choices"]]
+        return [{"text": c["text"], "logprobs": c["logprobs"]} if 'logprobs' in c else c["text"] for c in response["choices"]]
 
 
 # @functools.lru_cache(maxsize=None if cache_turn_on else 0)

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -206,7 +206,7 @@ class HFClientVLLM(HFModel):
                 completions = json_response["choices"]
                 response = {
                     "prompt": prompt,
-                    "choices": [{"text": c["text"]} for c in completions],
+                    "choices": [{"text": c["text"], "logprobs": c["logprobs"]} if c["logprobs"] else {"text": c["text"]} for c in completions],
                 }
                 return response
 


### PR DESCRIPTION
This is part of https://github.com/stanfordnlp/dspy/issues/879.
I tested it and it behaves the same as the other PR.
```
lm = dspy.HFClientVLLM(model="NurtureAI/Meta-Llama-3-8B-Instruct-32k", port=38242, url="http://localhost", max_tokens=4)
test_text = "This is a test article."
output_normal = lm(test_text)
print("output_normal:", output_normal)

output_with_logprobs = lm(test_text, logprobs=2)
print("output_with_logprobs:", output_with_logprobs)
```
```
output_normal: [' It is a test']
output_with_logprobs: [{'text': ' It is a test', 'logprobs': {'text_offset': [0, 3, 6, 8], 'token_logprobs': [-1.7945036888122559, -0.6691504716873169, -1.303508996963501, -0.7093929052352905], 'tokens': [' It', ' is', ' a', ' test'], 'top_logprobs': [{' It': -1.7945036888122559, ' This': -1.7945036888122559}, {' is': -0.6691504716873169, ' will': -2.0441503524780273}, {' a': -1.303508996963501, ' not': -1.803508996963501}, {' test': -0.7093929052352905, ' sample': -3.20939302444458}]}}]
```