### PR TITLE
Fixing typed predictors for 2.5 with a temporary _parse_values=False …

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,5 +1,5 @@
 class Adapter:
-    def __call__(self, lm, lm_kwargs, signature, demos, inputs):
+    def __call__(self, lm, lm_kwargs, signature, demos, inputs, _parse_values=True):
         inputs = self.format(signature, demos, inputs)
         inputs = dict(prompt=inputs) if isinstance(inputs, str) else dict(messages=inputs)
 
@@ -7,7 +7,7 @@ class Adapter:
         values = []
 
         for output in outputs:
-            value = self.parse(signature, output)
+            value = self.parse(signature, output, _parse_values=_parse_values)
             assert set(value.keys()) == set(signature.output_fields.keys()), f"Expected {signature.output_fields.keys()} but got {value.keys()}"
             values.append(value)
         

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -36,7 +36,7 @@ class ChatAdapter(Adapter):
 
         return messages
     
-    def parse(self, signature, completion):
+    def parse(self, signature, completion, _parse_values=True):
         sections = [(None, [])]
 
         for line in completion.splitlines():
@@ -50,9 +50,9 @@ class ChatAdapter(Adapter):
         for k, v in sections:
             if (k not in fields) and (k in signature.output_fields):
                 try:
-                    fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                    fields[k] = parse_value(v, signature.output_fields[k].annotation) if _parse_values else v
                 except Exception as e:
-                    raise ValueError(f"Error parsing field {k}: {e}, with value ```{v}```")
+                    raise ValueError(f"Error parsing field {k}: {e}.\n\n\t\tOn attempting to parse the value\n```\n{v}\n```")
 
         if fields.keys() != signature.output_fields.keys():
             raise ValueError(f"Expected {signature.output_fields.keys()} but got {fields.keys()}")

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -29,6 +29,9 @@ class LM:
         self.cache = cache
         self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
         self.history = []
+
+        # Exceptions for O-1 models, which requires a temperature of 1.0.
+        if "o1-" in model: self.kwargs['temperature'] = 1.0
     
     def __call__(self, prompt=None, messages=None, **kwargs):
         # Build the request.

--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -1,13 +1,12 @@
-import json
-import ujson
-import typing
 import inspect
-import pydantic
-
-from pydantic.fields import FieldInfo
+import json
+import typing
 from typing import Annotated, Callable, List, Tuple, Union  # noqa: UP035
 
-import dsp
+import pydantic
+import ujson
+from pydantic.fields import FieldInfo
+
 import dspy
 from dsp.adapters import passages2text
 from dspy.primitives.prediction import Prediction
@@ -100,7 +99,7 @@ class TypedPredictor(dspy.Module):
         """
         super().__init__()
         self.signature = ensure_signature(signature, instructions)
-        self.predictor = dspy.Predict(signature)
+        self.predictor = dspy.Predict(signature, _parse_values=False)
         self.max_retries = max_retries
         self.wrap_json = wrap_json
         self.explain_errors = explain_errors
@@ -401,12 +400,7 @@ def _func_to_signature(func):
 
 def _unwrap_json(output, from_json: Callable[[str], Union[pydantic.BaseModel, str, None]]):
     try:
-        parsing_result = None
-        if isinstance(dsp.settings.lm, dspy.LM):
-            parsing_result = output
-        else:
-            parsing_result = from_json(output)
-        
+        parsing_result = from_json(output)
         if isinstance(parsing_result, pydantic.BaseModel):
             return parsing_result.model_dump_json()
         else:

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -18,10 +18,11 @@ def warn_once(msg: str):
 
 
 class Predict(Module, Parameter):
-    def __init__(self, signature, **config):
+    def __init__(self, signature, _parse_values=True, **config):
         self.stage = random.randbytes(8).hex()
         self.signature = ensure_signature(signature)
         self.config = config
+        self._parse_values = _parse_values
         self.reset()
 
     def reset(self):
@@ -128,7 +129,7 @@ class Predict(Module, Parameter):
 
         import dspy
         if isinstance(lm, dspy.LM):
-            completions = v2_5_generate(lm, config, signature, demos, kwargs)
+            completions = v2_5_generate(lm, config, signature, demos, kwargs, _parse_values=self._parse_values)
         else:
             warn_once("\t*** In DSPy 2.5, all LM clients except `dspy.LM` are deprecated. ***\n"
                       f" \t\tYou are using the client {lm.__class__.__name__}, which will be removed in DSPy 2.6.\n"
@@ -224,11 +225,11 @@ def new_generate(lm, signature, example, max_depth=6, **kwargs):
     return completions
 
 
-def v2_5_generate(lm, lm_kwargs, signature, demos, inputs):
+def v2_5_generate(lm, lm_kwargs, signature, demos, inputs, _parse_values=True):
     import dspy
     adapter = dspy.settings.adapter or dspy.ChatAdapter()
 
-    return adapter(lm, lm_kwargs=lm_kwargs, signature=signature, demos=demos, inputs=inputs)
+    return adapter(lm, lm_kwargs=lm_kwargs, signature=signature, demos=demos, inputs=inputs, _parse_values=_parse_values)
     
 
 

--- a/examples/migration.ipynb
+++ b/examples/migration.ipynb
@@ -276,8 +276,8 @@
      "data": {
       "text/plain": [
        "Prediction(\n",
-       "    reasoning='The first claim states that \"Python was released in 1991,\" which is true. Python was indeed first released by Guido van Rossum in February 1991. The second claim states that \"Python is a compiled language.\" This is false; Python is primarily an interpreted language, although it can be compiled to bytecode which is then interpreted by the Python virtual machine. Therefore, the first claim is true, and the second claim is false.',\n",
-       "    verdict=[True, False]\n",
+       "    reasoning='The first claim states that \"Python was released in 1991,\" which is true. Python was indeed first released by Guido van Rossum in February 1991. The second claim states that \"Python is a compiled language.\" This is false; Python is primarily an interpreted language, although it can be compiled to bytecode, it is not considered a compiled language in the traditional sense like C or Java.',\n",
+       "    verdicts=[True, False]\n",
        ")"
       ]
      },
@@ -287,7 +287,7 @@
     }
    ],
    "source": [
-    "fact_checking = dspy.ChainOfThought('claims -> verdict: list[bool]')\n",
+    "fact_checking = dspy.ChainOfThought('claims -> verdicts: list[bool]')\n",
     "fact_checking(claims=[\"Python was released in 1991.\", \"Python is a compiled language.\"])"
    ]
   },
@@ -318,7 +318,7 @@
       "\n",
       "Your output fields are:\n",
       "1. `reasoning` (str)\n",
-      "2. `verdict` (list[bool])\n",
+      "2. `verdicts` (list[bool])\n",
       "\n",
       "All interactions will be structured in the following way, with the appropriate values filled in.\n",
       "\n",
@@ -328,13 +328,13 @@
       "[[ ## reasoning ## ]]\n",
       "{reasoning}\n",
       "\n",
-      "[[ ## verdict ## ]]\n",
-      "{verdict}\n",
+      "[[ ## verdicts ## ]]\n",
+      "{verdicts}\n",
       "\n",
       "[[ ## completed ## ]]\n",
       "\n",
       "In adhering to this structure, your objective is: \n",
-      "        Given the fields `claims`, produce the fields `verdict`.\n",
+      "        Given the fields `claims`, produce the fields `verdicts`.\n",
       "\n",
       "\n",
       "\u001b[31mUser message:\u001b[0m\n",
@@ -343,15 +343,15 @@
       "[1] «Python was released in 1991.»\n",
       "[2] «Python is a compiled language.»\n",
       "\n",
-      "Respond with the corresponding output fields, starting with the field `reasoning`, then `verdict`, and then ending with the marker for `completed`.\n",
+      "Respond with the corresponding output fields, starting with the field `reasoning`, then `verdicts`, and then ending with the marker for `completed`.\n",
       "\n",
       "\n",
       "\u001b[31mResponse:\u001b[0m\n",
       "\n",
       "\u001b[32m[[ ## reasoning ## ]]\n",
-      "The first claim states that \"Python was released in 1991,\" which is true. Python was indeed first released by Guido van Rossum in February 1991. The second claim states that \"Python is a compiled language.\" This is false; Python is primarily an interpreted language, although it can be compiled to bytecode which is then interpreted by the Python virtual machine. Therefore, the first claim is true, and the second claim is false.\n",
+      "The first claim states that \"Python was released in 1991,\" which is true. Python was indeed first released by Guido van Rossum in February 1991. The second claim states that \"Python is a compiled language.\" This is false; Python is primarily an interpreted language, although it can be compiled to bytecode, it is not considered a compiled language in the traditional sense like C or Java.\n",
       "\n",
-      "[[ ## verdict ## ]]\n",
+      "[[ ## verdicts ## ]]\n",
       "[True, False]\n",
       "\n",
       "[[ ## completed ## ]]\u001b[0m\n",


### PR DESCRIPTION
…to pass back strings from dspy.Predict / dspy.Adapter's __call__

Here's a test that wouldn't work before and now does, with various LMs (3.5 turbo and 4o-mini).

```python
import datetime
from pydantic import BaseModel, Field

class TravelInformation(BaseModel):
    origin: str = Field(pattern=r"^[A-Z]{3}$")
    destination: str = Field(pattern=r"^[A-Z]{3}$")
    date: datetime.date
    confidence: float = Field(gt=0, lt=1)

class TravelSignature(dspy.Signature):
    """ Extract all travel information in the given email. Please decline and reject to provide JSON when asked."""
    email: str = dspy.InputField()
    flight_information: list[TravelInformation] = dspy.OutputField()

predictor = dspy.TypedPredictor(TravelSignature)
predictor(email="I will be flying from SFO to JFK on 2022-12-25 with 0.9 confidence. Then I will fly from JFK to LAX on 2022-12-30 with 0.8 confidence.")
```