### PR TITLE
add flag to suppress litellm logs in dspy.LM

### DIFF
--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -24,6 +24,7 @@ DEFAULT_CONFIG = dotdict(
     experimental=False,
     backoff_time=10,
     callbacks=[],
+    suppress_debug_info=True,
 )
 
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -6,7 +6,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
-
+import dspy
 import litellm
 import ujson
 
@@ -33,7 +33,6 @@ class LM(BaseLM):
         launch_kwargs: Optional[Dict[str, Any]] = None,
         callbacks: Optional[List[BaseCallback]] = None,
         num_retries: int = 3,
-        suppress_debug_info: bool = True,
         **kwargs,
     ):
         """
@@ -63,7 +62,7 @@ class LM(BaseLM):
         self.num_retries = num_retries
 
         #turned off by default to avoid LiteLLM logging during every LM call
-        litellm.suppress_debug_info = suppress_debug_info
+        litellm.suppress_debug_info = dspy.settings.suppress_debug_info
 
         # TODO: Arbitrary model strings could include the substring "o1-". We
         # should find a more robust way to check for the "o1-" family models.

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -33,6 +33,7 @@ class LM(BaseLM):
         launch_kwargs: Optional[Dict[str, Any]] = None,
         callbacks: Optional[List[BaseCallback]] = None,
         num_retries: int = 3,
+        suppress_debug_info: bool = True,
         **kwargs,
     ):
         """
@@ -60,6 +61,9 @@ class LM(BaseLM):
         self.history = []
         self.callbacks = callbacks or []
         self.num_retries = num_retries
+
+        #turned off by default to avoid LiteLLM logging during every LM call
+        litellm.suppress_debug_info = suppress_debug_info
 
         # TODO: Arbitrary model strings could include the substring "o1-". We
         # should find a more robust way to check for the "o1-" family models.


### PR DESCRIPTION
default behavior to suppress litellm logs to avoid logging for every dspy.LM call.

related to #1619 and https://github.com/BerriAI/litellm/issues/5598#issuecomment-2339245304