### PR TITLE
Bugfix/signature replace and pydantic 2.10

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import logging
 import re
 import types
 import typing
@@ -11,8 +12,9 @@ from pydantic import BaseModel, Field, create_model
 from pydantic.fields import FieldInfo
 
 import dsp
-from dspy.signatures.field import InputField, OutputField, new_to_old_field
 from dspy.adapters.image_utils import Image
+from dspy.signatures.field import InputField, OutputField, new_to_old_field
+
 
 def signature_to_template(signature, adapter=None) -> dsp.Template:
     """Convert from new to legacy format."""
@@ -242,7 +244,7 @@ class Signature(BaseModel, metaclass=SignatureMeta):
     @classmethod
     @contextmanager
     def replace(
-        cls: "Signature",
+        cls,
         new_signature: "Signature",
         validate_new_signature: bool = True,
     ) -> typing.Generator[None, None, None]:
@@ -262,16 +264,28 @@ class Signature(BaseModel, metaclass=SignatureMeta):
                         f"Field '{field}' is missing from the updated signature '{new_signature.__class__}.",
                     )
 
-        class OldSignature(cls, Signature):
+        class OldSignature(cls):
             pass
 
-        replace_fields = ["__doc__", "model_fields", "model_extra", "model_config"]
-        for field in replace_fields:
-            setattr(cls, field, getattr(new_signature, field))
+        replace_attrs = ["__doc__", "__pydantic_fields__", "model_fields", "model_extra", "model_config"]
+        for attr in replace_attrs:
+            try:
+                setattr(cls, attr, getattr(new_signature, attr))
+            except AttributeError as exc:
+                if attr == "model_fields":
+                    logging.debug("Model attribute model_fields not replaced, expected with pydantic > 2.10")
+                else:
+                    raise exc
         cls.model_rebuild(force=True)
         yield
-        for field in replace_fields:
-            setattr(cls, field, getattr(OldSignature, field))
+        for attr in replace_attrs:
+            try:
+                setattr(cls, attr, getattr(OldSignature, attr))
+            except AttributeError as exc:
+                if attr == "model_fields":
+                    logging.debug("Model attribute model_fields not replaced, expected with pydantic > 2.10")
+                else:
+                    raise exc
         cls.model_rebuild(force=True)
 
 
@@ -383,7 +397,7 @@ def _parse_type_node(node, names=None) -> Any:
 
     without using structural pattern matching introduced in Python 3.10.
     """
-    
+
     if names is None:
         names = typing.__dict__
 
@@ -401,7 +415,7 @@ def _parse_type_node(node, names=None) -> Any:
         id_ = node.id
         if id_ in names:
             return names[id_]
-        
+
         for type_ in [int, str, float, bool, list, tuple, dict, Image]:
             if type_.__name__ == id_:
                 return type_
@@ -420,7 +434,7 @@ def _parse_type_node(node, names=None) -> Any:
         keys = [kw.arg for kw in node.keywords]
         values = [kw.value.value for kw in node.keywords]
         return Field(**dict(zip(keys, values)))
-    
+
     if isinstance(node, ast.Attribute) and node.attr == "Image":
         return Image
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,7 @@
 black==24.2.0
+datamodel-code-generator==0.26.3
+litellm[proxy]==1.51.0
+pillow==10.4.0
 pre-commit==3.7.0
 pytest==8.3.3
 pytest-env==1.1.3
@@ -6,5 +9,3 @@ pytest-mock==3.12.0
 ruff==0.3.0
 torch==2.2.1
 transformers==4.38.2
-pillow==10.4.0
-litellm[proxy]==1.51.0


### PR DESCRIPTION
[Pydantic 2.10 includes a change to model_fields](https://github.com/pydantic/pydantic/pull/10493/files) turning it into a property. Dspy's Signature.replace method cannot replace that property. This PR updates the replacement to also target `__pydantic_fields__`.

* Reorganized imports in `dspy/signatures/signature.py` for better readability and maintainability.
* Simplified the `OldSignature` class definition by removing the unnecessary `Signature` base class.
* Updated `requirements-dev.txt` to include new dependencies: `datamodel-code-generator==0.26.3` sorted reqs