### PR TITLE
fix: No longer crashing notebooks & spamming console w image urls

### DIFF
--- a/dspy/adapters/image_utils.py
+++ b/dspy/adapters/image_utils.py
@@ -44,6 +44,11 @@ class Image(pydantic.BaseModel):
         import PIL
         return cls(url=encode_image(PIL.Image.open(pil_image)))
 
+    def __str__(self):
+        len_base64 = len(self.url.split("base64,")[1])
+        return f"Image(url = {self.url.split('base64,')[0]}base64,<IMAGE_BASE_64_ENCODED({str(len_base64)})>)"
+
+
 def is_url(string: str) -> bool:
     """Check if a string is a valid URL."""
     try:

--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -46,7 +46,7 @@ class Example:
 
     def __repr__(self):
         # return f"Example({self._store})" + f" (input_keys={self._input_keys}, demos={self._demos})"
-        d = {k: str(v) for k, v in self._store.items() if not k.startswith("dspy_")}
+        d = {k: v for k, v in self._store.items() if not k.startswith("dspy_")}
         return f"Example({d})" + f" (input_keys={self._input_keys})"
 
     def __str__(self):

--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -46,7 +46,7 @@ class Example:
 
     def __repr__(self):
         # return f"Example({self._store})" + f" (input_keys={self._input_keys}, demos={self._demos})"
-        d = {k: v for k, v in self._store.items() if not k.startswith("dspy_")}
+        d = {k: str(v) for k, v in self._store.items() if not k.startswith("dspy_")}
         return f"Example({d})" + f" (input_keys={self._input_keys})"
 
     def __str__(self):

--- a/tests/primitives/test_example.py
+++ b/tests/primitives/test_example.py
@@ -1,4 +1,5 @@
 import pytest
+import dspy
 from dspy import Example
 
 
@@ -47,6 +48,20 @@ def test_example_deletion():
 def test_example_len():
     example = Example(a=1, b=2, dspy_hidden=3)
     assert len(example) == 2
+
+
+def test_example_repr_str_img():
+    example = Example(
+        img=dspy.Image(url="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7")
+    )
+    assert (
+        repr(example)
+        == "Example({'img': Image(url = data:image/gif;base64,<IMAGE_BASE_64_ENCODED(56)>)}) (input_keys=None)"
+    )
+    assert (
+        str(example)
+        == "Example({'img': Image(url = data:image/gif;base64,<IMAGE_BASE_64_ENCODED(56)>)}) (input_keys=None)"
+    )
 
 
 def test_example_repr_str():


### PR DESCRIPTION
Printing DSPy Examples containing images creates problems because they flood the console / notebook outputs with massive base64-encoded strings. 

Base64-encoded images can be thousands of characters long, making it nearly impossible to read other important output or debug information.