### PR TITLE
Bug Fix: Multiline init regex parsing (MIPROv2)

### DIFF
--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -192,7 +192,7 @@ class GenerateModuleInstruction(dspy.Module):
             print(f"PROGRAM DESCRIPTION: {program_description}")
 
             # Identify all modules
-            init_pattern = r"def __init__\(.*?\):([\s\S]*?)(?=^\s*def|\Z)"
+            init_pattern = r"def __init__\([\s\S]*?\):([\s\S]*?)(?=^\s*def|\Z)"
             init_content_match = re.search(init_pattern, self.program_code_string)
             init_content = init_content_match.group(0)
             pattern = r"^(.*dspy\.(ChainOfThought|Predict).*)$"  # TODO: make it so that this extends out to any dspy Module


### PR DESCRIPTION
Fixes the error where multiline __init__ definitions for modules are not properly parsed by the program aware regex.

Fixes #1460