### PR TITLE
Add comprehensive URL redirects for legacy /docs/* paths

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -155,15 +155,11 @@ plugins:
 
         # Tutorial redirects
         'docs/tutorials/rag.md': 'tutorials/rag.md'
-        'docs/tutorials/rag/index.md': 'tutorials/rag.md'
         'docs/tutorials/simplified-baleen.md': 'tutorials/simplified-baleen.md'
-        'docs/tutorials/simplified-baleen/index.md': 'tutorials/simplified-baleen.md'
         'docs/tutorials/summarization.md': 'tutorials/summarization.md'
-        'docs/tutorials/summarization/index.md': 'tutorials/summarization.md'
         'docs/tutorials/other_tutorial.md': 'tutorials/other_tutorial.md'
-        'docs/tutorials/other_tutorial/index.md': 'tutorials/other_tutorial.md'
         'docs/tutorials/examples.md': 'tutorials/examples.md'
-        'docs/tutorials/examples/index.md': 'tutorials/examples.md'
+
 
 extra:
   social:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -128,13 +128,42 @@ plugins:
   - mkdocs-jupyter
   - redirects:
       redirect_maps:
+        # Main redirects
         'index.md': 'intro.md'
-        'docs/tutorials/rag.md': 'tutorials/rag.md'
-        'docs/tutorials/simplified-baleen.md': 'tutorials/simplified-baleen.md'
-        'docs/tutorials/summarization.md': 'tutorials/summarization.md'
-        'docs/tutorials/other_tutorial.md': 'tutorials/other_tutorial.md'
-        'docs/tutorials/examples.md': 'tutorials/examples.md'
+        'docs/intro/index.md': 'intro.md'
+        'docs/intro.md': 'intro.md'
+        'docs/faqs/index.md': 'faqs.md'
+        'docs/faqs.md': 'faqs.md'
+        'docs/cheatsheet/index.md': 'cheatsheet.md'
+        'docs/cheatsheet.md': 'cheatsheet.md'
+        'docs/dspy-usecases/index.md': 'dspy-usecases.md'
+        'docs/dspy-usecases.md': 'dspy-usecases.md'
         
+        # Quick Start redirects
+        'docs/quick-start/installation/index.md': 'quick-start/installation.md'
+        'docs/quick-start/installation.md': 'quick-start/installation.md'
+        'docs/quick-start/getting-started-01/index.md': 'quick-start/getting-started-01.md'
+        'docs/quick-start/getting-started-01.md': 'quick-start/getting-started-01.md'
+        'docs/quick-start/getting-started-02/index.md': 'quick-start/getting-started-02.md'
+        'docs/quick-start/getting-started-02.md': 'quick-start/getting-started-02.md'
+
+        # Deep Dive redirects
+        'docs/deep-dive/data-handling/examples/index.md': 'deep-dive/data-handling/examples.md'
+        'docs/deep-dive/data-handling/examples.md': 'deep-dive/data-handling/examples.md'
+        'docs/deep-dive/data-handling/built-in-datasets.md': 'deep-dive/data-handling/built-in-datasets.md'
+        'docs/deep-dive/data-handling/loading-custom-data.md': 'deep-dive/data-handling/loading-custom-data.md'
+
+        # Tutorial redirects
+        'docs/tutorials/rag.md': 'tutorials/rag.md'
+        'docs/tutorials/rag/index.md': 'tutorials/rag.md'
+        'docs/tutorials/simplified-baleen.md': 'tutorials/simplified-baleen.md'
+        'docs/tutorials/simplified-baleen/index.md': 'tutorials/simplified-baleen.md'
+        'docs/tutorials/summarization.md': 'tutorials/summarization.md'
+        'docs/tutorials/summarization/index.md': 'tutorials/summarization.md'
+        'docs/tutorials/other_tutorial.md': 'tutorials/other_tutorial.md'
+        'docs/tutorials/other_tutorial/index.md': 'tutorials/other_tutorial.md'
+        'docs/tutorials/examples.md': 'tutorials/examples.md'
+        'docs/tutorials/examples/index.md': 'tutorials/examples.md'
 
 extra:
   social:


### PR DESCRIPTION

<img width="1145" alt="Screenshot 2024-10-23 at 11 34 13 PM" src="https://github.com/user-attachments/assets/62e6f15d-1396-4734-ad37-48c41c0b1ce3">


## Description
Added comprehensive URL redirects to handle legacy paths that were causing 404 errors for users. This change ensures users accessing documentation through old URLs like `/docs/tutorials/rag` or `/docs/intro` are properly redirected to the new paths.

## Key Changes

### Added redirects for main sections:
- `/docs/intro/*` → `/intro`
- `/docs/faqs/*` → `/faqs`
- `/docs/cheatsheet/*` → `/cheatsheet`
- `/docs/dspy-usecases/*` → `/dspy-usecases`

### Added redirects for Quick Start:
- `/docs/quick-start/installation/*` → `/quick-start/installation`
- `/docs/quick-start/getting-started-01/*` → `/quick-start/getting-started-01`
- `/docs/quick-start/getting-started-02/*` → `/quick-start/getting-started-02`

### Added redirects for Deep Dive:
- `/docs/deep-dive/data-handling/examples/*` → `/deep-dive/data-handling/examples`
- Plus other deep-dive section redirects

### Added redirects for Tutorials:
- `/docs/tutorials/rag/*` → `/tutorials/rag`
- `/docs/tutorials/simplified-baleen/*` → `/tutorials/simplified-baleen`
- `/docs/tutorials/summarization/*` → `/tutorials/summarization`
- `/docs/tutorials/other_tutorial/*` → `/tutorials/other_tutorial`
- `/docs/tutorials/examples/*` → `/tutorials/examples`

## Implementation Details
- Used mkdocs-redirects plugin for handling redirects
- Added both `/index.md` and direct `.md` variants for each path
- Organized redirects by sections for better maintainability
- Maintained all existing configuration while adding new redirects

## Testing Done
- Verified all redirects work locally using `mkdocs serve`
- Tested specific URLs:
 - https://dspy-docs.vercel.app/intro/
 - https://dspy-docs.vercel.app/quick-start/installation/
 - https://dspy-docs.vercel.app/deep-dive/data-handling/examples/
 - https://dspy-docs.vercel.app/faqs/
 - https://dspy-docs.vercel.app/cheatsheet/
 - https://dspy-docs.vercel.app/dspy-usecases/

## Setup Required
```bash
pip install mkdocs-redirects