### PR TITLE
fix(MiproV2): custom view_data_batch_size for dataset summary creation

### DIFF
--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -237,6 +237,7 @@ class GroundedProposer(Proposer):
         prompt_model,
         trainset,
         program_code_string=None,
+        view_data_batch_size=10,
         use_dataset_summary=True,
         program_aware=True,
         use_task_demos=True,
@@ -257,7 +258,7 @@ class GroundedProposer(Proposer):
         self.prompt_model = prompt_model
         self.program_code_string = program_code_string
         self.data_summary = create_dataset_summary(
-            trainset=trainset, view_data_batch_size=10, prompt_model=prompt_model,
+            trainset=trainset, view_data_batch_size=view_data_batch_size, prompt_model=prompt_model,
         )
         print(f"DATA SUMMARY: {self.data_summary}")
 

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -220,6 +220,7 @@ class MIPROv2(Teleprompter):
                 trainset=trainset,
                 prompt_model=self.prompt_model,
                 program_code_string=self.program_code_string,
+                view_data_batch_size=self.view_data_batch_size,
                 program_aware=program_aware_proposer,
             )
 


### PR DESCRIPTION
**Scenario:** When compiling with MiproV2, my large trainset examples led to an error - `model context limit exceeded`. To address this, I set a custom view_data_batch_size. However, the error persisted as the parameter value was not reflected during dataset summary generation. 

**Problem:** The custom view_data_batch_size is not applied during the creation of the dataset summary in GroundedProposer. This occurs because the create_dataset_summary() function within the GroundedProposer defaults to a predefined batch size, ignoring the custom view_data_batch_size parameter value. 
<img width="667" alt="image" src="https://github.com/stanfordnlp/dspy/assets/79463685/005e71d0-4655-4a67-a557-0fcca9c21693">
<img width="657" alt="image" src="https://github.com/stanfordnlp/dspy/assets/79463685/3ca8e325-0206-457d-9e73-233e4f85169b">

**Solution:** The solution involves passing the view_data_batch_size parameter to GroundedProposer in MiproV2, ensuring it is utilized when create_dataset_summary() is called in GroundedProposer. 

**Testing:** Verified that the changes made in this PR successfully resolve this issue and the view_data_batch_size parameter set upon initialization of MIPROv2 optimizer is getting used for dataset summary generation. (Also, if not set by the user then it uses the default value of 10 defined in MIRPOv2 class). 

_Feel free to adjust the specifics as needed to better match the project's requirements or to add additional information._