### PR TITLE
Fix misleading warning

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -2,9 +2,9 @@ import contextlib
 import signal
 import sys
 import threading
+import traceback
 import types
 from typing import Any
-import traceback
 
 import pandas as pd
 import tqdm
@@ -69,11 +69,6 @@ class Evaluate:
         self.return_all_scores = return_all_scores
         self.return_outputs = return_outputs
         self.provide_traceback = provide_traceback
-        if "display" in _kwargs:
-            dspy.logger.warning(
-                "DeprecationWarning: 'display' has been deprecated. To see all information for debugging,"
-                " use 'dspy.set_log_level('debug')'. In the future this will raise an error.",
-            )
 
     def _execute_single_thread(self, wrapped_program, devset, display_progress):
         ncorrect = 0


### PR DESCRIPTION
Resolve #1286 

The warning was completely wrong, we should just remove it and let it error out. Made a few minor lint fixes along with the deletion.

A followup is to explicitly document how to change logging level for user. The `show_logging` util should work. 