### PR TITLE
[Doc PR Part 2] Fix docstring that renders oddly on mkdocs-powered API reference page

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -48,23 +48,22 @@ class BootstrapFewShot(Teleprompter):
         A Teleprompter class that composes a set of demos/examples to go into a predictor's prompt.
         These demos come from a combination of labeled examples in the training set, and bootstrapped demos.
 
-        Parameters
-        ----------
-        metric: Callable
-            A function that compares an expected value and predicted value, outputting the result of that comparison. 
-        metric_threshold: optional float, default `None`
-            If the metric yields a numerical value, then check it against this threshold when
-            deciding whether or not to accept a bootstrap example.
-        teacher_settings: dict, optional
-            Settings for the `teacher` model.
-        max_bootstrapped_demos: int, default 4
-            Maximum number of bootstrapped demonstrations to include
-        max_labeled_demos: int, default 16
-            Maximum number of labeled demonstrations to include.
-        max_rounds: int, default 1
-            Number of iterations to attempt generating the required bootstrap examples. If unsuccessful after `max_rounds`, the program ends.
-        max_errors: int, default 5
-            Maximum number of errors until program ends.
+        Args:
+            metric: Callable
+                A function that compares an expected value and predicted value, outputting the result of that comparison. 
+            metric_threshold: optional float, default `None`
+                If the metric yields a numerical value, then check it against this threshold when
+                deciding whether or not to accept a bootstrap example.
+            teacher_settings: dict, optional
+                Settings for the `teacher` model.
+            max_bootstrapped_demos: int, default 4
+                Maximum number of bootstrapped demonstrations to include
+            max_labeled_demos: int, default 16
+                Maximum number of labeled demonstrations to include.
+            max_rounds: int, default 1
+                Number of iterations to attempt generating the required bootstrap examples. If unsuccessful after `max_rounds`, the program ends.
+            max_errors: int, default 5
+                Maximum number of errors until program ends.
         """
         self.metric = metric
         self.metric_threshold = metric_threshold

--- a/dspy/utils/asyncify.py
+++ b/dspy/utils/asyncify.py
@@ -10,6 +10,7 @@ _limiter = None
 
 def get_async_max_workers():
     import dspy
+
     return dspy.settings.async_max_workers
 
 
@@ -36,16 +37,19 @@ def asyncify(program: Module) -> Callable[[Any, Any], Awaitable[Any]]:
         program: The DSPy program to be wrapped for asynchronous execution.
 
     Returns:
-        An async function that, when awaited, runs the program in a worker thread. The current 
-        thread's configuration context is inherited for each call.
+        An async function: An async function that, when awaited, runs the program in a worker thread.
+            The current thread's configuration context is inherited for each call.
     """
+
     async def async_program(*args, **kwargs) -> Any:
         # Capture the current overrides at call-time.
         from dspy.dsp.utils.settings import thread_local_overrides
+
         parent_overrides = thread_local_overrides.overrides.copy()
 
         def wrapped_program(*a, **kw):
             from dspy.dsp.utils.settings import thread_local_overrides
+
             original_overrides = thread_local_overrides.overrides
             thread_local_overrides.overrides = parent_overrides.copy()
             try:

--- a/dspy/utils/dummies.py
+++ b/dspy/utils/dummies.py
@@ -4,57 +4,66 @@ from typing import Any, Dict, Union
 
 import numpy as np
 
-from dspy.dsp.utils.utils import dotdict
 from dspy.adapters.chat_adapter import FieldInfoWithName, field_header_pattern, format_fields
 from dspy.clients.lm import LM
+from dspy.dsp.utils.utils import dotdict
 from dspy.signatures.field import OutputField
 from dspy.utils.callback import with_callbacks
 
 
 class DummyLM(LM):
-    """
-    Dummy language model for unit testing purposes.
+    """Dummy language model for unit testing purposes.
 
     Three modes of operation:
 
-    ## 1. List of dictionaries
+    Mode 1: List of dictionaries
 
     If a list of dictionaries is provided, the dummy model will return the next dictionary
     in the list for each request, formatted according to the `format_fields` function.
     from the chat adapter.
 
-    ```python
-        lm = DummyLM([{"answer": "red"}, {"answer": "blue"}])
-        dspy.settings.configure(lm=lm)
-        predictor("What color is the sky?")
-        # Output: "[[## answer ##]]\nred"
-        predictor("What color is the sky?")
-        # Output: "[[## answer ##]]\nblue"
+    Example:
+
+    ```
+    lm = DummyLM([{"answer": "red"}, {"answer": "blue"}])
+    dspy.settings.configure(lm=lm)
+    predictor("What color is the sky?")
+    # Output:
+    # [[## answer ##]]
+    # red
+    predictor("What color is the sky?")
+    # Output:
+    # [[## answer ##]]
+    # blue
     ```
 
-    ## 2. Dictionary of dictionaries
+    Mode 2: Dictionary of dictionaries
 
     If a dictionary of dictionaries is provided, the dummy model will return the value
     corresponding to the key which is contained with the final message of the prompt,
     formatted according to the `format_fields` function from the chat adapter.
 
-    ```python
-        lm = DummyLM({"What color is the sky?": {"answer": "blue"}})
-        dspy.settings.configure(lm=lm)
-        predictor("What color is the sky?")
-        # Output: "[[## answer ##]]\nblue"
+    ```
+    lm = DummyLM({"What color is the sky?": {"answer": "blue"}})
+    dspy.settings.configure(lm=lm)
+    predictor("What color is the sky?")
+    # Output:
+    # [[## answer ##]]
+    # blue
     ```
 
-    ## 3. Follow examples
+    Mode 3: Follow examples
 
     If `follow_examples` is set to True, and the prompt contains an example input exactly equal to the prompt,
     the dummy model will return the output from that example.
 
-    ```python
-        lm = DummyLM([{"answer": "red"}], follow_examples=True)
-        dspy.settings.configure(lm=lm)
-        predictor("What color is the sky?, demos=dspy.Example(input="What color is the sky?", output="blue"))
-        # Output: "[[## answer ##]]\nblue"
+    ```
+    lm = DummyLM([{"answer": "red"}], follow_examples=True)
+    dspy.settings.configure(lm=lm)
+    predictor("What color is the sky?, demos=dspy.Example(input="What color is the sky?", output="blue"))
+    # Output:
+    # [[## answer ##]]
+    # blue
     ```
 
     """


### PR DESCRIPTION
These docstring right now renders oddly on the API reference page, we need to fix them.