### PR TITLE
miprov2 patch for proper parsing

### DIFF
--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -192,7 +192,7 @@ class GenerateModuleInstruction(dspy.Module):
             print(f"PROGRAM DESCRIPTION: {program_description}")
 
             # Identify all modules
-            init_pattern = r"def __init__.*?\):([\s\S]*?)(?=\n\s{4}def|\Z)"
+            init_pattern = r"def __init__\(.*?\):([\s\S]*?)(?=^\s*def|\Z)"
             init_content_match = re.search(init_pattern, self.program_code_string)
             init_content = init_content_match.group(0)
             pattern = r"^(.*dspy\.(ChainOfThought|Predict).*)$"  # TODO: make it so that this extends out to any dspy Module

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -391,7 +391,7 @@ def get_dspy_source_code(module):
                 if item.signature is not None and item.signature.__pydantic_parent_namespace__['signature_name'] + "_sig" not in completed_set:
                     try:
                         header.append(inspect.getsource(item.signature))
-                    except TypeError:
+                    except (TypeError, OSError):
                         header.append(str(item.signature))
                     completed_set.add(item.signature.__pydantic_parent_namespace__['signature_name'] + "_sig")
             if isinstance(item, dspy.Module):

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -348,9 +348,37 @@ def create_n_fewshot_demo_sets(
 
     return demo_candidates
 
-def new_getfile(object, _old_getfile=inspect.getfile):
+def old_getfile(object):
+    """Work out which source or compiled file an object was defined in."""
+    if inspect.ismodule(object):
+        if getattr(object, '__file__', None):
+            return object.__file__
+        raise TypeError('{!r} is a built-in module'.format(object))
+    if inspect.isclass(object):
+        if hasattr(object, '__module__'):
+            module = sys.modules.get(object.__module__)
+            if getattr(module, '__file__', None):
+                return module.__file__
+            if object.__module__ == '__main__':
+                raise OSError('source code not available')
+        raise TypeError('{!r} is a built-in class'.format(object))
+    if inspect.ismethod(object):
+        object = object.__func__
+    if inspect.isfunction(object):
+        object = object.__code__
+    if inspect.istraceback(object):
+        object = object.tb_frame
+    if inspect.isframe(object):
+        object = object.f_code
+    if inspect.iscode(object):
+        return object.co_filename
+    raise TypeError('module, class, method, function, traceback, frame, or '
+                    'code object was expected, got {}'.format(
+                    type(object).__name__))
+
+def new_getfile(object):
     if not inspect.isclass(object):
-        return _old_getfile(object)
+        return old_getfile(object)
     
     # Lookup by parent module (as in current inspect)
     if hasattr(object, '__module__'):
@@ -363,19 +391,22 @@ def new_getfile(object, _old_getfile=inspect.getfile):
         if inspect.isfunction(member) and object.__qualname__ + '.' + member.__name__ == member.__qualname__:
             return inspect.getfile(member)
     raise TypeError(f'Source for {object!r} not found')
-    
+
 inspect.getfile = new_getfile
 
 def get_dspy_source_code(module):
     header = []
     base_code = ""
-    try:
-        base_code = inspect.getsource(type(module))
-    except TypeError:
-        obj = type(module)
-        cell_code = "".join(inspect.linecache.getlines(new_getfile(obj)))
-        class_code = extract_symbols(cell_code, obj.__name__)[0][0]
-        base_code = str(class_code)
+
+    # Don't get source code for Predict or ChainOfThought modules (NOTE we will need to extend this list as more DSPy.modules are added)
+    if not type(module).__name__ == "Predict" and not type(module).__name__ == "ChainOfThought":
+        try:
+            base_code = inspect.getsource(type(module))
+        except TypeError:
+            obj = type(module)
+            cell_code = "".join(inspect.linecache.getlines(new_getfile(obj)))
+            class_code = extract_symbols(cell_code, obj.__name__)[0][0]
+            base_code = str(class_code)
 
     completed_set = set()
     for attribute in module.__dict__.keys():
@@ -388,16 +419,18 @@ def get_dspy_source_code(module):
             if item in completed_set:
                 continue
             if isinstance(item, Parameter):
-                if item.signature is not None and item.signature.__pydantic_parent_namespace__['signature_name'] + "_sig" not in completed_set:
+                if hasattr(item, 'signature') and item.signature is not None and item.signature.__pydantic_parent_namespace__['signature_name'] + "_sig" not in completed_set:
                     try:
                         header.append(inspect.getsource(item.signature))
+                        print(inspect.getsource(item.signature))
                     except (TypeError, OSError):
                         header.append(str(item.signature))
                     completed_set.add(item.signature.__pydantic_parent_namespace__['signature_name'] + "_sig")
             if isinstance(item, dspy.Module):
-                if type(item) not in completed_set:
-                    header.append(get_dspy_source_code(item))
-                    completed_set.add(type(item))
+                code = get_dspy_source_code(item).strip()
+                if code not in completed_set:
+                    header.append(code)
+                    completed_set.add(code)
             completed_set.add(item)
         
     return '\n\n'.join(header) + '\n\n' + base_code


### PR DESCRIPTION
MIPROv2 was erroring out when using the latest changes on the repo (particularly  [Convert Predict and ChainOfThought into Modules, while retaining backward compatible .load()](https://github.com/stanfordnlp/dspy/commit/730fd1363f9d329db23cb2d88340268dd8cdf68d) and while using [`dspy.experimental`](https://github.com/stanfordnlp/dspy/commit/5e57bb27a8d88966c3793edd7d2001047ef1ae14))

Fixes:
1. [patches](https://github.com/stanfordnlp/dspy/pull/1280/files#diff-c76579dace3800072e78f8254f10e08dfc927275120b1127eeb8e3030e4b1eb4R394) error from [`inspect.getsource`](https://github.com/stanfordnlp/dspy/blob/b30bb8b631c106f1dc37d020c81e3ae819a92aaf/dspy/teleprompt/utils.py#L393) used in MIPROv2 to retrieve code definitions of uncompiled DSPy program. previously seeing`Error getting source code: could not find class definition` and now fixed to catch error and default to signature string

2. [modify](https://github.com/stanfordnlp/dspy/commit/5e57bb27a8d88966c3793edd7d2001047ef1ae14) regex parsing in identifying modules part of MIPROv2 in light of `dspy.Predict` and `dspy.ChainOfThought` changes.
