### PR TITLE
Revert "cache:use temp dir by default"

### DIFF
--- a/dsp/modules/cache_utils.py
+++ b/dsp/modules/cache_utils.py
@@ -1,6 +1,6 @@
 import os
 from functools import wraps
-from tempfile import mkdtemp
+from pathlib import Path
 
 from joblib import Memory
 
@@ -23,7 +23,7 @@ def noop_decorator(arg=None, *noop_args, **noop_kwargs):
         return decorator
 
 
-cachedir = os.environ.get('DSP_CACHEDIR') or mkdtemp()
+cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), 'cachedir_joblib')
 CacheMemory = Memory(location=cachedir, verbose=0)
 
 cachedir2 = os.environ.get('DSP_NOTEBOOK_CACHEDIR')
@@ -32,6 +32,7 @@ NotebookCacheMemory.cache = noop_decorator
 
 if cachedir2:
     NotebookCacheMemory = Memory(location=cachedir2, verbose=0)
+
 
 if not cache_turn_on:
     CacheMemory = dotdict()


### PR DESCRIPTION
Reverts stanfordnlp/dspy#1278

@okhat @lsgrep temporarily reverting for now. will look back into how to add this PR to maintain backward compatibility with the cache soon!