### PR TITLE
Fix signature saving at Predict saving

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -64,7 +64,7 @@ class Predict(Module, Parameter):
             if name not in excluded_keys:
                 setattr(self, name, value)
 
-        self.signature.load_state(state["signature"])
+        self.signature = self.signature.load_state(state["signature"])
 
         if "extended_signature" in state:
             self.extended_signature.load_state(state["extended_signature"])

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -68,6 +68,13 @@ class Predict(Module, Parameter):
         if use_legacy_loading:
             self._load_state_legacy(state)
             return
+        if "signature" not in state and ("signature_instructions" in state or "signature_prefix" in state):
+            # Check if the state is from a version of DSPy prior to v2.5.3.
+            raise ValueError(
+                "The saved state is from a version of DSPy prior to v2.5.3. Please use `use_legacy_loading=True` to "
+                "load the state."
+            )
+
         excluded_keys = ["signature", "extended_signature"]
         for name, value in state.items():
             # `excluded_keys` are fields that go through special handling.

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -57,7 +57,17 @@ class Predict(Module, Parameter):
 
         return state
 
-    def load_state(self, state):
+    def load_state(self, state, use_legacy_loading=False):
+        """Load the saved state of a `Predict` object.
+
+        Args:
+            state (dict): The saved state of a `Predict` object.
+            use_legacy_loading (bool): Whether to use the legacy loading method. Only use it when you are loading a
+                saved state from a version of DSPy prior to v2.5.3.
+        """
+        if use_legacy_loading:
+            self._load_state_legacy(state)
+            return
         excluded_keys = ["signature", "extended_signature"]
         for name, value in state.items():
             # `excluded_keys` are fields that go through special handling.
@@ -68,6 +78,34 @@ class Predict(Module, Parameter):
 
         if "extended_signature" in state:
             self.extended_signature.load_state(state["extended_signature"])
+
+    def _load_state_legacy(self, state):
+        """Legacy state loading for backwards compatibility.
+
+        This method is used to load the saved state of a `Predict` object from a version of DSPy prior to v2.5.3.
+        """
+        for name, value in state.items():
+            setattr(self, name, value)
+
+        # Reconstruct the signature.
+        if "signature_instructions" in state:
+            instructions = state["signature_instructions"]
+            self.signature = self.signature.with_instructions(instructions)
+
+        if "signature_prefix" in state:
+            prefix = state["signature_prefix"]
+            *_, last_key = self.signature.fields.keys()
+            self.signature = self.signature.with_updated_fields(last_key, prefix=prefix)
+
+        # Some special stuff for CoT.
+        if "extended_signature_instructions" in state:
+            instructions = state["extended_signature_instructions"]
+            self.extended_signature = self.extended_signature.with_instructions(instructions)
+
+        if "extended_signature_prefix" in state:
+            prefix = state["extended_signature_prefix"]
+            *_, last_key = self.extended_signature.fields.keys()
+            self.extended_signature = self.extended_signature.with_updated_fields(last_key, prefix=prefix)
 
 
     def __call__(self, **kwargs):

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -68,7 +68,7 @@ class Predict(Module, Parameter):
         if use_legacy_loading:
             self._load_state_legacy(state)
             return
-        if "signature" not in state and ("signature_instructions" in state or "signature_prefix" in state):
+        if "signature" not in state:
             # Check if the state is from a version of DSPy prior to v2.5.3.
             raise ValueError(
                 "The saved state is from a version of DSPy prior to v2.5.3. Please use `use_legacy_loading=True` to "

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -152,17 +152,17 @@ class BaseModule:
         print(self.named_parameters())
         return {name: param.dump_state(save_verbose) for name, param in self.named_parameters()}
 
-    def load_state(self, state):
+    def load_state(self, state, use_legacy_loading=False):
         for name, param in self.named_parameters():
-            param.load_state(state[name])
+            param.load_state(state[name], use_legacy_loading=use_legacy_loading)
 
     def save(self, path, save_field_meta=False):
         with open(path, "w") as f:
             f.write(ujson.dumps(self.dump_state(save_field_meta), indent=2))
 
-    def load(self, path):
+    def load(self, path, use_legacy_loading=False):
         with open(path) as f:
-            self.load_state(ujson.loads(f.read()))
+            self.load_state(ujson.loads(f.read()), use_legacy_loading=use_legacy_loading)
 
 
 def postprocess_parameter_name(name, value):

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -164,24 +164,26 @@ class SignatureMeta(type(BaseModel)):
         return Signature(new_fields, cls.instructions)
 
     def dump_state(cls):
-        state = {
-            "instructions": cls.instructions,
-            "fields": []
-        }
+        state = {"instructions": cls.instructions, "fields": []}
         for field in cls.fields:
-            state["fields"].append({
-                "prefix": cls.fields[field].json_schema_extra["prefix"],
-                "description": cls.fields[field].json_schema_extra["desc"],
-            })
+            state["fields"].append(
+                {
+                    "prefix": cls.fields[field].json_schema_extra["prefix"],
+                    "description": cls.fields[field].json_schema_extra["desc"],
+                }
+            )
 
         return state
 
     def load_state(cls, state):
-        cls.instructions = state["instructions"]
+        signature_copy = Signature(deepcopy(cls.fields), cls.instructions)
 
-        for field, saved_field in zip(cls.fields.values(), state["fields"]):
+        signature_copy.instructions = state["instructions"]
+        for field, saved_field in zip(signature_copy.fields.values(), state["fields"]):
             field.json_schema_extra["prefix"] = saved_field["prefix"]
             field.json_schema_extra["desc"] = saved_field["description"]
+
+        return signature_copy
 
     def equals(cls, other) -> bool:
         """Compare the JSON schema of two Pydantic models."""
@@ -210,7 +212,6 @@ class SignatureMeta(type(BaseModel)):
             field_reprs.append(f"{name} = Field({field})")
         field_repr = "\n    ".join(field_reprs)
         return f"{cls.__name__}({cls.signature}\n    instructions={repr(cls.instructions)}\n    {field_repr}\n)"
-
 
 
 # A signature for a predictor.

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -238,3 +238,38 @@ def test_multiple_replaced_by_update_signatures():
         assert "input4" in SignatureTwo.input_fields
     assert "input1" in SignatureOne.input_fields
     assert "input2" in SignatureTwo.input_fields
+
+def test_dump_and_load_state():
+    class CustomSignature(dspy.Signature):
+        """I am just an instruction."""
+        sentence = dspy.InputField(desc="I am an innocent input!")
+        sentiment = dspy.OutputField()
+
+    state = CustomSignature.dump_state()
+    expected = {
+        "instructions": "I am just an instruction.",
+        "fields": [
+            {
+                "prefix": "Sentence:",
+                "description": "I am an innocent input!",
+            },
+            {
+                "prefix": "Sentiment:",
+                "description": "${sentiment}",
+            },
+        ],
+    }
+    assert state == expected
+
+    class CustomSignature2(dspy.Signature):
+        """I am a malicious instruction."""
+        sentence = dspy.InputField(desc="I am an malicious input!")
+        sentiment = dspy.OutputField()
+
+    assert CustomSignature2.dump_state() != expected
+    # Overwrite the state with the state of CustomSignature.
+    CustomSignature2.load_state(state)
+    assert CustomSignature2.instructions == "I am just an instruction."
+    # After `load_state`, the state should be the same as CustomSignature.
+    assert CustomSignature2.dump_state() == expected
+

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -239,9 +239,11 @@ def test_multiple_replaced_by_update_signatures():
     assert "input1" in SignatureOne.input_fields
     assert "input2" in SignatureTwo.input_fields
 
+
 def test_dump_and_load_state():
     class CustomSignature(dspy.Signature):
         """I am just an instruction."""
+
         sentence = dspy.InputField(desc="I am an innocent input!")
         sentiment = dspy.OutputField()
 
@@ -263,13 +265,17 @@ def test_dump_and_load_state():
 
     class CustomSignature2(dspy.Signature):
         """I am a malicious instruction."""
+
         sentence = dspy.InputField(desc="I am an malicious input!")
         sentiment = dspy.OutputField()
 
     assert CustomSignature2.dump_state() != expected
     # Overwrite the state with the state of CustomSignature.
-    CustomSignature2.load_state(state)
-    assert CustomSignature2.instructions == "I am just an instruction."
+    loaded_signature = CustomSignature2.load_state(state)
+    assert loaded_signature.instructions == "I am just an instruction."
     # After `load_state`, the state should be the same as CustomSignature.
-    assert CustomSignature2.dump_state() == expected
-
+    assert loaded_signature.dump_state() == expected
+    # CustomSignature2 should not have been modified.
+    assert CustomSignature2.instructions == "I am a malicious instruction."
+    assert CustomSignature2.fields["sentence"].json_schema_extra["desc"] == "I am an malicious input!"
+    assert CustomSignature2.fields["sentiment"].json_schema_extra["prefix"] == "Sentiment:"


### PR DESCRIPTION
resolve #1045 

Change summary:

- Add a `dump_state`/`load_state` pair to Signature class for better modularization.
- Remove the `save_verbose` option, as it doesn't make sense to change input fields to output fields at loading time. As we are doing "weights-only" saving, the signatures' architecture should match, i.e., input fields and output fields' number and name.  Only changeable attributes should be included with saving.
- Save prefix for every field as requested in #1045.
- Added unit testing. 