### PR TITLE
Improve the observability and readability of BootstrapFewShot optimizer

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -136,9 +136,11 @@ class BootstrapFewShot(Teleprompter):
 
         bootstrapped = {}
         self.name2traces = {name: [] for name in self.name2predictor}
-
+        progbar = tqdm.tqdm(total=max_bootstraps, desc=f"Bootstrapping {max_bootstraps} examples")
         for round_idx in range(self.max_rounds):
-            progbar = tqdm.tqdm(total=max_bootstraps, desc=f"Round {round_idx + 1}")
+            if len(bootstrapped) >= max_bootstraps:
+                # If we've already bootstrapped enough examples, don't go to the next round.
+                break
             for example_idx, example in enumerate(self.trainset):
                 if len(bootstrapped) >= max_bootstraps:
                     break
@@ -150,7 +152,7 @@ class BootstrapFewShot(Teleprompter):
                     progbar.update(1)
             progbar.close()
 
-        dspy.logger.debug(
+        dspy.logger.info(
             f"Bootstrapped {len(bootstrapped)} full traces after {example_idx + 1} examples in round {round_idx}.",
         )
         # Examples not used in bootstrapping becomes the validation set.


### PR DESCRIPTION
The PR has two parts:

1. Better progbar, currently the progbar is quite confusing because it never finishes. Instead of setting the length of progbar as the training set size, it should reflect the actual step. See below for logging change after this PR:

Before the PR:
```
 40%|█████████████████████████████████████████████▏                                                                   | 4/10 [00:00<00:00, 800.94it/s]
  0%|                                                                                                                          | 0/10 [00:00<?, ?it/s]
  0%|                                                                                                                          | 0/10 [00:00<?, ?it/s]
  0%|                                                                                                                          | 0/10 [00:00<?, ?it/s]
  0%|                                                                                                                          | 0/10 [00:00<?, ?it/s]
Bootstrapped 4 full traces after 1 examples in round 4.
```

After the PR:
```
Bootstrapping 4 examples: 100%|████████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 721.88it/s]
2024-10-02T00:33:26.452003Z [info     ] Bootstrapped 4 full traces after 5 examples in round 1. [dspy.teleprompt.bootstrap] filename=bootstrap.py lineno=155
```

2. Improved readability, including renaming vague variables and methods, adding comments on code that cannot self explain, and deleting unused code. 