### PR TITLE
[`docs`] Add an example for a local embedding model as the custom function

### DIFF
--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -48,7 +48,7 @@ class Embedder:
         from sentence_transformers import SentenceTransformer
 
         # Load an extremely efficient local model for retrieval
-        model = SentenceTransformer("static-retrieval-mrl-en-v1", device="cpu")
+        model = SentenceTransformer("sentence-transformers/static-retrieval-mrl-en-v1", device="cpu")
 
         embedder = dspy.Embedder(model.encode)
         embeddings = embedder(["hello", "world"], batch_size=1)

--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -40,7 +40,23 @@ class Embedder:
         assert embeddings.shape == (2, 1536)
         ```
 
-        Example 2: Using a custom function.
+        Example 2: Using any local embedding model, e.g. from https://huggingface.co/models?library=sentence-transformers.
+
+        ```python
+        # pip install sentence_transformers
+        import dspy
+        from sentence_transformers import SentenceTransformer
+
+        # Load an extremely efficient local model for retrieval
+        model = SentenceTransformer("static-retrieval-mrl-en-v1", device="cpu")
+
+        embedder = dspy.Embedder(model.encode)
+        embeddings = embedder(["hello", "world"], batch_size=1)
+
+        assert embeddings.shape == (2, 1024)
+        ```
+
+        Example 3: Using a custom function.
 
         ```python
         import dspy


### PR DESCRIPTION
Hello!

## Pull Request overview
* Add an example for a local embedding model as the custom function

## Details
I've been getting asked whether Sentence Transformers is compatible with DSPy. And the answer is: Yes. The [SentenceTranformer.encode](https://sbert.net/docs/package_reference/sentence_transformer/SentenceTransformer.html#sentence_transformers.SentenceTransformer.encode) method can just be passed to the `Embedder` class out of the box.

However, it is not abundently clear in the current [API Documentation](https://dspy.ai/api/models/Embedder/) that this is possible. Because of this, I think it's useful to add another example of a custom embedding function that uses Sentence Transformers with one of the models: https://huggingface.co/models?library=sentence-transformers

The [`sentence-transformers/static-retrieval-mrl-en-v1` model](https://huggingface.co/sentence-transformers/static-retrieval-mrl-en-v1) I've picked was released yesterday in my [Static Embedding blogpost](https://huggingface.co/blog/static-embeddings), and is designed to be considerably faster than any other embedding solution (API or otherwise) without requiring a GPU.

This does mean that it's worse than OpenAI's text-embedding-large-3, but if users care a lot about retrieval performance then they can always choose one of the models that outperforms it. There's lots by now.

- Tom Aarsen