### PR TITLE
feature(dspy): Add helper methods to `Module` and `Predict` classes

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,11 +1,12 @@
+from __future__ import annotations  # Required for type hints of the class itself, see Predict._is_structurally_equivalent
 import random
+from typing import Optional
 
 from pydantic import BaseModel
 
 import dsp
 from dspy.predict.parameter import Parameter
 from dspy.primitives.program import Module
-
 from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import ensure_signature, signature_to_template
 
@@ -17,28 +18,22 @@ class Predict(Module, Parameter):
         self.config = config
         self.reset()
 
-    def _is_structurally_equivalent(self, other) -> bool:
-        """ Check if two predictors are structurally equivalent by comparing their signatures.
-        
-        Args:
-            other: The predictor to compare with.
-        
-        Returns:
-            bool: `True` if the predictors are structurally equivalent, `False` otherwise.
-        """
-        # Check if the two predictors are instances of the Predictor class
-        if not isinstance(other, self.__class__):
-            return False
+    def _assert_structural_equivalency(self, other: Predict) -> Optional[AssertionError]:
+        """ Assert that this predict object is structurally equivalent to another predict object.
 
-        # Check if the predictors have matching signatures
-        # TODO: Can we ensure that all the signatures implement the equals method?
-        err_msg = f"Signatures of the two predictors do not match. {type(self.signature)} != {type(other.signature)}"
-        if hasattr(self.signature, "equals"):
-            return self.signature.equals(other.signature), err_msg
-        elif hasattr(other.signature, "equals"):
-            return other.signature.equals(self.signature), err_msg
-        else:
-            return self.signature == other.signature, err_msg
+        Args:
+            other: The predict object to compare with.
+
+        Raises:
+            AssertionError: If the two predict objects are not structurally equivalent.
+        """
+        # Assert that the other object is an instance of the same class
+        err_msg = f"Structural equivalency requires both objects to be instances of the same class: '{self.__class__.__name__}' != '{other.__class__.__name__}'"
+        assert isinstance(other, self.__class__), err_msg
+
+        # Assert that the predictors have equivalent signatures
+        err_msg = f"Structural equivalency requires the same signature: '{self.signature.signature}' != '{other.signature.signature}'"
+        assert self.signature.equals(other.signature), err_msg
 
     def reset(self):
         self.lm = None

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -17,6 +17,28 @@ class Predict(Module, Parameter):
         self.config = config
         self.reset()
 
+    def _is_structurally_equivalent(self, other) -> bool:
+        """ Check if two predictors are structurally equivalent by comparing their signatures.
+        
+        Args:
+            other: The predictor to compare with.
+        
+        Returns:
+            bool: `True` if the predictors are structurally equivalent, `False` otherwise.
+        """
+        # Check if the two predictors are instances of the Predictor class
+        if not isinstance(other, self.__class__):
+            return False
+
+        # Check if the predictors have matching signatures
+        err_msg = f"Signatures of the two predictors do not match. {type(self.signature)} != {type(other.signature)}"
+        if hasattr(self.signature, "equals"):
+            return self.signature.equals(other.signature), err_msg
+        elif hasattr(other.signature, "equals"):
+            return other.signature.equals(self.signature), err_msg
+        else:
+            return self.signature == other.signature, err_msg
+
     def reset(self):
         self.lm = None
         self.traces = []

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -20,10 +20,10 @@ other object: '{sname}' != '{oname}'"""
 _ERR_MSG_SIGNATURE = """Structurally equivalent predictors must have the same \
 signature: '{sname}' != '{oname}'"""
 
+
 #-------------------------------------------------------------------------------
 #    Classes
 #-------------------------------------------------------------------------------
-
 
 class Predict(Module, Parameter):
     def __init__(self, signature, **config):

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,4 +1,4 @@
-from __future__ import annotations  # Required for type hints of the class itself, see Predict._is_structurally_equivalent
+from __future__ import annotations  # Used for self type hints
 import random
 from typing import Optional
 
@@ -10,6 +10,20 @@ from dspy.primitives.program import Module
 from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import ensure_signature, signature_to_template
 
+#-------------------------------------------------------------------------------
+#    Templates for the user-facing strings used by this module
+#-------------------------------------------------------------------------------
+
+_ERR_MSG_CLASS = """The class of this object does not match the class of the \
+other object: '{sname}' != '{oname}'"""
+
+_ERR_MSG_SIGNATURE = """Structurally equivalent predictors must have the same \
+signature: '{sname}' != '{oname}'"""
+
+#-------------------------------------------------------------------------------
+#    Classes
+#-------------------------------------------------------------------------------
+
 
 class Predict(Module, Parameter):
     def __init__(self, signature, **config):
@@ -18,21 +32,28 @@ class Predict(Module, Parameter):
         self.config = config
         self.reset()
 
-    def _assert_structural_equivalency(self, other: Predict) -> Optional[AssertionError]:
-        """ Assert that this predict object is structurally equivalent to another predict object.
+    def _assert_structural_equivalency(
+            self,
+            other: Predict
+        ) -> Optional[AssertionError]:
+        """Assert that the predictor is structurally equivalent to another.
 
         Args:
-            other: The predict object to compare with.
+            other: The predictor to compare with.
 
         Raises:
-            AssertionError: If the two predict objects are not structurally equivalent.
+            AssertionError: If the predictors are not structurally equivalent.
         """
         # Assert that the other object is an instance of the same class
-        err_msg = f"Structural equivalency requires both objects to be instances of the same class: '{self.__class__.__name__}' != '{other.__class__.__name__}'"
+        sname = self.__class__.__name__
+        oname = other.__class__.__name__
+        err_msg = _ERR_MSG_CLASS.format(sname=sname, oname=oname)
         assert isinstance(other, self.__class__), err_msg
 
         # Assert that the predictors have equivalent signatures
-        err_msg = f"Structural equivalency requires the same signature: '{self.signature.signature}' != '{other.signature.signature}'"
+        sname = self.signature.signature
+        oname = other.signature.signature
+        err_msg = _ERR_MSG_SIGNATURE.format(sname=sname, oname=oname)
         assert self.signature.equals(other.signature), err_msg
 
     def reset(self):

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -10,15 +10,30 @@ from dspy.primitives.program import Module
 from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import ensure_signature, signature_to_template
 
+
 #-------------------------------------------------------------------------------
-#    Templates for the user-facing strings used by this module
+#    Helper functions
 #-------------------------------------------------------------------------------
 
-_ERR_MSG_CLASS = """The class of this object does not match the class of the \
-other object: '{sname}' != '{oname}'"""
+def assert_structural_equivalency_for_predictors(
+        predictor1: object,
+        predictor2: object,
+    ) -> Optional[AssertionError]:
+    """Assert that the two predictors are structurally equivalent to each other.
 
-_ERR_MSG_SIGNATURE = """Structurally equivalent predictors must have the same \
-signature: '{sname}' != '{oname}'"""
+    Args:
+        predictor1: The predictor to compare with.
+        predictor2: The predictor to compare with.
+
+    Raises:
+        AssertionError: If the predictors are not structurally equivalent.
+    """
+    # Assert that the objects are predictors
+    assert isinstance(predictor1, Predict)
+    assert isinstance(predictor2, Predict)
+
+    # Assert that the predictors have equivalent signatures
+    assert predictor1.signature.equals(predictor2.signature)
 
 
 #-------------------------------------------------------------------------------
@@ -31,30 +46,6 @@ class Predict(Module, Parameter):
         self.signature = ensure_signature(signature)
         self.config = config
         self.reset()
-
-    def _assert_structural_equivalency(
-            self,
-            other: Predict
-        ) -> Optional[AssertionError]:
-        """Assert that the predictor is structurally equivalent to another.
-
-        Args:
-            other: The predictor to compare with.
-
-        Raises:
-            AssertionError: If the predictors are not structurally equivalent.
-        """
-        # Assert that the other object is an instance of the same class
-        sname = self.__class__.__name__
-        oname = other.__class__.__name__
-        err_msg = _ERR_MSG_CLASS.format(sname=sname, oname=oname)
-        assert isinstance(other, self.__class__), err_msg
-
-        # Assert that the predictors have equivalent signatures
-        sname = self.signature.signature
-        oname = other.signature.signature
-        err_msg = _ERR_MSG_SIGNATURE.format(sname=sname, oname=oname)
-        assert self.signature.equals(other.signature), err_msg
 
     def reset(self):
         self.lm = None

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -31,6 +31,7 @@ class Predict(Module, Parameter):
             return False
 
         # Check if the predictors have matching signatures
+        # TODO: Can we ensure that all the signatures implement the equals method?
         err_msg = f"Signatures of the two predictors do not match. {type(self.signature)} != {type(other.signature)}"
         if hasattr(self.signature, "equals"):
             return self.signature.equals(other.signature), err_msg

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -4,6 +4,7 @@ from typing import Optional
 import magicattr
 
 from dsp.modules.lm import LM
+import dspy
 from dspy.primitives.assertions import *
 from dspy.primitives.module import BaseModule
 
@@ -11,44 +12,183 @@ from dspy.primitives.module import BaseModule
 #-------------------------------------------------------------------------------
 #    Templates for the user-facing strings used by this module
 #-------------------------------------------------------------------------------
-# TODO: It might be good to control all user-facing strings from a central place
 
-_ERR_MSG_SHARED_PREDICTORS = """This module shares the following predictor(s) \
-with the other module: {pred_names}"""
+_ERR_MSG_NUM_PREDICTORS = """Structurally equivalent programs must have the \
+the number of predictors. The number of predictors for the two modules do not \
+match: {num1} != {num2}"""
 
-_ERR_MSG_CLASS = """The class of this object does not match the class of the \
-other object: '{sname}' != '{oname}'"""
+_ERR_MSG_PREDICTOR_NAMES = """Program predictor names must match at \
+corresponding indices for structural equivalency. The predictor names for the \
+programs do not match at index {ind}: '{name1}' != '{name2}'"""
 
-_ERR_MSG_NUM_PREDICTORS = """Structurally equivalent modules must have the \
-the number of predictors. The number of predictors for this module does not \
-match that of the other module: {snum} != {onum}"""
+_ERR_MSG_SHARED_PREDICTORS = """The programs share the following predictor(s) \
+with each other: {pred_names}"""
 
-_ERR_MSG_PREDICTOR_NAMES = """Module predictor names must match at \
-corresponding indices for structural equivalency. The predictor names for this \
-module and the other module do not match at index {ind}: {sname} != {oname}"""
-
-_ERR_MSG_UNSET_DSPY_LM = """LM consistency violated: Expected all predictors' \
-LMs to be set when dspy.settings.lm is set to 'NoneType', but some \
+_ERR_MSG_UNSET_DSPY_LM = """LM consistency violated: Expected all predictors’ \
+LMs to be set when dspy.settings.lm is set to ‘NoneType’, but some \
 predictors have 'NoneType' LMs.
 
 {lm_info}"""
 
 _ERR_MSG_SET_DSPY_LM = """LM consistency violated: Expected all predictors' \
-LMs to be 'NoneType' when dspy.settings.lm is set, but some predictors have \
+LMs to be 'NoneType' when 'dspy.settings.lm' is set, but some predictors have \
 LMs set.
 
 {lm_info}"""
 
-_INFO_LM_MODULE = """The LM set in dspy.settings.lm is an instance of '{lname}'
-LMs set for the predictors in the module are:{pred_lm_info}"""
+_ERR_MSG_PROGRAM_LM = """Setting or getting the LM of a program is an \
+experimental feature. Please enable the 'dspy.settings.experimental' flag to \
+use these feature."""
+
+_INFO_LM_PROGRAM = """The LM set in 'dspy.settings.lm' is an instance of \
+'{lname}' LMs set for the predictors in the module are:{pred_lm_info}"""
 
 _INFO_LM_PRED = """
-    LM for {pname} is an instance of '{lname}'"""
+    LM for {pname} is an instance of ’{lname}’"""
+
+
+#-------------------------------------------------------------------------------
+#    Helper functions
+#-------------------------------------------------------------------------------
+
+def assert_structural_equivalency_for_programs(
+        program1: object,
+        program2: object,
+    ) -> Optional[AssertionError]:
+    """Assert that the program is structurally equivalent to another program.
+
+    Args:
+        program1: The program to compare with.
+        program2: The program to compare with.
+
+    Raises:
+        AssertionError: If the programs are not structurally equivalent.
+    """
+    # TODO: The following import can be removed if "Program" class can be moved
+    # to its own module, since "Module" is the base class for both the “Program”
+    # and "Predict" classes.
+    # Function level import to prevent issues with circular imports.
+    from dspy.predict.predict import (
+        assert_structural_equivalency_for_predictors
+    )
+
+    # Assert that the objects are predictors
+    assert isinstance(program1, Program)
+    assert isinstance(program2, Program)
+
+    # Assert that the two programs have the same number of predictors
+    num1 = len(program1.predictors())
+    num2 = len(program2.predictors())
+    err_msg = _ERR_MSG_NUM_PREDICTORS.format(num1=num1, num2=num2)
+    assert num1 == num2, err_msg
+
+    # Assert that the two programs have structurally equivalent predictors
+    # sharing the same names
+    pzip = zip(program1.named_predictors(), program2.named_predictors())
+    for ind, ((name1, pred1), (name2, pred2)) in enumerate(pzip):
+        # Check for predictor name match
+        err_msg = _ERR_MSG_PREDICTOR_NAMES.format(
+            ind=ind, name1=name1, name2=name2
+        )
+        assert name1 == name2, err_msg
+
+        # Check for structural equivalency of the predictors
+        assert_structural_equivalency_for_predictors(pred1, pred2)
+
+
+def assert_no_shared_predictor_for_programs(
+        program1: Program,
+        program2: Program,
+    ) -> Optional[AssertionError]:
+    """Assert that the programs shares no predictor with each other.
+
+    Args:
+        program1: The program to compare with.
+        program2: The program to compare with.
+
+    Raises:
+        AssertionError: If the two programs share predictors.
+    """
+    # Get the names and IDs of the predictors in the two programs
+    id_to_name1 = {id(p): n for n, p in program1.named_predictors()}
+    id_to_name2 = {id(p): n for n, p in program2.named_predictors()}
+
+    # Find the shared predictors
+    shared_ids = set(id_to_name1.keys()) & set(id_to_name2.keys())
+    if shared_ids:
+        pred_names = ", ".join(id_to_name1[id] for id in shared_ids)
+        err_msg = _ERR_MSG_SHARED_PREDICTORS.format(pred_names=pred_names)
+        raise AssertionError(err_msg)
+
+
+def are_all_predictor_lms_set_for_program(program: Program) -> bool:
+    """Check if all predictors in the program have their LMs set.
+
+    Returns:
+        bool: `True` if all predictors have their LMs set, `False` otherwise.
+    """
+    return all(pred.lm is not None for pred in program.predictors())
+
+
+def are_all_predictor_lms_unset_for_program(program: Program) -> bool:
+    """Check if all predictors in the program have their LMs unset.
+
+    Returns:
+        bool: True if all predictors have their LMs unset, False otherwise.
+    """
+    return all(pred.lm is None for pred in program.predictors())
+
+
+def get_lm_info_str_for_program(program: Program):
+    """Get an informational string about the LMs affecting this program."""
+    # The informational string to be returned
+    pred_lm_info = ""
+
+    # Get the LM information for each predictor in the program
+    for pname, pred in program.named_predictors():
+        lname = pred.lm.__class__.__name__
+        pred_lm_info += _INFO_LM_PRED.format(pname=pname, lname=lname)
+
+    # Get the LM information from the global setting; augment the information
+    # string
+    lname = dspy.settings.lm.__class__.__name__
+    info = _INFO_LM_PROGRAM.format(lname=lname, pred_lm_info=pred_lm_info)
+
+    return info
+
+
+def assert_lm_consistency_for_program(
+        program: Program
+    ) -> Optional[AssertionError]:
+    """Assert that the program satisfies the LM consistency property.
+
+    Ensure either that (1) all predictors in the module have their LMs set when
+    `dspy.settings.lm` is `NoneType`, or, (2) none of the program predictors
+    have their LMs set when `dspy.settings.lm` is set.
+
+    Raises:
+        AssertionError: If the LM consistency property is violated.
+    """
+    # The error message to be raised if the LM consistency property is violated
+    err_msg = None
+
+    # Check if the LM consistency property is violated
+    global_flag = dspy.settings.lm is not None
+    if not global_flag and not are_all_predictor_lms_set_for_program(program):
+        err_msg = _ERR_MSG_UNSET_DSPY_LM
+    elif global_flag and not are_all_predictor_lms_unset_for_program(program):
+        err_msg = _ERR_MSG_SET_DSPY_LM
+
+    # Raise an error if the LM consistency property is violated
+    if err_msg is not None:
+        lm_info = get_lm_info_str_for_program(program)
+        err_msg = err_msg.format(lm_info=lm_info)
+        raise AssertionError(err_msg)
+
 
 #-------------------------------------------------------------------------------
 #    Classes
 #-------------------------------------------------------------------------------
-
 
 class ProgramMeta(type):
     pass
@@ -71,129 +211,25 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def __call__(self, *args, **kwargs):
         return self.forward(*args, **kwargs)
 
-    def _assert_no_shared_predictor(
-            self,
-            other: Module
-        ) -> Optional[AssertionError]:
-        """Assert the module shares no predictor with another module.
+    def set_lm(self, lm: LM) -> Optional[AssertionError]:
+        """Set the LM for all predictors in the module.
+
+        This is an experimental method, which requires dsp.settings.experimental
+        to be enabled.
 
         Args:
-            other: The module to compare with.
+            lm: The LM to set for all predictors.
 
         Raises:
-            AssertionError: If the two modules share predictors.
+            AssertionError: If the dspy experimental setting is not enabled.
         """
-        # Get the names and IDs of the predictors in the two modules
-        self_id_to_name = {id(p): n for n, p in self.named_predictors()}
-        other_id_to_name = {id(p): n for n, p in other.named_predictors()}
+        # Check if the experimental setting is enabled
+        err_msg = _ERR_MSG_PROGRAM_LM
+        assert dspy.settings.experimental, err_msg
 
-        # Find the shared predictors
-        shared_ids = set(self_id_to_name.keys()) & set(other_id_to_name.keys())
-        if shared_ids:
-            pred_names = ", ".join(self_id_to_name[id] for id in shared_ids)
-            err_msg = _ERR_MSG_SHARED_PREDICTORS.format(pred_names=pred_names)
-            raise AssertionError(err_msg)
-
-    def _assert_structural_equivalency(
-            self,
-            other: Module
-        ) -> Optional[AssertionError]:
-        """Assert that the module is structurally equivalent to another module.
-        
-        Args:
-            other: The module to compare with.
-
-        Raises:
-            AssertionError: If the modules are not structurally equivalent.
-        """
-        # Assert that the other object is an instance of the same class
-        sname = self.__class__.__name__
-        oname = other.__class__.__name__
-        err_msg = _ERR_MSG_CLASS.format(sname=sname, oname=oname)
-        assert isinstance(other, self.__class__), err_msg
-
-        # Assert that the two modules have the same number of predictors
-        snum = len(self.predictors())
-        onum = len(other.predictors())
-        err_msg = _ERR_MSG_NUM_PREDICTORS.format(snum=snum, onum=onum)
-        assert snum == onum, err_msg
-
-        # Assert that the two modules have structurally equivalent predictors
-        # sharing the same names
-        pzip = zip(self.named_predictors(), other.named_predictors())
-        for ind, ((sname, spred), (oname, opred)) in enumerate(pzip):
-            err_msg = _ERR_MSG_PREDICTOR_NAMES.format(
-                ind=ind, sname=sname, oname=oname
-            )
-            assert sname == oname, err_msg
-
-            spred._assert_structural_equivalency(opred)
-
-    def _are_all_predictor_lms_set(self) -> bool:
-        """Check if all predictors in the module have their LMs set.
-        
-        Returns:
-            bool: True if all predictors have their LMs set, False otherwise.
-        """
-        return all(pred.lm is not None for pred in self.predictors())
-
-    def _are_all_predictor_lms_unset(self) -> bool:
-        """Check if all predictors in the module have their LMs unset.
-        
-        Returns:
-            bool: True if all predictors have their LMs unset, False otherwise.
-        """
-        return all(pred.lm is None for pred in self.predictors())
-
-    def _set_all_predictor_lms(
-            self,
-            lm: LM
-        ):
-        """Set the LMs of all predictors in the module.
-        
-        Args:
-            lm: The LM to set.
-        """
-        for pred in self.predictors():
+        # Set the LM for all predictors
+        for _, pred in self.named_predictors():
             pred.lm = lm
-
-    def _unset_all_predictor_lms(self):
-        """Unset the LMs of all predictors in the module."""
-        for pred in self.predictors():
-            pred.lm = None
-
-    def _get_lm_info_str(self):
-        """Get an informational string about the LMs affecting this module."""
-        pred_lm_info = ""
-        for pname, pred in self.named_predictors():
-            lname = pred.lm.__class__.__name__
-            pred_lm_info += _INFO_LM_PRED.format(pname=pname, lname=lname)
-
-        lname = dspy.settings.lm.__class__.__name__
-        info = _INFO_LM_MODULE.format(lname=lname, pred_lm_info=pred_lm_info)
-        return info
-
-    def _assert_lm_consistency(self) -> Optional[AssertionError]:
-        """Assert that the module satisfies the LM consistency property.
-
-        Ensures either that (1) all predictors in the module have their LMs set
-        when dspy.settings.lm is NoneType, or, (2) none of the module predictors
-        have their LMs set when dspy.settings.lm is set.
-
-        Raises:
-            AssertionError: If the LM consistency property is violated.
-        """
-        err_msg = None
-        global_lm = dspy.settings.lm
-        if global_lm is None and not self._are_all_predictor_lms_set():
-            err_msg = _ERR_MSG_UNSET_DSPY_LM
-        elif global_lm is not None and not self._are_all_predictor_lms_unset():
-            err_msg = _ERR_MSG_SET_DSPY_LM
-        
-        if err_msg is not None:
-            lm_info = self._get_lm_info_str()
-            err_msg = err_msg.format(lm_info=lm_info)
-            raise AssertionError(err_msg)
 
     def named_predictors(self):
         from dspy.predict.predict import Predict

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -19,7 +19,6 @@ class ProgramMeta(type):
     #     return obj
 
 
-# TODO: Replace print statements with logging
 class Module(BaseModule, metaclass=ProgramMeta):
     def _base_init(self):
         self._compiled = False

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -68,7 +68,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
                 return True
         return False
 
-    def _is_all_predictor_lms_set(self) -> bool:
+    def _are_all_predictor_lms_set(self) -> bool:
         """ Check if all predictors in the module have their LMs set.
         
         Returns:
@@ -76,7 +76,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
         """
         return all(predictor.lm is not None for predictor in self.predictors())
 
-    def _is_all_predictor_lms_unset(self) -> bool:
+    def _are_all_predictor_lms_unset(self) -> bool:
         """ Check if all predictors in the module have their LMs unset.
         
         Returns:
@@ -114,9 +114,9 @@ class Module(BaseModule, metaclass=ProgramMeta):
             AssertionError: If the module does not satisfy the LM consistency property.
         """
         err_msg = None
-        if dspy.settings.lm is None and not self._is_all_predictor_lms_unset():
+        if dspy.settings.lm is None and not self._are_all_predictor_lms_unset():
             err_msg = "LM consistency property violated: LM is not set in a module predictor when dspy.settings.lm is None."
-        elif dspy.settings.lm is not None and not self._is_all_predictor_lms_set():
+        elif dspy.settings.lm is not None and not self._are_all_predictor_lms_set():
             err_msg = "LM consistency property violated: LM is set in a module predictor when dspy.settings.lm is set."
         
         if err_msg is not None:

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -19,6 +19,7 @@ class ProgramMeta(type):
     #     return obj
 
 
+# TODO: Replace print statements with logging
 class Module(BaseModule, metaclass=ProgramMeta):
     def _base_init(self):
         self._compiled = False
@@ -47,8 +48,8 @@ class Module(BaseModule, metaclass=ProgramMeta):
             return False
 
         # Check if the two modules have structurally equivalent predictors
-        for (name1, pred1), (name2, pred2) in zip(self.named_parameters(), other.named_parameters()):
-            if name1 != name2 or not pred1.is_structurally_equivalent(pred2):
+        for (name1, pred1), (name2, pred2) in zip(self.named_predictors(), other.named_predictors()):
+            if name1 != name2 or not pred1._is_structurally_equivalent(pred2):
                 return False
 
         return True
@@ -115,12 +116,12 @@ class Module(BaseModule, metaclass=ProgramMeta):
         """
         if dspy.settings.lm is not None:
             err_msg = "LM consistency property violated: LM is set in a module predictor when dspy.settings.lm is set."
-            if not self.is_all_predictor_lms_unset():
+            if not self._is_all_predictor_lms_unset():
                 self._print_lm_information()
                 raise AssertionError(err_msg)
         else:
             err_msg = "LM consistency property violated: LM is not set in a module predictor when dspy.settings.lm is None."
-            if not self.is_all_predictor_lms_unset():
+            if not self._is_all_predictor_lms_unset():
                 self._print_lm_information()
                 raise AssertionError(err_msg)
 

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -99,31 +99,29 @@ class Module(BaseModule, metaclass=ProgramMeta):
             predictor.lm = None
 
     def _print_lm_information(self):
-        print(f"The LM set in dspy.settings.lm: {dspy.settings.lm}")
+        print(f"The LM set in dspy.settings.lm is {dspy.settings.lm}")
         print("Looping through all predictors in the program:")
         for name, predictor in self.named_predictors():
-            print(f"    Predictor {name} is set to LM: {predictor.lm}")
+            print(f"    Predictor {name} is set to LM {predictor.lm}")
 
     def _assert_lm_consistency(self) -> Optional[AssertionError]:
         """ Check if the module satisfies the LM consistency property.
 
-        Ensures that (1) None of the module predictors have their LMs set (to a same or different LM) when
-        `dspy.settings.lm` is set, and, (2) all predictors in the module have their LMs set when `dspy.settings.lm` is
-        `None`.
+        Ensures that (1) all predictors in the module have their LMs set when `dspy.settings.lm` is `None`, and, (2)
+        none of the module predictors have their LMs set (to a same or different LM) when `dspy.settings.lm` is set.
 
         Raises:
             AssertionError: If the module does not satisfy the LM consistency property.
         """
-        if dspy.settings.lm is not None:
-            err_msg = "LM consistency property violated: LM is set in a module predictor when dspy.settings.lm is set."
-            if not self._is_all_predictor_lms_unset():
-                self._print_lm_information()
-                raise AssertionError(err_msg)
-        else:
+        err_msg = None
+        if dspy.settings.lm is None and not self._is_all_predictor_lms_unset():
             err_msg = "LM consistency property violated: LM is not set in a module predictor when dspy.settings.lm is None."
-            if not self._is_all_predictor_lms_unset():
-                self._print_lm_information()
-                raise AssertionError(err_msg)
+        elif dspy.settings.lm is not None and not self._is_all_predictor_lms_set():
+            err_msg = "LM consistency property violated: LM is set in a module predictor when dspy.settings.lm is set."
+        
+        if err_msg is not None:
+            self._print_lm_information()
+            raise AssertionError(err_msg)
 
     def named_predictors(self):
         from dspy.predict.predict import Predict


### PR DESCRIPTION
This PR introduces several helper methods for the `Module` and `Predict` classes in order to allow for convenient ways to:
1. Check if two modules (e.g. a student and a teacher program) are "structurally_equivalent", which is a precondition for many teleprompters to work properly,
2. Manage and ensure consistency of the LM(s) used by a program, either through `dspy.settings.lm` or predictor LMs.
Shared below are some example usages. These methods are meant to be used by the other, internal DSPy classes.

**Example use of the structural equivalency methods**
```
    # Ensure that the student program and the teacher program have the same program structure
    student._assert_structural_equivalency(teacher)

    # Ensure that the predictors of the programs point to differenT objects
    assert not student._assert_no_shared_predictor(teacher)
```

**Example use of the Module level LM methods**
```
    # Ensure that the LM consistency is satisfied, push the global LM to the predictors if dspy.settings.lm is set
    program._assert_lm_consistency()
    if dspy.settings.lm:
        program._set_all_predictor_lms(dspy.settings.lm)
```