### PR TITLE
Support Default Headers in OpenAI Client

### DIFF
--- a/dsp/modules/gpt3.py
+++ b/dsp/modules/gpt3.py
@@ -56,11 +56,13 @@ class GPT3(LM):
             model_type: Literal["chat", "text"] = None,
             system_prompt: Optional[str] = None,
             http_client: Optional[httpx.Client] = None,
+            default_headers: Optional[dict[str, str]] = None,
             **kwargs,
     ):
         super().__init__(model)
         self.provider = "openai"
         openai.api_type = api_provider
+        openai.default_headers = default_headers
 
         self.system_prompt = system_prompt
 


### PR DESCRIPTION
See https://github.com/stanfordnlp/dspy/issues/1367 for information about the issue

**Tests Done**
- [ X ] Initialized OpenAI LM Client and used it (both chat and completions)
-  [ X ] ran pytest