### PR TITLE
feat: allow to disable dspy write to history when running in prod

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+import dspy
+
 GLOBAL_HISTORY = []
 
 class BaseLM(ABC):
@@ -18,6 +20,9 @@ class BaseLM(ABC):
         _inspect_history(self.history, n)
 
     def update_global_history(self, entry):
+        if dspy.settings.disable_history:
+            return
+
         GLOBAL_HISTORY.append(entry)
 
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -126,6 +126,9 @@ class LM(BaseLM):
         else:
             outputs = [c.message.content if hasattr(c, "message") else c["text"] for c in response["choices"]]
 
+        if dspy.settings.disable_history:
+            return outputs
+
         # Logging, with removed api key & where `cost` is None on cache hit.
         kwargs = {k: v for k, v in kwargs.items() if not k.startswith("api_")}
         entry = dict(prompt=prompt, messages=messages, kwargs=kwargs, response=response)

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -19,6 +19,7 @@ DEFAULT_CONFIG = dotdict(
     callbacks=[],
     async_max_workers=8,
     send_stream=None,
+    disable_history=False,
 )
 
 # Global base configuration and owner tracking


### PR DESCRIPTION
This PR is to add setting to disable writing history when running in production.

Related discussion:
- https://github.com/stanfordnlp/dspy/issues/7262