### PR TITLE
Fix error in Evaluate with display_table=True with outputs that cannot be converted to dict

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -227,7 +227,11 @@ class Evaluate:
             results = [(example, prediction, score) for _, example, prediction, score in predicted_devset]
 
         data = [
-            dict(example) | {"prediction": prediction, "correct": score}
+            (
+                merge_dicts(example, prediction) | {"correct": score}
+                if isinstance(prediction, dict)
+                else dict(example) | {"prediction": prediction, "correct": score}
+            )
             for _, example, prediction, score in predicted_devset
         ]
 
@@ -274,6 +278,23 @@ class Evaluate:
             return round(100 * ncorrect / ntotal, 2), results
 
         return round(100 * ncorrect / ntotal, 2)
+
+
+def merge_dicts(d1, d2) -> dict:
+    merged = {}
+    for k, v in d1.items():
+        if k in d2:
+            merged[f"example_{k}"] = v
+        else:
+            merged[k] = v
+
+    for k, v in d2.items():
+        if k in d1:
+            merged[f"pred_{k}"] = v
+        else:
+            merged[k] = v
+
+    return merged
 
 
 def truncate_cell(content) -> str:

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -227,7 +227,8 @@ class Evaluate:
             results = [(example, prediction, score) for _, example, prediction, score in predicted_devset]
 
         data = [
-            merge_dicts(example, prediction) | {"correct": score} for _, example, prediction, score in predicted_devset
+            dict(example) | {"prediction": prediction, "correct": score}
+            for _, example, prediction, score in predicted_devset
         ]
 
         result_df = pd.DataFrame(data)
@@ -273,23 +274,6 @@ class Evaluate:
             return round(100 * ncorrect / ntotal, 2), results
 
         return round(100 * ncorrect / ntotal, 2)
-
-
-def merge_dicts(d1, d2) -> dict:
-    merged = {}
-    for k, v in d1.items():
-        if k in d2:
-            merged[f"example_{k}"] = v
-        else:
-            merged[k] = v
-
-    for k, v in d2.items():
-        if k in d1:
-            merged[f"pred_{k}"] = v
-        else:
-            merged[k] = v
-
-    return merged
 
 
 def truncate_cell(content) -> str:

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -226,10 +226,17 @@ class Evaluate:
         if return_outputs:  # Handle the return_outputs logic
             results = [(example, prediction, score) for _, example, prediction, score in predicted_devset]
 
+        def prediction_is_dictlike(prediction):
+            try:
+                dict(prediction)
+                return True
+            except Exception:
+                return False
+
         data = [
             (
                 merge_dicts(example, prediction) | {"correct": score}
-                if isinstance(prediction, dict)
+                if prediction_is_dictlike(prediction)
                 else dict(example) | {"prediction": prediction, "correct": score}
             )
             for _, example, prediction, score in predicted_devset

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -124,6 +124,7 @@ def test_evaluate_call_bad():
 @pytest.mark.parametrize(
     "program_with_example",
     [
+        (Predict("question -> answer"), new_example("What is 1+1?", "2")),
         (
             # Create a program that extracts entities from text and returns them as a list,
             # rather than returning a Predictor() wrapper. This is done intentionally to test

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -125,6 +125,10 @@ def test_evaluate_call_bad():
     "program_with_example",
     [
         (
+            # Create a program that extracts entities from text and returns them as a list,
+            # rather than returning a Predictor() wrapper. This is done intentionally to test
+            # the case where the program does not output a dictionary-like object because
+            # Evaluate() has failed for this case in the past
             lambda text: TypedPredictor("text: str -> entities: List[str]")(text=text).entities,
             dspy.Example(text="United States", entities=["United States"]).with_inputs("text"),
         ),

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -120,13 +120,22 @@ def test_evaluate_call_bad():
     assert score == 0.0
 
 
+@pytest.mark.parametrize(
+    "program_with_example",
+    [
+        (Predict("question -> answer"), new_example("What is 1+1?", "2")),
+        (
+            Predict("text -> entities"),
+            dspy.Example(text="United States", entities=["United States"]).with_inputs("text"),
+        ),
+    ],
+)
 @pytest.mark.parametrize("display_table", [True, False, 1])
 @pytest.mark.parametrize("is_in_ipython_notebook_environment", [True, False])
-def test_evaluate_display_table(display_table, is_in_ipython_notebook_environment, capfd):
-    devset = [new_example("What is 1+1?", "2")]
-    program = Predict("question -> answer")
+def test_evaluate_display_table(program_with_example, display_table, is_in_ipython_notebook_environment, capfd):
+    program, example = program_with_example
     ev = Evaluate(
-        devset=devset,
+        devset=[example],
         metric=answer_exact_match,
         display_table=display_table,
     )
@@ -140,4 +149,5 @@ def test_evaluate_display_table(display_table, is_in_ipython_notebook_environmen
         if not is_in_ipython_notebook_environment and display_table:
             # In console environments where IPython is not available, the table should be printed
             # to the console
-            assert "What is 1+1?" in out
+            example_input = next(iter(example.inputs().values()))
+            assert example_input in out


### PR DESCRIPTION
If I write a DSPy module that returns an object that is not coercable to `dict`, I cannot currently call `Evaluate()` on the module with `display_table=True` because `display_table()` assumes that all outputs are dictionaries. This PR fixes the issue and adds a test.