### PR TITLE
Add tools calling for dspy.LM

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -106,6 +106,9 @@ class Predict(Module, Parameter):
             missing = [k for k in signature.input_fields if k not in kwargs]
             print(f"WARNING: Not all input fields were provided to module. Present: {present}. Missing: {missing}.")
 
+        if "tools" in kwargs:
+            config["tools"]  = kwargs.pop("tools")
+
         import dspy
         adapter = dspy.settings.adapter or dspy.ChatAdapter()
         completions = adapter(lm, lm_kwargs=config, signature=signature, demos=demos, inputs=kwargs)

--- a/dspy/predict/predict_with_tools.py
+++ b/dspy/predict/predict_with_tools.py
@@ -1,0 +1,48 @@
+from dspy.predict.predict import Predict
+
+
+class PredictWithTools(Predict):
+    """Predict with tool calling support.
+
+    This class is a thin wrapper around the Predict class that explicit has tool calling support.
+    """
+    def __init__(self, signature, callbacks=None, tools=None, tool_choice="auto", **configs):
+        """Initialize the PredictWithTools class.
+
+        Args:
+            signature (str): The signature of `PredictWithTools`.
+            callbacks (list): The callbacks that are called before and after the Predict call.
+            tools (list): The list of tools to use. For more details, please refer to
+                https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools
+            tool_choice (str): The tool choice strategy, defaults to "auto". For more details, please refer to
+                https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice
+            **configs: Additional configurations.
+        """
+        super().__init__(signature, callbacks, **configs)
+        self.tools = tools
+        self.tool_choice = tool_choice
+
+    def __call__(self, tools=None, tool_choice="auto", **kwargs):
+        """Call the PredictWithTools class.
+
+        This method performs prediction using the configured language model, with the ability
+        to invoke tools if specified. It can either return tool calling instructions or
+        direct prediction results.
+
+        Args:
+            tools (list, optional): List of available tools for the LLM to choose from.
+                If provided, overrides the `tools` set during initialization.
+            tool_choice (str, optional): Strategy for tool selection, defaults to "auto".
+                If provided, overrides the `tool_choice` set during initialization.
+            **kwargs: Additional arguments passed to the underlying Predict class.
+
+        Returns:
+            dspy.Prediction: One of two types:
+                - Tool calling scenario: Contains a single field 'tool_calls' with a list
+                  of tool invocations and their arguments.
+                - Direct prediction: Contains fields as specified by self.signature.
+        """
+        kwargs["tools"] = tools or self.tools
+        kwargs["tool_choice"] = tool_choice or self.tool_choice
+
+        return super().__call__(**kwargs)

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -9,6 +9,7 @@ import ujson
 import dspy
 from dspy import Predict, Signature
 from dspy.utils.dummies import DummyLM
+import os
 
 
 def test_initialization_with_string_signature():
@@ -344,3 +345,22 @@ def test_load_state_chaining():
     new_instance = Predict("question -> answer").load_state(state)
     assert new_instance is not None
     assert new_instance.demos == original.demos
+
+@pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OpenAI API key is not set")
+def test_predict_tool_calls_are_returned():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini")):
+        predict = Predict("question -> answer")
+        outputs = predict(question="what's the weather in Paris?", tools=tools)
+        assert "tool_calls" in outputs

--- a/tests/predict/test_predict_with_tools.py
+++ b/tests/predict/test_predict_with_tools.py
@@ -1,0 +1,26 @@
+import os
+
+import pytest
+
+import dspy
+from dspy.predict.predict_with_tools import PredictWithTools
+
+
+@pytest.mark.skipif("OPENAI_API_KEY" not in os.environ, reason="OpenAI API key is not set")
+def test_basic_predict_with_tools():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini")):
+        predict = PredictWithTools("question -> answer", tools=tools)
+        outputs = predict(question="what's the weather in Paris?", tools=tools)
+        assert "tool_calls" in outputs


### PR DESCRIPTION
Add `tools` arg for `dspy.LM`, since litellm natively supports tool calling. We may also consider have `dspy.ReAct` use the default tool calling from LLM providers for robustness. 

A sample code looks like:
```
import dspy

lm = dspy.LM("openai/gpt-4o-mini")

tools = [
    {
        "type": "function",
        "function": {
            "name": "get_current_weather",
            "description": "Get the current weather in a given location",
            "parameters": {
                "type": "object",
                "properties": {
                    "location": {
                        "type": "string",
                        "description": "The city and state, e.g. San Francisco, CA",
                    },
                    "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
                },
                "required": ["location"],
            },
        },
    }
]

outputs = lm("What's the weather like in Paris today?", tools=tools)

print(outputs)
```

The output is:

```
(dspy) [add-tool-calling][~/Documents/genai/dspy]$ python3 tool_tmp.py
[{'text': None, 'tool_calls': [ChatCompletionMessageToolCall(function=Function(arguments='{"location":"Paris, France"}', name='get_current_weather'), id='call_s7pLflqklT2MekZt8eIOBQDU', type='function')]}]
```

We also change the adapter and `dspy.Predict` so that users can use the `tools` with `dspy.Predict`.