### PR TITLE
Update search.py

### DIFF
--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -122,7 +122,7 @@ def retrieveEnsemblewithMetadata(
     queries = [q for q in queries if q]
 
     if len(queries) == 1:
-        return retrieve(queries[0], k)
+        return retrievewithMetadata(queries[0], k, **kwargs)
     all_queries_passages = []
     for q in queries:
         passages = {}

--- a/dsp/primitives/search.py
+++ b/dsp/primitives/search.py
@@ -116,7 +116,7 @@ def retrieveEnsemblewithMetadata(
 
     if not dsp.settings.rm:
         raise AssertionError("No RM is loaded.")
-    if not dsp.settings.reranker:
+    if dsp.settings.reranker:
         return retrieveRerankEnsemblewithMetadata(queries=queries,k=k)
 
     queries = [q for q in queries if q]


### PR DESCRIPTION
Two edits:

1. Removed `not` from line in `retrieveEnsemblewithMetadata`, as the logic was faulty: using a reranker if it has *not* been set.
2. Retrieving with metadata was not possible - `retrievewithMetadata` was not called and `**kwargs` was missing.

Additionally, using `WeaviateRM` I believe that metatada will never be returned either way, due to the line `parsed_results = [result.properties[self._weaviate_collection_text_key] for result in results.objects]`, as it only returns the collection key text. An issue should be created if my understanding is true.