### PR TITLE
fix: forward return in class MilvusRM

### DIFF
--- a/dspy/retrieve/milvus_rm.py
+++ b/dspy/retrieve/milvus_rm.py
@@ -104,4 +104,4 @@ class MilvusRM(dspy.Retrieve):
         sorted_passages = sorted(
             passage_scores.items(), key=lambda x: x[1], reverse=True,
         )[:k]
-        return dspy.Prediction(passages=[dotdict({"long_text": passage}) for passage, _ in sorted_passages])
+        return [dotdict({"long_text": passage}) for passage, _ in sorted_passages]


### PR DESCRIPTION
I encountered the following issue while using MilvusRM. Through debugging, I found that the format of the passages returned seems incorrect. By comparing with other RM implementations, I discovered that the problem lies in the data structure returned by the forward method of MilvusRM.
![image](https://github.com/user-attachments/assets/11201e56-f76e-404f-9929-e0d2dc64fddf)
This PR can address the aforementioned issue.
![image](https://github.com/user-attachments/assets/feac7584-3eab-49b6-b35c-351bd720e862)
