### PR TITLE
WIP feature(dspy): add the ability to pass feedback to mipro

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -111,6 +111,8 @@ class MIPROv2(Teleprompter):
         data_aware_proposer=True,
         view_data_batch_size=10,
         tip_aware_proposer=True,
+        feedback_aware_proposer=False,
+        feedback=None,
         fewshot_aware_proposer=True,
         requires_permission_to_run=True,
     ):
@@ -274,6 +276,8 @@ class MIPROv2(Teleprompter):
                 use_task_demos=fewshot_aware_proposer,
                 use_tip=tip_aware_proposer,
                 set_tip_randomly=tip_aware_proposer,
+                use_feedback=feedback_aware_proposer,
+                feedback=feedback,
                 use_instruct_history=False,
                 set_history_randomly=False,
                 verbose = self.verbose,


### PR DESCRIPTION
Add the ability to pass feedback to mipro for multi-step compilation when you take feedback from the user. For example, at Pretrain we take the user's feedback on the frontend after generation 1 and pass it to MIPRO during subsequence generations.