### PR TITLE
added configurable backoff max time

### DIFF
--- a/docs/docs/faqs.md
+++ b/docs/docs/faqs.md
@@ -137,7 +137,27 @@ Firstly, please refer to your LM/RM provider to ensure stable status or sufficie
 
 Additionally, try reducing the number of threads you are testing on as the corresponding servers may get overloaded with requests and trigger a backoff + retry mechanism.
 
-If all variables seem stable, you may be experiencing timeouts or backoff errors due to incorrect payload requests sent to the api providers. Please verify your arguments are compatible with the SDK you are interacting with. At times, DSPy may have hard-coded arguments that are not relevant for your compatible, in which case, please free to open a PR alerting this or comment out these default settings for your usage. 
+If all variables seem stable, you may be experiencing timeouts or backoff errors due to incorrect payload requests sent to the api providers. Please verify your arguments are compatible with the SDK you are interacting with. 
+
+You can configure backoff times for your LM/RM provider by setting `dspy.settings.backoff_time` while configuring your DSPy workflow. 
+
+```python
+dspy.settings.configure(backoff_time = ...)
+```
+
+Additionally, if you'd like to set individual backoff times for specific providers, you can do through the DSPy context manager: 
+
+```python
+with dspy.context(backoff_time = ..):
+      dspy.OpenAI(...) # example
+
+with dspy.context(backoff_time = ..):
+      dspy.AzureOpenAI(...) # example
+```
+
+At times, DSPy may have hard-coded arguments that are not relevant for your compatible, in which case, please free to open a PR alerting this or comment out these default settings for your usage. 
+
+Note that
 
 ## Contributing
 

--- a/docs/docs/faqs.md
+++ b/docs/docs/faqs.md
@@ -157,8 +157,6 @@ with dspy.context(backoff_time = ..):
 
 At times, DSPy may have hard-coded arguments that are not relevant for your compatible, in which case, please free to open a PR alerting this or comment out these default settings for your usage. 
 
-Note that
-
 ## Contributing
 
 **What if I have a better idea for prompting or synthetic data generation?** Perfect. We encourage you to think if it's best expressed as a module or an optimizer, and we'd love to merge it in DSPy so everyone can use it. DSPy is not a complete project; it's an ongoing effort to create structure (modules and optimizers) in place of hacky prompt and pipeline engineering tricks.

--- a/docs/docs/faqs.md
+++ b/docs/docs/faqs.md
@@ -145,7 +145,7 @@ You can configure backoff times for your LM/RM provider by setting `dspy.setting
 dspy.settings.configure(backoff_time = ...)
 ```
 
-Additionally, if you'd like to set individual backoff times for specific providers, you can do through the DSPy context manager: 
+Additionally, if you'd like to set individual backoff times for specific providers, you can do so through the DSPy context manager: 
 
 ```python
 with dspy.context(backoff_time = ..):

--- a/dsp/modules/anthropic.py
+++ b/dsp/modules/anthropic.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, Optional
 
 import backoff
+import dspy
 
 from dsp.modules.lm import LM
 
@@ -90,7 +91,7 @@ class Claude(LM):
     @backoff.on_exception(
         backoff.expo,
         (anthropic_rate_limit),
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,

--- a/dsp/modules/anthropic.py
+++ b/dsp/modules/anthropic.py
@@ -3,7 +3,7 @@ import os
 from typing import Any, Optional
 
 import backoff
-import dspy
+from dsp.utils.settings import settings
 
 from dsp.modules.lm import LM
 
@@ -91,7 +91,7 @@ class Claude(LM):
     @backoff.on_exception(
         backoff.expo,
         (anthropic_rate_limit),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,

--- a/dsp/modules/aws_providers.py
+++ b/dsp/modules/aws_providers.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional
 
 import backoff
+import dspy
 
 try:
     import boto3
@@ -80,7 +81,7 @@ class AWSProvider(ABC):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
@@ -155,7 +156,7 @@ class Sagemaker(AWSProvider):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,

--- a/dsp/modules/aws_providers.py
+++ b/dsp/modules/aws_providers.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Optional
 
 import backoff
-import dspy
+from dsp.utils.settings import settings
 
 try:
     import boto3
@@ -81,7 +81,7 @@ class AWSProvider(ABC):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
@@ -156,7 +156,7 @@ class Sagemaker(AWSProvider):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,

--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -8,7 +8,8 @@ import openai
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
+
 
 try:
     OPENAI_LEGACY = int(openai.version.__version__[0]) == 0
@@ -167,7 +168,7 @@ class AzureOpenAI(LM):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def request(self, prompt: str, **kwargs):

--- a/dsp/modules/azure_openai.py
+++ b/dsp/modules/azure_openai.py
@@ -8,6 +8,7 @@ import openai
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
 from dsp.modules.lm import LM
+import dspy
 
 try:
     OPENAI_LEGACY = int(openai.version.__version__[0]) == 0
@@ -166,7 +167,7 @@ class AzureOpenAI(LM):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def request(self, prompt: str, **kwargs):

--- a/dsp/modules/cloudflare.py
+++ b/dsp/modules/cloudflare.py
@@ -7,6 +7,7 @@ import requests
 from pydantic import BaseModel, ValidationError
 
 from dsp.modules.lm import LM
+import dspy
 
 
 def backoff_hdlr(details) -> None:
@@ -69,7 +70,7 @@ class CloudflareAI(LM):
     @backoff.on_exception(
         backoff.expo,
         requests.exceptions.RequestException,
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
         on_giveup=giveup_hdlr,
     )

--- a/dsp/modules/cloudflare.py
+++ b/dsp/modules/cloudflare.py
@@ -7,7 +7,7 @@ import requests
 from pydantic import BaseModel, ValidationError
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 
 def backoff_hdlr(details) -> None:
@@ -70,7 +70,7 @@ class CloudflareAI(LM):
     @backoff.on_exception(
         backoff.expo,
         requests.exceptions.RequestException,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
         on_giveup=giveup_hdlr,
     )

--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 try:
     import cohere
@@ -102,7 +102,7 @@ class Cohere(LM):
     @backoff.on_exception(
         backoff.expo,
         (cohere_api_error),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
+import dspy
 
 try:
     import cohere
@@ -101,7 +102,7 @@ class Cohere(LM):
     @backoff.on_exception(
         backoff.expo,
         (cohere_api_error),
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/google.py
+++ b/dsp/modules/google.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
+import dspy
 
 try:
     import google.generativeai as genai
@@ -133,7 +134,7 @@ class Google(LM):
     @backoff.on_exception(
         backoff.expo,
         (google_api_error),
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,

--- a/dsp/modules/google.py
+++ b/dsp/modules/google.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 try:
     import google.generativeai as genai
@@ -134,7 +134,7 @@ class Google(LM):
     @backoff.on_exception(
         backoff.expo,
         (google_api_error),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         max_tries=8,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,

--- a/dsp/modules/googlevertexai.py
+++ b/dsp/modules/googlevertexai.py
@@ -6,7 +6,7 @@ import backoff
 from pydantic_core import PydanticCustomError
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 try:
     import vertexai  # type: ignore[import-untyped]
@@ -185,7 +185,7 @@ class GoogleVertexAI(LM):
     @backoff.on_exception(
         backoff.expo,
         (Exception),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/googlevertexai.py
+++ b/dsp/modules/googlevertexai.py
@@ -6,6 +6,7 @@ import backoff
 from pydantic_core import PydanticCustomError
 
 from dsp.modules.lm import LM
+import dspy
 
 try:
     import vertexai  # type: ignore[import-untyped]
@@ -184,7 +185,7 @@ class GoogleVertexAI(LM):
     @backoff.on_exception(
         backoff.expo,
         (Exception),
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -8,7 +8,7 @@ import openai
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 try:
     OPENAI_LEGACY = int(openai.version.__version__[0]) == 0
@@ -134,7 +134,7 @@ class GPT3(LM):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def request(self, prompt: str, **kwargs):

--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -8,6 +8,7 @@ import openai
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory, cache_turn_on
 from dsp.modules.lm import LM
+import dspy
 
 try:
     OPENAI_LEGACY = int(openai.version.__version__[0]) == 0
@@ -133,11 +134,11 @@ class GPT3(LM):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def request(self, prompt: str, **kwargs):
-        """Handles retreival of GPT-3 completions whilst handling rate limiting and caching."""
+        """Handles retrieval of GPT-3 completions whilst handling rate limiting and caching."""
         if "model_type" in kwargs:
             del kwargs["model_type"]
 

--- a/dsp/modules/groq_client.py
+++ b/dsp/modules/groq_client.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 
 def backoff_hdlr(details):
@@ -92,7 +92,7 @@ class GroqLM(LM):
     @backoff.on_exception(
         backoff.expo,
         groq_api_error,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def request(self, prompt: str, **kwargs):

--- a/dsp/modules/groq_client.py
+++ b/dsp/modules/groq_client.py
@@ -13,6 +13,7 @@ except ImportError:
 
 
 from dsp.modules.lm import LM
+import dspy
 
 
 def backoff_hdlr(details):
@@ -91,7 +92,7 @@ class GroqLM(LM):
     @backoff.on_exception(
         backoff.expo,
         groq_api_error,
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def request(self, prompt: str, **kwargs):

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -11,7 +11,7 @@ import requests
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory
 from dsp.modules.hf import HFModel, openai_to_hf
-import dspy
+from dsp.utils.settings import settings
 
 ERRORS = (Exception)
 
@@ -341,7 +341,7 @@ class Together(HFModel):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def _generate(self, prompt, use_chat_api=False, **kwargs):

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -11,6 +11,7 @@ import requests
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory
 from dsp.modules.hf import HFModel, openai_to_hf
+import dspy
 
 ERRORS = (Exception)
 
@@ -340,7 +341,7 @@ class Together(HFModel):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
     )
     def _generate(self, prompt, use_chat_api=False, **kwargs):

--- a/dsp/modules/mistral.py
+++ b/dsp/modules/mistral.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 try:
     import mistralai
@@ -100,7 +100,7 @@ class Mistral(LM):
     @backoff.on_exception(
         backoff.expo,
         (mistralai_api_error),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/mistral.py
+++ b/dsp/modules/mistral.py
@@ -3,6 +3,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
+import dspy
 
 try:
     import mistralai
@@ -99,7 +100,7 @@ class Mistral(LM):
     @backoff.on_exception(
         backoff.expo,
         (mistralai_api_error),
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/premai.py
+++ b/dsp/modules/premai.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 try:
     import premai
@@ -180,7 +180,7 @@ class PremAI(LM):
     @backoff.on_exception(
         backoff.expo,
         (premai_api_error),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/premai.py
+++ b/dsp/modules/premai.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 import backoff
 
 from dsp.modules.lm import LM
+import dspy
 
 try:
     import premai
@@ -179,7 +180,7 @@ class PremAI(LM):
     @backoff.on_exception(
         backoff.expo,
         (premai_api_error),
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/snowflake.py
+++ b/dsp/modules/snowflake.py
@@ -6,7 +6,7 @@ import backoff
 from pydantic_core import PydanticCustomError
 
 from dsp.modules.lm import LM
-import dspy
+from dsp.utils.settings import settings
 
 try:
     from snowflake.snowpark import Session
@@ -147,7 +147,7 @@ class Snowflake(LM):
     @backoff.on_exception(
         backoff.expo,
         (Exception),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/modules/snowflake.py
+++ b/dsp/modules/snowflake.py
@@ -6,6 +6,7 @@ import backoff
 from pydantic_core import PydanticCustomError
 
 from dsp.modules.lm import LM
+import dspy
 
 try:
     from snowflake.snowpark import Session
@@ -146,7 +147,7 @@ class Snowflake(LM):
     @backoff.on_exception(
         backoff.expo,
         (Exception),
-        max_time=1000,
+        max_time=dspy.settings.backoff_time,
         on_backoff=backoff_hdlr,
         giveup=giveup_hdlr,
     )

--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -42,6 +42,7 @@ class Settings:
                 suggest_failures=0,
                 langchain_history=[],
                 experimental=False,
+                backoff_time = 10
             )
             cls._instance.__append(config)
 

--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -124,7 +124,7 @@ class ChromadbRM(dspy.Retrieve):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=15,
+        max_time=dspy.settings.backoff_time,
     )
     def _get_embeddings(self, queries: List[str]) -> List[List[float]]:
         """Return query vector after creating embedding using OpenAI

--- a/dspy/retrieve/chromadb_rm.py
+++ b/dspy/retrieve/chromadb_rm.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 import backoff
 import openai
 
-import dspy
+from dsp.utils.settings import settings
 from dsp.utils import dotdict
 
 try:
@@ -124,7 +124,7 @@ class ChromadbRM(dspy.Retrieve):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
     )
     def _get_embeddings(self, queries: List[str]) -> List[List[float]]:
         """Return query vector after creating embedding using OpenAI

--- a/dspy/retrieve/mongodb_atlas_rm.py
+++ b/dspy/retrieve/mongodb_atlas_rm.py
@@ -10,7 +10,7 @@ from openai import (
     UnprocessableEntityError,
 )
 
-import dspy
+from dsp.utils.settings import settings
 
 try:
     from pymongo import MongoClient
@@ -61,7 +61,7 @@ class Embedder:
             RateLimitError,
             UnprocessableEntityError,
         ),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
     )
     def __call__(self, queries) -> Any:
         embedding = self.client.embeddings.create(input=queries, model=self.model)

--- a/dspy/retrieve/mongodb_atlas_rm.py
+++ b/dspy/retrieve/mongodb_atlas_rm.py
@@ -61,7 +61,7 @@ class Embedder:
             RateLimitError,
             UnprocessableEntityError,
         ),
-        max_time=15,
+        max_time=dspy.settings.backoff_time,
     )
     def __call__(self, queries) -> Any:
         embedding = self.client.embeddings.create(input=queries, model=self.model)

--- a/dspy/retrieve/neo4j_rm.py
+++ b/dspy/retrieve/neo4j_rm.py
@@ -10,7 +10,7 @@ from openai import (
     UnprocessableEntityError,
 )
 
-import dspy
+from dsp.utils.settings import settings
 from dsp.utils import dotdict
 
 try:
@@ -42,7 +42,7 @@ class Embedder:
             RateLimitError,
             UnprocessableEntityError,
         ),
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
     )
     def __call__(self, queries) -> Any:
         embedding = self.client.embeddings.create(input=queries, model=self.model)

--- a/dspy/retrieve/neo4j_rm.py
+++ b/dspy/retrieve/neo4j_rm.py
@@ -42,7 +42,7 @@ class Embedder:
             RateLimitError,
             UnprocessableEntityError,
         ),
-        max_time=15,
+        max_time=dspy.settings.backoff_time,
     )
     def __call__(self, queries) -> Any:
         embedding = self.client.embeddings.create(input=queries, model=self.model)

--- a/dspy/retrieve/pinecone_rm.py
+++ b/dspy/retrieve/pinecone_rm.py
@@ -178,7 +178,7 @@ class PineconeRM(dspy.Retrieve):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=15,
+        max_time=dspy.settings.backoff_time,
     )
     def _get_embeddings(
         self, 

--- a/dspy/retrieve/pinecone_rm.py
+++ b/dspy/retrieve/pinecone_rm.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 
 import backoff
 
-import dspy
+from dsp.utils.settings import settings
 from dsp.utils import dotdict
 
 try:
@@ -178,7 +178,7 @@ class PineconeRM(dspy.Retrieve):
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
-        max_time=dspy.settings.backoff_time,
+        max_time=settings.backoff_time,
     )
     def _get_embeddings(
         self, 


### PR DESCRIPTION
allows for user-configurable backoff times across LM/RM providers.

Note that if you'd like to set individual backoff times for specific providers, you can do through the dspy context manager 

```
with dspy.context(backoff_time = ..):
      dspy.OpenAI(...) # example

with dspy.context(backoff_time = ..):
      dspy.AzureOpenAI(...) # example
```