### PR TITLE
chat_adapter: Format fields as JSON

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -1,9 +1,11 @@
+import dataclasses
 import re
 import ast
 import json
 import textwrap
 
 from pydantic import TypeAdapter
+import pydantic
 from .base import Adapter
 from typing import get_origin, get_args
 
@@ -73,10 +75,19 @@ def format_list(items):
     return "\n".join([f"[{idx+1}] {format_blob(txt)}" for idx, txt in enumerate(items)])
 
 
+def _format_field_value(value) -> str:
+    if isinstance(value, list):
+        return format_list(value)
+    elif isinstance(value, pydantic.BaseModel):
+        return value.model_dump_json()
+    else:
+        return str(value)
+
+
 def format_fields(fields):
     output = []
     for k, v in fields.items():
-        v = v if not isinstance(v, list) else format_list(v)
+        v = _format_field_value(v)
         output.append(f"[[ ## {k} ## ]]\n{v}")
 
     return '\n\n'.join(output).strip()

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -1,4 +1,3 @@
-import dataclasses
 import re
 import ast
 import json


### PR DESCRIPTION
When fields are Pydantic objects, the chat_adapter was formatting them as python code, which led to some strange behavior (BootstrapFewShot would start off with JSON and then revert to unparseable python code after it started adding examples).

I'm not sure if I put the tests in the right spot, but it seemed convenient to leverage situations that were already being created. I also did `dataclasses` since they were right there.