### PR TITLE
Removing `@functools.lru_cache` from dspy.LM as litellm cache already covers it

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -1,6 +1,5 @@
 import os
 import ujson
-import functools
 from pathlib import Path
 
 try:
@@ -61,7 +60,6 @@ class LM:
         _inspect_history(self, n)
 
 
-@functools.lru_cache(maxsize=None)
 def cached_litellm_completion(request):
     return litellm_completion(request, cache={"no-cache": False, "no-store": False})
 
@@ -69,7 +67,6 @@ def litellm_completion(request, cache={"no-cache": True, "no-store": True}):
     kwargs = ujson.loads(request)
     return litellm.completion(cache=cache, **kwargs)
 
-@functools.lru_cache(maxsize=None)
 def cached_litellm_text_completion(request):
     return litellm_text_completion(request, cache={"no-cache": False, "no-store": False})
 


### PR DESCRIPTION
Hello there: 👋 

In order to make it more clear why some LM calls didn't cost anything, I'm trying to detect weather a call was cached:

<img width="1023" alt="image" src="https://github.com/user-attachments/assets/7e7c3a81-4bcc-47ce-bd69-4f4879bbddbf">

However I noticed there is a two-level cache on dspy.LM right now for the same requests: the litellm cache and a thin `@functools.lru_cache` on top, I wonder what is the need of this second layer of `@functools.lru_cache`, and if that just doesn't increase memory usage with no benefits since litellm cache already covers for it. This makes it a bit extra confusing to detect and bust the cache.

On my tests running optimizations it doesn't seem that removing this lru_cache lines made any effects, when I stop and rerun MIPROv2 it quickly uses all cached calls and get me back where I stopped

So I suggest to remove it and keep only the "no-cache" and reliance on litellm cache for having a more straightforward understanding how caching works here and perhaps smaller memory footprint (haven't measured though)