### PR TITLE
Caching: Use reentrant locks, don't discard callables (or any other unhashable object in the future) from the cache key

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -299,7 +299,6 @@ def cached_litellm_completion(request: Dict[str, Any], num_retries: int):
 
 
 def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
-    print("RUNNING NOT CACHED", request)
     return litellm.completion(
         num_retries=num_retries,
         cache=cache,

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -272,7 +272,6 @@ def request_cache(maxsize: Optional[int] = None):
             lock=threading.RLock(),
         )
         def func_cached(key: str, request: Dict[str, Any], *args, **kwargs):
-            print("RUNNING CACHED", request, key)
             return func(request, *args, **kwargs)
 
         @functools.wraps(func)
@@ -283,7 +282,6 @@ def request_cache(maxsize: Optional[int] = None):
             except Exception:
                 # If the cache key cannot be computed (e.g. because it contains a value that cannot
                 # be converted to JSON), bypass the cache and call the target function directly
-                print("RUNNING NOT CACHED", request)
                 return func(request, *args, **kwargs)
 
         return wrapper
@@ -301,6 +299,7 @@ def cached_litellm_completion(request: Dict[str, Any], num_retries: int):
 
 
 def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
+    print("RUNNING NOT CACHED", request)
     return litellm.completion(
         num_retries=num_retries,
         cache=cache,

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -240,9 +240,10 @@ def request_cache(maxsize: Optional[int] = None):
 
         Note: Values that cannot be converted to JSON should *not* be ignored / discarded, since
         that would potentially lead to cache collisions. For example, consider request A
-        containing only hashable values and request B containing the same hashable values in
-        addition to one unhashable value. Discarding the unhashable value would lead to a cache
-        collision between requests A and B, even though they are semantically different.
+        containing only JSON-convertible values and request B containing the same JSON-convertible
+        values in addition to one unconvertible value. Discarding the unconvertible value would
+        lead to a cache collision between requests A and B, even though they are semantically
+        different.
         """
 
         def transform_value(value):

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -272,6 +272,7 @@ def request_cache(maxsize: Optional[int] = None):
             lock=threading.RLock(),
         )
         def func_cached(key: str, request: Dict[str, Any], *args, **kwargs):
+            print("RUNNING CACHED", request, key)
             return func(request, *args, **kwargs)
 
         @functools.wraps(func)

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -250,10 +250,11 @@ def request_cache(maxsize: Optional[int] = None):
                 return value.schema()
             elif isinstance(value, pydantic.BaseModel):
                 return value.dict()
-            elif callable(value) and hasattr(value, "__code__") and hasattr(value.__code__, "co_code"):
-                return value.__code__.co_code.decode("utf-8")
             else:
-                return value
+                try:
+                    return hash(value)
+                except Exception:
+                    return value
 
         params = {k: transform_value(v) for k, v in request.items()}
         return sha256(ujson.dumps(params, sort_keys=True).encode()).hexdigest()

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -281,7 +281,7 @@ def request_cache(maxsize: Optional[int] = None):
                 return func_cached(key, request, *args, **kwargs)
             except Exception:
                 # If the cache key cannot be computed (e.g. because it contains a value that cannot
-                # be converted to JSON), fall back to the uncached version of the function
+                # be converted to JSON), bypass the cache and call the target function directly
                 return func(request, *args, **kwargs)
 
         return wrapper

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -280,8 +280,8 @@ def request_cache(maxsize: Optional[int] = None):
                 key = cache_key(request)
                 return func_cached(key, request, *args, **kwargs)
             except Exception:
-                # If the cache key cannot be computed (e.g. because it contains an unhahsable
-                # value), fall back to the uncached version of the function
+                # If the cache key cannot be computed (e.g. because it contains a value that cannot
+                # be converted to JSON), fall back to the uncached version of the function
                 return func(request, *args, **kwargs)
 
         return wrapper

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -246,10 +246,12 @@ def request_cache(maxsize: Optional[int] = None):
         """
 
         def transform_value(value):
-            if isinstance(value, pydantic.BaseModel):
+            if isinstance(value, type) and issubclass(value, pydantic.BaseModel):
+                return value.schema()
+            elif isinstance(value, pydantic.BaseModel):
                 return value.dict()
             elif callable(value) and hasattr(value, "__code__") and hasattr(value.__code__, "co_code"):
-                return value.__code__.co_code
+                return value.__code__.co_code.decode("utf-8")
             else:
                 return value
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -283,6 +283,7 @@ def request_cache(maxsize: Optional[int] = None):
             except Exception:
                 # If the cache key cannot be computed (e.g. because it contains a value that cannot
                 # be converted to JSON), bypass the cache and call the target function directly
+                print("RUNNING NOT CACHED", request)
                 return func(request, *args, **kwargs)
 
         return wrapper

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -238,11 +238,11 @@ def request_cache(maxsize: Optional[int] = None):
         representation. For request fields having types that are known to be JSON-incompatible,
         convert them to a JSON-serializable format before hashing.
 
-        Note: Unhashable values should *not* be ignored / discarded, since that would
-        potentially lead to cache collisions. For example, consider request A containing only
-        hashable values and request B containing the same hashable values in addition to one
-        unhashable value. Discarding the unhashable value would lead to a cache collision between
-        requests A and B, even though they are semantically different.
+        Note: Values that cannot be converted to JSON should *not* be ignored / discarded, since
+        that would potentially lead to cache collisions. For example, consider request A
+        containing only hashable values and request B containing the same hashable values in
+        addition to one unhashable value. Discarding the unhashable value would lead to a cache
+        collision between requests A and B, even though they are semantically different.
         """
 
         def transform_value(value):

--- a/tests/caching/test_caching.py
+++ b/tests/caching/test_caching.py
@@ -127,7 +127,7 @@ def test_lm_calls_skip_in_memory_cache_if_key_not_computable():
         assert mock_litellm_completion.call_count == 2
 
 
-def test_lm_calls_with_callables_are_cached_as_expected(litellm_test_server, temporary_blank_cache_dir):
+def test_lm_calls_with_callables_are_cached_in_memory_as_expected(litellm_test_server, temporary_blank_cache_dir):
     api_base, server_log_file_path = litellm_test_server
 
     lm_with_callable = dspy.LM(

--- a/tests/caching/test_caching.py
+++ b/tests/caching/test_caching.py
@@ -125,3 +125,32 @@ def test_lm_calls_skip_in_memory_cache_if_key_not_computable():
         lm("Example query")
 
         assert mock_litellm_completion.call_count == 2
+
+
+def test_lm_calls_with_callables_are_cached_as_expected(litellm_test_server, temporary_blank_cache_dir):
+    api_base, server_log_file_path = litellm_test_server
+
+    lm_with_callable = dspy.LM(
+        model="openai/dspy-test-model",
+        api_base=api_base,
+        api_key="fakekey",
+        # Define a callable kwarg for the LM to use during inference
+        azure_ad_token_provider=lambda *args, **kwargs: None,
+    )
+    # Invoke the LM twice; the second call should be cached in memory
+    lm_with_callable("Query")
+    lm_with_callable("Query")
+
+    # Define and invoke a nearly-identical LM that lacks the callable kwarg
+    lm_without_callable = dspy.LM(
+        model="openai/dspy-test-model",
+        api_base=api_base,
+        api_key="fakekey",
+    )
+    lm_without_callable("Query")
+
+    # Verify that 2 requests were made to the LiteLLM server - one for each LM.
+    # This verifies that there wasn't a cache collision between the LMs due to
+    # the callable
+    request_logs = read_litellm_test_server_request_logs(server_log_file_path)
+    assert len(request_logs) == 2

--- a/tests/caching/test_caching.py
+++ b/tests/caching/test_caching.py
@@ -127,7 +127,7 @@ def test_lm_calls_skip_in_memory_cache_if_key_not_computable():
         assert mock_litellm_completion.call_count == 2
 
 
-def test_lm_calls_with_callables_are_cached_as_expected(litellm_test_server, temporary_blank_cach_dir):
+def test_lm_calls_with_callables_are_cached_as_expected(litellm_test_server, temporary_blank_cache_dir):
     api_base, server_log_file_path = litellm_test_server
 
     lm_with_callable = dspy.LM(

--- a/tests/caching/test_caching.py
+++ b/tests/caching/test_caching.py
@@ -127,7 +127,7 @@ def test_lm_calls_skip_in_memory_cache_if_key_not_computable():
         assert mock_litellm_completion.call_count == 2
 
 
-def test_lm_calls_with_callables_are_cached_in_memory_as_expected(litellm_test_server, temporary_blank_cache_dir):
+def test_lm_calls_with_callables_are_cached_as_expected(litellm_test_server, temporary_blank_cach_dir):
     api_base, server_log_file_path = litellm_test_server
 
     lm_with_callable = dspy.LM(
@@ -139,9 +139,6 @@ def test_lm_calls_with_callables_are_cached_in_memory_as_expected(litellm_test_s
     )
     # Invoke the LM twice; the second call should be cached in memory
     lm_with_callable("Query")
-    # Remove the disk cache between the first and second call, after which the LM must rely solely
-    # on in-memory caching
-    shutil.rmtree(temporary_blank_cache_dir)
     lm_with_callable("Query")
 
     # Define and invoke a nearly-identical LM that lacks the callable kwarg

--- a/tests/caching/test_caching.py
+++ b/tests/caching/test_caching.py
@@ -139,6 +139,9 @@ def test_lm_calls_with_callables_are_cached_as_expected(litellm_test_server, tem
     )
     # Invoke the LM twice; the second call should be cached in memory
     lm_with_callable("Query")
+    # Remove the disk cache between the first and second call, after which the LM must rely solely
+    # on in-memory caching
+    shutil.rmtree(temporary_blank_cache_dir)
     lm_with_callable("Query")
 
     # Define and invoke a nearly-identical LM that lacks the callable kwarg

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -49,7 +49,7 @@ def test_text_lms_can_be_queried(litellm_test_server):
     assert azure_openai_lm("azure openai query") == expected_response
 
 
-def test_lm_calls_support_unhashable_types(litellm_test_server):
+def test_lm_calls_support_callables(litellm_test_server):
     api_base, server_log_file_path = litellm_test_server
 
     lm_with_unhashable_callable = dspy.LM(
@@ -68,10 +68,10 @@ def test_lm_calls_support_pydantic_models(litellm_test_server):
     class ResponseFormat(pydantic.BaseModel):
         response: str
 
-    lm = dspy.LM(
+    lm1 = dspy.LM(
         model="openai/dspy-test-model",
         api_base=api_base,
         api_key="fakekey",
         response_format=ResponseFormat,
     )
-    lm("Query")
+    lm1("Query")

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -59,6 +59,7 @@ def test_lm_calls_support_callables(litellm_test_server):
         # Define a callable kwarg for the LM to use during inference
         azure_ad_token_provider=lambda *args, **kwargs: None,
     )
+    # Invoke the LM twice
     lm_with_callable("Query")
     lm_with_callable("Query")
 

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -59,7 +59,7 @@ def test_lm_calls_support_callables(litellm_test_server):
         # Define a callable kwarg for the LM to use during inference
         azure_ad_token_provider=lambda *args, **kwargs: None,
     )
-    # Invoke the LM twice
+    # Invoke the LM twice; the second call should be cached in memory
     lm_with_callable("Query")
     lm_with_callable("Query")
 

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1,10 +1,11 @@
 from unittest import mock
 
+import litellm
 import pydantic
 import pytest
 
 import dspy
-from tests.test_utils.server import litellm_test_server, read_litellm_test_server_request_logs
+from tests.test_utils.server import litellm_test_server
 
 
 def test_chat_lms_can_be_queried(litellm_test_server):
@@ -50,32 +51,24 @@ def test_text_lms_can_be_queried(litellm_test_server):
 
 
 def test_lm_calls_support_callables(litellm_test_server):
-    api_base, server_log_file_path = litellm_test_server
+    api_base, _ = litellm_test_server
 
-    lm_with_callable = dspy.LM(
-        model="openai/dspy-test-model",
-        api_base=api_base,
-        api_key="fakekey",
-        # Define a callable kwarg for the LM to use during inference
-        azure_ad_token_provider=lambda *args, **kwargs: None,
-    )
-    # Invoke the LM twice; the second call should be cached in memory
-    lm_with_callable("Callable test query")
-    # lm_with_callable("Callable test query")
+    with mock.patch("litellm.completion", autospec=True, wraps=litellm.completion) as spy_completion:
+        azure_ad_token_provider = lambda *args, **kwargs: None
+        lm_with_callable = dspy.LM(
+            model="openai/dspy-test-model",
+            api_base=api_base,
+            api_key="fakekey",
+            azure_ad_token_provider=azure_ad_token_provider,
+        )
+        lm_with_callable("Query")
 
-    # Define and invoke a nearly-identical LM that lacks the callable kwarg
-    lm_without_callable = dspy.LM(
-        model="openai/dspy-test-model",
-        api_base=api_base,
-        api_key="fakekey",
-    )
-    lm_without_callable("Callable test query")
-
-    # Verify that 2 requests were made to the LiteLLM server - one for each LM.
-    # This verifies that there wasn't a cache collision between the LMs due to
-    # the callable
-    request_logs = read_litellm_test_server_request_logs(server_log_file_path)
-    assert len(request_logs) == 2
+        spy_completion.assert_called_once()
+        call_args = spy_completion.call_args.kwargs
+        assert call_args["model"] == "openai/dspy-test-model"
+        assert call_args["api_base"] == api_base
+        assert call_args["api_key"] == "fakekey"
+        assert call_args["azure_ad_token_provider"] is azure_ad_token_provider
 
 
 def test_lm_calls_support_pydantic_models(litellm_test_server):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -4,7 +4,7 @@ import pydantic
 import pytest
 
 import dspy
-from tests.test_utils.server import litellm_test_server
+from tests.test_utils.server import litellm_test_server, read_litellm_test_server_request_logs
 
 
 def test_chat_lms_can_be_queried(litellm_test_server):
@@ -52,18 +52,32 @@ def test_text_lms_can_be_queried(litellm_test_server):
 def test_lm_calls_support_callables(litellm_test_server):
     api_base, server_log_file_path = litellm_test_server
 
-    lm_with_unhashable_callable = dspy.LM(
+    lm_with_callable = dspy.LM(
         model="openai/dspy-test-model",
         api_base=api_base,
         api_key="fakekey",
         # Define a callable kwarg for the LM to use during inference
         azure_ad_token_provider=lambda *args, **kwargs: None,
     )
-    lm_with_unhashable_callable("Query")
+    lm_with_callable("Query")
+
+    # Define and invoke a nearly-identical LM that lacks the callable kwarg
+    lm_without_callable = dspy.LM(
+        model="openai/dspy-test-model",
+        api_base=api_base,
+        api_key="fakekey",
+    )
+    lm_without_callable("Query")
+
+    # Verify that 2 requests were made to the LiteLLM server - one for each LM.
+    # This verifies that there wasn't a cache collision between the LMs due to
+    # the callable
+    request_logs = read_litellm_test_server_request_logs(server_log_file_path)
+    assert len(request_logs) == 2
 
 
 def test_lm_calls_support_pydantic_models(litellm_test_server):
-    api_base, server_log_file_path = litellm_test_server
+    api_base, _ = litellm_test_server
 
     class ResponseFormat(pydantic.BaseModel):
         response: str

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -60,8 +60,8 @@ def test_lm_calls_support_callables(litellm_test_server):
         azure_ad_token_provider=lambda *args, **kwargs: None,
     )
     # Invoke the LM twice; the second call should be cached in memory
-    lm_with_callable("Query")
-    lm_with_callable("Query")
+    lm_with_callable("Callable test query")
+    lm_with_callable("Callable test query")
 
     # Define and invoke a nearly-identical LM that lacks the callable kwarg
     lm_without_callable = dspy.LM(
@@ -69,7 +69,7 @@ def test_lm_calls_support_callables(litellm_test_server):
         api_base=api_base,
         api_key="fakekey",
     )
-    lm_without_callable("Query")
+    lm_without_callable("Callable test query")
 
     # Verify that 2 requests were made to the LiteLLM server - one for each LM.
     # This verifies that there wasn't a cache collision between the LMs due to

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -68,10 +68,10 @@ def test_lm_calls_support_pydantic_models(litellm_test_server):
     class ResponseFormat(pydantic.BaseModel):
         response: str
 
-    lm1 = dspy.LM(
+    lm = dspy.LM(
         model="openai/dspy-test-model",
         api_base=api_base,
         api_key="fakekey",
         response_format=ResponseFormat,
     )
-    lm1("Query")
+    lm("Query")

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -61,7 +61,7 @@ def test_lm_calls_support_callables(litellm_test_server):
     )
     # Invoke the LM twice; the second call should be cached in memory
     lm_with_callable("Callable test query")
-    lm_with_callable("Callable test query")
+    # lm_with_callable("Callable test query")
 
     # Define and invoke a nearly-identical LM that lacks the callable kwarg
     lm_without_callable = dspy.LM(

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -60,6 +60,7 @@ def test_lm_calls_support_callables(litellm_test_server):
         azure_ad_token_provider=lambda *args, **kwargs: None,
     )
     lm_with_callable("Query")
+    lm_with_callable("Query")
 
     # Define and invoke a nearly-identical LM that lacks the callable kwarg
     lm_without_callable = dspy.LM(

--- a/tests/test_utils/server/litellm_server_config.yaml
+++ b/tests/test_utils/server/litellm_server_config.yaml
@@ -7,7 +7,6 @@ model_list:
       model: "dspy-test-provider/dspy-test-model"
 
 litellm_settings:
-  cache: False
   custom_provider_map:
     - {
         "provider": "dspy-test-provider",

--- a/tests/test_utils/server/litellm_server_config.yaml
+++ b/tests/test_utils/server/litellm_server_config.yaml
@@ -7,6 +7,7 @@ model_list:
       model: "dspy-test-provider/dspy-test-model"
 
 litellm_settings:
+  cache: False
   custom_provider_map:
     - {
         "provider": "dspy-test-provider",


### PR DESCRIPTION
Caching: Use reentrant locks, don't discard callables (or any other unhashable object in the future) from the cache key