### PR TITLE
Update multi_chain_comparison.py

### DIFF
--- a/dspy/predict/multi_chain_comparison.py
+++ b/dspy/predict/multi_chain_comparison.py
@@ -37,7 +37,7 @@ class MultiChainComparison(Module):
 
         for c in completions:
             rationale = c.get('rationale', c.get('reasoning')).strip().split("\n")[0].strip()
-            answer = c[self.last_key].strip().split("\n")[0].strip()
+            answer = str(c[self.last_key]).strip().split("\n")[0].strip()
             attempts.append(
                 f"«I'm trying to {rationale} I'm not sure but my prediction is {answer}»",
             )


### PR DESCRIPTION
Encountered a type error locally since my signature was returning a float (score), which doesn't have the `strip()` method. Once we cast this answer to a string, things work smoothly. 

NOTE: It seems like the answers provided within the completions only contain the final output field, but this does not generalize to cases where the signature has multiple output fields.