### PR TITLE
Make output processing in typed Pred compatible to LM Module

### DIFF
--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -3,7 +3,6 @@ import ujson
 import typing
 import inspect
 import pydantic
-import warnings
 
 from pydantic.fields import FieldInfo
 from typing import Annotated, Callable, List, Tuple, Union  # noqa: UP035

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -1,12 +1,14 @@
-import inspect
 import json
+import ujson
 import typing
+import inspect
+import pydantic
+import warnings
+
+from pydantic.fields import FieldInfo
 from typing import Annotated, Callable, List, Tuple, Union  # noqa: UP035
 
-import pydantic
-import ujson
-from pydantic.fields import FieldInfo
-
+import dsp
 import dspy
 from dsp.adapters import passages2text
 from dspy.primitives.prediction import Prediction
@@ -400,7 +402,12 @@ def _func_to_signature(func):
 
 def _unwrap_json(output, from_json: Callable[[str], Union[pydantic.BaseModel, str, None]]):
     try:
-        parsing_result = from_json(output)
+        parsing_result = None
+        if isinstance(dsp.settings.lm, dspy.LM):
+            parsing_result = output
+        else:
+            parsing_result = from_json(output)
+        
         if isinstance(parsing_result, pydantic.BaseModel):
             return parsing_result.model_dump_json()
         else:


### PR DESCRIPTION
Main issue what the output was a BaseModel already so no need to create one, added:
```
        if isinstance(dsp.settings.lm, dspy.LM):
            parsing_result = output
        else:
            parsing_result = from_json(output)
```

Closes #1541 