### PR TITLE
fix(dspy): Allow `Union` with pydantic objects in `TypedPredictor` 

### DIFF
--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -36,7 +36,7 @@ def test_list_output():
         pass
 
     expected = ["What is the speed of light?", "What is the speed of sound?"]
-    lm = DummyLM(['{"value": ["What is the speed of light?", "What is the speed of sound?"]}'])
+    lm = DummyLM(['["What is the speed of light?", "What is the speed of sound?"]'])
     dspy.settings.configure(lm=lm)
 
     question = hard_questions(topics=["Physics", "Music"])
@@ -557,7 +557,7 @@ def test_parse_type_string():
 
 
 def test_literal():
-    lm = DummyLM([f'{{"value": "{i}"}}' for i in range(100)])
+    lm = DummyLM([f'"{i}"' for i in range(100)])
     dspy.settings.configure(lm=lm)
 
     @predictor
@@ -568,7 +568,7 @@ def test_literal():
 
 
 def test_literal_int():
-    lm = DummyLM([f'{{"value": {i}}}' for i in range(100)])
+    lm = DummyLM([f'{i}' for i in range(100)])
     dspy.settings.configure(lm=lm)
 
     @predictor
@@ -897,7 +897,7 @@ def _test_demos_missing_input():
 
 def test_conlist():
     dspy.settings.configure(
-        lm=DummyLM(['{"value": []}', '{"value": [1]}', '{"value": [1, 2]}', '{"value": [1, 2, 3]}'])
+        lm=DummyLM(['[]', '[1]', '[1, 2]', '[1, 2, 3]'])
     )
 
     @predictor
@@ -909,7 +909,7 @@ def test_conlist():
 
 def test_conlist2():
     dspy.settings.configure(
-        lm=DummyLM(['{"value": []}', '{"value": [1]}', '{"value": [1, 2]}', '{"value": [1, 2, 3]}'])
+        lm=DummyLM(['[]', '[1]', '[1, 2]', '[1, 2, 3]'])
     )
 
     make_numbers = TypedPredictor("input:str -> output:Annotated[List[int], Field(min_items=2)]")

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -557,7 +557,7 @@ def test_parse_type_string():
 
 
 def test_literal():
-    lm = DummyLM([f'"{i}"' for i in range(100)])
+    lm = DummyLM(['"2"', '"3"'])
     dspy.settings.configure(lm=lm)
 
     @predictor
@@ -567,8 +567,22 @@ def test_literal():
     assert f() == "2"
 
 
+def test_literal_missmatch():
+    lm = DummyLM([f'"{i}"' for i in range(5, 100)])
+    dspy.settings.configure(lm=lm)
+
+    @predictor(max_retries=1)
+    def f() -> Literal["2", "3"]:
+        pass
+
+    with pytest.raises(Exception) as e_info:
+        f()
+
+    assert e_info.value.args[1]["f"] == "Input should be '2' or '3':  (error type: literal_error)"
+
+
 def test_literal_int():
-    lm = DummyLM([f'{i}' for i in range(100)])
+    lm = DummyLM(["2", "3"])
     dspy.settings.configure(lm=lm)
 
     @predictor
@@ -576,6 +590,20 @@ def test_literal_int():
         pass
 
     assert f() == 2
+
+
+def test_literal_int_missmatch():
+    lm = DummyLM([f"{i}" for i in range(5, 100)])
+    dspy.settings.configure(lm=lm)
+
+    @predictor(max_retries=1)
+    def f() -> Literal[2, 3]:
+        pass
+
+    with pytest.raises(Exception) as e_info:
+        f()
+
+    assert e_info.value.args[1]["f"] == "Input should be 2 or 3:  (error type: literal_error)"
 
 
 def test_fields_on_base_signature():
@@ -896,9 +924,7 @@ def _test_demos_missing_input():
 
 
 def test_conlist():
-    dspy.settings.configure(
-        lm=DummyLM(['[]', '[1]', '[1, 2]', '[1, 2, 3]'])
-    )
+    dspy.settings.configure(lm=DummyLM(["[]", "[1]", "[1, 2]", "[1, 2, 3]"]))
 
     @predictor
     def make_numbers(input: str) -> Annotated[list[int], Field(min_items=2)]:
@@ -908,9 +934,7 @@ def test_conlist():
 
 
 def test_conlist2():
-    dspy.settings.configure(
-        lm=DummyLM(['[]', '[1]', '[1, 2]', '[1, 2, 3]'])
-    )
+    dspy.settings.configure(lm=DummyLM(["[]", "[1]", "[1, 2]", "[1, 2, 3]"]))
 
     make_numbers = TypedPredictor("input:str -> output:Annotated[List[int], Field(min_items=2)]")
     assert make_numbers(input="What are the first two numbers?").output == [1, 2]

--- a/tests/functional/test_signature_opt_typed.py
+++ b/tests/functional/test_signature_opt_typed.py
@@ -109,7 +109,7 @@ def test_opt():
         [
             # Seed prompts
             "some thoughts",
-            '{"value": [{"instructions": "I", "question_desc": "$q", "question_prefix": "Q:", "answer_desc": "$a", "answer_prefix": "A:"}]}',
+            '[{"instructions": "I", "question_desc": "$q", "question_prefix": "Q:", "answer_desc": "$a", "answer_prefix": "A:"}]',
         ]
     )
     dspy.settings.configure(lm=qa_model)

--- a/tests/functional/test_signature_opt_typed.py
+++ b/tests/functional/test_signature_opt_typed.py
@@ -10,7 +10,8 @@ from dspy.utils import DummyLM
 from dspy.evaluate import Evaluate
 from dspy.evaluate.metrics import answer_exact_match
 from dspy.functional import TypedPredictor
-
+import json
+from pydantic_core import to_jsonable_python
 
 hotpotqa = [
     ex.with_inputs("question")
@@ -163,18 +164,13 @@ def test_opt_composed():
 
     info2 = make_info(ExpectedSignature2)
 
-    T = TypeVar("T")
-
-    class OutputWrapper(pydantic.BaseModel, Generic[T]):
-        value: list[T]
-
     qa_model = DummyLM([])
     prompt_model = DummyLM(
         [
             "some thoughts",
-            OutputWrapper[type(info1)](value=[info1]).model_dump_json(),
+            json.dumps([to_jsonable_python(info1)]),
             "some thoughts",
-            OutputWrapper[type(info2)](value=[info2]).model_dump_json(),
+            json.dumps([to_jsonable_python(info2)]),
         ]
     )
     dspy.settings.configure(lm=qa_model)

--- a/tests/functional/test_signature_typed.py
+++ b/tests/functional/test_signature_typed.py
@@ -1,0 +1,105 @@
+from typing import Generic, TypeVar, Any, Optional, Union
+import pytest
+
+import pydantic
+import dspy
+from dspy.evaluate import Evaluate
+from dspy.functional import TypedPredictor
+from dspy.utils import DummyLM
+
+def get_field_and_parser(signature:dspy.Signature) -> tuple[Any, Any]:
+    module = TypedPredictor(signature)
+    signature = module._prepare_signature()
+    assert "answer" in signature.fields, "'answer' not in signature.fields"
+    field = signature.fields.get('answer')
+    parser = field.json_schema_extra.get("parser")
+    return field, parser
+    
+
+@pytest.mark.parametrize("test_type,serialized, expected", [(str, "foo", "foo"), (int, "42", 42), (float, "42.42", 42.42)])
+def test_basic_types(test_type:type, serialized:str, expected:Any):
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: test_type = dspy.OutputField()
+        
+    _, parser = get_field_and_parser(MySignature)
+    assert parser is test_type, "Parser is not correct for 'answer'"
+    assert parser(serialized) == expected, f"{test_type}({serialized})!= {expected}"
+    
+    
+    
+def test_boolean():
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: bool = dspy.OutputField()
+            
+    _, parser = get_field_and_parser(MySignature)
+    assert parser("true"), f"Parsing 'true' failed"
+    assert not parser("false"), f"Parsing 'false' failed"
+    
+    
+@pytest.mark.parametrize("test_type,serialized, expected", [(list[str], '{"value" : ["foo", "bar"]}', ['foo', 'bar']), (tuple[int, float], '{"value":[42, 3.14]}', (42, 3.14))])
+def test_sequences(test_type:type, serialized:str, expected:Any):
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: test_type = dspy.OutputField()
+        
+    
+    _, parser = get_field_and_parser(MySignature)
+    
+    assert parser(serialized) == expected, f"Parsing {expected} failed"
+    
+@pytest.mark.parametrize("test_type,serialized, expected", [
+    (Optional[str], '{"value": "foobar"}', "foobar"),
+    (Optional[str], '{"value": null}', None),
+    (Union[str, float], '{"value": 3.14}', 3.14),
+    (Union[str, bool], '{"value": true}', True)
+    ])
+def test_unions(test_type:type, serialized:str, expected:Any):
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: test_type = dspy.OutputField()
+        
+    _, parser = get_field_and_parser(MySignature)
+    
+    assert parser(serialized) == expected, f"Parsing {expected} failed"
+    
+    
+def test_pydantic():
+    
+    class Mysubmodel(pydantic.BaseModel):
+        sub_floating: float
+        
+    class MyModel(pydantic.BaseModel):
+        floating: float
+        string: str
+        boolean: bool
+        integer: int
+        optional: Optional[str]
+        sequence_of_strings: list[str]
+        union: Union[str, float]
+        submodel: Mysubmodel
+        optional_submodel: Optional[Mysubmodel]
+        
+        
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: MyModel = dspy.OutputField()
+        
+    _, parser = get_field_and_parser(MySignature)
+    
+    instance = MyModel(
+        floating=3.14,
+        string="foobar",
+        boolean=True,
+        integer=42,
+        optional=None,
+        sequence_of_strings=["foo", "bar"],
+        union=3.14,
+        submodel=Mysubmodel(sub_floating=42.42),
+        optional_submodel=None
+    )
+    
+    parser(instance.model_dump_json()) == instance, f"{instance}!= {parser(instance)}"
+    
+        

--- a/tests/functional/test_signature_typed.py
+++ b/tests/functional/test_signature_typed.py
@@ -6,17 +6,20 @@ import dspy
 from dspy.functional import TypedPredictor
 from dspy.signatures.signature import signature_to_template
 
-def get_field_and_parser(signature:dspy.Signature) -> tuple[Any, Any]:
+
+def get_field_and_parser(signature: dspy.Signature) -> tuple[Any, Any]:
     module = TypedPredictor(signature)
     signature = module._prepare_signature()
     assert "answer" in signature.fields, "'answer' not in signature.fields"
-    field = signature.fields.get('answer')
+    field = signature.fields.get("answer")
     parser = field.json_schema_extra.get("parser")
     return field, parser
-    
+
+
 class Mysubmodel(pydantic.BaseModel):
     sub_floating: float
-    
+
+
 class MyModel(pydantic.BaseModel):
     floating: float
     string: str
@@ -28,7 +31,8 @@ class MyModel(pydantic.BaseModel):
     submodel: Mysubmodel
     optional_submodel: Optional[Mysubmodel]
     optional_existing_submodule: Optional[Mysubmodel]
-    
+
+
 def build_model_instance() -> MyModel:
     return MyModel(
         floating=3.14,
@@ -42,101 +46,109 @@ def build_model_instance() -> MyModel:
         optional_submodel=None,
         optional_existing_submodule=Mysubmodel(sub_floating=42.42),
     )
-        
 
-@pytest.mark.parametrize("test_type,serialized, expected", [(str, "foo", "foo"), (int, "42", 42), (float, "42.42", 42.42)])
-def test_basic_types(test_type:type, serialized:str, expected:Any):
+
+@pytest.mark.parametrize(
+    "test_type,serialized, expected", [(str, "foo", "foo"), (int, "42", 42), (float, "42.42", 42.42)]
+)
+def test_basic_types(test_type: type, serialized: str, expected: Any):
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: test_type = dspy.OutputField()
-        
+
     _, parser = get_field_and_parser(MySignature)
     assert parser is test_type, "Parser is not correct for 'answer'"
     assert parser(serialized) == expected, f"{test_type}({serialized})!= {expected}"
-    
-    
-    
+
+
 def test_boolean():
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: bool = dspy.OutputField()
-            
+
     _, parser = get_field_and_parser(MySignature)
     assert parser("true"), f"Parsing 'true' failed"
     assert not parser("false"), f"Parsing 'false' failed"
-    
-    
-@pytest.mark.parametrize("test_type,serialized, expected", [(list[str], '["foo", "bar"]', ['foo', 'bar']), (tuple[int, float], '[42, 3.14]', (42, 3.14))])
-def test_sequences(test_type:type, serialized:str, expected:Any):
+
+
+@pytest.mark.parametrize(
+    "test_type,serialized, expected",
+    [(list[str], '["foo", "bar"]', ["foo", "bar"]), (tuple[int, float], "[42, 3.14]", (42, 3.14))],
+)
+def test_sequences(test_type: type, serialized: str, expected: Any):
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: test_type = dspy.OutputField()
-        
-    
+
     _, parser = get_field_and_parser(MySignature)
-    
+
     assert parser(serialized) == expected, f"Parsing {expected} failed"
-    
-@pytest.mark.parametrize("test_type,serialized, expected", [
-    (Optional[str], '"foobar"', "foobar"),
-    (Optional[str], "null", None),
-    (Union[str, float], "3.14", 3.14),
-    (Union[str, bool], "true", True)
-    ])
-def test_unions(test_type:type, serialized:str, expected:Any):
+
+
+@pytest.mark.parametrize(
+    "test_type,serialized, expected",
+    [
+        (Optional[str], '"foobar"', "foobar"),
+        (Optional[str], "null", None),
+        (Union[str, float], "3.14", 3.14),
+        (Union[str, bool], "true", True),
+    ],
+)
+def test_unions(test_type: type, serialized: str, expected: Any):
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: test_type = dspy.OutputField()
-        
+
     _, parser = get_field_and_parser(MySignature)
-    
+
     assert parser(serialized) == expected, f"Parsing {expected} failed"
-    
-    
+
+
 def test_pydantic():
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: MyModel = dspy.OutputField()
-        
+
     _, parser = get_field_and_parser(MySignature)
-    
+
     instance = build_model_instance()
     parsed_instance = parser(instance.model_dump_json())
-    
+
     assert parsed_instance == instance, f"{instance} != {parsed_instance}"
-    
-def test_optional_pydantic():    
+
+
+def test_optional_pydantic():
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: Optional[MyModel] = dspy.OutputField()
-        
+
     _, parser = get_field_and_parser(MySignature)
-    
+
     instance = build_model_instance()
     parsed_instance = parser(instance.model_dump_json())
     assert parsed_instance == instance, f"{instance} != {parsed_instance}"
-    
-    #Check null case
+
+    # Check null case
     parsed_instance = parser("null")
-    assert parsed_instance == None, "Optional[MyModel] should be None" 
-    
+    assert parsed_instance == None, "Optional[MyModel] should be None"
+
+
 def test_dataclass():
-    
     from dataclasses import dataclass
-    
-    @dataclass(frozen = True)
+
+    @dataclass(frozen=True)
     class MyDataclass:
         string: str
         number: int
         floating: float
         boolean: bool
-        
+
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: MyDataclass = dspy.OutputField()
-        
+
     _, parser = get_field_and_parser(MySignature)
-    
+
     instance = MyDataclass("foobar", 42, 3.14, True)
     parsed_instance = parser('{"string": "foobar", "number": 42, "floating": 3.14, "boolean": true}')
     assert parsed_instance == instance, f"{instance} != {parsed_instance}"


### PR DESCRIPTION
See  #1349

This uses pydantics [`TypeAdapter`](https://docs.pydantic.dev/latest/api/type_adapter/) to wrap objects into pydantic serializable instances.

This also eliminates the need to prepend single values with a value field in the JSON schema,, e.g. a field of type `list[int]` will now be expressed as `[1,2,3]` instead of `{"value": [1,2,3]}`. 

I also added tests for the most common field types to ensure that they are deserialized properly.