### PR TITLE
Make linenos font size same as code blocks

### DIFF
--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -220,6 +220,10 @@ h2.doc-heading {
     font-size: 0.75em;
 }
 
+.highlight .linenos {
+    font-size: 0.75em;
+}
+
 /* Copy button styling */
 .highlight .md-clipboard {
     color: var(--md-default-fg-color--lighter);


### PR DESCRIPTION
There is a font mismatch in linenos and code classed in the docs codeblocks, that lead to misalignment:

![image](https://github.com/user-attachments/assets/8daf12b8-1c1c-489e-8576-346d0f42de95)

Proposing a fix to make linenos class font-size same as code, we can completely remove the font-size thing as well but that'll make some codeblock scrollable which I think is why this change was done in the first place. Hence adding a new CSS field.