### PR TITLE
feat(dspy): Add input for AWS credentials for AWSProvider, Bedrock and Sagemaker class

### DIFF
--- a/dsp/modules/aws_providers.py
+++ b/dsp/modules/aws_providers.py
@@ -8,7 +8,6 @@ import backoff
 
 from dsp.utils.settings import settings
 
-# Check if 'boto3' is available
 boto3_spec = importlib.util.find_spec("boto3")
 
 if boto3_spec is not None:
@@ -16,7 +15,6 @@ if boto3_spec is not None:
 
     ERRORS = (ClientError,)
 else:
-    # If 'boto3' is not available, fall back to using a general Exception
     ERRORS = (Exception,)
 
 

--- a/dsp/modules/aws_providers.py
+++ b/dsp/modules/aws_providers.py
@@ -1,6 +1,5 @@
 """AWS providers for LMs."""
 
-import importlib.util
 from abc import ABC, abstractmethod
 from typing import Any, Optional
 
@@ -8,13 +7,12 @@ import backoff
 
 from dsp.utils.settings import settings
 
-boto3_spec = importlib.util.find_spec("boto3")
-
-if boto3_spec is not None:
+try:
     from botocore.exceptions import ClientError
 
     ERRORS = (ClientError,)
-else:
+
+except ImportError:
     ERRORS = (Exception,)
 
 


### PR DESCRIPTION
This pull request introduces enhancements to the **AWSProvider**, **Bedrock**, and **Sagemaker** classes by **adding the capability to input AWS credentials directly**. This update provides greater flexibility beyond using the a profile within the AWS credentials file.

**Motivation:**
The primary goal of this update is to **increase flexibility in managing AWS credentials**.

