### PR TITLE
fix (mipro): enable running mipro using only labeled demos

### DIFF
--- a/dspy/teleprompt/mipro_optimizer.py
+++ b/dspy/teleprompt/mipro_optimizer.py
@@ -419,12 +419,10 @@ class MIPRO(Teleprompter):
             module = student.deepcopy()
             evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
 
-            # In the case where the bootstrapped and labeled demos are set to 0, we'll stil bootstrap examples to use in our meta prompt
-            if (
-                max_bootstrapped_demos == 0 and max_labeled_demos == 0
-            ):  # TODO: address case when max_bootstrapped alone is 0
+            # In the case where the bootstrapped demos are set to 0, we'll stil bootstrap examples to use in our meta prompt
+            if max_bootstrapped_demos == 0:
                 max_bootstrapped_demos_for_candidate_gen = 1
-                max_labeled_demos_for_candidate_gen = 1  # TODO: this might only need to be 0
+                max_labeled_demos_for_candidate_gen = max_labeled_demos
             else:
                 max_bootstrapped_demos_for_candidate_gen = max_bootstrapped_demos
                 max_labeled_demos_for_candidate_gen = max_labeled_demos

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -254,9 +254,9 @@ class MIPROv2(Teleprompter):
             evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
 
             # Determine the number of fewshot examples to use to generate demos for prompt
-            if max_bootstrapped_demos == 0 and max_labeled_demos == 0:
+            if max_bootstrapped_demos == 0:
                 max_bootstrapped_demos_for_candidate_gen = BOOTSTRAPPED_FEWSHOT_EXAMPLES_IN_CONTEXT
-                max_labeled_demos_for_candidate_gen = LABELED_FEWSHOT_EXAMPLES_IN_CONTEXT
+                max_labeled_demos_for_candidate_gen = max_labeled_demos
             else:
                 max_bootstrapped_demos_for_candidate_gen = max_bootstrapped_demos
                 max_labeled_demos_for_candidate_gen = max_labeled_demos


### PR DESCRIPTION
Enable performing mipro prompt optimization while only using labeled demos. Here, bootstrapped demos are solely used for the meta-prompt to enhance the final prompt.

Before fix:  

- max_bootstrapped_demos = 0 
and 
- max_labeled_demos > 0  

mipro optimizer raises ValueError: "No examples found for the given predictor" 