### PR TITLE
Do not initialize the cache if DSP_CACHEBOOL is false

### DIFF
--- a/dspy/dsp/cache_utils.py
+++ b/dspy/dsp/cache_utils.py
@@ -22,10 +22,6 @@ def noop_decorator(arg=None, *noop_args, **noop_kwargs):
     else:
         return decorator
 
-
-cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), 'cachedir_joblib')
-CacheMemory = Memory(location=cachedir, verbose=0)
-
 cachedir2 = os.environ.get('DSP_NOTEBOOK_CACHEDIR')
 NotebookCacheMemory = dotdict()
 NotebookCacheMemory.cache = noop_decorator
@@ -34,7 +30,10 @@ if cachedir2:
     NotebookCacheMemory = Memory(location=cachedir2, verbose=0)
 
 
-if not cache_turn_on:
+if cache_turn_on:
+    cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), 'cachedir_joblib')
+    CacheMemory = Memory(location=cachedir, verbose=0)
+else:
     CacheMemory = dotdict()
     CacheMemory.cache = noop_decorator
 

--- a/dspy/dsp/cache_utils.py
+++ b/dspy/dsp/cache_utils.py
@@ -22,20 +22,16 @@ def noop_decorator(arg=None, *noop_args, **noop_kwargs):
     else:
         return decorator
 
-cachedir2 = os.environ.get('DSP_NOTEBOOK_CACHEDIR')
 NotebookCacheMemory = dotdict()
 NotebookCacheMemory.cache = noop_decorator
 
-if cachedir2:
-    NotebookCacheMemory = Memory(location=cachedir2, verbose=0)
-
+CacheMemory = dotdict()
+CacheMemory.cache = noop_decorator
 
 if cache_turn_on:
     cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), 'cachedir_joblib')
     CacheMemory = Memory(location=cachedir, verbose=0)
-else:
-    CacheMemory = dotdict()
-    CacheMemory.cache = noop_decorator
 
-    NotebookCacheMemory = dotdict()
-    NotebookCacheMemory.cache = noop_decorator
+    cachedir2 = os.environ.get('DSP_NOTEBOOK_CACHEDIR')
+    if cachedir2:
+        NotebookCacheMemory = Memory(location=cachedir2, verbose=0)


### PR DESCRIPTION
Even if DSP_CACHEBOOL is set to false, the Memory context will still be initialized. 

This is not desirable in cases where the file system is not available or is read only. 

This code is run when the dspy package is imported, whether or not the caching is used. So, it's important to be able to completely opt out of filesystem access.