### PR TITLE
Support nested objects in set_attribute_by_name() via magicattr

### DIFF
--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -1,4 +1,5 @@
 import re
+import magicattr
 
 from dspy.primitives.assertions import *
 from dspy.primitives.module import BaseModule
@@ -74,37 +75,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
     #     return new_copy
 
 
-# FIXME(Shangyint): This may cause some problems for nested patterns.
 def set_attribute_by_name(obj, name, value):
-    # Regular expressions for different patterns
-    module_pattern = re.compile(r"^([^.]+)\.(.+)$")
-    list_pattern = re.compile(r"^([^\[]+)\[([0-9]+)\]$")
-    dict_pattern = re.compile(r"^([^\[]+)\['([^']+)'\]$")
-
-    # Match for module.attribute pattern
-    module_match = module_pattern.match(name)
-    if module_match:
-        module_name, sub_name = module_match.groups()
-        sub_obj = getattr(obj, module_name)
-        set_attribute_by_name(sub_obj, sub_name, value)
-        return
-
-    # Match for list[index] pattern
-    list_match = list_pattern.match(name)
-    if list_match:
-        list_name, index = list_match.groups()
-        getattr(obj, list_name)[int(index)] = value
-        return
-
-    # Match for dict['key'] pattern
-    dict_match = dict_pattern.match(name)
-    if dict_match:
-        dict_name, key = dict_match.groups()
-        getattr(obj, dict_name)[key] = value
-        return
-
-    # Default case for simple attributes
-    setattr(obj, name, value)
-
+    magicattr.set(obj, name, value)
 
 Program = Module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,8 @@ dependencies = [
     "optuna",
     "pydantic~=2.0",
     "structlog",
-    "jinja2"
+    "jinja2",
+    "magicattr~=0.1.6"
 ]
 
 [project.optional-dependencies]
@@ -127,6 +128,7 @@ structlog = "^24.1.0"
 llama-index = {version = "^0.10.30", optional = true}
 snowflake-snowpark-python = { version = "*",optional=true, python = ">=3.9,<3.12" }
 jinja2 = "^3.1.3"
+magicattr = "^0.1.6"
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests
 structlog
 tqdm
 ujson
+magicattr~=0.1.6

--- a/tests/primitives/test_program.py
+++ b/tests/primitives/test_program.py
@@ -137,6 +137,29 @@ def test_complex_module_traversal():
         found_names == expected_names
     ), f"Missing or extra modules found. Missing: {expected_names-found_names}, Extra: {found_names-expected_names}"
 
+
+def test_complex_module_set_attribute_by_name():
+    root = Module()
+    root.sub_module = Module()
+    root.sub_module.nested_list = [Module(), {"key": Module()}]
+    same_module = Module()
+    root.sub_module.nested_tuple = (Module(), [same_module, same_module])
+
+    set_attribute_by_name(root, "test_attrib", True)
+    assert root.test_attrib is True
+    set_attribute_by_name(root, "sub_module.test_attrib", True)
+    assert root.sub_module.test_attrib is True
+    set_attribute_by_name(root, "sub_module.nested_list[0].test_attrib", True)
+    assert root.sub_module.nested_list[0].test_attrib is True
+    set_attribute_by_name(root, "sub_module.nested_list[1]['key'].test_attrib", True)
+    assert root.sub_module.nested_list[1]["key"].test_attrib is True
+    set_attribute_by_name(root, "sub_module.nested_tuple[0].test_attrib", True)
+    assert root.sub_module.nested_tuple[0].test_attrib is True
+    set_attribute_by_name(root, "sub_module.nested_tuple[1][0].test_attrib", True)
+    assert root.sub_module.nested_tuple[1][0].test_attrib is True
+    assert root.sub_module.nested_tuple[1][1].test_attrib is True
+
+
 class DuplicateModule(Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## Fix

I propose using [magicattr](https://github.com/frmdstryr/magicattr) for implementing `set_attribute_by_name()`. While this does introduce an additional dependency, I think it is better than the alternatives of either reinventing the wheel or using `exec()` directly.

## Problem

Originally, `set_attribute_by_name()` sets an attribute specified by its string name via regex. However, for a name such as `"some_list[0].some_attrib"`, it would be matched by `module_pattern`, which would in turn interpret `"some_list[0]"` as the name of a submodule and an attribute of the parent object `obj`, and call `getattr(obj, "some_list[0]")` to retrieve it. However, `getattr()` does not support accessing the member of a list/dict attribute directly and would thus fail.

Fixes #882. While #882 concerns the issue of using both a list of predictors and that the predictors are typed, I think the use of typed predictors is not the root cause of the issue. The original regex implementation works just fine with non-nested list/dict attributes, but when using typed predictors, note that `TypedPredictor` wraps a `Predict` object in the `predictor` attribute. Therefore, the actual predictor/parameter would not be named as `"predictor_list[0]"`, but rather `"predictor_list[0].predictor"` and trigger the issue.

I encountered this issue without using typed predictors, but rather simply using `assert_transform_module()` on nested modules with lists and dicts of other modules.