### PR TITLE
Bug - Dataset summary generation failing due to log file set to None

### DIFF
--- a/dspy/propose/dataset_summary_generator.py
+++ b/dspy/propose/dataset_summary_generator.py
@@ -73,7 +73,8 @@ def create_dataset_summary(trainset, view_data_batch_size, prompt_model, log_fil
                 continue
             observations += output["observations"]
             
-            log_file.write(f"observations {observations}\n")
+            if log_file: 
+                log_file.write(f"observations {observations}\n")
     except Exception as e:
         print(f"e {e}. using observations from past round for a summary.")
 


### PR DESCRIPTION
The dataset summary generation was failing when log_file is None, as at line 76 it does not check if the log_file is None resulting in an exception.

I fixed the problem by adding the code to check if log_file is None before write operation.  