### PR TITLE
Add filter for QdrantRM

### DIFF
--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -38,7 +38,7 @@ class QdrantRM(dspy.Retrieve):
 
         Below is a code snippet that shows how to use Qdrant in the forward() function of a module
         ```python
-        self.retrieve = QdrantRM("my_collection_name", qdrant_client=qdrant_client, k=num_passages)
+        self.retrieve = QdrantRM(question, k=num_passages, filter=filter)
         ```
     """
 

--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -62,7 +62,7 @@ class QdrantRM(dspy.Retrieve):
 
         super().__init__(k=k)
 
-    def forward(self, query_or_queries: Union[str, list[str]], k: Optional[int] = None) -> dspy.Prediction:
+    def forward(self, query_or_queries: Union[str, list[str]], k: Optional[int] = None, filter: Optional[models.Filter]=None) -> dspy.Prediction:
         """Search with Qdrant for self.k top passages for query.
 
         Args:
@@ -90,6 +90,7 @@ class QdrantRM(dspy.Retrieve):
                 vector=vector,
                 limit=k or self.k,
                 with_payload=[self._document_field],
+                filter=filter,
             )
             for vector in vectors
         ]

--- a/dspy/retrieve/qdrant_rm.py
+++ b/dspy/retrieve/qdrant_rm.py
@@ -68,6 +68,7 @@ class QdrantRM(dspy.Retrieve):
         Args:
             query_or_queries (Union[str, List[str]]): The query or queries to search for.
             k (Optional[int]): The number of top passages to retrieve. Defaults to self.k.
+            filter (Optional["Filter"]): "Look only for points which satisfies this conditions". Default: None.
 
         Returns:
             dspy.Prediction: An object containing the retrieved passages.


### PR DESCRIPTION
Add filter support for QdrantRM to support qdrant search filter like

https://qdrant.tech/documentation/concepts/filtering/

uses

![image](https://github.com/stanfordnlp/dspy/assets/2004071/41823742-e7c4-4f94-9964-c32e25536e5d)

