### PR TITLE
added the changes for missing assertion.md file in the modules

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,7 +43,7 @@ nav:
       - ReAct: deep-dive/modules/react.md
       - MultiChainComparison: deep-dive/modules/multi-chain-comparison.md
       - ProgramOfThought: deep-dive/modules/program-of-thought.md
-      - Assertions: deep-dive/modules/assertions.md
+      # - Assertions: deep-dive/modules/assertions.md
       - Retreive: deep-dive/modules/retrieve.md
       - Modules Guide: deep-dive/modules/guide.md
     - Optimizers (formerly Teleprompters):


### PR DESCRIPTION
The assertions.md from the https://dspy-docs.vercel.app/deep-dive/modules/assertions.md

is removed and giving the 404 error..fix for that