### PR TITLE
Replace relative imports by absolute imports

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -1,15 +1,16 @@
-from .predict import *
-from .primitives import *
-from .retrieve import *
-from .signatures import *
+from dspy.predict import *
+from dspy.primitives import *
+from dspy.retrieve import *
+from dspy.signatures import *
+from dspy.teleprompt import *
 
 import dspy.retrievers
 
 # Functional must be imported after primitives, predict and signatures
-from .functional import * # isort: skip
-from dspy.evaluate import Evaluate # isort: skip
-from dspy.clients import * # isort: skip
-from dspy.adapters import * # isort: skip
+from dspy.functional import *  # isort: skip
+from dspy.evaluate import Evaluate  # isort: skip
+from dspy.clients import *  # isort: skip
+from dspy.adapters import *  # isort: skip
 from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, enable_logging
 from dspy.utils.asyncify import asyncify
 from dspy.utils.saving import load

--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -1,3 +1,4 @@
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
+from dspy.adapters.image_utils import Image

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -1,7 +1,7 @@
-from .lm import LM
-from .provider import Provider, TrainingJob
-from .base_lm import BaseLM, inspect_history
-from .embedding import Embedder
+from dspy.clients.lm import LM
+from dspy.clients.provider import Provider, TrainingJob
+from dspy.clients.base_lm import BaseLM, inspect_history
+from dspy.clients.embedding import Embedder
 import litellm
 import os
 from pathlib import Path
@@ -15,7 +15,7 @@ DISK_CACHE_LIMIT = int(os.environ.get("DSPY_CACHE_LIMIT", 3e10))  # 30 GB defaul
 litellm.cache = Cache(disk_cache_dir=DISK_CACHE_DIR, type="disk")
 
 if litellm.cache.cache.disk_cache.size_limit != DISK_CACHE_LIMIT:
-    litellm.cache.cache.disk_cache.reset('size_limit', DISK_CACHE_LIMIT)
+    litellm.cache.cache.disk_cache.reset("size_limit", DISK_CACHE_LIMIT)
 
 litellm.telemetry = False
 
@@ -26,8 +26,22 @@ if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
     # Accessed at run time by litellm; i.e., fine to keep after import
     os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 
+
 def enable_litellm_logging():
     litellm.suppress_debug_info = False
 
+
 def disable_litellm_logging():
     litellm.suppress_debug_info = True
+
+
+__all__ = [
+    "LM",
+    "Provider",
+    "TrainingJob",
+    "BaseLM",
+    "inspect_history",
+    "Embedder",
+    "enable_litellm_logging",
+    "disable_litellm_logging",
+]

--- a/dspy/datasets/__init__.py
+++ b/dspy/datasets/__init__.py
@@ -1,5 +1,13 @@
-from .colors import Colors
-from .dataloader import DataLoader
-from .dataset import Dataset
-from .hotpotqa import HotPotQA
-from .math import MATH
+from dspy.datasets.colors import Colors
+from dspy.datasets.dataloader import DataLoader
+from dspy.datasets.dataset import Dataset
+from dspy.datasets.hotpotqa import HotPotQA
+from dspy.datasets.math import MATH
+
+__all__ = [
+    "Colors",
+    "DataLoader",
+    "Dataset",
+    "HotPotQA",
+    "MATH",
+]

--- a/dspy/evaluate/__init__.py
+++ b/dspy/evaluate/__init__.py
@@ -1,5 +1,13 @@
 from dspy.dsp.utils import EM, normalize_text
 
-from .auto_evaluation import *
-from .evaluate import Evaluate
-from .metrics import *
+from dspy.evaluate import auto_evaluation
+from dspy.evaluate.evaluate import Evaluate
+from dspy.evaluate import metrics
+
+__all__ = [
+    "auto_evaluation",
+    "Evaluate",
+    "metrics",
+    "EM",
+    "normalize_text",
+]

--- a/dspy/experimental/__init__.py
+++ b/dspy/experimental/__init__.py
@@ -1,4 +1,4 @@
-from .module_graph import *
+from dspy.experimental.module_graph import *
 
-from .synthesizer import *
-from .synthetic_data import *
+from dspy.experimental.synthesizer import *
+from dspy.experimental.synthetic_data import *

--- a/dspy/experimental/synthesizer/__init__.py
+++ b/dspy/experimental/synthesizer/__init__.py
@@ -1,1 +1,1 @@
-from .synthesizer import *
+from dspy.experimental.synthesizer import *

--- a/dspy/predict/__init__.py
+++ b/dspy/predict/__init__.py
@@ -1,10 +1,22 @@
-from .aggregation import majority
-from .chain_of_thought import ChainOfThought
-from .chain_of_thought_with_hint import ChainOfThoughtWithHint
-from .knn import KNN
-from .multi_chain_comparison import MultiChainComparison
-from .predict import Predict
-from .program_of_thought import ProgramOfThought
-from .react import ReAct, Tool
-from .parallel import Parallel
-# from .retry import Retry
+from dspy.predict.aggregation import majority
+from dspy.predict.chain_of_thought import ChainOfThought
+from dspy.predict.chain_of_thought_with_hint import ChainOfThoughtWithHint
+from dspy.predict.knn import KNN
+from dspy.predict.multi_chain_comparison import MultiChainComparison
+from dspy.predict.predict import Predict
+from dspy.predict.program_of_thought import ProgramOfThought
+from dspy.predict.react import ReAct, Tool
+from dspy.predict.parallel import Parallel
+
+__all__ = [
+    "majority",
+    "ChainOfThought",
+    "ChainOfThoughtWithHint",
+    "KNN",
+    "MultiChainComparison",
+    "Predict",
+    "ProgramOfThought",
+    "ReAct",
+    "Tool",
+    "Parallel",
+]

--- a/dspy/predict/avatar/__init__.py
+++ b/dspy/predict/avatar/__init__.py
@@ -1,3 +1,3 @@
-from .avatar import *
-from .models import *
-from .signatures import *
+from dspy.predict.avatar.avatar import *
+from dspy.predict.avatar.models import *
+from dspy.predict.avatar.signatures import *

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -1,5 +1,20 @@
-from .assertions import *
-from .example import *
-from .prediction import *
-from .program import *
-from .python_interpreter import *
+from dspy.primitives import assertions
+from dspy.primitives.example import Example
+from dspy.primitives.module import BaseModule
+from dspy.primitives.prediction import Prediction, Completions
+from dspy.primitives.program import Program, Module
+from dspy.primitives.python_interpreter import PythonInterpreter, TextPrompt, CodePrompt
+
+
+__all__ = [
+    "assertions",
+    "Example",
+    "BaseModule",
+    "Prediction",
+    "Completions",
+    "Program",
+    "Module",
+    "PythonInterpreter",
+    "TextPrompt",
+    "CodePrompt",
+]

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -1,7 +1,6 @@
 import magicattr
 
 from dspy.predict.parallel import Parallel
-from dspy.primitives.assertions import assert_transform_module, backtrack_handler
 from dspy.primitives.module import BaseModule
 from dspy.utils.callback import with_callbacks
 

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -1,10 +1,9 @@
-from dspy.utils.callback import with_callbacks
 import magicattr
 
 from dspy.predict.parallel import Parallel
+from dspy.primitives.assertions import assert_transform_module, backtrack_handler
 from dspy.primitives.module import BaseModule
-# import dspy
-# from dspy.primitives.assertions import *
+from dspy.utils.callback import with_callbacks
 
 
 class ProgramMeta(type):

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -18,14 +18,7 @@ import importlib
 import re
 import typing
 from collections.abc import Mapping
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-)
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 
 class InterpreterError(ValueError):

--- a/dspy/propose/__init__.py
+++ b/dspy/propose/__init__.py
@@ -1,1 +1,5 @@
-from .grounded_proposer import GroundedProposer
+from dspy.propose.grounded_proposer import GroundedProposer
+
+__all__ = [
+    "GroundedProposer",
+]

--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -5,7 +5,7 @@ from dspy.propose.dataset_summary_generator import create_dataset_summary
 from dspy.propose.utils import create_example_string, create_predictor_level_history_string, strip_prefix, get_dspy_source_code
 from dspy.teleprompt.utils import get_signature, get_prompt_model
 
-from .propose_base import Proposer
+from dspy.propose.propose_base import Proposer
 
 # Hardcoded variables (TODO: update)
 MAX_INSTRUCT_IN_HISTORY = 5  # 10

--- a/dspy/retrieve/__init__.py
+++ b/dspy/retrieve/__init__.py
@@ -1,1 +1,5 @@
-from .retrieve import Retrieve
+from dspy.retrieve.retrieve import Retrieve
+
+__all__ = [
+    "Retrieve",
+]

--- a/dspy/retrievers/__init__.py
+++ b/dspy/retrievers/__init__.py
@@ -1,1 +1,3 @@
-from .embeddings import Embeddings
+from dspy.retrievers.embeddings import Embeddings
+
+__all__ = ["Embeddings"]

--- a/dspy/signatures/__init__.py
+++ b/dspy/signatures/__init__.py
@@ -1,2 +1,23 @@
-from .field import *
-from .signature import *
+from dspy.signatures.field import InputField, OutputField, OldField, OldInputField, OldOutputField
+from dspy.signatures.signature import (
+    SignatureMeta,
+    Signature,
+    update_signatures,
+    ensure_signature,
+    make_signature,
+    infer_prefix,
+)
+
+__all__ = [
+    "InputField",
+    "OutputField",
+    "OldField",
+    "OldInputField",
+    "OldOutputField",
+    "SignatureMeta",
+    "Signature",
+    "infer_prefix",
+    "update_signatures",
+    "ensure_signature",
+    "make_signature",
+]

--- a/dspy/teleprompt/__init__.py
+++ b/dspy/teleprompt/__init__.py
@@ -1,15 +1,31 @@
-from .avatar_optimizer import *
-from .bettertogether import BetterTogether
-from .bootstrap import *
-from .bootstrap_finetune import BootstrapFinetune
-from .copro_optimizer import COPRO
-from .ensemble import *
-from .knn_fewshot import *
+from dspy.teleprompt.avatar_optimizer import AvatarOptimizer
+from dspy.teleprompt.bettertogether import BetterTogether
+from dspy.teleprompt.bootstrap import BootstrapFewShot
+from dspy.teleprompt.bootstrap_finetune import BootstrapFinetune
+from dspy.teleprompt.copro_optimizer import COPRO
+from dspy.teleprompt.ensemble import Ensemble
+from dspy.teleprompt.knn_fewshot import KNNFewShot
+
 # from .mipro_optimizer import MIPRO
-from .mipro_optimizer_v2 import MIPROv2
-from .random_search import *
+from dspy.teleprompt.mipro_optimizer_v2 import MIPROv2
+from dspy.teleprompt.random_search import BootstrapFewShotWithRandomSearch
+
 # from .signature_opt import SignatureOptimizer
 # from .signature_opt_bayesian import BayesianSignatureOptimizer
-from .teleprompt import *
-from .teleprompt_optuna import *
-from .vanilla import *
+from dspy.teleprompt.teleprompt import Teleprompter
+from dspy.teleprompt.teleprompt_optuna import BootstrapFewShotWithOptuna
+from dspy.teleprompt.vanilla import LabeledFewShot
+
+__all__ = [
+    "AvatarOptimizer",
+    "BetterTogether",
+    "BootstrapFewShot",
+    "BootstrapFinetune",
+    "COPRO",
+    "Ensemble",
+    "KNNFewShot",
+    "MIPROv2",
+    "BootstrapFewShotWithRandomSearch",
+    "BootstrapFewShotWithOptuna",
+    "LabeledFewShot",
+]

--- a/dspy/teleprompt/bootstrap_finetune.py
+++ b/dspy/teleprompt/bootstrap_finetune.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional, Union
 
 import dspy
-from dspy import LM  # TODO: Remove after the old LM class is removed
 from dspy.adapters.base import Adapter
+from dspy.clients.lm import LM  # TODO: Remove after the old LM class is removed
 from dspy.clients.utils_finetune import infer_data_format
 from dspy.evaluate.evaluate import Evaluate
 from dspy.predict.predict import Predict

--- a/dspy/utils/__init__.py
+++ b/dspy/utils/__init__.py
@@ -1,18 +1,27 @@
 from dspy.utils.callback import BaseCallback, with_callbacks
-from dspy.utils.dummies import *
-from dspy.utils.caching import *
-from dspy.utils.logging_utils import *
+from dspy.utils.dummies import DummyLM, DummyVectorizer, dummy_rm
 
 import os
-import ujson
 import requests
+
 
 def download(url):
     filename = os.path.basename(url)
-    remote_size = int(requests.head(url, allow_redirects=True).headers.get('Content-Length', 0))
+    remote_size = int(requests.head(url, allow_redirects=True).headers.get("Content-Length", 0))
     local_size = os.path.getsize(filename) if os.path.exists(filename) else 0
 
     if local_size != remote_size:
         print(f"Downloading '{filename}'...")
-        with requests.get(url, stream=True) as r, open(filename, 'wb') as f:
-            for chunk in r.iter_content(chunk_size=8192): f.write(chunk)
+        with requests.get(url, stream=True) as r, open(filename, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+
+__all__ = [
+    "download",
+    "BaseCallback",
+    "with_callbacks",
+    "DummyLM",
+    "DummyVectorizer",
+    "dummy_rm",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,7 +229,7 @@ target-version = "py39"
 select = [
     "F", # Pyflakes
     "E", # Pycodestyle
-
+    "TID252",  # Absolute imports
 ]
 ignore = [
     "E501", # Line too long


### PR DESCRIPTION
We are replacing all relative imports by absolute imports to get compatible with Google style guide. This is beneficial for automatic API reference generation, which we are adding now. 