### PR TITLE
Minor readability fix

### DIFF
--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -2,7 +2,6 @@ import dspy
 from dspy.primitives.program import Module
 from dspy.signatures.signature import ensure_signature
 
-
 # TODO: This shouldn't inherit from Predict. It should be a module that has one or two predictors.
 # Let's focus on the activated case. It's a predictor with the expanded signature.
 # Now, when deactivated, it's a predictor with the original signature.
@@ -19,13 +18,13 @@ class ChainOfThought(Module):
         *_keys, last_key = signature.output_fields.keys()
 
         prefix = "Reasoning: Let's think step by step in order to"
-        desc = "${produce the " + last_key + "}. We ..."
-
         if dspy.settings.experimental:
             desc = "${produce the output fields}. We ..."
+        else:
+            desc = f"${{produce the {last_key}}}. We ..."
 
         rationale_type = rationale_type or dspy.OutputField(prefix=prefix, desc=desc)
-
+        # Add "rationale" field to the output signature.
         extended_signature = signature.prepend("rationale", rationale_type, type_=str)
         self._predict = dspy.Predict(extended_signature, **config)
         self._predict.extended_signature = extended_signature
@@ -35,15 +34,15 @@ class ChainOfThought(Module):
 
         signature = kwargs.pop("new_signature", self._predict.extended_signature if self.activated else self.signature)
         return self._predict(signature=signature, **kwargs)
-        # return super().forward(signature=signature, **kwargs)
 
     @property
     def demos(self):
         return self._predict.demos
-    
+
     @property
     def extended_signature(self):
         return self._predict.extended_signature
+
 
 """
 TODO: In principle, we can update the field's prefix during forward too to fill any thing based on the input args.


### PR DESCRIPTION
Use f-string instead of concat, and add some comments for readability.

Personally I find `signature.prepend()` a bit confusing, because in this case we are adding `rationale` to output signature, but prepend gives a feeling of adding things at the front, e.g., `question -> answer` becomes `rationale, question -> answer`. 