### PR TITLE
.load_demos(**kwargs) for dynamically loading demos

### DIFF
--- a/dspy/predict/langchain.py
+++ b/dspy/predict/langchain.py
@@ -93,7 +93,7 @@ class LangChainPredict(Predict, Runnable, metaclass=LangChainPredictMetaClass):
     def forward(self, **kwargs):
         # Extract the three privileged keyword arguments.
         signature = kwargs.pop("signature", self.signature)
-        demos = kwargs.pop("demos", self.demos)
+        demos = kwargs.pop("demos", None) or self.load_demos(**kwargs)
         config = dict(**self.config, **kwargs.pop("config", {}))
 
         prompt = signature(dsp.Example(demos=demos, **kwargs))

--- a/dspy/predict/retry.py
+++ b/dspy/predict/retry.py
@@ -53,7 +53,6 @@ class Retry(Predict):
     def __call__(self, **kwargs):
         copy.deepcopy(kwargs)
         kwargs["_trace"] = False
-        kwargs.setdefault("demos", self.demos if self.demos is not None else [])
 
         # perform backtracking
         if dspy.settings.backtrack_to == self:


### PR DESCRIPTION
In preparation for `BootstrapKNNFewShotWithRandomSearch`, the change is:

```python
demos = kwargs.pop("demos", self.demos) # old
demos = kwargs.pop("demos", None) or self.load_demos(**kwargs) # new
```

Which should let enable us to do dynamic demo loading at runtime (i.e. test-time compute)