### PR TITLE
fix(dspy): fix null reference in settings.trace

### DIFF
--- a/dspy/primitives/assertions.py
+++ b/dspy/primitives/assertions.py
@@ -211,12 +211,14 @@ def backtrack_handler(func, bypass_suggest=True, max_backtracks=2):
                 if i == max_backtracks:
                     if isinstance(current_error, DSPyAssertionError):
                         raise current_error
-                    dsp.settings.trace.clear()
+                    if dsp.settings.trace:
+                        dsp.settings.trace.clear()
                     result = bypass_suggest_handler(func)(*args, **kwargs) if bypass_suggest else None
                     break
                 else:
                     try:
-                        dsp.settings.trace.clear()
+                        if dsp.settings.trace:
+                            dsp.settings.trace.clear()
                         result = func(*args, **kwargs)
                         break
                     except (DSPySuggestionError, DSPyAssertionError) as e:


### PR DESCRIPTION
Using `dspy-ai===2.4.5`
When using the following code:

```python
__llm = dspy.Google(model="models/gemini-1.5-flash")
dspy.settings.configure(lm=__llm) # error below!
dspy.settings.configure(lm=__llm, trace=[]) # mitigates error (but NOT the fix)

# __llm = dspy.OpenAI(model="gpt-4o") # Works fine


class PlannerModule(dspy.Module):
  def forward(self, ...):
    # ... trivial implementation ...
    dspy.Suggest(...)

exec = PlannerModule().activate_assertions(max_backtracks=3)
prediction: dspy.Prediction = exec(input)
```

I get the following error:
```text
Traceback (most recent call last):
  File "...xyz.py", line 91, in <module>
    prediction: dspy.Prediction = exec(input)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Data/repos/jigxie/.venv/lib/python3.12/site-packages/dspy/primitives/program.py", line 26, in __call__
    return self.forward(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Data/repos/jigxie/.venv/lib/python3.12/site-packages/dspy/primitives/assertions.py", line 318, in forward
    return wrapped_forward(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Data/repos/jigxie/.venv/lib/python3.12/site-packages/dspy/primitives/assertions.py", line 241, in wrapper
    dsp.settings.trace.clear()
    ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'clear'
```

Not sure why there is a difference in behavior between `OpenAI` and `Google`, however, via visual inspection the fix is both defensive & trivial:
- Added a null-check per similar code elsewhere in the codebase.