### PR TITLE
Add chainable loading for Predict modules

### DIFF
--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -218,3 +218,48 @@ def test_output_only():
     lm = DummyLM([{"output": "short answer"}])
     dspy.settings.configure(lm=lm)
     assert predictor().output == "short answer"
+
+
+
+def test_chainable_load(tmp_path):
+    """Test both traditional and chainable load methods."""
+    
+    file_path = tmp_path / "test_chainable.json"
+    
+    
+    original = Predict("question -> answer")
+    original.demos = [{"question": "test", "answer": "response"}]
+    original.save(file_path)
+    
+    
+    traditional = Predict("question -> answer")
+    traditional.load(file_path)
+    assert traditional.demos == original.demos
+    
+    
+    chainable = Predict("question -> answer").load(file_path, return_self=True)
+    assert chainable is not None  
+    assert chainable.demos == original.demos
+    
+    
+    assert chainable.signature.dump_state() == original.signature.dump_state()
+    
+    
+    result = Predict("question -> answer").load(file_path)
+    assert result is None
+
+def test_load_state_chaining():
+    """Test that load_state returns self for chaining."""
+    original = Predict("question -> answer")
+    original.demos = [{"question": "test", "answer": "response"}]
+    state = original.dump_state()
+    
+    
+    new_instance = Predict("question -> answer").load_state(state)
+    assert new_instance is not None
+    assert new_instance.demos == original.demos
+    
+    
+    legacy_instance = Predict("question -> answer").load_state(state, use_legacy_loading=True)
+    assert legacy_instance is not None
+    assert legacy_instance.demos == original.demos


### PR DESCRIPTION


Currently, loading a predictor after optimization requires two separate lines:
```python
predictor = dspy.Predict("question -> answer")
predictor.load(saved_path)
```

This PR adds support for chainable loading to improve code ergonomics:
```python
predictor = dspy.Predict("question -> answer").load(saved_path, return_self=True)
```

## Changes
- Modified `load_state()` and `_load_state_legacy()` to return `self` for chaining
- Added a new `return_self` parameter to `load()` method
- Added comprehensive tests for both traditional and chainable loading patterns
- Maintained backward compatibility with existing code by defaulting `return_self=False`

## Testing
Added two new test cases:
- `test_chainable_load`: Verifies both traditional and chainable loading methods
- `test_load_state_chaining`: Ensures state loading supports chaining in both normal and legacy modes

## Backward Compatibility
The changes are fully backward compatible:
- Existing code using `load()` without `return_self` continues to work as before
- New code can opt into chainable loading by setting `return_self=True`


Closes #1738
