### PR TITLE
Add landing page for api reference

### DIFF
--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -1,0 +1,3 @@
+# API Reference
+
+Welcome to the DSPy API reference documentation. This section provides detailed information about DSPy's classes, modules, and functions.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
         - Cheatsheet: cheatsheet.md
 
     - API Reference:
+        - API Reference: api/index.md
         - Adapters:
             - Adapter: api/adapters/Adapter.md
             - ChatAdapter: api/adapters/ChatAdapter.md

--- a/docs/scripts/generate_api_docs.py
+++ b/docs/scripts/generate_api_docs.py
@@ -235,7 +235,10 @@ def remove_empty_dirs(path: Path):
 if __name__ == "__main__":
     api_dir = Path("docs/api")
     if api_dir.exists():
-        shutil.rmtree(api_dir)
+        # Delete only subdirectories
+        for item in api_dir.iterdir():
+            if item.is_dir():
+                shutil.rmtree(item)
 
     for keys in API_MAPPING.keys():
         # Create a directory for each API category
@@ -243,6 +246,7 @@ if __name__ == "__main__":
         subpath.mkdir(parents=True, exist_ok=True)
 
     excluded_modules = ["dspy.dsp"]
+
     generate_md_docs(api_dir, excluded_modules=excluded_modules)
     # Clean up empty directories
     remove_empty_dirs(api_dir)

--- a/docs/scripts/generate_api_summary.py
+++ b/docs/scripts/generate_api_summary.py
@@ -112,6 +112,7 @@ def main():
 
     # Create API section
     api_section = ["    - API Reference:"]
+    api_section.append("        - API Reference: api/index.md")
     api_section.extend(format_nav_section(api_nav))
     api_section.append("")  # Add empty line before theme section
 


### PR DESCRIPTION
 Add a landing page for DSPy api reference doc. right now the landing page is `dspy.Adapter`:

<img width="1724" alt="image" src="https://github.com/user-attachments/assets/e99c2bc3-91eb-4d8b-8693-9795af607bfc" />
