### PR TITLE
Correction in Usage of GroqLM in documentation

### DIFF
--- a/docs/api/language_model_clients/Groq.md
+++ b/docs/api/language_model_clients/Groq.md
@@ -7,7 +7,7 @@ sidebar_position: 9
 ### Usage
 
 ```python
-lm = dspy.GROQ(model='mixtral-8x7b-32768', api_key ="gsk_***" )
+lm = dspy.GroqLM(model='mixtral-8x7b-32768', api_key ="gsk_***" )
 ```
 
 ### Constructor


### PR DESCRIPTION
**correction in Usage code part dspy.GROQ to dspy.GroqLM (same name as constructor is defined)** 
![image](https://github.com/user-attachments/assets/5fe95c4b-c423-40b2-90af-8d9685fe756d)
