### PR TITLE
Redirect math dataset to DigitalLearningGmbH/MATH-lighteval

### DIFF
--- a/dspy/datasets/math.py
+++ b/dspy/datasets/math.py
@@ -8,7 +8,7 @@ class MATH:
 
         import dspy
 
-        ds = load_dataset("lighteval/MATH", subset)
+        ds = load_dataset("DigitalLearningGmbH/MATH-lighteval", subset)
 
         # NOTE: Defaults to sub-splitting MATH's 'test' split into train/dev/test, presuming that current
         # LMs are trained on MATH's train. Makes no difference for gpt-4o-mini, but might for other models.


### PR DESCRIPTION
Resolve #3358 

The original dataset has been taken down, and the replacement is `DigitalLearningGmbH/MATH-lighteval`. 

Tested manually:

```
(dspy) (base) [fix-math-dataset][~/Documents/mlflow_team/dspy]$ python3
Python 3.12.4 | packaged by Anaconda, Inc. | (main, Jun 18 2024, 10:07:17) [Clang 14.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from dspy.datasets import MATH
>>> dataset = MATH(subset='algebra')
Downloading readme: 100%|██████████████████████████████████████████████████████████████████████████████████████| 8.41k/8.41k [00:00<00:00, 80.2kB/s]
Downloading data: 100%|██████████████████████████████████████████████████████████████████████████████████████████| 505k/505k [00:00<00:00, 1.00MB/s]
Downloading data: 100%|██████████████████████████████████████████████████████████████████████████████████████████| 353k/353k [00:00<00:00, 1.34MB/s]
Generating train split: 100%|████████████████████████████████████████████████████████████████████████| 1744/1744 [00:00<00:00, 311482.97 examples/s]
Generating test split: 100%|█████████████████████████████████████████████████████████████████████████| 1187/1187 [00:00<00:00, 519907.98 examples/s]
>>> 
```