### PR TITLE
Improve MIPROv2 program aware regex

### DIFF
--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -195,7 +195,7 @@ class GenerateModuleInstruction(dspy.Module):
             init_pattern = r"def __init__\(.*?\):([\s\S]*?)(?=^\s*def|\Z)"
             init_content_match = re.search(init_pattern, self.program_code_string)
             init_content = init_content_match.group(0)
-            pattern = r"^(.*dspy\.(ChainOfThought|Predict).*)$"  # TODO: make it so that this extends out to any dspy Module
+            pattern = r"^(.*dspy\.(ChainOfThought|Predict|TypedPredictor|TypedChainOfThought).*)$"  # TODO: make it so that this extends out to any dspy Module
             matches = re.findall(pattern, init_content, re.MULTILINE)
             modules = [match[0].strip() for match in matches]
             module_code = modules[pred_i]


### PR DESCRIPTION
Now supports typed variants of `Predict` and `ChainOfThought` as well.

First mentioned in #1295 