### PR TITLE
Allow returning empty results when nothing is retrieved from DatabricksRM

### DIFF
--- a/dspy/retrieve/databricks_rm.py
+++ b/dspy/retrieve/databricks_rm.py
@@ -273,16 +273,12 @@ class DatabricksRM(dspy.Retrieve):
 
         # Extracting the results
         items = []
-        if "data_array" not in results["result"]:
-            raise ValueError(
-                "`data_array` not found in the results from the Databricks Vector Search Index. Please check if your "
-                "index is running."
-            )
-        for _, data_row in enumerate(results["result"]["data_array"]):
-            item = {}
-            for col_name, val in zip(col_names, data_row):
-                item[col_name] = val
-            items += [item]
+        if "data_array" in results["result"]:
+            for _, data_row in enumerate(results["result"]["data_array"]):
+                item = {}
+                for col_name, val in zip(col_names, data_row):
+                    item[col_name] = val
+                items += [item]
 
         # Sorting results by score in descending order
         sorted_docs = sorted(items, key=lambda x: x["score"], reverse=True)[: self.k]

--- a/dspy/retrieve/databricks_rm.py
+++ b/dspy/retrieve/databricks_rm.py
@@ -273,6 +273,11 @@ class DatabricksRM(dspy.Retrieve):
 
         # Extracting the results
         items = []
+        if "data_array" not in results["result"]:
+            raise ValueError(
+                "`data_array` not found in the results from the Databricks Vector Search Index. Please check if your "
+                "index is running."
+            )
         for _, data_row in enumerate(results["result"]["data_array"]):
             item = {}
             for col_name, val in zip(col_names, data_row):


### PR DESCRIPTION
Right now in the following code, it's possible that key `data_array` doesn't exist, which leads to a opaque error to users. This happens when Databricks vector search index is not ready.  We should not fail when this happens, and just return empty results.

```
        for _, data_row in enumerate(results["result"]["data_array"]):
            item = {}
            for col_name, val in zip(col_names, data_row):
                item[col_name] = val
            items += [item]
```