### PR TITLE
Fix conditional in Module.named_parameters() to prevent infinite recursion

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -23,10 +23,11 @@ class BaseModule:
         named_parameters = []
 
         def add_parameter(param_name, param_value):
-            if isinstance(param_value, Parameter) and id(param_value) not in visited:
-                visited.add(id(param_value))
-                param_name = postprocess_parameter_name(param_name, param_value)
-                named_parameters.append((param_name, param_value))
+            if isinstance(param_value, Parameter):
+                if id(param_value) not in visited:
+                    visited.add(id(param_value))
+                    param_name = postprocess_parameter_name(param_name, param_value)
+                    named_parameters.append((param_name, param_value))
             
             elif isinstance(param_value, dspy.Module):
                 # When a sub-module is pre-compiled, keep it frozen.

--- a/tests/primitives/test_program.py
+++ b/tests/primitives/test_program.py
@@ -136,3 +136,15 @@ def test_complex_module_traversal():
     assert (
         found_names == expected_names
     ), f"Missing or extra modules found. Missing: {expected_names-found_names}, Extra: {found_names-expected_names}"
+
+class DuplicateModule(Module):
+    def __init__(self):
+        super().__init__()
+        self.p0 = dspy.Predict("question -> answer")
+        self.p1 = self.p0
+
+def test_named_parameters_duplicate_references():
+   module = DuplicateModule()
+   # Only testing for whether exceptions are thrown or not
+   # As Module.named_parameters() is recursive, this is mainly for catching infinite recursion
+   module.named_parameters()


### PR DESCRIPTION
The problem is illustrated as follows:

For a module such as the following I added to the tests:
```python3
class DuplicateModule(Module):
    def __init__(self):
        super().__init__()
        self.p0 = dspy.Predict("question -> answer")
        self.p1 = self.p0
```
Running its `named_parameters()` method would result in infinite recursion. This is due to that `Predict` is both a `Module` and a `Parameter`. Thus, according to the original arrangement of the if statements, suppose that `p0` is already visited. Then, by having the `Predict` instance already a member of the `visited` set and that it is a `Module`, the second condition would still execute when `p1` is visited.

I originally discovered this problem when using `assert_transform_module()`, which calls `Module.named_parameters()` at some point.