### PR TITLE
Improve error logging with a stacktrace

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -4,6 +4,7 @@ import sys
 import threading
 import types
 from typing import Any
+import traceback
 
 import pandas as pd
 import tqdm
@@ -53,6 +54,7 @@ class Evaluate:
         max_errors=5,
         return_all_scores=False,
         return_outputs=False,
+        provide_traceback=False,
         **_kwargs,
     ):
         self.devset = devset
@@ -66,7 +68,7 @@ class Evaluate:
         self.cancel_jobs = threading.Event()
         self.return_all_scores = return_all_scores
         self.return_outputs = return_outputs
-
+        self.provide_traceback = provide_traceback
         if "display" in _kwargs:
             dspy.logger.warning(
                 "DeprecationWarning: 'display' has been deprecated. To see all information for debugging,"
@@ -194,9 +196,12 @@ class Evaluate:
                     current_error_count = self.error_count
                 if current_error_count >= self.max_errors:
                     raise e
-
-                dspy.logger.error(f"Error for example in dev set: \t\t {e}")
-
+                
+                if self.provide_traceback:
+                    dspy.logger.error(f"Error for example in dev set: \t\t {e}\n\twith inputs:\n\t\t{example.inputs()}\n\nStack trace:\n\t{traceback.format_exc()}")
+                else:
+                    dspy.logger.error(f"Error for example in dev set: \t\t {e}. Set `provide_traceback=True` to see the stack trace.")
+                
                 return example_idx, example, {}, 0.0
             finally:
                 if creating_new_thread:


### PR DESCRIPTION
Related to issue https://github.com/stanfordnlp/dspy/issues/788

This prints out the example inputs and a stacktrace for the error that occurred. I understand that this change would add more excessive error messages that you have tried to avoid

> The current behavior was designed to limit excessive outputted error messages, partly handled through [how many errors can occur before completely halting execution](https://github.com/stanfordnlp/dspy/blob/5c5e8071916688f462b3b779e0c6adca42f660b8/dspy/evaluate/evaluate.py#L140)

But at least to me this has been the number 1 issue I have been experiencing when testing out dspy for the past week. This change works like a charm in my use case.

If the printed error message seems too excessive with large datasets, then another option would be to add the stacktrace logging behind an env variable that can be set if needed (though my personal preference would be to have the stacktrace visible as the default option and having the possibility to limit the error traces with a similar approach)

```
 if os.environ.get('DEBUG') == 'true':
     dspy.logger.error(f"Error for example in dev set: \t\t {e}\n\twith inputs:\n\t\t{example.inputs()}\n\nStack trace:\n\t{traceback.format_exc()}")
```
