### PR TITLE
fix typo in lm.py

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -13,7 +13,7 @@ try:
         litellm.telemetry = False
 
     from litellm.caching import Cache
-    disk_cache_dir = os.environ.get('DSPY_CACHEDIR') or os.path.join(Path.home(), '.dspy_cache')
+    disk_cache_dir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), '.dspy_cache')
     litellm.cache = Cache(disk_cache_dir=disk_cache_dir, type="disk")
 
 except ImportError:


### PR DESCRIPTION
Looks like there is a typo in the name of env variable, in the documentation it is referenced as `DSP_CACHEDIR` [faqs.md](https://github.com/stanfordnlp/dspy/blob/b3ecf879cc18d6c15a2b8654d217cc34a66489fe/docs/docs/faqs.md?plain=1#L90)