### PR TITLE
enh(mistral): Upgrade mistralai dependency from 0.4.2 to 1.0.2

### DIFF
--- a/dsp/modules/mistral.py
+++ b/dsp/modules/mistral.py
@@ -5,8 +5,9 @@ import backoff
 from dsp.modules.lm import LM
 from dsp.utils.settings import settings
 
+mistralai_api_error = None
 try:
-    from mistralai.client import MistralClient
+    from mistralai import Mistral as MistralAI
     from mistralai.models.usermessage import UserMessage
 except ImportError:
     mistralai_api_error = Exception
@@ -58,7 +59,7 @@ class Mistral(LM):
                 "Not loading Mistral AI because it is not installed. Install it with `pip install mistralai`."
             )
 
-        self.client = MistralClient(api_key=api_key)
+        self.client = MistralAI(api_key=api_key)
 
         self.provider = "mistral"
         self.kwargs = {
@@ -84,7 +85,7 @@ class Mistral(LM):
         if n is not None and n > 1 and kwargs["temperature"] == 0.0:
             kwargs["temperature"] = 0.7
 
-        response = self.client.chat(**kwargs)
+        response = self.client.chat.complete(**kwargs)
 
         history = {
             "prompt": prompt,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 #replace_package_name_marker
 name="dspy-ai"
 #replace_package_version_marker
-version="2.4.12"
+version="2.4.10"
 description = "DSPy"
 readme = "README.md"
 authors = [{ name = "Omar Khattab", email = "okhattab@stanford.edu" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 #replace_package_name_marker
 name="dspy-ai"
 #replace_package_version_marker
-version="2.4.10"
+version="2.4.12"
 description = "DSPy"
 readme = "README.md"
 authors = [{ name = "Omar Khattab", email = "okhattab@stanford.edu" }]


### PR DESCRIPTION
Following the [mistralai package upgrade instructions](https://github.com/mistralai/client-python/blob/main/MIGRATION.md):
* change `.chat()` to `.chat.complete()`
* change `MistralClient` to `Mistral` (aliased as `MistralAI`)

Also corrected a problem with `@backoff.on_exception` where it needs object `mistralai_api_error` to exist.