### PR TITLE
Add shuffle to dataset split in `_set_and_validate_datasets`in MIPROv2

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -242,7 +242,7 @@ class MIPROv2(Teleprompter):
                 )
             valset_size = min(1000, max(1, int(len(trainset) * 0.80)))
             cutoff = len(trainset) - valset_size
-            random.shuffle(trainset)
+            self.rng.shuffle(trainset)
             valset = trainset[cutoff:]
             trainset = trainset[:cutoff]
         else:

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -242,6 +242,7 @@ class MIPROv2(Teleprompter):
                 )
             valset_size = min(1000, max(1, int(len(trainset) * 0.80)))
             cutoff = len(trainset) - valset_size
+            random.shuffle(trainset)
             valset = trainset[cutoff:]
             trainset = trainset[:cutoff]
         else:


### PR DESCRIPTION
### Summary
Added `random.shuffle` to `_set_and_validate_datasets` for better randomness in train/validation split when no validation set is provided.

### Notes
- Improves representativeness of validation set.
- Open to feedback on whether this responsibility fits within the method's scope.
