### PR TITLE
Fix AzureAISearchRM Error when doing vector/hybrid search

### DIFF
--- a/dspy/retrieve/azureaisearch_rm.py
+++ b/dspy/retrieve/azureaisearch_rm.py
@@ -255,7 +255,7 @@ class AzureAISearchRM(dspy.Retrieve):
                     query_speller=query_speller,
                     semantic_configuration_name=semantic_configuration_name,
                     top=top,
-                    vector_queries=[vector_query],
+                    vector_queries=vector_query,
                     vector_filter_mode=vector_filter_mode,
                     query_caption=("extractive|highlight-false" if use_semantic_captions else None),
                 )
@@ -266,7 +266,7 @@ class AzureAISearchRM(dspy.Retrieve):
                     query_language=query_language,
                     query_speller=query_speller,
                     top=top,
-                    vector_queries=[vector_query],
+                    vector_queries=vector_query,
                     vector_filter_mode=vector_filter_mode,
                 )
         if is_fulltext_search:

--- a/dspy/retrieve/azureaisearch_rm.py
+++ b/dspy/retrieve/azureaisearch_rm.py
@@ -229,7 +229,7 @@ class AzureAISearchRM(dspy.Retrieve):
                     search_text=None,
                     filter=filter,
                     query_type=query_type,
-                    vector_queries=[vector_query],
+                    vector_queries=vector_query,
                     vector_filter_mode=vector_filter_mode,
                     semantic_configuration_name=semantic_configuration_name,
                     top=top,
@@ -239,7 +239,7 @@ class AzureAISearchRM(dspy.Retrieve):
                 results = client.search(
                     search_text=None,
                     filter=filter,
-                    vector_queries=[vector_query],
+                    vector_queries=vector_query,
                     vector_filter_mode=vector_filter_mode,
                     top=top,
                 )


### PR DESCRIPTION
In hybrid/vector search case, 
when calling client.search, get_embedding() is returning List[VectorQueries]: 
https://github.com/stanfordnlp/dspy/blob/main/dspy/retrieve/azureaisearch_rm.py#L380

It can directly passed to the client.search.

Currently, an extra '[]' is added when passing the vector_query to the client.search:
https://github.com/stanfordnlp/dspy/blob/main/dspy/retrieve/azureaisearch_rm.py#L258

Results in serialization error from AISearch library.

The fix is to remove that extra []. Test is done with positive result after fix.



