### PR TITLE
MIPRO Bootstrap + Evaluation Parallelism

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -1,10 +1,11 @@
 import contextlib
-import signal
 import sys
 import threading
 import traceback
 import types
 from typing import Any
+from joblib import Parallel, delayed
+import contextvars
 
 import pandas as pd
 import tqdm
@@ -94,45 +95,61 @@ class Evaluate:
         reordered_devset = []
         job_cancelled = "cancelled"
 
-        # context manger to handle sigint
-        @contextlib.contextmanager
-        def interrupt_handler_manager():
-            """Sets the cancel_jobs event when a SIGINT is received."""
-            default_handler = signal.getsignal(signal.SIGINT)
-
-            def interrupt_handler(sig, frame):
-                self.cancel_jobs.set()
-                dspy.logger.warning("Received SIGINT. Cancelling evaluation.")
-                default_handler(sig, frame)
-
-            signal.signal(signal.SIGINT, interrupt_handler)
-            yield
-            # reset to the default handler
-            signal.signal(signal.SIGINT, default_handler)
-
         def cancellable_wrapped_program(idx, arg):
             # If the cancel_jobs event is set, return the cancelled_job literal
             if self.cancel_jobs.is_set():
                 return None, None, job_cancelled, None
             return wrapped_program(idx, arg)
 
-        with ThreadPoolExecutor(max_workers=num_threads) as executor, interrupt_handler_manager():
-            futures = {executor.submit(cancellable_wrapped_program, idx, arg) for idx, arg in devset}
-            pbar = tqdm.tqdm(total=len(devset), dynamic_ncols=True, disable=not display_progress)
+        try:
+            with ThreadPoolExecutor(max_workers=num_threads) as executor:
+                futures = {executor.submit(cancellable_wrapped_program, idx, arg) for idx, arg in devset}
+                pbar = tqdm.tqdm(total=len(devset), dynamic_ncols=True, disable=not display_progress, file=sys.stdout)
 
-            for future in as_completed(futures):
-                example_idx, example, prediction, score = future.result()
+                for future in as_completed(futures):
+                    if self.cancel_jobs.is_set():
+                        break  # Exit the loop if jobs are cancelled
+                    try:
+                        example_idx, example, prediction, score = future.result()
+                    except KeyboardInterrupt:
+                        self.cancel_jobs.set()
+                        dspy.logger.warning("Received KeyboardInterrupt. Cancelling evaluation.")
+                        # Optionally cancel remaining futures
+                        for f in futures:
+                            f.cancel()
+                        break
+                    except Exception as e:
+                        # Handle exceptions in worker threads
+                        with self.error_lock:
+                            self.error_count += 1
+                            current_error_count = self.error_count
+                        if current_error_count >= self.max_errors:
+                            raise e
+                        if self.provide_traceback:
+                            dspy.logger.error(
+                                f"Error for example in dev set: \t\t {e}\n\twith inputs:\n\t\t{arg}\n\nStack trace:\n\t{traceback.format_exc()}"
+                            )
+                        else:
+                            dspy.logger.error(
+                                f"Error for example in dev set: \t\t {e}. Set `provide_traceback=True` to see the stack trace."
+                            )
+                        continue  # Skip this future and continue
 
-                # use the cancelled_job literal to check if the job was cancelled - use "is" not "=="
-                # in case the prediction is "cancelled" for some reason.
-                if prediction is job_cancelled:
-                    continue
+                    if prediction is job_cancelled:
+                        continue
 
-                reordered_devset.append((example_idx, example, prediction, score))
-                ncorrect += score
-                ntotal += 1
-                self._update_progress(pbar, ncorrect, ntotal)
-            pbar.close()
+                    reordered_devset.append((example_idx, example, prediction, score))
+                    ncorrect += score
+                    ntotal += 1
+                    self._update_progress(pbar, ncorrect, ntotal)
+                pbar.close()
+        except KeyboardInterrupt:
+            self.cancel_jobs.set()
+            dspy.logger.warning("Received KeyboardInterrupt. Cancelling evaluation.")
+            # Optionally cancel remaining futures
+            for f in futures:
+                f.cancel()
+            raise
 
         if self.cancel_jobs.is_set():
             dspy.logger.warning("Evaluation was cancelled. The results may be incomplete.")
@@ -164,21 +181,22 @@ class Evaluate:
         return_outputs = return_outputs if return_outputs is not None else self.return_outputs
         results = []
 
+        # Initialize context variable for the stack
+        stack_var = contextvars.ContextVar('stack', default=dspy.settings.main_stack)
+
         def wrapped_program(example_idx, example):
-            # NOTE: TODO: Won't work if threads create threads!
-            thread_stacks = dspy.settings.stack_by_thread
-            creating_new_thread = threading.get_ident() not in thread_stacks
-            if creating_new_thread:
-                thread_stacks[threading.get_ident()] = list(dspy.settings.main_stack)
+            # Use the context variable to manage the stack
+            stack = stack_var.get()
+            # No need to check for thread identity or manually manage stacks
 
             try:
-                prediction = program(**example.inputs())
-                score = metric(
-                    example,
-                    prediction,
-                )  # FIXME: TODO: What's the right order? Maybe force name-based kwargs!
+                # Set the context variable for the current thread
+                token = stack_var.set(list(stack))  # Copy the current stack
 
-                # increment assert and suggest failures to program's attributes
+                prediction = program(**example.inputs())
+                score = metric(example, prediction)
+
+                # Increment assert and suggest failures to program's attributes
                 if hasattr(program, "_assert_failures"):
                     program._assert_failures += dspy.settings.get("assert_failures")
                 if hasattr(program, "_suggest_failures"):
@@ -191,16 +209,20 @@ class Evaluate:
                     current_error_count = self.error_count
                 if current_error_count >= self.max_errors:
                     raise e
-                
+
                 if self.provide_traceback:
-                    dspy.logger.error(f"Error for example in dev set: \t\t {e}\n\twith inputs:\n\t\t{example.inputs()}\n\nStack trace:\n\t{traceback.format_exc()}")
+                    dspy.logger.error(
+                        f"Error for example in dev set: \t\t {e}\n\twith inputs:\n\t\t{example.inputs()}\n\nStack trace:\n\t{traceback.format_exc()}"
+                    )
                 else:
-                    dspy.logger.error(f"Error for example in dev set: \t\t {e}. Set `provide_traceback=True` to see the stack trace.")
-                
+                    dspy.logger.error(
+                        f"Error for example in dev set: \t\t {e}. Set `provide_traceback=True` to see the stack trace."
+                    )
+
                 return example_idx, example, {}, 0.0
             finally:
-                if creating_new_thread:
-                    del thread_stacks[threading.get_ident()]
+                # Reset the context variable to the previous state
+                stack_var.reset(token)
 
         devset = list(enumerate(devset))
         tqdm.tqdm._instances.clear()

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -60,6 +60,7 @@ class MIPROv2(Teleprompter):
         track_stats: bool = True,
         log_dir: Optional[str] = None,
         metric_threshold: Optional[float] = None,
+        parallel_bootstrapping: bool = False,
     ):
         # Validate 'auto' parameter
         allowed_modes = {None, "light", "medium", "heavy"}
@@ -87,6 +88,7 @@ class MIPROv2(Teleprompter):
         self.metric_threshold = metric_threshold
         self.seed = seed
         self.rng = None
+        self.parallel_bootstrapping = parallel_bootstrapping
 
     def compile(
         self,
@@ -400,7 +402,7 @@ class MIPROv2(Teleprompter):
                 teacher_settings=self.teacher_settings,
                 seed=seed,
                 metric_threshold=self.metric_threshold,
-                rng=self.rng,
+                parallel_bootstrapping=self.parallel_bootstrapping,
             )
         except Exception as e:
             print(f"Error generating few-shot examples: {e}")

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -6,6 +6,7 @@ import random
 import shutil
 import sys
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import numpy as np
 
 try:
@@ -282,32 +283,32 @@ def create_n_fewshot_demo_sets(
     teacher=None,
     include_non_bootstrapped=True,
     seed=0,
-    rng=None
+    parallel_bootstrapping=False,
 ):
     """
-    This function is copied from random_search.py, and creates fewshot examples in the same way that random search does.
-    This allows us to take advantage of using the same fewshot examples when we use the same random seed in our optimizers.
+    This function creates few-shot examples in the same way that random search does.
+    If parallel_bootstrapping is True, it parallelizes the bootstrapping process over the seeds.
     """
     demo_candidates = {}
 
-    # Account for confusing way this is set up, where we add in 3 more candidate sets to the N specified
-    num_candidate_sets -= 3
+    # Account for the way this is set up, where we add in 3 more candidate sets to the N specified
+    total_candidate_sets = num_candidate_sets + 3
 
     # Initialize demo_candidates dictionary
     for i, _ in enumerate(student.predictors()):
         demo_candidates[i] = []
 
-    rng = rng or random.Random(seed)
+    # Prepare the list of seeds
+    seeds = list(range(-3, num_candidate_sets))
 
-    # Go through and create each candidate set
-    for seed in range(-3, num_candidate_sets):
+    # Define the function to create a candidate set for a given seed
+    def create_candidate(seed):
+        trainset_copy = list(trainset)  # Copy of trainset
 
-        print(f"Bootstrapping set {seed+4}/{num_candidate_sets+3}")
-
-        trainset_copy = list(trainset)
+        print(f"Bootstrapping set {seed + 4}/{total_candidate_sets}")
 
         if seed == -3 and include_non_bootstrapped:
-            # zero-shot
+            # Zero-shot
             program2 = student.reset_copy()
 
         elif (
@@ -315,14 +316,14 @@ def create_n_fewshot_demo_sets(
             and max_labeled_demos > 0
             and include_non_bootstrapped
         ):
-            # labels only
+            # Labels only
             teleprompter = LabeledFewShot(k=max_labeled_demos)
             program2 = teleprompter.compile(
                 student, trainset=trainset_copy, sample=labeled_sample,
             )
 
         elif seed == -1:
-            # unshuffled few-shot
+            # Unshuffled few-shot
             program = BootstrapFewShot(
                 metric=metric,
                 max_errors=max_errors,
@@ -334,9 +335,9 @@ def create_n_fewshot_demo_sets(
             program2 = program.compile(student, teacher=teacher, trainset=trainset_copy)
 
         else:
-            # shuffled few-shot
-            rng.shuffle(trainset_copy)
-            size = rng.randint(min_num_samples, max_bootstrapped_demos)
+            # Shuffled few-shot
+            random.Random(seed).shuffle(trainset_copy)
+            size = random.Random(seed).randint(min_num_samples, max_bootstrapped_demos)
 
             teleprompter = BootstrapFewShot(
                 metric=metric,
@@ -352,8 +353,44 @@ def create_n_fewshot_demo_sets(
                 student, teacher=teacher, trainset=trainset_copy,
             )
 
+        # Collect the demos for each predictor
+        predictor_demos = {}
         for i, _ in enumerate(student.predictors()):
-            demo_candidates[i].append(program2.predictors()[i].demos)
+            predictor_demos[i] = program2.predictors()[i].demos
+
+        return seed, predictor_demos
+
+    if parallel_bootstrapping:
+        # Use ThreadPoolExecutor to parallelize the creation of candidate sets
+        num_threads = total_candidate_sets  # As per your request
+
+        # Dictionary to store the results in order
+        seed_to_result = {}
+
+        with ThreadPoolExecutor(max_workers=num_threads) as executor:
+            future_to_seed = {executor.submit(create_candidate, s): s for s in seeds}
+            for future in as_completed(future_to_seed):
+                seed = future_to_seed[future]
+                try:
+                    seed_result, predictor_demos = future.result()
+                    seed_to_result[seed] = predictor_demos
+                except Exception as e:
+                    print(f"Error creating candidate set for seed {seed}: {e}")
+                    # Handle exceptions as needed
+
+        # After all threads have completed, collect the results in order
+        for seed in sorted(seed_to_result.keys()):
+            predictor_demos = seed_to_result[seed]
+            for i in demo_candidates:
+                demo_candidates[i].append(predictor_demos[i])
+
+    else:
+        # Sequential execution
+        for seed in seeds:
+            seed_result, predictor_demos = create_candidate(seed)
+            # Append the demos to demo_candidates
+            for i in demo_candidates:
+                demo_candidates[i].append(predictor_demos[i])
 
     return demo_candidates
 


### PR DESCRIPTION
This PR includes two main updates:

1. Enables nested parallelism in Evaluate.  Before the way that signal handling for user terminations was incompatible with nested threading.  If a user program used multi-threading (for instance calling BootstrapFewshotWithRandomSearch as a meta-optimization within a program they were evaluating or optimizing) then Evaluate would throw an exception.  This nested multithreading now works.
2. MIPRO bootstraps in parallel.  Theoretically this change can be applied to BootstrapFewshotWithRandomSearch as well.  Now all runs of the program to bootstrap the fewshot demonstrations occur at the same time.  This is only enabled by setting `bootstrap_parallel=True` in the MIPROv2 class (which is False by default).  The main TODO is to fix printing on this, because currently all the evaluation bars print simultaneously and make for a bit of an ugly printout.

I would appreciate a more thorough review of this PR since it touches functionality outside of my area of expertise (by modifying Evaluate), and because I am a relative novice when it comes to multithreading in python.