### PR TITLE
Support returning logprobs in Predictor

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -22,7 +22,12 @@ class Adapter(ABC):
 
         try:
             for output in outputs:
-                output_text, output_logprobs = output["text"], output["logprobs"]
+                if type(output) is str:
+                    output_text, output_logprobs = output, None
+                elif type(output) is dict:
+                    output_text, output_logprobs = output["text"], output["logprobs"]
+                else:
+                    raise ValueError(f"Expected str or dict but got {type(output)}")
                 value = self.parse(signature, output_text, _parse_values=_parse_values)
                 assert set(value.keys()) == set(signature.output_fields.keys()), f"Expected {signature.output_fields.keys()} but got {value.keys()}"
                 value["logprobs"] = output_logprobs

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -22,8 +22,10 @@ class Adapter(ABC):
 
         try:
             for output in outputs:
-                value = self.parse(signature, output, _parse_values=_parse_values)
+                output_text, output_logprobs = output["text"], output["logprobs"]
+                value = self.parse(signature, output_text, _parse_values=_parse_values)
                 assert set(value.keys()) == set(signature.output_fields.keys()), f"Expected {signature.output_fields.keys()} but got {value.keys()}"
+                value["logprobs"] = output_logprobs
                 values.append(value)
             return values
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -95,7 +95,7 @@ class LM(BaseLM):
             request=ujson.dumps(dict(model=self.model, messages=messages, **kwargs)),
             num_retries=self.num_retries,
         )
-        if self.kwargs.get("logprobs"):
+        if kwargs.get("logprobs"):
             outputs = [
                 {
                     "text": c.message.content if hasattr(c, "message") else c["text"],

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -95,8 +95,23 @@ class LM(BaseLM):
             request=ujson.dumps(dict(model=self.model, messages=messages, **kwargs)),
             num_retries=self.num_retries,
         )
-        outputs = [c.message.content if hasattr(c, "message") else c["text"] for c in response["choices"]]
+        if self.kwargs.get("logprobs"):
+            outputs = [
+                {
+                    "text": c.message.content if hasattr(c, "message") else c["text"],
+                    "logprobs": c.logprobs if hasattr(c, "logprobs") else c["logprobs"]
+                }
+                for c in response["choices"]
+            ]
+        else:
+            outputs = [
+                {
+                    "text": c.message.content if hasattr(c, "message") else c["text"],
+                    "logprobs": None
+                } for c in response["choices"]
+            ]
 
+            
         # Logging, with removed api key & where `cost` is None on cache hit.
         kwargs = {k: v for k, v in kwargs.items() if not k.startswith("api_")}
         entry = dict(prompt=prompt, messages=messages, kwargs=kwargs, response=response)

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -104,12 +104,7 @@ class LM(BaseLM):
                 for c in response["choices"]
             ]
         else:
-            outputs = [
-                {
-                    "text": c.message.content if hasattr(c, "message") else c["text"],
-                    "logprobs": None
-                } for c in response["choices"]
-            ]
+            outputs = [c.message.content if hasattr(c, "message") else c["text"] for c in response["choices"]]
 
             
         # Logging, with removed api key & where `cost` is None on cache hit.


### PR DESCRIPTION
This PR allows `Predict` to return logprobs of each token as part of `Prediction`.

## Example usage

**If you want logprobs:**
Set `logprobs=True` and optionally `top_logprobs` (int between 0 and 20, see [openai doc](https://platform.openai.com/docs/api-reference/chat/create#chat-create-top_logprobs) for details):
```
import dspy
from dspy import Predict

predict_instance = Predict("question -> answer")
lm = dspy.LM("gpt-4o-mini", logprobs=True)
dspy.configure(lm=lm)
result = predict_instance(question="Where is the Eiffel Tower located?")
print(result)
```
Output:
```
Prediction(
    answer='The Eiffel Tower is located in Paris, France, on the Champ de Mars near the Seine River.',
    logprobs={'content': [{'token': '[[', 'bytes': [91, 91], 'logprob': -2.1008714e-06, 'top_logprobs': []}, {'token': ' ##', 'bytes': [32, 35, 35], 'logprob': -1.9361265e-07, 'top_logprobs': []}, {'token': ' answer', 'bytes': [32, 97, 110, 115, 119, 101, 114], 'logprob': 0.0, 'top_logprobs': []}, {'token': ' ##', 'bytes': [32, 35, 35], 'logprob': -8.180258e-06, 'top_logprobs': []}, {'token': ' ]]\n', 'bytes': [32, 93, 93, 10], 'logprob': -0.00010926496, 'top_logprobs': []}, {'token': 'The', 'bytes': [84, 104, 101], 'logprob': 0.0, 'top_logprobs': []}, {'token': ' Eiffel', 'bytes': [32, 69, 105, 102, 102, 101, 108], 'logprob': 0.0, 'top_logprobs': []}, ...], 'refusal': None}
)
```

**If you don't want logprobs:**
The usage and behavior is the same as before:
```
... # everything else stays the same
lm = dspy.LM("gpt-4o-mini")
...
```
Output:
```
Prediction(
    answer='The Eiffel Tower is located in Paris, France, on the Champ de Mars near the Seine River.'
) 
```

## Caveat
If an LM (e.g. `o1-mini`) doesn't take `logprobs` as argument and you still set `dspy.LM(..., logprobs=True)`, you will get an error like `openai does not support parameters: {'logprobs': True}, for model=o1-mini.` Please check the corresponding LM documentation before setting this parameter.