### PR TITLE
Fix metadata processing in chat adapter

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -349,8 +349,8 @@ def get_annotation_name(annotation: Type) -> str:
     origin = get_origin(annotation)
     args = get_args(annotation)
     if origin is None:
-        if hasattr(annotation, "_name_"):
-            return annotation._name_
+        if hasattr(annotation, "__name__"):
+            return annotation.__name__
         else:
             return str(annotation)
     else:


### PR DESCRIPTION
This PR enhances the ChatAdapter implementation with two improvements:

**1. Added Field Metadata Processing:**
- Introduced new metadata handling capabilities for numeric field constraints with PERMITTED_CONSTRAINTS
- Added new utility functions to process field metadata:
  - _format_constraint(): Formats numeric constraints (gt, lt, ge, le, multiple_of, allow_inf_nan) based on the constraints that can be passed in Pydantic's fields class (https://docs.pydantic.dev/latest/concepts/fields/#field-aliases)
  - format_metadata_summary(): Creates human-readable metadata summaries for each field
  - format_metadata_constraints(): Formats field constraints for prompt generation 
- Enhanced field descriptions in prompts to include metadata information (using the summary and the paragraphical format). 
- Added support for numeric field constraints in field metadata processing

**example:**
relevance_and_significance (float): The score of the argument based on its relevance and significance.
When evaluating relevance and significance, consider the following questions:
- How significant is the central claim the argument is trying to establish?
- How relevant is the claim to the topic?
The score should be a floating-point number between the specified lower and upper bounds. [Metadata: Ge(ge=0.0); Le(le=1.0)] (this is formatted using format_metadata_summary())
[[ ## relevance_and_significance ## ]]
{relevance_and_significance}        # note: the value you produce must be a single float value that is greater than or equal to 0.0 and less than or equal to 1.0. (this is formatted using format_metadata_constraints())

**2. Improved Code Documentation and Type Hints:**
- Added comprehensive docstring to all functions and classes
- Added proper type hints throughout the file
- Improved function signatures with explicit type annotations
- Enhanced error messages for better debugging
- Added descriptive comments for complex logic sections