### PR TITLE
Some minor fixes to the newly introduced callback

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -1,23 +1,22 @@
-from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 import functools
 import os
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-import ujson
-import uuid
 
-from dspy.utils.logging import logger
-from dspy.clients.finetune import FinetuneJob, TrainingMethod
-from dspy.clients.lm_finetune_utils import (
-    get_provider_finetune_job_class,
-    execute_finetune_job,
-)
-
-from dspy.utils.callback import with_callbacks
 import litellm
+import ujson
 from litellm.caching import Cache
 
+from dspy.clients.finetune import FinetuneJob, TrainingMethod
+from dspy.clients.lm_finetune_utils import (
+    execute_finetune_job,
+    get_provider_finetune_job_class,
+)
+from dspy.utils.callback import with_callbacks
+from dspy.utils.logging import logger
 
 DISK_CACHE_DIR = os.environ.get("DSPY_CACHEDIR") or os.path.join(Path.home(), ".dspy_cache")
 litellm.cache = Cache(disk_cache_dir=DISK_CACHE_DIR, type="disk")

--- a/dspy/utils/__init__.py
+++ b/dspy/utils/__init__.py
@@ -1,3 +1,3 @@
-from .callback import *
-from .dummies import *
-from .logging import *
+from dspy.utils.callback import BaseCallback, with_callbacks
+from dspy.utils.dummies import *
+from dspy.utils.logging import *

--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -18,6 +18,8 @@ def reset_settings():
 
 
 class MyCallback(BaseCallback):
+    """A simple callback that records the calls."""
+
     def __init__(self):
         self.calls = []
 
@@ -33,17 +35,17 @@ class MyCallback(BaseCallback):
     def on_lm_end(self, call_id, outputs, exception):
         self.calls.append({"handler": "on_lm_end", "outputs": outputs, "exception": exception})
 
-    def on_format_start(self, call_id, instance, inputs):
-        self.calls.append({"handler": "on_format_start", "instance": instance, "inputs": inputs})
+    def on_adapter_format_start(self, call_id, instance, inputs):
+        self.calls.append({"handler": "on_adapter_format_start", "instance": instance, "inputs": inputs})
 
-    def on_format_end(self, call_id, outputs, exception):
-        self.calls.append({"handler": "on_format_end", "outputs": outputs, "exception": exception})
+    def on_adapter_format_end(self, call_id, outputs, exception):
+        self.calls.append({"handler": "on_adapter_format_end", "outputs": outputs, "exception": exception})
 
-    def on_parse_start(self, call_id, instance, inputs):
-        self.calls.append({"handler": "on_parse_start", "instance": instance, "inputs": inputs})
+    def on_adapter_parse_start(self, call_id, instance, inputs):
+        self.calls.append({"handler": "on_adapter_parse_start", "instance": instance, "inputs": inputs})
 
-    def on_parse_end(self, call_id, outputs, exception):
-        self.calls.append({"handler": "on_parse_end", "outputs": outputs, "exception": exception})
+    def on_adapter_parse_end(self, call_id, outputs, exception):
+        self.calls.append({"handler": "on_adapter_parse_end", "outputs": outputs, "exception": exception})
 
 
 @pytest.mark.parametrize(
@@ -163,17 +165,17 @@ def test_callback_complex_module():
     assert [call["handler"] for call in callback.calls] == [
         "on_module_start",
         "on_module_start",
-        "on_format_start",
-        "on_format_end",
+        "on_adapter_format_start",
+        "on_adapter_format_end",
         "on_lm_start",
         "on_lm_end",
         # Parsing will run per output (n=3)
-        "on_parse_start",
-        "on_parse_end",
-        "on_parse_start",
-        "on_parse_end",
-        "on_parse_start",
-        "on_parse_end",
+        "on_adapter_parse_start",
+        "on_adapter_parse_end",
+        "on_adapter_parse_start",
+        "on_adapter_parse_end",
+        "on_adapter_parse_start",
+        "on_adapter_parse_end",
         "on_module_end",
         "on_module_end",
     ]


### PR DESCRIPTION
Some fixes to callbacks for better readability and usability, including:

- Rename Adapter-related callbacks to have `adapter` in the name for clarity, as `on_parse_start` is a bit ambiguous.
- Some code simplifications, e.g., reduce nesting levels.
- Docstring and error message improvements. 
