### PR TITLE
Return `"None"` when dspy.Image is missing for the input, similarly to `str` input fields

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -61,6 +61,8 @@ def format_field_value(field_info: FieldInfo, value: Any, assume_text=True) -> U
         except ImportError:
             raise ImportError("PIL is required to format images; Run `pip install pillow` to install it.")
         image_value = value
+        if not image_value:
+            return {"type": "text", "text": "None"}
         if not isinstance(image_value, Image):
             if isinstance(image_value, dict) and "url" in image_value:
                 image_value = image_value["url"]


### PR DESCRIPTION
when using the new `dspy.Image` field, it's not possible to make it optional (for example if you have 2-3 images as input, but not all of them are required). For `str` input fields, that's not a problem, as `None` inputs are just rendered as a literal `"None"` on the prompt for the LMs

simple example, this breaks for the image field, but not for the description field:

```python
class ImageReader(dspy.Signature):
    """What is in the image?"""

    image: dspy.Image = dspy.InputField()
    description: str = dspy.InputField()
    response: str = dspy.OutputField()


dspy.Predict(ImageReader)(image=None, description=None)
```

I propose then simply returning "None", explicitly as a text type, so the LM knows clearly that the input is lacking an image