### PR TITLE
litellm.py : disable telemetry

### DIFF
--- a/dsp/modules/__init__.py
+++ b/dsp/modules/__init__.py
@@ -30,3 +30,4 @@ from .snowflake import *
 from .tensorrt_llm import TensorRTModel
 from .watsonx import *
 from .you import You
+from .litellm import *

--- a/dsp/modules/litellm.py
+++ b/dsp/modules/litellm.py
@@ -1,7 +1,13 @@
 from typing import Any, Optional, Literal, Dict, List, Union, cast
 from pydantic import BaseModel
+import os
 
-import litellm
+if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+
+import litellm  
+litellm.telemetry = False
+
 from litellm.types.utils import Choices, ModelResponse, Usage
 from litellm.caching import Cache
 

--- a/dsp/modules/litellm.py
+++ b/dsp/modules/litellm.py
@@ -19,53 +19,38 @@ litellm.set_verbose = True
 
 class Message(BaseModel):
     role: str
-    content: Optional[str] = None # Only null for assistant messages with function calls
-    name: Optional[str] = None
-    function_call: Optional[Dict[str, Any]] = None
+    content: Optional[str] # Only null for assistant messages with function calls
+    name: Optional[str]
+    function_call: Optional[Dict[str, Any]]
+
+    def __init__(self, **data):  
+        super().__init__(**data)  
+        self.__dict__ = {  
+            k: v for k, v in self.__dict__.items() if v is not None  
+        }  
+
+    # TODO: test this
+    @classmethod  
+    def create_from_kwargs(cls, kwargs_list):  
+        kwargs_dict = {}  
+        for kwargs in kwargs_list:  
+            kwargs_dict.update(kwargs)  
+        return cls(**kwargs_dict)
+    
+    def to_dict(self):  
+        kwargs = self.model_dump(exclude_unset=True)
+        return kwargs
 
 class LLM(BaseModel):
-    # TODO: See all commented out params and see if we need to support them.
     ### required params
     model: str
-    model_type: str # This is needed for litellm.get_supported_openai_params call - this needs to be the name of the model itself (not the deployment name). Figure out a better name for this
-    messages: List[Message] = []
-    ### litellm-specific params
-    api_key: Optional[str] = None 
-    api_base: Optional[str] = None
-    api_version: Optional[str] = None
-    num_retries: Optional[int] = 0
-    # context_window_fallback_dict
-    # fallbacks
-    # metadata
-    ### openai params
-    temperature: Optional[float] = 0.0
-    top_p: Optional[float] = 1
-    n: Optional[int] = 1
-    stop: Optional[Union[str, List[str]]] = None
-    max_tokens: Optional[int] = 150
-    presence_penalty: Optional[float] = None
-    seed: Optional[int] = None
-    frequency_penalty: Optional[float] = None
-    logit_bias: Optional[Dict[str, float]] = None
-    user: Optional[str] = None
-    timeout: Optional[int] = 600
-    logprobs: Optional[bool] = False
-    top_logprobs: Optional[int] = 0 # TODO: This might cause an error
-    # stream
-    # stream_options
-    # response_format
-    # tools
-    # tool_choice
-    # parallel_tool_calls
-    # Note: litellm also allows a <provider>_key which is excluded as each LLM object points to a specific LLM
-    ### Google - TODO: are these needed? Litellm docs confusing
-    vertex_credentials: Optional[str] = None
-    vertex_project: Optional[str] = None
-    vertex_location: Optional[str] = None
-    ### Custom prompt template TODO: see if needed https://docs.litellm.ai/docs/completion/input
-    ### dspy params - these need to be removed from litellm calls
-    history: Optional[List[Dict[str, Any]]] = None
-    provider: Optional[str] = "openai"
+    # model_type: str # This is needed for litellm.get_supported_openai_params call - this needs to be the name of the model itself (not the deployment name).
+    messages: Optional[List[Message]] = []
+    ### dspy params 
+    history: Optional[List[Dict[str, Any]]] = []
+    provider: Optional[str] = "openai" # TODO: do we need the provider?
+    # These need to be removed from litellm calls TODO: this list isn't needed
+    # non_litellm_params: List[str] = ["model_type", "history", "provider"]
 
     # Allows extra kwargs to be passed in
     class Config:
@@ -75,17 +60,62 @@ class LLM(BaseModel):
         """
         Litellm request
         """
-        pass
+        print(kwargs)
 
-    def required_params(self):
-        return 
+        response = litellm.completion(**kwargs)
+        return response
+
+    def update_messages(self, input, input_type):
+        if input_type == "prompt":
+            self.messages.append(Message(role="user", content=input, name=None, function_call=None))
+        else: #list of messages
+            for msg in input:
+                self.messages.append(Message.create_from_kwargs(msg))
+        return
 
     def set_provider(self):
         # TODO: confirm if it's ok to assume the provider is openai or the prefix as https://docs.litellm.ai/docs/providers/aleph_alpha doesn't seem to include a prefix
+        # TODO: might not be needed unless we want to use litellm.get_supported_openai_params() to get list of params for each model + provider and validate all the args before the llm call
         if "/" in self.model:
             self.provider = self.model.split("/")[0]
+        
+    def postprocess(self, litellm_response, input_type, only_completed, org_kwargs, litellm_kwargs):
 
-    def pre_process(self, drop_params, **kwargs):   
+        # extract litellm response
+
+        # to standardize the history, the input is always in the form of the message sent to litellm, however input_type indicates whether it was passed in as a prompt or as is. TODO: review & confirm.
+
+        org_kwargs["only_completed"] = only_completed
+        # drop_params already in litellm_kwargs
+
+        # This could technically be a update_history function
+        # TODO: I changed the fields in the history, does that impact anything?
+        history = {
+            "input": [msg.to_dict() for msg in self.messages],
+            "input_type": input_type,
+            "response": litellm_response,
+            "kwargs": org_kwargs,
+            "litellm_kwargs": litellm_kwargs,
+        }
+
+        self.history.append(history)
+        self.messages = [] # TODO: change this if we want to accumlate message history for litellm
+
+        result = []
+
+        if only_completed:
+            for choice in litellm_response.choices: 
+                if choice.finish_reason == "stop":
+                    result.append(choice)
+            return result
+        else:
+            return litellm_response.choices
+
+
+    def preprocess(self, drop_params, input, input_type, **kwargs):   
+        """
+        Update the kwargs with the necessary parameters to make the litellm call
+        """
         # Add caching to kwargs
         enable_cache = dspy.settings.enable_cache
         if "enable_cache" in kwargs: 
@@ -99,38 +129,51 @@ class LLM(BaseModel):
         # get litellm params and exclude rest
         if drop_params:
             kwargs["drop_params"] = True
-        
-        # set the provider
+
+        # add the litellm params to kwargs
+        kwargs["model"] = self.model
+
+        # TODO: see notes in function def
         self.set_provider()
 
-        supported_params = litellm.get_supported_openai_params(model=self.model_type, custom_llm_provider=self.provider)
+        self.update_messages(input, input_type) # TODO: should we always send all the messages to the litellm call? Or do we need to have a parameter for "keep n messages?" Note that it's not as simple as just truncating the start of the list if we're considering the system message, which would need to stay regardless of the truncation.
 
+        kwargs["messages"] = []
+        for msg in self.messages:
+            kwargs["messages"].append(msg.to_dict())
 
-
+        return kwargs
 
     def __call__(
         self, 
-        prompt: str, 
+        prompt: Optional[str] = None,
+        messages = None, #providing this as an option if someone wants to pass in >1 messsages, especially if they want to include a system message. TODO: better way to do it? Does it make sense to allow a system message in init?
         only_completed: bool = False,
-        return_sorted: bool = False,
         drop_params: bool = True,
-        additional_drop_params: list = [],
         **kwargs
     ) -> list[dict[str, Any]]:
         
-        self.pre_process(drop_params, **kwargs)
+        assert (prompt is not None) != (messages is not None), "Either 'prompt' or 'message' must be set, but not both."
 
-        response = self.request(**kwargs)
+        if prompt: 
+            input = prompt
+            input_type = "prompt"
+        else: 
+            input = messages
+            input_type = "message"
 
-        # postprocessing
+        # all_kwargs = self.model_dump()   
+          
+        # # Filter out the standard fields to get only the extra kwargs  
+        # standard_fields = set(self.__fields__.keys())  
+        # extra_kwargs = {k: v for k, v in all_kwargs.items() if k not in standard_fields}
+        extra_kwargs = self.model_extra
+  
+        # Merge the kwargs with any additional ones passed directly to the method
+        kwargs = kwargs | extra_kwargs  
 
+        litellm_kwargs = self.preprocess(drop_params, input, input_type, **kwargs) 
+        litellm_response = self.request(**litellm_kwargs)
+        result = self.postprocess(litellm_response, input_type, only_completed, kwargs, litellm_kwargs) 
 
-"""
-Useful litellm helper functions/flags:
-
-check_valid_key() -> Check if a user submitted a valid key for the model they're trying to call.
-
-litellm.get_supported_openai_params() -> get list of params for each model + provider
-
-litellm.drop_params = True
-"""
+        return result

--- a/dsp/modules/litellm.py
+++ b/dsp/modules/litellm.py
@@ -1,28 +1,136 @@
-from typing import Any, Optional, Literal, cast
+from typing import Any, Optional, Literal, Dict, List, Union, cast
+from pydantic import BaseModel
 
 import litellm
 from litellm.types.utils import Choices, ModelResponse, Usage
+from litellm.caching import Cache
 
+import dspy
 from dspy.utils.logging import logger
-from dsp.modules.schemas import (
-    ChatMessage,
-    DSPyModelResponse,
-    LLMParams
-)
 
 from dsp.modules.lm import LM
 from dsp.utils.settings import settings
 
-class LLM(LM):
-    def __init__(
-        self,
-        model: str,
-        api_key: Optional[str],
-        api_provider: str,
-        api_base: str,
-        model_type: Literal["chat", "text"] = "chat",
-        system_prompt: Optional[str] = None,
-        **kwargs,
-    ):
-        super().__init__(model)
+# Initialize the cache
+litellm.cache = Cache(disk_cache_dir=".dspy_cache", type="disk")
+
+# Use this for development testing
+litellm.set_verbose = True
+
+class Message(BaseModel):
+    role: str
+    content: Optional[str] = None # Only null for assistant messages with function calls
+    name: Optional[str] = None
+    function_call: Optional[Dict[str, Any]] = None
+
+class LLM(BaseModel):
+    # TODO: See all commented out params and see if we need to support them.
+    ### required params
+    model: str
+    model_type: str # This is needed for litellm.get_supported_openai_params call - this needs to be the name of the model itself (not the deployment name). Figure out a better name for this
+    messages: List[Message] = []
+    ### litellm-specific params
+    api_key: Optional[str] = None 
+    api_base: Optional[str] = None
+    api_version: Optional[str] = None
+    num_retries: Optional[int] = 0
+    # context_window_fallback_dict
+    # fallbacks
+    # metadata
+    ### openai params
+    temperature: Optional[float] = 0.0
+    top_p: Optional[float] = 1
+    n: Optional[int] = 1
+    stop: Optional[Union[str, List[str]]] = None
+    max_tokens: Optional[int] = 150
+    presence_penalty: Optional[float] = None
+    seed: Optional[int] = None
+    frequency_penalty: Optional[float] = None
+    logit_bias: Optional[Dict[str, float]] = None
+    user: Optional[str] = None
+    timeout: Optional[int] = 600
+    logprobs: Optional[bool] = False
+    top_logprobs: Optional[int] = 0 # TODO: This might cause an error
+    # stream
+    # stream_options
+    # response_format
+    # tools
+    # tool_choice
+    # parallel_tool_calls
+    # Note: litellm also allows a <provider>_key which is excluded as each LLM object points to a specific LLM
+    ### Google - TODO: are these needed? Litellm docs confusing
+    vertex_credentials: Optional[str] = None
+    vertex_project: Optional[str] = None
+    vertex_location: Optional[str] = None
+    ### Custom prompt template TODO: see if needed https://docs.litellm.ai/docs/completion/input
+    ### dspy params - these need to be removed from litellm calls
+    history: Optional[List[Dict[str, Any]]] = None
+    provider: Optional[str] = "openai"
+
+    # Allows extra kwargs to be passed in
+    class Config:
+        extra = "allow"
+
+    def request(self, **kwargs):
+        """
+        Litellm request
+        """
+        pass
+
+    def required_params(self):
+        return 
+
+    def set_provider(self):
+        # TODO: confirm if it's ok to assume the provider is openai or the prefix as https://docs.litellm.ai/docs/providers/aleph_alpha doesn't seem to include a prefix
+        if "/" in self.model:
+            self.provider = self.model.split("/")[0]
+
+    def pre_process(self, drop_params, **kwargs):   
+        # Add caching to kwargs
+        enable_cache = dspy.settings.enable_cache
+        if "enable_cache" in kwargs: 
+            # request param takes precedence
+            enable_cache = kwargs["enable_cache"]
+        if enable_cache: 
+            kwargs['cache'] = {"no-cache": False, "no-store": False}
+        else:
+            kwargs['cache'] = {"no-cache": True, "no-store": True}
+
+        # get litellm params and exclude rest
+        if drop_params:
+            kwargs["drop_params"] = True
         
+        # set the provider
+        self.set_provider()
+
+        supported_params = litellm.get_supported_openai_params(model=self.model_type, custom_llm_provider=self.provider)
+
+
+
+
+    def __call__(
+        self, 
+        prompt: str, 
+        only_completed: bool = False,
+        return_sorted: bool = False,
+        drop_params: bool = True,
+        additional_drop_params: list = [],
+        **kwargs
+    ) -> list[dict[str, Any]]:
+        
+        self.pre_process(drop_params, **kwargs)
+
+        response = self.request(**kwargs)
+
+        # postprocessing
+
+
+"""
+Useful litellm helper functions/flags:
+
+check_valid_key() -> Check if a user submitted a valid key for the model they're trying to call.
+
+litellm.get_supported_openai_params() -> get list of params for each model + provider
+
+litellm.drop_params = True
+"""

--- a/dsp/modules/litellm.py
+++ b/dsp/modules/litellm.py
@@ -1,0 +1,28 @@
+from typing import Any, Optional, Literal, cast
+
+import litellm
+from litellm.types.utils import Choices, ModelResponse, Usage
+
+from dspy.utils.logging import logger
+from dsp.modules.schemas import (
+    ChatMessage,
+    DSPyModelResponse,
+    LLMParams
+)
+
+from dsp.modules.lm import LM
+from dsp.utils.settings import settings
+
+class LLM(LM):
+    def __init__(
+        self,
+        model: str,
+        api_key: Optional[str],
+        api_provider: str,
+        api_base: str,
+        model_type: Literal["chat", "text"] = "chat",
+        system_prompt: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(model)
+        

--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -42,7 +42,8 @@ class Settings:
                 suggest_failures=0,
                 langchain_history=[],
                 experimental=False,
-                backoff_time = 10
+                backoff_time = 10,
+                enable_cache=True
             )
             cls._instance.__append(config)
 

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -13,6 +13,7 @@ from .functional import *  # isort: skip
 settings = dsp.settings
 
 LM = dsp.LM
+LLM = dsp.LLM
 
 AzureOpenAI = dsp.AzureOpenAI
 OpenAI = dsp.GPT3


### PR DESCRIPTION
Uses the "LITELLM_LOCAL_MODEL_COST_MAP" variable to turn off an API call when liteLLM is imported. 
Set 'litellm.telemetry = False' as well. 

https://docs.litellm.ai/docs/completion/token_usage#9-register_model
https://github.com/BerriAI/litellm/blob/main/litellm/__init__.py