### PR TITLE
loosen joblib, backoff dependency restrictions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
 # `pip install .` will pull from pyproject.toml dependencies
 
 dependencies = [
-    "backoff~=2.2.1",
-    "joblib~=1.3.2",
+    "backoff~=2.2",
+    "joblib~=1.3",
     "openai>=0.28.1,<2.0.0",
     "pandas",
     "regex",
@@ -88,8 +88,8 @@ keywords = ["dspy", "ai", "language models", "llm", "openai"]
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 pydantic = "^2.0"
-backoff = "^2.2.1"
-joblib = "^1.3.2"
+backoff = "^2.2"
+joblib = "^1.3"
 openai = ">=0.28.1,<2.0.0"
 pandas = "^2.1.1"
 regex = "^2023.10.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 backoff
 datasets
-joblib<=1.3.2
+joblib~=1.3
 openai>=0.28.1,<2.0.0
 optuna
 pandas


### PR DESCRIPTION
This is meant to give users of this library more flexibility in the version of these dependencies that are used, as there does not appear to be a specific reason that they are pinned back currently.

The version in the lock files has not been updated.