### PR TITLE
Make litellm version more flexible

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8523,4 +8523,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "0675fa1dd1f44d63bafaffc6c2dfb384f2d016cfa20db379c19515ca182e867c"
+content-hash = "d7c6fe24c44afc0e694de8270035ac4cd9831f9bf9d6253f1cd1dbfe03ec2835"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ llama-index = { version = "^0.10.30", optional = true }
 snowflake-snowpark-python = { version = "*", optional = true, python = ">=3.9,<3.12" }
 jinja2 = "^3.1.3"
 magicattr = "^0.1.6"
-litellm = "1.51.0"
+litellm = "^1.51.0"
 diskcache = "^5.6.0"
 redis = "^5.1.1"
 falkordb = "^1.0.9"
@@ -150,7 +150,7 @@ pre-commit = "^3.7.0"
 ipykernel = "^6.29.4"
 semver = "^3.0.2"
 pillow = "^10.1.0"
-litellm = { version = "1.51.0", extras = ["proxy"] }
+litellm = { version = "^1.51.0", extras = ["proxy"] }
 
 [tool.poetry.extras]
 chromadb = ["chromadb"]


### PR DESCRIPTION
hey there!

I wanted to install dspy in a project where I also use litellm more explicitly, but unfortunately I couldn't update litellm version independently, I'm then adding the caret^ to flexibilize the minor version of it

now, that may be a risk as indeed I've seen litellm having quite few breaking changes in the past, @krypticmouse you were the one to change that from ^ to a explicit version before, do you remember what was the reason for that? https://github.com/stanfordnlp/dspy/commit/f5a781ca1e443a445cf8cbab8e6f0c8580375fae