### PR TITLE
feature(dspy): refined missing hf error

### DIFF
--- a/dsp/modules/hf.py
+++ b/dsp/modules/hf.py
@@ -72,7 +72,7 @@ class HFModel(LM):
                 from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
             except ImportError as exc:
                 raise ModuleNotFoundError(
-                    "You need to install Hugging Face transformers library to use HF models.",
+                    "You need to install Hugging Face transformers (with torch dependencies) library to use HF models.",
                 ) from exc
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             try:

--- a/dsp/modules/hf.py
+++ b/dsp/modules/hf.py
@@ -72,7 +72,7 @@ class HFModel(LM):
                 from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForSeq2SeqLM, AutoTokenizer
             except ImportError as exc:
                 raise ModuleNotFoundError(
-                    "You need to install Hugging Face transformers (with torch dependencies) library to use HF models.",
+                    "You need to install Hugging Face transformers (with torch dependencies - pip install transformers[torch]) library to use HF models.",
                 ) from exc
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
             try:

--- a/dspy/retrieve/pinecone_rm.py
+++ b/dspy/retrieve/pinecone_rm.py
@@ -85,7 +85,7 @@ class PineconeRM(Retrieve):
                 from transformers import AutoModel, AutoTokenizer
             except ImportError as exc:
                 raise ModuleNotFoundError(
-                "You need to install Hugging Face transformers library to use a local embedding model with PineconeRM.",
+                "You need to install Hugging Face transformers (with torch dependencies) library to use a local embedding model with PineconeRM.",
             ) from exc
 
             self._local_embed_model = AutoModel.from_pretrained(local_embed_model)

--- a/dspy/retrieve/pinecone_rm.py
+++ b/dspy/retrieve/pinecone_rm.py
@@ -85,7 +85,7 @@ class PineconeRM(Retrieve):
                 from transformers import AutoModel, AutoTokenizer
             except ImportError as exc:
                 raise ModuleNotFoundError(
-                "You need to install Hugging Face transformers (with torch dependencies) library to use a local embedding model with PineconeRM.",
+                "You need to install Hugging Face transformers (with torch dependencies - pip install transformers[torch]) library to use a local embedding model with PineconeRM.",
             ) from exc
 
             self._local_embed_model = AutoModel.from_pretrained(local_embed_model)


### PR DESCRIPTION
The error doesn't specify that you need torch (as `pip install transformers` is not the same as `pip install transformers[torch]`. This makes things a bit clearer