### PR TITLE
Fixes #1530: Fix BoolOp is not supported exception in Python interpreter.

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -188,6 +188,8 @@ class PythonInterpreter:
             return self._execute_call(expression)
         elif isinstance(expression, ast.Compare):
             return self._execute_condition(expression)
+        elif isinstance(expression, ast.BoolOp):
+            return self._execute_condition(expression)
         elif isinstance(expression, ast.Constant):
             # Constant -> just return the value
             return expression.value

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -7,6 +7,12 @@ def test_execute_simple_code():
     result = interpreter.execute(code)
     assert result is None, "Simple print statement should return None"
 
+def test_execute_boolop_code():
+    interpreter = PythonInterpreter(action_space={'print': print})
+    code = "if (True and True) or (False and False): result = True"
+    result = interpreter.execute(code)
+    assert result is True, "Conditional with boolop should not raise an exception"    
+
 def test_action_space_limitation():
     def func(string):
         pass


### PR DESCRIPTION
This pull request fixes issue #1530 that causes the Python interpreter to throw an exception on a BoolOp.