### PR TITLE
Fix (dspy) Remove extra argument passed to Cohere client

### DIFF
--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -87,8 +87,8 @@ class Cohere(LM):
         if "n" in kwargs.keys():
             kwargs.pop("n")
         
-        if "pop" in kwargs.keys():
-            kwargs.pop("pop")
+        if "stop" in kwargs.keys():
+            kwargs.pop("stop")
         response = self.co.chat(**kwargs)
 
         self.history.append(

--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -86,7 +86,6 @@ class Cohere(LM):
         kwargs.pop("num_generations")
         if "n" in kwargs.keys():
             kwargs.pop("n")
-        
         if "stop" in kwargs.keys():
             kwargs.pop("stop")
         response = self.co.chat(**kwargs)

--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -89,7 +89,6 @@ class Cohere(LM):
         
         if "pop" in kwargs.keys():
             kwargs.pop("pop")
-            
         response = self.co.chat(**kwargs)
 
         self.history.append(

--- a/dsp/modules/cohere.py
+++ b/dsp/modules/cohere.py
@@ -86,6 +86,10 @@ class Cohere(LM):
         kwargs.pop("num_generations")
         if "n" in kwargs.keys():
             kwargs.pop("n")
+        
+        if "pop" in kwargs.keys():
+            kwargs.pop("pop")
+            
         response = self.co.chat(**kwargs)
 
         self.history.append(


### PR DESCRIPTION
Simple fix to an issue where an exception is thrown when using the Cohere LLM (for prediction, with experimental=True). It was due to an extra parameter (`stop`) being passed to the API. This change checks for it and removes it.