### PR TITLE
Add support for GA to docs website

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -248,6 +248,9 @@ extra:
       link: https://github.com/stanfordnlp/dspy
     - icon: fontawesome/brands/discord
       link: https://discord.gg/XCGy2WDCQB
+  analytics:
+    - provider: google
+    - property: !!python/object/apply:os.getenv ["GOOGLE_ANALYTICS_TOKEN"]
 
 extra_javascript:
   - "js/runllm-widget.js"


### PR DESCRIPTION
Added Google Analytics tracking configuration under `analytics` section in `docs/mkdocs.yml`.

**Note**: Will merge this once token setup is done myself.