### PR TITLE
Add trust_remote_code arg to load hotpot_qa

### DIFF
--- a/dspy/datasets/hotpotqa.py
+++ b/dspy/datasets/hotpotqa.py
@@ -11,8 +11,8 @@ class HotPotQA(Dataset):
         assert only_hard_examples, "Care must be taken when adding support for easy examples." \
                                    "Dev must be all hard to match official dev, but training can be flexible."
         
-        hf_official_train = load_dataset("hotpot_qa", 'fullwiki', split='train')
-        hf_official_dev = load_dataset("hotpot_qa", 'fullwiki', split='validation')
+        hf_official_train = load_dataset("hotpot_qa", 'fullwiki', split='train', trust_remote_code=True)
+        hf_official_dev = load_dataset("hotpot_qa", 'fullwiki', split='validation', trust_remote_code=True)
 
         official_train = []
         for raw_example in hf_official_train:


### PR DESCRIPTION
Added trust_remote_code=True to hotpot_qa dataset to skip prompt for allowing custom code to be run when using the HotPotQA dataset.