### PR TITLE
Add OpenLIT as integration in usecase docs

### DIFF
--- a/docs/docs/community/use-cases.md
+++ b/docs/docs/community/use-cases.md
@@ -103,5 +103,6 @@ TODO: This list in particular is highly incomplete. There are a couple dozen oth
 | **LlamaIndex** | [Link](https://github.com/stanfordnlp/dspy/blob/main/examples/llamaindex/dspy_llamaindex_rag.ipynb) |
 | **Langtrace** | [Link](https://docs.langtrace.ai/supported-integrations/llm-frameworks/dspy) |
 | **Langfuse** | [Link](https://langfuse.com/docs/integrations/dspy) |
+| **OpenLIT** | [Link](https://docs.openlit.io/latest/integrations/dspy) |
 
 Credit: Some of these resources were originally compiled in the [Awesome DSPy](https://github.com/ganarajpr/awesome-dspy/tree/master) repo.

--- a/docs/docs/dspy-usecases.md
+++ b/docs/docs/dspy-usecases.md
@@ -103,6 +103,7 @@ TODO: This list in particular is highly incomplete. There are a couple dozen oth
 | **LlamaIndex** | [Link](https://github.com/stanfordnlp/dspy/blob/main/examples/llamaindex/dspy_llamaindex_rag.ipynb) |
 | **Langtrace** | [Link](https://docs.langtrace.ai/supported-integrations/llm-frameworks/dspy) |
 | **Langfuse** | [Link](https://langfuse.com/docs/integrations/dspy) |
+| **OpenLIT** | [Link](https://docs.openlit.io/latest/integrations/dspy) |
 
 ## A Few Blogs & Videos on using DSPy
 


### PR DESCRIPTION
Hi Team, I am one of the maintainers of [OpenLIT](https://github.com/openlit/openlit) and we support Obserability for LLM apps built using DSPy, It is all OpenTelemetry-native so the traces and metrics can be sent to any platfrom like [Grafana](https://grafana.com/docs/grafana-cloud/monitor-applications/ai-observability/introduction/) or any [OSS OTel tools](https://opentelemetry.io/blog/2024/llm-observability/)

Figured the mention here might be useful for developers using DSPy hence adding the reference in documentation page.