### PR TITLE
Fix streamify docstring

### DIFF
--- a/dspy/utils/streaming.py
+++ b/dspy/utils/streaming.py
@@ -18,23 +18,27 @@ def streamify(program: Module) -> Callable[[Any, Any], Awaitable[Any]]:
 
     Args:
         program: The DSPy program to wrap with streaming functionality.
+
     Returns:
         A function that takes the same arguments as the original program, but returns an async
-        generator that yields the program's outputs incrementally.
+            generator that yields the program's outputs incrementally.
 
     Example:
-        >>> class TestSignature(dspy.Signature):
-        >>>     input_text: str = dspy.InputField()
-        >>>     output_text: str = dspy.OutputField()
-        >>>
-        >>> # Create the program and wrap it with streaming functionality
-        >>> program = dspy.streamify(dspy.Predict(TestSignature))
-        >>>
-        >>> # Use the program with streaming output
-        >>> async def use_streaming():
-        >>>     output_stream = program(input_text="Test")
-        >>>     async for value in output_stream:
-        >>>         print(value)  # Print each streamed value incrementally
+
+    ```python
+    class TestSignature(dspy.Signature):
+        input_text: str = dspy.InputField()
+        output_text: str = dspy.OutputField()
+
+    # Create the program and wrap it with streaming functionality
+    program = dspy.streamify(dspy.Predict(TestSignature))
+
+    # Use the program with streaming output
+    async def use_streaming():
+        output_stream = program(input_text="Test")
+        async for value in output_stream:
+            print(value)  # Print each streamed value incrementally
+    ```
     """
     import dspy
 


### PR DESCRIPTION
Two small fixes in order to render correctly on API reference page:

- Empty line before "Returns" section
- Use code block for code example section.

Before:
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/a5b36021-06fe-46be-bb45-c935b8028026" />

After:
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/0ea2322a-c327-4460-a996-9aef8b531762" />
