### PR TITLE
Fixed Bug - MIPROv2 fails when program_aware_proposer parameter set to False

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -212,6 +212,8 @@ class MIPROv2(Teleprompter):
                     print(f"Error getting source code: {e}.\n\nRunning without program aware proposer.")
                     self.program_code_string = None
                     program_aware_proposer = False
+            else:
+                self.program_code_string = None
 
             # Setup our proposer 
             proposer = GroundedProposer(


### PR DESCRIPTION
If program_aware_proposer parameter is set to False when compiling the program with MIPROv2 optimizer, it results in the following error - `AttributeError: 'MIPROv2' object has no attribute 'program_code_string'`. 

The error occurs on line no. 220 when program_code_string in GroundedProposer is assigned. It is due to program_code_string not set to None if program_aware_proposer is false. 

<img width="571" alt="image" src="https://github.com/stanfordnlp/dspy/assets/79463685/a24a6b71-2ab6-45b7-a003-91f24190e100">
