### PR TITLE
Revert "Correction in Usage of GroqLM in documentation"

### DIFF
--- a/docs/api/language_model_clients/Groq.md
+++ b/docs/api/language_model_clients/Groq.md
@@ -7,7 +7,7 @@ sidebar_position: 9
 ### Usage
 
 ```python
-lm = dspy.GroqLM(model='mixtral-8x7b-32768', api_key ="gsk_***" )
+lm = dspy.GROQ(model='mixtral-8x7b-32768', api_key ="gsk_***" )
 ```
 
 ### Constructor


### PR DESCRIPTION
dspy.GROQ() is working fine with recent update of dspy-ai==2.4.12. So revert the changes @okhat 