### PR TITLE
Change the way of enable/disable litellm logging

### DIFF
--- a/dsp/utils/settings.py
+++ b/dsp/utils/settings.py
@@ -1,6 +1,6 @@
 import threading
-from copy import deepcopy
 from contextlib import contextmanager
+from copy import deepcopy
 
 from dsp.utils.utils import dotdict
 
@@ -24,7 +24,6 @@ DEFAULT_CONFIG = dotdict(
     experimental=False,
     backoff_time=10,
     callbacks=[],
-    suppress_debug_info=True,
 )
 
 

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -10,7 +10,15 @@ from litellm.caching import Cache
 DISK_CACHE_DIR = os.environ.get("DSPY_CACHEDIR") or os.path.join(Path.home(), ".dspy_cache")
 litellm.cache = Cache(disk_cache_dir=DISK_CACHE_DIR, type="disk")
 litellm.telemetry = False
+# Turn off by default to avoid LiteLLM logging during every LM call.
+litellm.suppress_debug_info = True
 
 if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
-    # accessed at run time by litellm; i.e., fine to keep after import
+    # Accessed at run time by litellm; i.e., fine to keep after import
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+
+def enable_litellm_logging():
+    litellm.suppress_debug_info = False
+
+def disable_litellm_logging():
+    litellm.suppress_debug_info = True

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Literal, Optional
 import litellm
 import ujson
 
-import dspy
 from dspy.adapters.base import Adapter
 from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, TrainingJob
@@ -69,9 +68,6 @@ class LM(BaseLM):
         self.callbacks = callbacks or []
         self.num_retries = num_retries
         self.finetuning_model = finetuning_model
-
-        #turned off by default to avoid LiteLLM logging during every LM call
-        litellm.suppress_debug_info = dspy.settings.suppress_debug_info
 
         # TODO(bug): Arbitrary model strings could include the substring "o1-".
         # We should find a more robust way to check for the "o1-" family models.


### PR DESCRIPTION
We introduced litellm logging suppression in #1768, but we were configuring `litellm` inside the `__init__` call. So if users do:

```
lm = dspy.LM("...")
dspy.settings.configure(suppress_debug_info=False)
lm("some query")
```

Then the logging won't be turned on. In this PR I am introducing a pair of util functions: `dspy.clients.enable_litellm_logging()` and `dspy.client.disable_litellm_logging()` to turn on/off the litellm logging dynamically. 
