### PR TITLE
Fix: package name and version in setup.py and pyproject.toml

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -102,9 +102,9 @@ jobs:
       - name: Update version in pyproject.toml
         run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
       - name: Update package name in setup.py  
-        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-hmoazam"/;}' setup.py
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai"/;}' setup.py
       - name: Update package name in pyproject.toml
-        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-hmoazam"/;}' pyproject.toml 
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai"/;}' pyproject.toml 
       - name: Build a binary wheel
         run: python3 setup.py sdist bdist_wheel
       - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -41,13 +41,13 @@ jobs:
           echo "Version to be used for TestPyPI release: $NEW_VERSION"  
           echo "::set-output name=version::$NEW_VERSION"  
       - name: Update version in setup.py
-        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ steps.check_version.outputs.version }}"/;}' setup.py
+        run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ steps.check_version.outputs.version }}"/;}' setup.py
       - name: Update version in pyproject.toml
-        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ steps.check_version.outputs.version }}"/;}' pyproject.toml        
+        run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ steps.check_version.outputs.version }}"/;}' pyproject.toml        
       - name: Update package name in setup.py
-        run: sed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-test"/;}' setup.py
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-test"/;}' setup.py
       - name: Update package name in pyproject.toml
-        run: sed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-test"/;}' pyproject.toml  
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-test"/;}' pyproject.toml  
       - name: Build a binary wheel
         run: python3 setup.py sdist bdist_wheel
       - name: Publish distribution 📦 to test-PyPI
@@ -98,13 +98,13 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install setuptools wheel twine
       - name: Update version in setup.py
-        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ needs.extract-tag.outputs.version }}"/;}' setup.py
+        run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' setup.py
       - name: Update version in pyproject.toml
-        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
+        run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
       - name: Update package name in setup.py  
-        run: ssed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-hmoazam"/;}' setup.py
+        run: ssed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-hmoazam"/;}' setup.py
       - name: Update package name in pyproject.toml
-        run: sed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-hmoazam"/;}' pyproject.toml 
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-hmoazam"/;}' pyproject.toml 
       - name: Build a binary wheel
         run: python3 setup.py sdist bdist_wheel
       - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -41,13 +41,13 @@ jobs:
           echo "Version to be used for TestPyPI release: $NEW_VERSION"  
           echo "::set-output name=version::$NEW_VERSION"  
       - name: Update version in setup.py
-        run: sed -i "s/{{VERSION_PLACEHOLDER}}/${{ steps.check_version.outputs.version }}/g" setup.py
+        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ steps.check_version.outputs.version }}"/;}' setup.py
       - name: Update version in pyproject.toml
-        run: sed -i "s/{{VERSION_PLACEHOLDER}}/${{ steps.check_version.outputs.version }}/g" pyproject.toml
+        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ steps.check_version.outputs.version }}"/;}' pyproject.toml        
       - name: Update package name in setup.py
-        run: sed -i "s/{{PACKAGE_NAME_PLACEHOLDER}}/dspy-ai-test/g" setup.py
+        run: sed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-test"/;}' setup.py
       - name: Update package name in pyproject.toml
-        run: sed -i "s/{{PACKAGE_NAME_PLACEHOLDER}}/dspy-ai-test/g" pyproject.toml
+        run: sed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-test"/;}' pyproject.toml  
       - name: Build a binary wheel
         run: python3 setup.py sdist bdist_wheel
       - name: Publish distribution 📦 to test-PyPI
@@ -98,13 +98,13 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install setuptools wheel twine
       - name: Update version in setup.py
-        run: sed -i "s/{{VERSION_PLACEHOLDER}}/${{ needs.extract-tag.outputs.version }}/g" setup.py
+        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ needs.extract-tag.outputs.version }}"/;}' setup.py
       - name: Update version in pyproject.toml
-        run: sed -i "s/{{VERSION_PLACEHOLDER}}/${{ needs.extract-tag.outputs.version }}/g" pyproject.toml
+        run: sed -i '/#replace_package_version_marker/{n;s/version = "[^"]*"/version = "${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
       - name: Update package name in setup.py  
-        run: sed -i "s/{{PACKAGE_NAME_PLACEHOLDER}}/dspy-ai/g" setup.py
+        run: ssed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-hmoazam"/;}' setup.py
       - name: Update package name in pyproject.toml
-        run: sed -i "s/{{PACKAGE_NAME_PLACEHOLDER}}/dspy-ai/g" pyproject.toml
+        run: sed -i '/#replace_package_name_marker/{n;s/name = "[^"]*"/name = "dspy-ai-hmoazam"/;}' pyproject.toml 
       - name: Build a binary wheel
         run: python3 setup.py sdist bdist_wheel
       - name: Publish distribution 📦 to PyPI

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Update version in pyproject.toml
         run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
       - name: Update package name in setup.py  
-        run: ssed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-hmoazam"/;}' setup.py
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-hmoazam"/;}' setup.py
       - name: Update package name in pyproject.toml
         run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-hmoazam"/;}' pyproject.toml 
       - name: Build a binary wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,10 @@ requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "{{PACKAGE_NAME_PLACEHOLDER}}"
-version = "{{VERSION_PLACEHOLDER}}"
+#replace_package_name_marker
+name = "dspy-ai"
+#replace_package_version_marker
+version = "2.4.10"
 description = "DSPy"
 readme = "README.md"
 authors = [{ name = "Omar Khattab", email = "okhattab@stanford.edu" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 #replace_package_name_marker
-name = "dspy-ai"
+name="dspy-ai"
 #replace_package_version_marker
-version = "2.4.10"
+version="2.4.10"
 description = "DSPy"
 readme = "README.md"
 authors = [{ name = "Omar Khattab", email = "okhattab@stanford.edu" }]

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,10 @@ with open("requirements.txt", encoding="utf-8") as f:
     requirements = f.read().splitlines()
 
 setup(	
-    name="{{PACKAGE_NAME_PLACEHOLDER}}",
-    version="{{VERSION_PLACEHOLDER}}", 	
+    #replace_package_name_marker
+    name="dspy-ai",
+    #replace_package_version_marker
+    version="2.4.10", 	
     description="DSPy",	
     long_description=long_description,	
     long_description_content_type='text/markdown',	


### PR DESCRIPTION
Leave default values in project files for installation from source. Default values get replaced by automation by using comments as markers instead of placeholders.