### PR TITLE
Make the code example more readable

### DIFF
--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -217,7 +217,7 @@ h2.doc-heading {
 /* Ensure code is readable */
 .highlight code {
     font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
-    font-size: 0.9em;
+    font-size: 0.75em;
 }
 
 /* Copy button styling */

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,5 @@ mkdocs-redirects>=1.2.1
 mkdocstrings>=0.26.1
 mkdocstrings-python>=1.12.2
 urllib3==1.26.6
+mistune==3.0.2
 git+https://github.com/stanfordnlp/dspy.git


### PR DESCRIPTION
The previous font size is too big, we are making it smaller.

Effect:
<img width="1202" alt="image" src="https://github.com/user-attachments/assets/9e6ac3d1-a03f-410b-abf6-4a9f14aa6dd6" />

