### PR TITLE
Fix pgvector work with the tutorial

### DIFF
--- a/dspy/retrieve/pgvector_rm.py
+++ b/dspy/retrieve/pgvector_rm.py
@@ -14,8 +14,10 @@ except ImportError:
 try:
     import openai
 except ImportError:
-    warnings.warn("`openai` is not installed. Install it with `pip install openai` to use OpenAI embedding models.",
-                  category=ImportWarning)
+    warnings.warn(
+        "`openai` is not installed. Install it with `pip install openai` to use OpenAI embedding models.",
+        category=ImportWarning,
+    )
 
 
 class PgVectorRM(dspy.Retrieve):
@@ -32,6 +34,7 @@ class PgVectorRM(dspy.Retrieve):
         pg_table_name (Optional[str]): name of the table containing passages
         openai_client (openai.OpenAI): OpenAI client to use for computing query embeddings. Either openai_client or embedding_func must be provided.
         embedding_func (Callable): A function to use for computing query embeddings. Either openai_client or embedding_func must be provided.
+        content_field (str = "text"): Field containing the passage text. Defaults to "text"
         k (Optional[int]): Default number of top passages to retrieve. Defaults to 20
         embedding_field (str = "embedding"): Field containing passage embeddings. Defaults to "embedding"
         fields (List[str] = ['text']): Fields to retrieve from the table. Defaults to "text"
@@ -62,41 +65,46 @@ class PgVectorRM(dspy.Retrieve):
         self.retrieve = PgVectorRM(db_url, openai_client=openai_client, "paragraphs", fields=["text", "document_id"], k=20)
         ```
     """
+
     def __init__(
-            self,
-            db_url: str,
-            pg_table_name: str,
-            openai_client: Optional[openai.OpenAI] = None,
-            embedding_func: Optional[Callable] = None,
-            k: int = 20,
-            embedding_field: str = "embedding",
-            fields: Optional[list[str]] = None,
-            embedding_model: str = "text-embedding-ada-002",
-            include_similarity: bool = False,
+        self,
+        db_url: str,
+        pg_table_name: str,
+        openai_client: Optional[openai.OpenAI] = None,
+        embedding_func: Optional[Callable] = None,
+        k: int = 20,
+        embedding_field: str = "embedding",
+        fields: Optional[list[str]] = None,
+        content_filed: str = "text",
+        embedding_model: str = "text-embedding-ada-002",
+        include_similarity: bool = False,
     ):
         """
         k = 20 is the number of paragraphs to retrieve
         """
-        assert openai_client or embedding_func, "Either openai_client or embedding_func must be provided."
+        assert (
+            openai_client or embedding_func
+        ), "Either openai_client or embedding_func must be provided."
         self.openai_client = openai_client
         self.embedding_func = embedding_func
 
         self.conn = psycopg2.connect(db_url)
         register_vector(self.conn)
         self.pg_table_name = pg_table_name
-        self.fields = fields or ['text']
+        self.fields = fields or ["text"]
+        self.content_filed = content_filed
         self.embedding_field = embedding_field
         self.embedding_model = embedding_model
         self.include_similarity = include_similarity
 
         super().__init__(k=k)
 
-    def forward(self, query: str):
-        """Search with PgVector for self.k top passages for query using cosine similarity
+    def forward(self, query: str, k: int = None):
+        """Search with PgVector for k top passages for query using cosine similarity
 
         Args:
             query  (str): The query to search for
-            include_similarity (bool): Whether or not to include the similarity for each record
+            k (int): The number of top passages to retrieve. Defaults to the value set in the constructor.
         Returns:
             dspy.Prediction: an object containing the retrieved passages.
         """
@@ -105,21 +113,15 @@ class PgVectorRM(dspy.Retrieve):
 
         retrieved_docs = []
 
-        fields = sql.SQL(',').join([
-            sql.Identifier(f)
-            for f in self.fields
-        ])
+        fields = sql.SQL(",").join([sql.Identifier(f) for f in self.fields])
         if self.include_similarity:
-            similarity_field = (
-                sql.SQL(',') +
-                sql.SQL(
-                    '1 - ({embedding_field} <=> %s) AS similarity',
-                ).format(embedding_field=sql.Identifier(self.embedding_field))
-            )
+            similarity_field = sql.SQL(",") + sql.SQL(
+                "1 - ({embedding_field} <=> %s::vector) AS similarity",
+            ).format(embedding_field=sql.Identifier(self.embedding_field))
             fields += similarity_field
-            args = (query_embedding, query_embedding, self.k)
+            args = (query_embedding, query_embedding, k if k else self.k)
         else:
-            args = (query_embedding, self.k)
+            args = (query_embedding, k if k else self.k)
 
         sql_query = sql.SQL(
             "select {fields} from {table} order by {embedding_field} <=> %s::vector limit %s",
@@ -131,23 +133,26 @@ class PgVectorRM(dspy.Retrieve):
 
         with self.conn as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    sql_query,
-                    args)
+                cur.execute(sql_query, args)
                 rows = cur.fetchall()
                 columns = [descrip[0] for descrip in cur.description]
                 for row in rows:
                     data = dict(zip(columns, row))
+                    data["long_text"] = data[self.content_filed]
                     retrieved_docs.append(dspy.Example(**data))
         # Return Prediction
         return retrieved_docs
 
     def _get_embeddings(self, query: str) -> list[float]:
         if self.openai_client is not None:
-            return self.openai_client.embeddings.create(
-                model=self.embedding_model,
-                input=query,
-                encoding_format="float",
-            ).data[0].embedding
+            return (
+                self.openai_client.embeddings.create(
+                    model=self.embedding_model,
+                    input=query,
+                    encoding_format="float",
+                )
+                .data[0]
+                .embedding
+            )
         else:
             return self.embedding_func(query)

--- a/dspy/retrieve/pgvector_rm.py
+++ b/dspy/retrieve/pgvector_rm.py
@@ -75,7 +75,7 @@ class PgVectorRM(dspy.Retrieve):
         k: int = 20,
         embedding_field: str = "embedding",
         fields: Optional[list[str]] = None,
-        content_filed: str = "text",
+        content_field: str = "text",
         embedding_model: str = "text-embedding-ada-002",
         include_similarity: bool = False,
     ):
@@ -92,7 +92,7 @@ class PgVectorRM(dspy.Retrieve):
         register_vector(self.conn)
         self.pg_table_name = pg_table_name
         self.fields = fields or ["text"]
-        self.content_filed = content_filed
+        self.content_field = content_field
         self.embedding_field = embedding_field
         self.embedding_model = embedding_model
         self.include_similarity = include_similarity
@@ -138,7 +138,7 @@ class PgVectorRM(dspy.Retrieve):
                 columns = [descrip[0] for descrip in cur.description]
                 for row in rows:
                     data = dict(zip(columns, row))
-                    data["long_text"] = data[self.content_filed]
+                    data["long_text"] = data[self.content_field]
                     retrieved_docs.append(dspy.Example(**data))
         # Return Prediction
         return retrieved_docs


### PR DESCRIPTION
When working with the [Tutorial](https://dspy-docs.vercel.app/docs/tutorials/simplified-baleen), using OllamaLocal and PgVectorRM, I found some mismatch below and fixed it.

- Fix `long_text` KeyError by added `content_filed` attr
- Fix `psycopg2.errors.UndefinedFunction: operator does not exist: vector <=> numeric[]` when `include_similarity=True`
- Fix `TypeError: PgVectorRM.forward() got an unexpected keyword argument 'k'` in the forward method
- Code reformat with Ruff 