### PR TITLE
Fix AttributeError in MilvusRM: Add missing attribute 'k'

### DIFF
--- a/dspy/retrieve/milvus_rm.py
+++ b/dspy/retrieve/milvus_rm.py
@@ -89,7 +89,7 @@ class MilvusRM(dspy.Retrieve):
             query_or_queries = [query_or_queries]
         query_embeddings = self.embedding_function(query_or_queries)
 
-        k = k or self.top_k
+        k = k or self.k
 
         milvus_res = self.milvus_client.search(
             collection_name=self.collection_name,

--- a/dspy/retrieve/milvus_rm.py
+++ b/dspy/retrieve/milvus_rm.py
@@ -82,7 +82,7 @@ class MilvusRM(dspy.Retrieve):
         self.collection_name = collection_name
 
         self.embedding_function = embedding_function or openai_embedding_function
-        self.top_k = k
+        self.k = k
 
     def forward(self, query_or_queries: Union[str, List[str]], k: Optional[int] = None) -> dspy.Prediction:
         if isinstance(query_or_queries, str):


### PR DESCRIPTION
Problem: The MilvusRM object in our codebase is throwing an AttributeError due to a missing attribute k. This error occurs when attempting to access or use k, which has not been defined within the MilvusRM class.
Solution:

Replaced the existing attribute top_k with k.
error : AttributeError: 'MilvusRM' object has no attribute 'k'
