### PR TITLE
fix: prevent Chinese examples from being converted to Unicode encoding

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -165,7 +165,7 @@ def _format_field_value(field_info: FieldInfo, value: Any, assume_text=True) -> 
         # If the field has no special type requirements, format it as a nice numbered list for the LM.
         string_value = format_input_list_field_value(value)
     elif isinstance(value, pydantic.BaseModel) or isinstance(value, dict) or isinstance(value, list):
-        string_value = json.dumps(_serialize_for_json(value))
+        string_value = json.dumps(_serialize_for_json(value), ensure_ascii=False)
     else:
         string_value = str(value)
 


### PR DESCRIPTION
Using secure_ascii=False provides better support for Chinese characters directly

before:
```
[[ ## json_output ## ]]
[{"type": "narration", "content": "\u5c0f\u660e\u8d70\u51fa\u5bb6\u95e8\uff0c\u8ddf\u90bb\u5c45\u6253\u62db\u547c"}, {"type": "dialogue", "name": "\u5c0f\u660e", "reaction": "\u9ad8\u5174", "content": "\u4f60\u597d\u5440"}, {"type": "narration", "content": "\u90bb\u5c45\u5fae\u7b11\u671d\u4ed6\u70b9\u5934"}, {"type": "voiceover", "name": "\u90bb\u5c45", "reaction": "\u5185\u5fc3\u5947\u602a", "content": "\u8fd9\u5c0f\u5b50\u4eca\u5929\u600e\u4e48\u5bf9\u6211\u8fd9\u4e48\u6709\u793c\u8c8c"}]

[[ ## completed ## ]]
```

after:
```
[[ ## json_output ## ]]
[{"type": "narration", "content": "小明走出家门，跟邻居打招呼"}, {"type": "dialogue", "name": "小明", "reaction": "高兴", "content": "你好呀"}, {"type": "narration", "content": "邻居微笑朝他点头"}, {"type": "voiceover", "name": "邻居", "reaction": "内心奇怪", "content": "这小子今天怎么对我这么有礼貌"}]

[[ ## completed ## ]]
```
