### PR TITLE
Add `from_rm` to the DataLoader

### DIFF
--- a/docs/docs/deep-dive/retrieval_models_clients/WeaviateRM.mdx
+++ b/docs/docs/deep-dive/retrieval_models_clients/WeaviateRM.mdx
@@ -58,4 +58,4 @@ for result in results:
     print("Document:", result.long_text, "\n")
 ```
 
-You can follow along with more DSPy and Weaviate examples [here](https://weaviate.io/developers/weaviate/more-resources/dspy)!
+You can follow along with more DSPy and Weaviate examples [here](https://weaviate.io/developers/integrations/llm-frameworks/dspy)!

--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -97,6 +97,20 @@ class DataLoader(Dataset):
 
         return [dspy.Example({field: row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
 
+    def from_rm(self, num_samples: int,
+                fields: List[str], input_keys: List[str]) -> List[dspy.Example]:
+        try:
+            rm = dspy.settings.rm
+            try:
+                return [
+                    dspy.Example({field: row[field] for field in fields}).with_inputs(*input_keys)
+                    for row in rm.get_objects(num_samples=num_samples, fields=fields)
+                ]
+            except AttributeError:
+                raise ValueError("Retrieval module does not support get_objects. Please use a different retrieval module.")
+        except AttributeError:
+            raise ValueError("Retrieval module not found. Please set a retrieval module using dspy.settings.rm.")
+
     def sample(
         self,
         dataset: List[dspy.Example],

--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -107,9 +107,9 @@ class DataLoader(Dataset):
                     for row in rm.get_objects(num_samples=num_samples, fields=fields)
                 ]
             except AttributeError:
-                raise ValueError("Retrieval module does not support get_objects. Please use a different retrieval module.")
+                raise ValueError("Retrieval module does not support `get_objects`. Please use a different retrieval module.")
         except AttributeError:
-            raise ValueError("Retrieval module not found. Please set a retrieval module using dspy.settings.rm.")
+            raise ValueError("Retrieval module not found. Please set a retrieval module using `dspy.settings.configure`.")
 
     def sample(
         self,

--- a/dspy/retrieve/weaviate_rm.py
+++ b/dspy/retrieve/weaviate_rm.py
@@ -54,6 +54,7 @@ class WeaviateRM(dspy.Retrieve):
     ):
         self._weaviate_collection_name = weaviate_collection_name
         self._weaviate_client = weaviate_client
+        self._weaviate_collection = self._weaviate_client.collections.get(self._weaviate_collection_name)
         self._weaviate_collection_text_key = weaviate_collection_text_key
 
         # Check the type of weaviate_client (this is added to support v3 and v4)
@@ -83,7 +84,7 @@ class WeaviateRM(dspy.Retrieve):
         passages, parsed_results = [], []
         for query in queries:
             if self._client_type == "WeaviateClient":
-                results = self._weaviate_client.collections.get(self._weaviate_collection_name).query.hybrid(
+                results = self._weaviate_collection.query.hybrid(
                     query=query,
                     limit=k,
                     **kwargs,

--- a/dspy/retrieve/weaviate_rm.py
+++ b/dspy/retrieve/weaviate_rm.py
@@ -126,7 +126,7 @@ class WeaviateRM(dspy.Retrieve):
                 counter += 1
             return objects
         else:
-            raise ValueError("get_objects is not supported for the v3 Weaviate Python client, please upgrade to v4.")
+            raise ValueError("`get_objects` is not supported for the v3 Weaviate Python client, please upgrade to v4.")
         
     def insert(self, new_object_properties: dict):
         if self._client_type == "WeaviateClient":
@@ -135,4 +135,4 @@ class WeaviateRM(dspy.Retrieve):
                 uuid=get_valid_uuid(uuid4())
             )
         else:
-            raise AttributeError("insert is not supported for the v3 Weaviate Python client, please upgrade to v4.")
+            raise AttributeError("`insert` is not supported for the v3 Weaviate Python client, please upgrade to v4.")

--- a/dspy/retrieve/weaviate_rm.py
+++ b/dspy/retrieve/weaviate_rm.py
@@ -126,3 +126,12 @@ class WeaviateRM(dspy.Retrieve):
             return objects
         else:
             raise ValueError("get_objects is not supported for the v3 Weaviate Python client, please upgrade to v4.")
+        
+    def insert(self, new_object_properties: dict):
+        if self._client_type == "WeaviateClient":
+            self._weaviate_collection.data.insert(
+                properties=new_object_properties,
+                uuid=get_valid_uuid(uuid4())
+            )
+        else:
+            raise AttributeError("insert is not supported for the v3 Weaviate Python client, please upgrade to v4.")

--- a/dspy/retrieve/weaviate_rm.py
+++ b/dspy/retrieve/weaviate_rm.py
@@ -108,3 +108,21 @@ class WeaviateRM(dspy.Retrieve):
             passages.extend(dotdict({"long_text": d}) for d in parsed_results)
 
         return passages
+    
+    def get_objects(self, num_samples: int, fields: List[str]) -> List[dict]:
+        """Get objects from Weaviate using the cursor API."""
+        if self._client_type == "WeaviateClient":
+            objects = []
+            counter = 0
+            for item in self._weaviate_collection.iterator():
+                if counter >= num_samples:
+                    break
+                new_object = {}
+                for key in item.properties.keys():
+                    if key in fields:
+                      new_object[key] = item.properties[key]
+                objects.append(new_object)
+                counter += 1
+            return objects
+        else:
+            raise ValueError("get_objects is not supported for the v3 Weaviate Python client, please upgrade to v4.")

--- a/dspy/retrieve/weaviate_rm.py
+++ b/dspy/retrieve/weaviate_rm.py
@@ -6,6 +6,8 @@ from dspy.primitives.prediction import Prediction
 
 try:
     import weaviate
+    from weaviate.util import get_valid_uuid
+    from uuid import uuid4
 except ImportError as err:
     raise ImportError(
         "The 'weaviate' extra is required to use WeaviateRM. Install it with `pip install dspy-ai[weaviate]`",


### PR DESCRIPTION
# What

Load in a dataset of dspy.Example objects from the connected RM to DSPy.

# Why

This makes it easier to load in datasets for DSPy's optimizers.

# How

Implement `from_rm` in the DataLoader with the arguments `num_samples`, `fields`, `input_keys` (similar interface as `from_json`, `from_pandas`, ...)

Add `get_objects` to RM with the arguments `num_samples` and `fields`.

Tested locally.