### PR TITLE
[MIPROv2] Fixed min to max in demo check

### DIFF
--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -304,8 +304,8 @@ class GroundedProposer(Proposer):
             use_history = random.random() < 0.5
             self.use_instruct_history = use_history
             if self.verbose: print(f"Use history T/F: {self.use_instruct_history}")
-        
-        num_demos = min(len(demo_candidates[0]) if demo_candidates else N, 1)
+
+        num_demos = max(len(demo_candidates[0]) if demo_candidates else N, 1)
 
         if not demo_candidates:
             if self.verbose: print("No demo candidates provided. Running without task demos.")
@@ -339,6 +339,7 @@ class GroundedProposer(Proposer):
                         tip=selected_tip,
                     ),
                 )
+
         return proposed_instructions
 
     def propose_instruction_for_predictor(


### PR DESCRIPTION
This quick one-line fix switches a min to a max in the demo size check for MIPROv2.

This line is intended to ensure that at least one instruction is proposed, even if no demos are bootstrapped in MIPROv2. Instead, it caps the number of instructions proposed per module at one.