### PR TITLE
Fix the saving of TypePredictor

### DIFF
--- a/dspy/functional/functional.py
+++ b/dspy/functional/functional.py
@@ -98,11 +98,19 @@ class TypedPredictor(dspy.Module):
             explain_errors: If True, the model will try to explain the errors it encounters.
         """
         super().__init__()
-        self.signature = ensure_signature(signature, instructions)
+        signature = ensure_signature(signature, instructions)
         self.predictor = dspy.Predict(signature, _parse_values=False)
         self.max_retries = max_retries
         self.wrap_json = wrap_json
         self.explain_errors = explain_errors
+
+    @property
+    def signature(self) -> dspy.Signature:
+        return self.predictor.signature
+
+    @signature.setter
+    def signature(self, value: dspy.Signature):
+        self.predictor.signature = value
 
     def copy(self) -> "TypedPredictor":
         return TypedPredictor(

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -822,3 +822,23 @@ def test_model_validator():
 
     pred = predictor(input_data="What is the best animal?", allowed_categories=["cat", "dog"])
     assert pred.category == "dog"
+
+def test_save_type_predictor(tmp_path):
+    class MySignature(dspy.Signature):
+        """I am a benigh signature."""
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    class CustomModel(dspy.Module):
+        def __init__(self):
+            self.predictor = dspy.TypedPredictor(MySignature)
+
+    save_path = tmp_path / "state.json"
+    model = CustomModel()
+    model.predictor.signature = MySignature.with_instructions("I am a malicious signature.")
+    model.save(save_path)
+
+    loaded = CustomModel()
+    assert loaded.predictor.signature.instructions == "I am a benigh signature."
+    loaded.load(save_path)
+    assert loaded.predictor.signature.instructions == "I am a malicious signature."


### PR DESCRIPTION
resolve #1644 

We don't need a standalone signature attribute in `TypePredictor`, because it's never actually used. We keep the `self.signature` to be valid for backward compatibility