### PR TITLE
Very minor change - increase default on Cohere LLM module.

### DIFF
--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -63,7 +63,7 @@ class Cohere(LM):
         self.kwargs = {
             "model": model,
             "temperature": 0.0,
-            "max_tokens": 150,
+            "max_tokens": 2000,
             "p": 1,
             "num_generations": 1,
             **kwargs,


### PR DESCRIPTION
Increase from 150 to 2000. 

I think most people are using Command R / R+ for RAG tasks where 150 tokens are typically not enough. Very minor change to improve the UX a tiny amount.