### PR TITLE
Add URL redirects for legacy /docs/* paths

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -134,11 +134,7 @@ plugins:
         'docs/tutorials/summarization.md': 'tutorials/summarization.md'
         'docs/tutorials/other_tutorial.md': 'tutorials/other_tutorial.md'
         'docs/tutorials/examples.md': 'tutorials/examples.md'
-        # Adding redirects for other potential docs paths
-        'docs/quick-start/installation.md': 'quick-start/installation.md'
-        'docs/quick-start/getting-started-01.md': 'quick-start/getting-started-01.md'
-        'docs/quick-start/getting-started-02.md': 'quick-start/getting-started-02.md'
-        'docs/building-blocks/solving_your_task.md': 'building-blocks/solving_your_task.md'
+        
 
 extra:
   social:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -129,6 +129,17 @@ plugins:
   - redirects:
       redirect_maps:
         'index.md': 'intro.md'
+        'docs/tutorials/rag.md': 'tutorials/rag.md'
+        'docs/tutorials/simplified-baleen.md': 'tutorials/simplified-baleen.md'
+        'docs/tutorials/summarization.md': 'tutorials/summarization.md'
+        'docs/tutorials/other_tutorial.md': 'tutorials/other_tutorial.md'
+        'docs/tutorials/examples.md': 'tutorials/examples.md'
+        # Adding redirects for other potential docs paths
+        'docs/quick-start/installation.md': 'quick-start/installation.md'
+        'docs/quick-start/getting-started-01.md': 'quick-start/getting-started-01.md'
+        'docs/quick-start/getting-started-02.md': 'quick-start/getting-started-02.md'
+        'docs/building-blocks/solving_your_task.md': 'building-blocks/solving_your_task.md'
+
 extra:
   social:
     - icon: fontawesome/brands/github


### PR DESCRIPTION
## Description
Added URL redirects to handle the legacy paths starting with `/docs/*` that were causing 404 errors for users. This fixes the broken links issue where users were trying to access URLs like `docs/tutorials/rag` instead of `tutorials/rag`.

## Changes
- Added mkdocs-redirects plugin configuration to handle legacy URL patterns
- Implemented redirects for all tutorial pages:
  - `/docs/tutorials/rag` → `/tutorials/rag`
  - `/docs/tutorials/simplified-baleen` → `/tutorials/simplified-baleen`
  - `/docs/tutorials/summarization` → `/tutorials/summarization`
  - `/docs/tutorials/other_tutorial` → `/tutorials/other_tutorial`
  - `/docs/tutorials/examples` → `/tutorials/examples`

## Testing
- Verified redirects work locally using `mkdocs serve`
- Tested accessing old URLs to confirm proper redirection
- Ensured existing URLs continue to work as expected

## Dependencies
- Requires `mkdocs-redirects` plugin: `pip install mkdocs-redirects`


<img width="905" alt="Screenshot 2024-10-23 at 8 39 19 PM" src="https://github.com/user-attachments/assets/0432c3c2-d1ac-455b-9876-f2d82baca328">
