### PR TITLE
lm.py: disable telemetry in litellm

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -7,7 +7,10 @@ try:
     import warnings
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=UserWarning)
-        import litellm
+        if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
+             os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+        import litellm  
+        litellm.telemetry = False
 
     from litellm.caching import Cache
     disk_cache_dir = os.environ.get('DSPY_CACHEDIR') or os.path.join(Path.home(), '.dspy_cache')


### PR DESCRIPTION
Uses the "LITELLM_LOCAL_MODEL_COST_MAP" variable to turn off an API call when liteLLM is imported.
Set 'litellm.telemetry = False' as well.

https://docs.litellm.ai/docs/completion/token_usage#9-register_model
https://github.com/BerriAI/litellm/blob/main/litellm/__init__.py

Ran ruff this time, thanks for the heads up @okhat !