### PR TITLE
support for code imported libraries

### DIFF
--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -35,6 +35,7 @@ for await (const line of readLines(Deno.stdin)) {
   
   // Wrap execution in a try/catch so we can handle syntax errors, etc.
   try {
+    await pyodide.loadPackagesFromImports(code);
     // 1. Temporarily override stdout/stderr so we can capture prints.
     pyodide.runPython(`
 import sys


### PR DESCRIPTION
PythonInterpreter support for imported libraries in code
helps resolve cases like #1004 