### PR TITLE
Add the groq client version 0.9.0 to requirements*.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-mock==3.12.0
 ruff==0.3.0
 torch==2.2.1
 transformers==4.38.2
+groq==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests
 structlog
 tqdm
 ujson
+groq==0.9.0


### PR DESCRIPTION
Was tinkering with this library today and found that there is code that uses Groq client but it is not expressed as a requirement. 

Perhaps, it is intentional; but raising a PR anyway to clarify the stance on client libs because I saw the Open AI client in the requirements.txt.