### PR TITLE
feat(dspy): extend incomplete generations

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,5 +1,84 @@
-class Adapter:
-    def __call__(self, lm, lm_kwargs, signature, demos, inputs, _parse_values=True):
+from abc import ABC, abstractmethod
+from copy import deepcopy
+
+
+def update_output_with_keys_from_input(signature, inputs, output):
+    for key in signature.output_fields:
+        if key not in output and key in inputs:
+            if inputs[key] is not None:
+                output[key] = inputs[key]
+    return output
+
+
+def extend_generation(func):
+    """
+    Generate output values which conform to the given signature - repeatedly calling
+    the language model until a complete value is generated or the maximum number of
+    calls is reached.
+
+    Args:
+        func: The function to decorate - should be the __call__ method of the Adapter class
+    """
+
+    def wrapper(self, lm, lm_kwargs, signature, demos, inputs, _parse_values=True, max_extensions=1):
+        incomplete_generations = [inputs]
+        inner_lm_kwargs = deepcopy(lm_kwargs)
+        values = []
+        for _ in range(max_extensions):
+            still_incomplete_generations = []
+            for input_ in incomplete_generations:
+                parsed_generations = func(
+                    self, lm, inner_lm_kwargs, signature, demos, input_, _parse_values=_parse_values
+                )
+                for value in parsed_generations:
+                    value = update_output_with_keys_from_input(signature, input_, value)
+                    if set(value.keys()) != set(signature.output_fields.keys()):
+                        still_incomplete_generations.append({**input_, **value})
+                    else:
+                        values.append(value)
+
+            if len(still_incomplete_generations) == 0:
+                return values
+            # Only generate one completion at a time when extending generations
+            inner_lm_kwargs["n"] = 1
+            incomplete_generations = still_incomplete_generations
+
+        raise ValueError(f"Failed to generate the signature's complete output after {max_extensions} retries.")
+
+    return wrapper
+
+
+class Adapter(ABC):
+    @abstractmethod
+    def format(self, signature, demos, inputs):
+        ...
+
+    @abstractmethod
+    def parse(self, signature, completion, _parse_values=True):
+        ...
+
+    @extend_generation
+    def __call__(self, lm, lm_kwargs, signature, demos, inputs, _parse_values=True, **_):
+        """
+        Generate output values which conform to the given signature - repeatedly calling
+        the language model until a complete value is generated or the maximum number of
+        extensions is reached.
+
+        Args:
+            lm: The language model to use for generation.
+            lm_kwargs (dict): Keyword arguments for the language model.
+            signature: The expected signature of the output.
+            demos (list): Demonstration examples.
+            inputs (dict): Input data for generation.
+            _parse_values (bool): Whether to parse the generated values.
+            extension (int): Current recursion depth.
+
+        Returns:
+            list: A list of complete output values.
+
+        Raises:
+            ValueError: If unable to generate complete values within max_extensions.
+        """
         inputs = self.format(signature, demos, inputs)
         inputs = dict(prompt=inputs) if isinstance(inputs, str) else dict(messages=inputs)
 
@@ -8,7 +87,6 @@ class Adapter:
 
         for output in outputs:
             value = self.parse(signature, output, _parse_values=_parse_values)
-            assert set(value.keys()) == set(signature.output_fields.keys()), f"Expected {signature.output_fields.keys()} but got {value.keys()}"
             values.append(value)
-        
+
         return values

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -62,9 +62,6 @@ class ChatAdapter(Adapter):
                         f"Error parsing field {k}: {e}.\n\n\t\tOn attempting to parse the value\n```\n{v}\n```"
                     )
 
-        if fields.keys() != signature.output_fields.keys():
-            raise ValueError(f"Expected {signature.output_fields.keys()} but got {fields.keys()}")
-
         return fields
 
 
@@ -137,7 +134,7 @@ def format_turn(signature, values, role, incomplete=False):
     if role == "user":
         content.append(
             "Respond with the corresponding output fields, starting with the field "
-            + ", then ".join(f"`{f}`" for f in signature.output_fields)
+            + ", then ".join(f"`{f}`" for f in signature.output_fields if f not in values)
             + ", and then ending with the marker for `completed`."
         )
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -114,7 +114,6 @@ class Predict(Module, Parameter):
             *_, last_key = self.extended_signature.fields.keys()
             self.extended_signature = self.extended_signature.with_updated_fields(last_key, prefix=prefix)
 
-
     def __call__(self, **kwargs):
         return self.forward(**kwargs)
 
@@ -148,15 +147,18 @@ class Predict(Module, Parameter):
             print(f"WARNING: Not all input fields were provided to module. Present: {present}. Missing: {missing}.")
 
         import dspy
+
         if isinstance(lm, dspy.LM):
             completions = v2_5_generate(lm, config, signature, demos, kwargs, _parse_values=self._parse_values)
         else:
-            warn_once("\t*** In DSPy 2.5, all LM clients except `dspy.LM` are deprecated. ***\n"
-                      f" \t\tYou are using the client {lm.__class__.__name__}, which will be removed in DSPy 2.6.\n"
-                      " \t\tChanging the client is straightforward and will let you use new features (Adapters) that"
-                      " improve the consistency of LM outputs, especially when using chat LMs. \n\n"
-                      " \t\tLearn more about the changes and how to migrate at\n"
-                      " \t\thttps://github.com/stanfordnlp/dspy/blob/main/examples/migration.ipynb")
+            warn_once(
+                "\t*** In DSPy 2.5, all LM clients except `dspy.LM` are deprecated. ***\n"
+                f" \t\tYou are using the client {lm.__class__.__name__}, which will be removed in DSPy 2.6.\n"
+                " \t\tChanging the client is straightforward and will let you use new features (Adapters) that"
+                " improve the consistency of LM outputs, especially when using chat LMs. \n\n"
+                " \t\tLearn more about the changes and how to migrate at\n"
+                " \t\thttps://github.com/stanfordnlp/dspy/blob/main/examples/migration.ipynb"
+            )
 
             if dsp.settings.experimental:
                 completions = new_generate(lm, signature, dsp.Example(demos=demos, **kwargs), **config)
@@ -179,7 +181,6 @@ class Predict(Module, Parameter):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.signature})"
-
 
 
 def old_generate(demos, signature, kwargs, config, lm, stage):
@@ -208,7 +209,7 @@ def old_generate(demos, signature, kwargs, config, lm, stage):
 
 
 def new_generate(lm, signature, example, max_depth=6, **kwargs):
-    kwargs['stop'] = tuple(kwargs.get('stop', [])) or ('\n---', )
+    kwargs["stop"] = tuple(kwargs.get("stop", [])) or ("\n---",)
 
     # Generate and extract the fields.
     template = signature_to_template(signature, adapter=dsp.ExperimentalAdapter)
@@ -223,22 +224,28 @@ def new_generate(lm, signature, example, max_depth=6, **kwargs):
     for field_idx, key in enumerate(field_names):
         completions_ = [c for c in completions if key in c.keys() and c[key] is not None]
         completions = completions_ or completions
-        if len(completions_) == 0: break
+        if len(completions_) == 0:
+            break
 
     # If none of the completions is completed (i.e., none has the final field set).
     if len(completions_) == 0:
         # Pick the first completion that has gone farthest.
         completion = completions[0]
 
-        for field_idx_ in range(field_idx+1, len(field_names)):
-            if field_names[field_idx_] in completion: del completion[field_names[field_idx_]]
+        for field_idx_ in range(field_idx + 1, len(field_names)):
+            if field_names[field_idx_] in completion:
+                del completion[field_names[field_idx_]]
 
         # Recurse with greedy decoding.
-        new_kwargs = {**kwargs, "n": 1, "temperature": 0.0,}
+        new_kwargs = {
+            **kwargs,
+            "n": 1,
+            "temperature": 0.0,
+        }
 
         assert max_depth > 0
-        return new_generate(lm, signature, completion, max_depth=max_depth-1, **new_kwargs)
-    
+        return new_generate(lm, signature, completion, max_depth=max_depth - 1, **new_kwargs)
+
     # Keep only output fields.
     completions = [{k: v for k, v in c.items() if k in signature.output_fields} for c in completions]
 
@@ -247,10 +254,17 @@ def new_generate(lm, signature, example, max_depth=6, **kwargs):
 
 def v2_5_generate(lm, lm_kwargs, signature, demos, inputs, _parse_values=True):
     import dspy
-    adapter = dspy.settings.adapter or dspy.ChatAdapter()
 
-    return adapter(lm, lm_kwargs=lm_kwargs, signature=signature, demos=demos, inputs=inputs, _parse_values=_parse_values)
-    
+    adapter = dspy.settings.adapter or dspy.ChatAdapter()
+    return adapter(
+        lm,
+        lm_kwargs=lm_kwargs,
+        signature=signature,
+        demos=demos,
+        inputs=inputs,
+        _parse_values=_parse_values,
+        max_extensions=dspy.settings.max_extensions or 1,
+    )
 
 
 # TODO: get some defaults during init from the context window?

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -25,7 +25,6 @@ def test_simple():
     dspy.settings.configure(lm=lm)
 
     question = hard_question(topic="Physics")
-    lm.inspect_history(n=2)
 
     assert question == expected
 
@@ -40,7 +39,6 @@ def test_list_output():
     dspy.settings.configure(lm=lm)
 
     question = hard_questions(topics=["Physics", "Music"])
-    lm.inspect_history(n=2)
 
     assert question == expected
 
@@ -221,7 +219,7 @@ def test_bootstrap_effectiveness():
     teacher = SimpleModule()
     assert student.output.predictor.signature.equals(teacher.output.predictor.signature)
 
-    lm = DummyLM(["blue", "Ring-ding-ding-ding-dingeringeding!"], follow_examples=True)
+    lm = DummyLM([], follow_examples=True)
     dspy.settings.configure(lm=lm, trace=[])
 
     bootstrap = BootstrapFewShot(metric=simple_metric, max_bootstrapped_demos=1, max_labeled_demos=1)
@@ -719,7 +717,6 @@ def test_annotated_validator():
     dspy.settings.configure(lm=lm)
 
     m = TypedPredictor(MySignature)(n=2).next_square
-    lm.inspect_history(n=2)
 
     assert m == 4
 
@@ -738,7 +735,6 @@ def test_annotated_validator_functional():
     dspy.settings.configure(lm=lm)
 
     m = next_square(n=2)
-    lm.inspect_history(n=2)
 
     assert m == 4
 

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1,7 +1,7 @@
 import copy
-import textwrap
 
 import pydantic
+import pytest
 import ujson
 
 import dspy
@@ -126,9 +126,11 @@ def test_typed_demos_after_dump_and_load_state():
     # Demos don't need to keep the same types after saving and loading the state.
     assert new_instance.demos[0]["input"] == original_instance.demos[0].input.model_dump_json()
 
+
 def test_signature_fields_after_dump_and_load_state(tmp_path):
     class CustomSignature(dspy.Signature):
         """I am just an instruction."""
+
         sentence = dspy.InputField(desc="I am an innocent input!")
         sentiment = dspy.OutputField()
 
@@ -138,6 +140,7 @@ def test_signature_fields_after_dump_and_load_state(tmp_path):
 
     class CustomSignature2(dspy.Signature):
         """I am not a pure instruction."""
+
         sentence = dspy.InputField(desc="I am a malicious input!")
         sentiment = dspy.OutputField(desc="I am a malicious output!", prefix="I am a prefix!")
 
@@ -218,3 +221,84 @@ def test_output_only():
     lm = DummyLM([{"output": "short answer"}])
     dspy.settings.configure(lm=lm)
     assert predictor().output == "short answer"
+
+
+@pytest.fixture(name="SandwichIdea")
+def sandwich_idea_signature():
+    class SandwichIdea(dspy.Signature):
+        """Based on the meal and dietary requirements, suggest a sandwich idea."""
+
+        meal: str = dspy.InputField()
+        dietary_requiements: str = dspy.InputField()
+        bread: str = dspy.OutputField()
+        protein: str = dspy.OutputField()
+        fat: str = dspy.OutputField()
+        garnish: str = dspy.OutputField()
+        sauce: str = dspy.OutputField()
+
+    return SandwichIdea
+
+
+def test_max_extension_1_no_extension(SandwichIdea):
+    lm = DummyLM(
+        [
+            {"bread": "whole wheat", "protein": "turkey", "fat": "avocado"},
+            {"garnish": "tomato", "sauce": "mustard"},
+        ]
+    )
+    dspy.settings.configure(lm=lm, max_extensions=1)
+
+    with pytest.raises(ValueError):
+        Predict(SandwichIdea)(meal="lunch", dietary_requiements="N/A")
+
+
+def test_extend_generation(SandwichIdea):
+    lm = DummyLM(
+        [
+            {"bread": "whole wheat", "protein": "turkey", "fat": "avocado"},
+            {"garnish": "tomato", "sauce": "mustard"},
+        ]
+    )
+    dspy.settings.configure(lm=lm, max_extensions=2)
+
+    prediction = Predict(SandwichIdea)(meal="lunch", dietary_requiements="N/A")
+
+    assert prediction.bread == "whole wheat"
+    assert prediction.protein == "turkey"
+    assert prediction.fat == "avocado"
+    assert prediction.garnish == "tomato"
+    assert prediction.sauce == "mustard"
+
+
+def test_extend_generation_handles_skipped_field(SandwichIdea):
+    lm = DummyLM(
+        [
+            {"bread": "white", "fat": "butter"},
+            {"protein": "ham", "garnish": "tomato", "sauce": "mayo"},
+        ]
+    )
+    dspy.settings.configure(lm=lm, max_extensions=2)
+
+    predictor = Predict(SandwichIdea)(meal="lunch", dietary_requiements="N/A")
+    assert predictor.bread == "white"
+    assert predictor.protein == "ham"
+    assert predictor.fat == "butter"
+    assert predictor.garnish == "tomato"
+    assert predictor.sauce == "mayo"
+
+
+def test_extend_generation_with_empty_field(SandwichIdea):
+    lm = DummyLM(
+        [
+            {"bread": "white", "fat": ""},
+            {"protein": "ham", "garnish": "tomato", "sauce": "mayo"},
+        ]
+    )
+    dspy.settings.configure(lm=lm, max_extensions=2)
+
+    predictor = Predict(SandwichIdea)(meal="lunch", dietary_requiements="N/A")
+    assert predictor.bread == "white"
+    assert predictor.protein == "ham"
+    assert predictor.fat == ""
+    assert predictor.garnish == "tomato"
+    assert predictor.sauce == "mayo"


### PR DESCRIPTION
If the output parsed by `ChatAdapter.parse` does not include all the fields required by the signature, the lm will be called again up to `max_extensions` times, with the thus-far completed output added to the input fields for the next generation.

Logic is wrapped up as a decorator to allow the logic to be reused by future `Adaper`s.

Added tests for extended generation.

`max_extensions` defaults to 1 to maintain current behaviour.
