### PR TITLE
Loose the version check between saving/loading

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -219,9 +219,7 @@ class BaseModule:
             with open(path, "wb") as f:
                 cloudpickle.dump(state, f)
         else:
-            raise ValueError(
-                f"`path` must end with `.json` or `.pkl` when `save_program=False`, but received: {path}"
-            )
+            raise ValueError(f"`path` must end with `.json` or `.pkl` when `save_program=False`, but received: {path}")
 
     def load(self, path):
         """Load the saved module. You may also want to check out dspy.load, if you want to

--- a/dspy/utils/saving.py
+++ b/dspy/utils/saving.py
@@ -10,10 +10,11 @@ logger = logging.getLogger(__name__)
 
 
 def get_dependency_versions():
+    cloudpickle_version = '.'.join(cloudpickle.__version__.split('.')[:2])
     return {
-        "python": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        "python": f"{sys.version_info.major}.{sys.version_info.minor}",
         "dspy": importlib_metadata.version("dspy"),
-        "cloudpickle": cloudpickle.__version__,
+        "cloudpickle": cloudpickle_version,
     }
 
 


### PR DESCRIPTION
Earlier we raise warning on micro version mismatch for python and cloudpickle, with this PR we only check the major version. 