### PR TITLE
Fix the package version and name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 #replace_package_name_marker
-name="dspy-ai"
+name="dspy"
 #replace_package_version_marker
-version="2.5.8"
+version="2.5.12"
 description = "DSPy"
 readme = "README.md"
 authors = [{ name = "Omar Khattab", email = "okhattab@stanford.edu" }]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     #replace_package_name_marker
     name="dspy",
     #replace_package_version_marker
-    version="2.5.8", 	
+    version="2.5.12", 	
     description="DSPy",	
     long_description=long_description,	
     long_description_content_type="text/markdown",	


### PR DESCRIPTION
The version in pyproject.toml and setup.py are wrong, we should use `2.5.13.dev0` for now. Basically we should write it as the next minor release + `.dev0`, which is a standard way (not officially documented though).
