### PR TITLE
fix(dspy): fix langchain predict (#1091)

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -112,10 +112,17 @@ class BootstrapFewShot(Teleprompter):
 
         for (name1, predictor1), (name2, predictor2) in zip(student.named_predictors(), teacher.named_predictors()):
             assert name1 == name2, "Student and teacher must have the same program structure."
-            assert predictor1.signature.equals(
-                predictor2.signature,
-            ), (f"Student and teacher must have the same signatures. "
-                f"{type(predictor1.signature)} != {type(predictor2.signature)}"
+            if hasattr(predictor1.signature, "equals"):
+                assert predictor1.signature.equals(
+                    predictor2.signature,
+                ), (f"Student and teacher must have the same signatures. "
+                    f"{type(predictor1.signature)} != {type(predictor2.signature)}"
+                    )
+            else:
+                # fallback in case if .equals is not implemented (e.g. dsp.Prompt)
+                assert predictor1.signature == predictor2.signature, (
+                    f"Student and teacher must have the same signatures. "
+                    f"{type(predictor1.signature)} != {type(predictor2.signature)}"
                 )
             assert id(predictor1) != id(predictor2), "Student and teacher must be different objects."
 


### PR DESCRIPTION
Sharing a quick patch for #1091 

Error seen while running https://github.com/stanfordnlp/dspy/blob/main/examples/tweets/compiling_langchain.ipynb
```
File ~/dspy/teleprompt/bootstrap.py:115, in BootstrapFewShot._prepare_predictor_mappings(self)
    113 for (name1, predictor1), (name2, predictor2) in zip(student.named_predictors(), teacher.named_predictors()):
    114     assert name1 == name2, "Student and teacher must have the same program structure."
--> 115     assert predictor1.signature.equals(
    116         predictor2.signature,
    117     ), (f"Student and teacher must have the same signatures. "
    118         f"{type(predictor1.signature)} != {type(predictor2.signature)}"
    119         )
    120     assert id(predictor1) != id(predictor2), "Student and teacher must be different objects."
    122     name2predictor[name1] = None  # dict(student=predictor1, teacher=predictor2)

AttributeError: 'Template' object has no attribute 'equals'
```

