### PR TITLE
Handle lists of models in parameters

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -38,7 +38,16 @@ class Predict(Module, Parameter):
                 if isinstance(demo[field], Image):
                     demo[field] = demo[field].model_dump()
                 elif isinstance(demo[field], BaseModel):
-                    demo[field] = demo[field].model_dump_json()
+                    demo[field] = demo[field].model_dump()
+                # Handle lists of BaseModels
+                elif isinstance(demo[field], list):
+                    processed_list = []
+                    for item in demo[field]:
+                        if isinstance(item, BaseModel):
+                            processed_list.append(item.model_dump())
+                        else:
+                            processed_list.append(item)
+                    demo[field] = processed_list
 
             state["demos"].append(demo)
 


### PR DESCRIPTION
Simple fix for https://github.com/stanfordnlp/dspy/issues/3920

When dumping state check if the field is a list, and if so convert each item to a serializable dict if applicable. Lists of images are not handled.

I also changed it so that models are converted to dicts rather than a JSON string. This makes more sense to me as then the entire resulting object will be converted to a JSON string later.

I added a simple test case that passes.