### PR TITLE
Fixed 404 error in docs links

### DIFF
--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -140,4 +140,4 @@ Prediction(
 
 While signatures are convenient for prototyping with structured inputs/outputs, that's not the only reason to use them!
 
-You should compose multiple signatures into bigger [DSPy modules](/building-blocks/3-modules) and [compile these modules into optimized prompts](/building-blocks/6-optimizers#what-does-a-dspy-optimizer-tune-how-does-it-tune-them) and finetunes.
+You should compose multiple signatures into bigger [DSPy modules](modules.md) and [compile these modules into optimized prompts](/docs/docs/learn/optimization/optimizers.md) and finetunes.


### PR DESCRIPTION
Noticed two broken links at the bottom of https://dspy.ai/learn/programming/signatures/ so have updated the links accordingly. I've chosen the second broken link to redirect to https://dspy.ai/learn/optimization/optimizers/ rather than https://dspy.ai/learn/optimization/overview/ but this is equivocal.