### PR TITLE
refactor(inspect-history): Refactor providers

### DIFF
--- a/dsp/modules/lm.py
+++ b/dsp/modules/lm.py
@@ -46,13 +46,14 @@ class LM(ABC):
             prompt = x["prompt"]
 
             if prompt != last_prompt:
-                if (
-                    provider == "clarifai"
-                    or provider == "google"
-                    or provider == "groq"
-                    or provider == "Bedrock"
-                    or provider == "Sagemaker"
-                    or provider == "premai"
+                if provider in (
+                    "clarifai",
+                    "cloudflare"
+                    "google",
+                    "groq",
+                    "Bedrock",
+                    "Sagemaker",
+                    "premai",
                 ):
                     printed.append((prompt, x["response"]))
                 elif provider == "anthropic":
@@ -66,8 +67,6 @@ class LM(ABC):
                     printed.append((prompt, x["response"].text))
                 elif provider == "mistral":
                     printed.append((prompt, x["response"].choices))
-                elif provider == "cloudflare":
-                    printed.append((prompt, [x["response"]]))
                 elif provider == "ibm":
                     printed.append((prompt, x))
                 else:
@@ -87,12 +86,10 @@ class LM(ABC):
             printing_value += prompt
 
             text = ""
-            if provider == "cohere" or provider == "Bedrock" or provider == "Sagemaker":
+            if provider in ("cohere", "Bedrock", "Sagemaker", "clarifai", "claude", "ibm", "premai"):
                 text = choices
             elif provider == "openai" or provider == "ollama":
                 text = " " + self._get_choice_text(choices[0]).strip()
-            elif provider == "clarifai" or provider == "claude":
-                text = choices
             elif provider == "groq":
                 text = " " + choices
             elif provider == "google":
@@ -101,8 +98,6 @@ class LM(ABC):
                 text = choices[0].message.content
             elif provider == "cloudflare":
                 text = choices[0]
-            elif provider == "ibm" or provider == "premai":
-                text = choices
             else:
                 text = choices[0]["text"]
             printing_value += self.print_green(text, end="")


### PR DESCRIPTION
A small PR to refactor redundant logic within the `dspy.LM.inspect_history` method. 

I came across this when trying to integrate a custom LLM — `inspect_history` expects a particular schema from `self.history[i]['requests']` that isn't documented in the [docs](https://dspy-docs.vercel.app/docs/deep-dive/language_model_clients/custom-lm-client). These if/else statements indicate a deficiency of the existing interface. 

I'm happy to extend in the interface across all `LM` subclasses, cleaning up the if/else statement here and update the docs. However, I would first like to understand what is the concept of "choices" in `printed.append("<prompt>", "<choices>")`, and possibly some guidance on the proper interface if you have any. 

Thanks!