### PR TITLE
Include the Signature `__doc__` in the system message for the ReAct module.

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -64,7 +64,7 @@ class ReAct(Module):
         )
 
         fallback_signature = (
-            dspy.Signature({**signature.input_fields, **signature.output_fields})
+            dspy.Signature({**signature.input_fields, **signature.output_fields}, signature.instructions)
             .append("trajectory", dspy.InputField(), type_=str)
         )
 


### PR DESCRIPTION
Signed-off-by: myan <myan@redhat.com>

Resolve: https://github.com/stanfordnlp/dspy/issues/1836