### PR TITLE
Rework DSPy retrieve

### DIFF
--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -1,1 +1,2 @@
 from .lm import LM
+from .embedding import Embedding

--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+
+import litellm
+from litellm.caching import Cache
+
+DISK_CACHE_DIR = os.environ.get("DSPY_CACHEDIR") or os.path.join(Path.home(), ".dspy_cache")
+litellm.cache = Cache(disk_cache_dir=DISK_CACHE_DIR, type="disk")
+litellm.telemetry = False
+
+if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+
+
+class Embedding:
+    def __init__(self, model):
+        self.model = model
+
+    def __call__(self, inputs, caching=True, **kwargs):
+        if isinstance(self.model, str):
+            return litellm.embedding(model=self.model, input=inputs, caching=caching, **kwargs)
+        elif isinstance(self.model, callable):
+            return self.model(inputs, **kwargs)
+        else:
+            raise ValueError(f"`model` in `dspy.Embedding` must be a string or a callable, but got {type(self.model)}.")

--- a/dspy/retrieve/__init__.py
+++ b/dspy/retrieve/__init__.py
@@ -1,1 +1,2 @@
 from .retrieve import Retrieve, RetrieveThenRerank
+from dspy.retrieve.retrieve_v2 import RetrieveV2

--- a/dspy/retrieve/retrieve_v2.py
+++ b/dspy/retrieve/retrieve_v2.py
@@ -1,0 +1,43 @@
+import logging
+import os
+
+import cloudpickle
+
+from dspy.utils.callback import with_callbacks
+
+logger = logging.getLogger(__name__)
+
+
+class RetrieveV2:
+    def __init__(self, index=None, documents=None, build_index=False, callbacks=None):
+        self.build_index = build_index
+        self.documents = documents
+        self.index = index
+        if self.build_index:
+            self.index = self.build_local_index(documents)
+
+    def save(self, path):
+        if self.build_index:
+            with open(os.path.join(path, "documents.pkl"), "wb") as file:
+                cloudpickle.dump(self.documents, file)
+
+    def load(self, path):
+        if self.build_index:
+            file_path = os.path.join(path, "documents.pkl")
+            if not os.path.exists(file_path):
+                logger.warning(f"File {file_path} does not exist, nothing to load.")
+                return
+
+            with open(file_path, "rb") as file:
+                self.documents = cloudpickle.load(file)
+            self.index = self.build_local_index(self.documents)
+
+    def build_local_index(self, documents):
+        pass
+
+    @with_callbacks
+    def __call__(self, query, k=None, **kwargs):
+        return self.forward(query, k=k, **kwargs)
+
+    def forward(self, query, k=None, **kwargs):
+        raise NotImplementedError


### PR DESCRIPTION
Right now `dspy.Retrieve` is not a useful abstraction, and we have too many prebuilt `dspy.Retrieve` implementations. Although it would be nice to have DSPy play as a centralized hub for these retriever providers, this will quickly go outdated due to the maintenance challenge. Before our code smells, we are reworking the `dspy.Retrieve` with the goal that:

- `dspy.Retrieve` becomes a useful abstraction, which can help people instrument retrieval (with `callback` support), and save the retriever imlplementations.
-  Users find it easy to provide a custom function to do retrieval, without needing to worry about converting their code to DSPy's rules. It will be really bad if we force people to learn a over-engineered `dspy.Retrieve`.
- The interface is possible for future retrieval optimization, and in general expansible. 

Meanwhile, we realized that many retrievers require users to compute the embedding before querying, so we are exposing a `dspy.Embedding` interface, which is built on top of litellm, similar to `dspy.LM`.