### PR TITLE
Optimizer Doc Fixes

### DIFF
--- a/docs/docs/deep-dive/optimizers/copro.mdx
+++ b/docs/docs/deep-dive/optimizers/copro.mdx
@@ -95,7 +95,7 @@ In this teleprompter there is a breadth and depth argument that defines the numb
 ```python
 kwargs = dict(num_threads=64, display_progress=True, display_table=0) # Used in Evaluate class in the optimization process
 
-compiled_prompt_opt = teleprompter.compile(cot, trainset=devset, eval_kwargs=kwargs)
+compiled_prompt_opt = teleprompter.compile(cot, trainset=trainset, eval_kwargs=kwargs)
 ```
 
 Once the training is done you'll have better instructions and prefixes that you'll need to edit in signature manually. So let's say the output during optimization is like:

--- a/dspy/teleprompt/mipro_optimizer.py
+++ b/dspy/teleprompt/mipro_optimizer.py
@@ -32,7 +32,7 @@ eval_score = evaluate(compiled_prompt_opt, devset=evalset[:EVAL_NUM], **kwargs)
 Note that this teleprompter takes in the following parameters:
 
 * prompt_model: The model used for prompt generation. When unspecified, defaults to the model set in settings (i.e., dspy.settings.configure(lm=task_model)).
-* task_model: The model used for prompt generation. When unspecified, defaults to the model set in settings (i.e., dspy.settings.configure(lm=task_model)).
+* task_model: The model used for running your task. When unspecified, defaults to the model set in settings (i.e., dspy.settings.configure(lm=task_model)).
 * metric: The task metric used for optimization.
 * num_candidates: The number of new prompts and sets of fewshot examples to generate and evaluate. Default=10.
 * init_temperature: The temperature used to generate new prompts. Higher roughly equals more creative. Default=1.0.


### PR DESCRIPTION
Fixed Docstring in Deprecated MIPRO (v1) Optimizer.

Fixed trainset/devset confusion in COPRO Documentation.

Fixes #940 
Fixes #949