### PR TITLE
feat(dsp): Vertex Anthropic Module

### DIFF
--- a/dsp/modules/__init__.py
+++ b/dsp/modules/__init__.py
@@ -14,6 +14,7 @@ from .databricks import *
 from .dummy_lm import *
 from .google import *
 from .googlevertexai import *
+from .googlevertexai_anthropic import *
 from .gpt3 import *
 from .groq_client import *
 from .hf import HFModel

--- a/dsp/modules/googlevertexai_anthropic.py
+++ b/dsp/modules/googlevertexai_anthropic.py
@@ -1,0 +1,131 @@
+import logging
+from typing import Any, Optional
+
+import backoff
+
+from dsp.modules.lm import LM
+from dsp.utils.settings import settings
+
+try:
+    import anthropic
+
+    anthropic_rate_limit = anthropic.RateLimitError
+
+except ImportError:
+    anthropic_rate_limit = Exception
+
+logger = logging.getLogger(__name__)
+
+
+def backoff_hdlr(details):
+    """Handler from https://pypi.org/project/backoff/."""
+    print(
+        "Backing off {wait:0.1f} seconds after {tries} tries "
+        "calling function {target} with kwargs "
+        "{kwargs}".format(**details),
+    )
+
+
+def giveup_hdlr(details):
+    """Wrapper function that decides when to give up on retry."""
+    if "rate limits" in details.message:
+        return False
+    return True
+
+
+class ClaudeVertex(LM):
+    """Wrapper around anthropic's API. Supports Vertex APIs."""
+
+    def __init__(
+        self,
+        location: str,
+        project: str,
+        model: str = "claude-3-opus-20240229",
+        credentials: Optional[Any] = None,
+        **kwargs,
+    ):
+        super().__init__(model)
+        try:
+            from anthropic import AnthropicVertex
+        except ImportError as err:
+            raise ImportError("Claude requires `pip install google-cloud-aiplatform 'anthropic[vertex]'`.") from err
+
+        self.provider = "anthropic-vertex"
+        self.kwargs = {
+            "temperature": kwargs.get("temperature", 0.0),
+            "max_tokens": min(kwargs.get("max_tokens", 4096), 4096),
+            "top_p": kwargs.get("top_p", 1.0),
+            "top_k": kwargs.get("top_k", 1),
+            "n": kwargs.pop("n", kwargs.pop("num_generations", 1)),
+            **kwargs,
+        }
+        self.kwargs["model"] = model
+        self.history: list[dict[str, Any]] = []
+        vertex_params = {
+            "region": location,
+            "project_id": project,
+        }
+        if credentials:
+            vertex_params["credentials"] = credentials
+        self.client = AnthropicVertex(**vertex_params)
+
+    def log_usage(self, response):
+        """Log the total tokens from the Anthropic API response."""
+        usage_data = response.usage
+        if usage_data:
+            total_tokens = usage_data.input_tokens + usage_data.output_tokens
+            logger.debug(f"Anthropic Total Token Response Usage: {total_tokens}")
+
+    def basic_request(self, prompt: str, **kwargs):
+        raw_kwargs = kwargs
+        kwargs = {**self.kwargs, **kwargs}
+        # caching mechanism requires hashable kwargs
+        kwargs["messages"] = [{"role": "user", "content": prompt}]
+        kwargs.pop("n")
+        response = self.client.messages.create(**kwargs)
+        history = {
+            "prompt": prompt,
+            "response": response,
+            "kwargs": kwargs,
+            "raw_kwargs": raw_kwargs,
+        }
+        self.history.append(history)
+        return response
+
+    @backoff.on_exception(
+        backoff.expo,
+        (anthropic_rate_limit),
+        max_time=settings.backoff_time,
+        max_tries=8,
+        on_backoff=backoff_hdlr,
+        giveup=giveup_hdlr,
+    )
+    def request(self, prompt: str, **kwargs):
+        """Handles retrieval of completions from Anthropic whilst handling API errors."""
+        return self.basic_request(prompt, **kwargs)
+
+    def __call__(self, prompt, only_completed=True, return_sorted=False, **kwargs):
+        """Retrieves completions from Anthropic.
+
+        Args:
+            prompt (str): prompt to send to Anthropic
+            only_completed (bool, optional): return only completed responses and ignores completion due to length. Defaults to True.
+            return_sorted (bool, optional): sort the completion choices using the returned probabilities. Defaults to False.
+
+        Returns:
+            list[str]: list of completion choices
+        """
+        assert only_completed, "for now"
+        assert return_sorted is False, "for now"
+        # per eg here: https://docs.anthropic.com/claude/reference/messages-examples
+        # max tokens can be used as a proxy to return smaller responses
+        # so this cannot be a proper indicator for incomplete response unless it isnt the user-intent.
+        n = kwargs.pop("n", 1)
+        completions = []
+        for _ in range(n):
+            response = self.request(prompt, **kwargs)
+            self.log_usage(response)
+            if only_completed and response.stop_reason == "max_tokens":
+                continue
+            completions = [c.text for c in response.content]
+        return completions

--- a/dsp/modules/hf_client.py
+++ b/dsp/modules/hf_client.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import random
 import re
@@ -8,12 +9,14 @@ from typing import Literal
 # from dsp.modules.adapter import TurboAdapter, DavinciAdapter, LlamaAdapter
 import backoff
 import requests
+from opentelemetry import trace as trace_api
 
 from dsp.modules.cache_utils import CacheMemory, NotebookCacheMemory
 from dsp.modules.hf import HFModel, openai_to_hf
 from dsp.utils.settings import settings
 
-ERRORS = (Exception)
+ERRORS = Exception
+
 
 def backoff_hdlr(details):
     """Handler from https://pypi.org/project/backoff/"""
@@ -22,6 +25,7 @@ def backoff_hdlr(details):
         "calling function {target} with kwargs "
         "{kwargs}".format(**details),
     )
+
 
 class HFClientTGI(HFModel):
     def __init__(self, model, port, url="http://future-hgx-1", http_request_kwargs=None, **kwargs):
@@ -51,21 +55,22 @@ class HFClientTGI(HFModel):
         kwargs = {**self.kwargs, **kwargs}
 
         payload = {
-        "inputs": prompt,
-        "parameters": {
-            "do_sample": kwargs["n"] > 1,
-            "best_of": kwargs["n"],
-            "details": kwargs["n"] > 1,
-            # "max_new_tokens": kwargs.get('max_tokens', kwargs.get('max_new_tokens', 75)),
-            # "stop": ["\n", "\n\n"],
-            **kwargs,
+            "inputs": prompt,
+            "parameters": {
+                "do_sample": kwargs["n"] > 1,
+                "best_of": kwargs["n"],
+                "details": kwargs["n"] > 1,
+                # "max_new_tokens": kwargs.get('max_tokens', kwargs.get('max_new_tokens', 75)),
+                # "stop": ["\n", "\n\n"],
+                **kwargs,
             },
         }
 
         payload["parameters"] = openai_to_hf(**payload["parameters"])
 
         payload["parameters"]["temperature"] = max(
-            0.1, payload["parameters"]["temperature"],
+            0.1,
+            payload["parameters"]["temperature"],
         )
 
         # print(payload['parameters'])
@@ -87,14 +92,8 @@ class HFClientTGI(HFModel):
 
             completions = [json_response["generated_text"]]
 
-            if (
-                "details" in json_response
-                and "best_of_sequences" in json_response["details"]
-            ):
-                completions += [
-                    x["generated_text"]
-                    for x in json_response["details"]["best_of_sequences"]
-                ]
+            if "details" in json_response and "best_of_sequences" in json_response["details"]:
+                completions += [x["generated_text"] for x in json_response["details"]["best_of_sequences"]]
 
             response = {"prompt": prompt, "choices": [{"text": c} for c in completions]}
             return response
@@ -103,12 +102,13 @@ class HFClientTGI(HFModel):
             raise Exception("Received invalid JSON response from server")
 
 
-@CacheMemory.cache(ignore=['arg'])
+@CacheMemory.cache(ignore=["arg"])
 def send_hftgi_request_v01(arg, url, ports, **kwargs):
     return requests.post(arg, **kwargs)
 
+
 # @functools.lru_cache(maxsize=None if cache_turn_on else 0)
-@NotebookCacheMemory.cache(ignore=['arg'])
+@NotebookCacheMemory.cache(ignore=["arg"])
 def send_hftgi_request_v01_wrapped(arg, url, ports, **kwargs):
     return send_hftgi_request_v01(arg, url, ports, **kwargs)
 
@@ -119,18 +119,28 @@ def send_hftgi_request_v00(arg, **kwargs):
 
 
 class HFClientVLLM(HFModel):
-    def __init__(self, model, port, model_type: Literal['chat', 'text'] = 'text', url="http://localhost", http_request_kwargs=None, **kwargs):
+    def __init__(
+        self,
+        model,
+        port,
+        model_type: Literal["chat", "text"] = "text",
+        url="http://localhost",
+        http_request_kwargs=None,
+        **kwargs,
+    ):
         super().__init__(model=model, is_client=True)
 
         if isinstance(url, list):
             self.urls = url
-        
+
         elif isinstance(url, str):
-            self.urls = [f'{url}:{port}']
-        
+            self.urls = [f"{url}:{port}"]
+
         else:
-            raise ValueError(f"The url provided to `HFClientVLLM` is neither a string nor a list of strings. It is of type {type(url)}.")
-        
+            raise ValueError(
+                f"The url provided to `HFClientVLLM` is neither a string nor a list of strings. It is of type {type(url)}."
+            )
+
         self.urls_const = tuple(self.urls)
         self.port = port
         self.http_request_kwargs = http_request_kwargs or {}
@@ -138,19 +148,20 @@ class HFClientVLLM(HFModel):
         self.headers = {"Content-Type": "application/json"}
         self.kwargs |= kwargs
         # kwargs needs to have model, port and url for the lm.copy() to work properly
-        self.kwargs.update({
-            'port': port,
-            'url': self.urls_const,
-        })
-
+        self.kwargs.update(
+            {
+                "port": port,
+                "url": self.urls_const,
+            }
+        )
 
     def _generate(self, prompt, **kwargs):
         kwargs = {**self.kwargs, **kwargs}
-        
+
         # Round robin the urls.
         url = self.urls.pop(0)
         self.urls.append(url)
-     
+
         list_of_elements_to_allow = [
             "n",
             "best_of",
@@ -179,16 +190,14 @@ class HFClientVLLM(HFModel):
             "logits_processors",
             "truncate_prompt_tokens",
         ]
-        req_kwargs = {
-            k: v for k, v in kwargs.items() if k in list_of_elements_to_allow
-        }
-   
+        req_kwargs = {k: v for k, v in kwargs.items() if k in list_of_elements_to_allow}
+
         if self.model_type == "chat":
-            system_prompt = kwargs.get("system_prompt",None)
+            system_prompt = kwargs.get("system_prompt", None)
             messages = [{"role": "user", "content": prompt}]
             if system_prompt:
                 messages.insert(0, {"role": "system", "content": system_prompt})
-            
+
             payload = {
                 "model": self.kwargs["model"],
                 "messages": messages,
@@ -208,7 +217,7 @@ class HFClientVLLM(HFModel):
                 completions = json_response["choices"]
                 response = {
                     "prompt": prompt,
-                    "choices": [{"text": c["message"]['content']} for c in completions],
+                    "choices": [{"text": c["message"]["content"]} for c in completions],
                 }
                 return response
 
@@ -244,18 +253,22 @@ class HFClientVLLM(HFModel):
                 print("Failed to parse JSON response:", response.text)
                 raise Exception("Received invalid JSON response from server")
 
-@CacheMemory.cache(ignore=['arg'])
+
+@CacheMemory.cache(ignore=["arg"])
 def send_hfvllm_request_v01(arg, url, port, **kwargs):
     return requests.post(arg, **kwargs)
 
+
 # @functools.lru_cache(maxsize=None if cache_turn_on else 0)
-@NotebookCacheMemory.cache(ignore=['arg'])
+@NotebookCacheMemory.cache(ignore=["arg"])
 def send_hfvllm_request_v01_wrapped(arg, url, port, **kwargs):
     return send_hftgi_request_v01(arg, url, port, **kwargs)
+
 
 @CacheMemory.cache
 def send_hfvllm_request_v00(arg, **kwargs):
     return requests.post(arg, **kwargs)
+
 
 @CacheMemory.cache
 def send_hfvllm_chat_request_v00(arg, **kwargs):
@@ -269,30 +282,45 @@ class HFServerTGI:
             os.makedirs(self.model_weights_dir)
 
     def close_server(self, port):
-        process = subprocess.Popen(['docker', 'ps'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        process = subprocess.Popen(["docker", "ps"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, _ = process.communicate()
         print(stdout)
         if stdout:
-            container_ids = stdout.decode().strip().split('\n')
+            container_ids = stdout.decode().strip().split("\n")
             container_ids = container_ids[1:]
             for container_id in container_ids:
-                match = re.search(r'^([a-zA-Z0-9]+)', container_id)
+                match = re.search(r"^([a-zA-Z0-9]+)", container_id)
                 if match:
                     container_id = match.group(1)
-                    port_mapping = subprocess.check_output(['docker', 'port', container_id]).decode().strip()
-                    if f'0.0.0.0:{port}' in port_mapping:
-                        subprocess.run(['docker', 'stop', container_id], check=False)
+                    port_mapping = subprocess.check_output(["docker", "port", container_id]).decode().strip()
+                    if f"0.0.0.0:{port}" in port_mapping:
+                        subprocess.run(["docker", "stop", container_id], check=False)
 
-    def run_server(self, port, model_name=None, model_path=None, env_variable=None, gpus="all", num_shard=1, max_input_length=4000, max_total_tokens=4096, max_best_of=100):        
+    def run_server(
+        self,
+        port,
+        model_name=None,
+        model_path=None,
+        env_variable=None,
+        gpus="all",
+        num_shard=1,
+        max_input_length=4000,
+        max_total_tokens=4096,
+        max_best_of=100,
+    ):
         self.close_server(port)
         if model_path:
             model_file_name = os.path.basename(model_path)
             link_path = os.path.join(self.model_weights_dir, model_file_name)
             shutil.copytree(model_path, link_path)
-            model_name = os.path.sep + os.path.basename(self.model_weights_dir) + os.path.sep + os.path.basename(model_path)
-        docker_command = f'docker run --gpus {gpus} --shm-size 1g -p {port}:80 -v {self.model_weights_dir}:{os.path.sep + os.path.basename(self.model_weights_dir)} -e {env_variable} ghcr.io/huggingface/text-generation-inference:1.1.0 --model-id {model_name} --num-shard {num_shard} --max-input-length {max_input_length} --max-total-tokens {max_total_tokens} --max-best-of {max_best_of}'
+            model_name = (
+                os.path.sep + os.path.basename(self.model_weights_dir) + os.path.sep + os.path.basename(model_path)
+            )
+        docker_command = f"docker run --gpus {gpus} --shm-size 1g -p {port}:80 -v {self.model_weights_dir}:{os.path.sep + os.path.basename(self.model_weights_dir)} -e {env_variable} ghcr.io/huggingface/text-generation-inference:1.1.0 --model-id {model_name} --num-shard {num_shard} --max-input-length {max_input_length} --max-total-tokens {max_total_tokens} --max-best-of {max_best_of}"
         print(f"Connect Command: {docker_command}")
-        docker_process = subprocess.Popen(docker_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        docker_process = subprocess.Popen(
+            docker_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        )
         connected = False
         output = []
         while True:
@@ -300,7 +328,7 @@ class HFServerTGI:
             if not line:
                 break
             output.append(line.strip())
-            if 'Connected' in line:
+            if "Connected" in line:
                 connected = True
                 break
         if not connected:
@@ -310,6 +338,7 @@ class HFServerTGI:
             docker_process.terminate()
         docker_process.wait()
 
+
 class Together(HFModel):
     def __init__(self, model, api_base="https://api.together.xyz/v1", api_key=None, **kwargs):
         super().__init__(model=model, is_client=True)
@@ -317,6 +346,9 @@ class Together(HFModel):
         self.api_base = os.getenv("TOGETHER_API_BASE") or api_base
         assert not self.api_base.endswith("/"), "Together base URL shouldn't end with /"
         self.token = os.getenv("TOGETHER_API_KEY") or api_key
+        class_name = self.__class__.__name__
+        self.logger = logging.getLogger(class_name)
+        self.tracer = trace_api.get_tracer(class_name)
 
         self.model = model
 
@@ -338,6 +370,16 @@ class Together(HFModel):
             **kwargs,
         }
 
+    def log_usage(self, response):
+        """Log the total tokens from the Together API response."""
+        with self.tracer.start_as_current_span("log_usage") as span:
+            span.set_attribute("response", response)
+            usage_data = response.get("usage", {"total_tokens": 0})
+            span.set_attribute("usage", usage_data)
+            if usage_data:
+                total_tokens = usage_data.total_tokens
+                self.logger.debug(f"Together Total Token Response Usage: {total_tokens}")
+
     @backoff.on_exception(
         backoff.expo,
         ERRORS,
@@ -358,7 +400,10 @@ class Together(HFModel):
         if use_chat_api:
             url = f"{self.api_base}/chat/completions"
             messages = [
-                {"role": "system", "content": "You are a helpful assistant. You must continue the user text directly without *any* additional interjections."},
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant. You must continue the user text directly without *any* additional interjections.",
+                },
                 {"role": "user", "content": prompt},
             ]
             body = {
@@ -390,14 +435,16 @@ class Together(HFModel):
             with self.session.post(url, headers=headers, json=body) as resp:
                 resp_json = resp.json()
                 if use_chat_api:
-                    completions = [resp_json.get('choices', [])[0].get('message', {}).get('content', "")]
+                    completions = [resp_json.get("choices", [])[0].get("message", {}).get("content", "")]
                 else:
-                    completions = [resp_json.get('choices', [])[0].get('text', "")]
+                    completions = [resp_json.get("choices", [])[0].get("text", "")]
+                self.log_usage(resp_json)
                 response = {"prompt": prompt, "choices": [{"text": c} for c in completions]}
                 return response
         except Exception as e:
             if resp_json:
                 print(f"resp_json:{resp_json}")
+                self.log_usage(resp_json)
             print(f"Failed to parse JSON response: {e}")
             raise Exception("Received invalid JSON response from server")
 
@@ -418,16 +465,19 @@ class Anyscale(HFModel):
 
     def _generate(self, prompt, use_chat_api=False, **kwargs):
         url = f"{self.api_base}/completions"
-        
+
         kwargs = {**self.kwargs, **kwargs}
 
         temperature = kwargs.get("temperature")
-        max_tokens = kwargs.get("max_tokens", 150) 
+        max_tokens = kwargs.get("max_tokens", 150)
 
         if use_chat_api:
             url = f"{self.api_base}/chat/completions"
             messages = [
-                {"role": "system", "content": "You are a helpful assistant. You must continue the user text directly without *any* additional interjections."},
+                {
+                    "role": "system",
+                    "content": "You are a helpful assistant. You must continue the user text directly without *any* additional interjections.",
+                },
                 {"role": "user", "content": prompt},
             ]
             body = {
@@ -448,13 +498,13 @@ class Anyscale(HFModel):
 
         try:
             completions = []
-            for i in range(kwargs.get('n', 1)):
+            for i in range(kwargs.get("n", 1)):
                 with self.session.post(url, headers=headers, json=body) as resp:
                     resp_json = resp.json()
                     if use_chat_api:
-                        completions.extend([resp_json.get('choices', [])[0].get('message', {}).get('content', "")])
+                        completions.extend([resp_json.get("choices", [])[0].get("message", {}).get("content", "")])
                     else:
-                        completions.extend([resp_json.get('choices', [])[0].get('text', "")])
+                        completions.extend([resp_json.get("choices", [])[0].get("text", "")])
             response = {"prompt": prompt, "choices": [{"text": c} for c in completions]}
             return response
         except Exception as e:
@@ -469,7 +519,9 @@ class ChatModuleClient(HFModel):
         from mlc_chat import ChatConfig, ChatModule
 
         self.cm = ChatModule(
-            model=model, lib_path=model_path, chat_config=ChatConfig(conv_template="LM"),
+            model=model,
+            lib_path=model_path,
+            chat_config=ChatConfig(conv_template="LM"),
         )
 
     def _generate(self, prompt, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -8,22 +8,21 @@ with open("README.md", encoding="utf-8") as f:
 with open("requirements.txt", encoding="utf-8") as f:
     requirements = f.read().splitlines()
 
-setup(	
-    #replace_package_name_marker
+setup(
+    # replace_package_name_marker
     name="dspy-ai",
-    #replace_package_version_marker
-    version="2.4.12", 	
-    description="DSPy",	
-    long_description=long_description,	
-    long_description_content_type="text/markdown",	
-    url="https://github.com/stanfordnlp/dsp",	
-    author="Omar Khattab",	
-    author_email="okhattab@stanford.edu",	
-    license="MIT License",	
-    packages=find_packages(include=["dsp.*", "dspy.*", "dsp", "dspy"]),	
-    python_requires=">=3.9",	
-    install_requires=requirements,	
-
+    # replace_package_version_marker
+    version="2.4.12",
+    description="DSPy",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/stanfordnlp/dsp",
+    author="Omar Khattab",
+    author_email="okhattab@stanford.edu",
+    license="MIT License",
+    packages=find_packages(include=["dsp.*", "dspy.*", "dsp", "dspy"]),
+    python_requires=">=3.9",
+    install_requires=requirements,
     extras_require={
         "chromadb": ["chromadb~=0.4.14"],
         "qdrant": ["qdrant-client", "fastembed"],
@@ -34,18 +33,19 @@ setup(
         "faiss-cpu": ["sentence_transformers", "faiss-cpu"],
         "milvus": ["pymilvus~=2.3.7"],
         "google-vertex-ai": ["google-cloud-aiplatform==1.43.0"],
-        "myscale":["clickhouse-connect"],
+        "vertex-anthropic": ["google-cloud-aiplatform", "anthropic[vertex]"],
+        "myscale": ["clickhouse-connect"],
         "snowflake": ["snowflake-snowpark-python"],
         "fastembed": ["fastembed"],
         "groq": ["groq~=0.8.0"],
-    },	
-    classifiers=[	
-        "Development Status :: 3 - Alpha",	
-        "Intended Audience :: Science/Research",	
-        "License :: OSI Approved :: MIT License",	
-        "Operating System :: POSIX :: Linux",	
-        "Programming Language :: Python :: 3",	
-        "Programming Language :: Python :: 3.8",	
-        "Programming Language :: Python :: 3.9",	
-    ],	
-)	
+    },
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
+)


### PR DESCRIPTION
## 📝 Changes Description

This MR/PR contains the following changes:
- Add a seperate module in `dsp` for Anthropic via VertexAI as described here: https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude#use_the_anthropic_sdk

This is just a rough PR to gauge interest and discuss whether the existing Anthropic Module can be made generic enough to support Vertex as well (atm it shares like 95% code). 

Suprisingly despite claiming it, the existing vertex module does not support anthropic in my local setup (the module is in fact not really well documented).
...

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Anything we should be aware of ?


I am using this in my setup with `claude-3-haiku@20240307` and it works. I cannot guarantee that for any other claude model at the moment.

The reproduction code for instantiation looks like this:

```python
from dsp.modules import ClaudeVertex
llm = ClaudeVertex(
    model="claude-3-haiku@20240307",
    project="(snip)",
    location="europe-west1",
    temperature=0,
)
```

There has been some weird behaviour when passing in the Serviceaccount credentials like this:
```python
path_to_sa_file = "account.json"

os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = path_to_sa_file
from dsp.modules import ClaudeVertex
from google.oauth2 import service_account

credentials_sa = service_account.Credentials.from_service_account_file(path_to_sa_file)
gpt35 = ClaudeVertex(
    model="claude-3-haiku@20240307",
    project="(snip)",
    location="europe-west1",
    credentials=credentials_sa,
    temperature=0,
)
```
Setting it via default credentials in the gcloud cli helped.
