### PR TITLE
Fixes #1534: 'Name' object has no attribute 'ops' error

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -357,6 +357,8 @@ class PythonInterpreter:
                 return any(results)
             else: #TODO - add any other BoolOps missing
                 raise InterpreterError(f"Boolean operator {condition.op} is not supported")
+        elif isinstance(condition, ast.Name):
+            return self._execute_name(name=condition)
         elif isinstance(condition, ast.Compare):
             if len(condition.ops) > 1:
                 raise InterpreterError("Cannot evaluate conditions with multiple operators")

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -188,6 +188,8 @@ class PythonInterpreter:
             return self._execute_call(expression)
         elif isinstance(expression, ast.Compare):
             return self._execute_condition(expression)
+        elif isinstance(expression, ast.BoolOp):
+            return self._execute_condition(expression)
         elif isinstance(expression, ast.Constant):
             # Constant -> just return the value
             return expression.value

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -7,6 +7,12 @@ def test_execute_simple_code():
     result = interpreter.execute(code)
     assert result is None, "Simple print statement should return None"
 
+def test_execute_boolop_code():
+    interpreter = PythonInterpreter(action_space={'print': print})
+    code = "if (True and True) or (False and False): result = True"
+    result = interpreter.execute(code)
+    assert result is True, "Conditional with boolop should not raise an exception"    
+
 def test_action_space_limitation():
     def func(string):
         pass

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -11,7 +11,13 @@ def test_execute_boolop_code():
     interpreter = PythonInterpreter(action_space={'print': print})
     code = "if (True and True) or (False and False): result = True"
     result = interpreter.execute(code)
-    assert result is True, "Conditional with boolop should not raise an exception"    
+    assert result is True, "Conditional with boolop should not raise an exception"
+
+def test_execute_boolop_code():
+    interpreter = PythonInterpreter(action_space={'print': print})
+    code = "test=True\nif test:\n    result = True"
+    result = interpreter.execute(code)
+    assert result is True, "Conditional with object should not raise an exception"          
 
 def test_action_space_limitation():
     def func(string):


### PR DESCRIPTION
This pull request fixes issue #1534 that causes an exception in the Python interpreter when a named object is used in a conditional expression.