### PR TITLE
Update RunLLM's chat widget script path

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -159,12 +159,11 @@ const config: Config = {
     {
       id: "runllm-widget-script",
       type: "module",
-      src: "https://cdn.jsdelivr.net/npm/@runllm/search-widget@stable/dist/run-llm-search-widget.es.js",
+      src: "https://widget.runllm.com",
       "runllm-server-address": "https://api.runllm.com",
       "runllm-assistant-id": "132",
       "runllm-position": "BOTTOM_RIGHT",
       "runllm-keyboard-shortcut": "Mod+j",
-      version: "stable",
       "runllm-preset": "docusaurus",
       "runllm-slack-community-url": "",
       "runllm-name": "DSPy",


### PR DESCRIPTION
This PR updates RunLLM's chat widget's script path. RunLLM switched to a new deployment framework that resolved multiple issues related to jscdn's caching. This update ensures the RunLLM's ask AI widget is more consistently up-to-date.