### PR TITLE
Allow to configure Anyscale API in constructor

### DIFF
--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -401,6 +401,7 @@ class Anyscale(HFModel):
         super().__init__(model=model, is_client=True)
         self.session = requests.Session()
         self.api_base = os.getenv("ANYSCALE_API_BASE") or api_base
+        assert not self.api_base.endswith("/"), "Anyscale base URL shouldn't end with /"
         self.token = os.getenv("ANYSCALE_API_KEY") or api_key
         self.model = model
         self.kwargs = {

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -397,11 +397,11 @@ class Together(HFModel):
 
 
 class Anyscale(HFModel):
-    def __init__(self, model, **kwargs):
+    def __init__(self, model, api_base="https://api.endpoints.anyscale.com/v1", api_key=None, **kwargs):
         super().__init__(model=model, is_client=True)
         self.session = requests.Session()
-        self.api_base = os.getenv("ANYSCALE_API_BASE")
-        self.token = os.getenv("ANYSCALE_API_KEY")
+        self.api_base = os.getenv("ANYSCALE_API_BASE") or api_base
+        self.token = os.getenv("ANYSCALE_API_KEY") or api_key
         self.model = model
         self.kwargs = {
             "temperature": 0.0,


### PR DESCRIPTION
This simple PR just allows to configure Anyscale API in it's constructor, following the pattern on the others LMs.