### PR TITLE
Small fix on logging on bootstrap.py

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -150,7 +150,7 @@ class BootstrapFewShot(Teleprompter):
                         bootstrapped[example_idx] = True
 
         dspy.logger.info(
-            f"Bootstrapped {len(bootstrapped)} full traces after {example_idx + 1} examples in round {round_idx}.",
+            f"Bootstrapped {len(bootstrapped)} full traces after {example_idx} examples in round {round_idx}.",
         )
 
         # Unbootstrapped training examples


### PR DESCRIPTION
Since >= is used above before the break, example_idx then is already the length of the example, so the logging was sligthly misleading adding one more example count