### PR TITLE
Support status streaming

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -5,14 +5,10 @@ import re
 import threading
 import uuid
 from datetime import datetime
-from hashlib import sha256
 from typing import Any, Dict, List, Literal, Optional
 
 import litellm
-import pydantic
 import ujson
-from cachetools import LRUCache, cached
-from litellm import RetryPolicy
 
 from dspy.adapters.base import Adapter
 from dspy.clients.openai import OpenAIProvider
@@ -37,9 +33,8 @@ class LM(BaseLM):
         temperature: float = 0.0,
         max_tokens: int = 1000,
         cache: bool = True,
-        cache_in_memory: bool = True,
         callbacks: Optional[List[BaseCallback]] = None,
-        num_retries: int = 8,
+        num_retries: int = 3,
         provider=None,
         finetuning_model: Optional[str] = None,
         launch_kwargs: Optional[dict[str, Any]] = None,
@@ -56,7 +51,6 @@ class LM(BaseLM):
             max_tokens: The maximum number of tokens to generate per response.
             cache: Whether to cache the model responses for reuse to improve performance
                    and reduce costs.
-            cache_in_memory: To enable additional caching with LRU in memory.
             callbacks: A list of callback functions to run before and after each request.
             num_retries: The number of times to retry a request if it fails transiently due to
                          network error, rate limiting, etc. Requests are retried with exponential
@@ -69,7 +63,6 @@ class LM(BaseLM):
         self.model = model
         self.model_type = model_type
         self.cache = cache
-        self.cache_in_memory = cache_in_memory
         self.provider = provider or self.infer_provider()
         self.callbacks = callbacks or []
         self.history = []
@@ -97,39 +90,20 @@ class LM(BaseLM):
     def __call__(self, prompt=None, messages=None, **kwargs):
         # Build the request.
         cache = kwargs.pop("cache", self.cache)
-        # disable cache will also disable in memory cache
-        cache_in_memory = cache and kwargs.pop("cache_in_memory", self.cache_in_memory)
         messages = messages or [{"role": "user", "content": prompt}]
         kwargs = {**self.kwargs, **kwargs}
 
         # Make the request and handle LRU & disk caching.
-        if cache_in_memory:
-            completion = cached_litellm_completion if self.model_type == "chat" else cached_litellm_text_completion
-
-            response = completion(
-                request=dict(model=self.model, messages=messages, **kwargs),
-                num_retries=self.num_retries,
-            )
+        if self.model_type == "chat":
+            completion = cached_litellm_completion if cache else litellm_completion
         else:
-            completion = litellm_completion if self.model_type == "chat" else litellm_text_completion
+            completion = cached_litellm_text_completion if cache else litellm_text_completion
 
-            response = completion(
-                request=dict(model=self.model, messages=messages, **kwargs),
-                num_retries=self.num_retries,
-                # only leverage LiteLLM cache in this case
-                cache={"no-cache": not cache, "no-store": not cache},
-            )
-
-        if kwargs.get("logprobs"):
-            outputs = [
-                {
-                    "text": c.message.content if hasattr(c, "message") else c["text"],
-                    "logprobs": c.logprobs if hasattr(c, "logprobs") else c["logprobs"],
-                }
-                for c in response["choices"]
-            ]
-        else:
-            outputs = [c.message.content if hasattr(c, "message") else c["text"] for c in response["choices"]]
+        response = completion(
+            request=ujson.dumps(dict(model=self.model, messages=messages, **kwargs)),
+            num_retries=self.num_retries,
+        )
+        outputs = [c.message.content if hasattr(c, "message") else c["text"] for c in response["choices"]]
 
         if dspy.settings.disable_history:
             return outputs
@@ -144,7 +118,6 @@ class LM(BaseLM):
             timestamp=datetime.now().isoformat(),
             uuid=str(uuid.uuid4()),
             model=self.model,
-            response_model=response["model"],
             model_type=self.model_type,
         )
         self.history.append(entry)
@@ -154,11 +127,11 @@ class LM(BaseLM):
 
     def launch(self, launch_kwargs: Optional[Dict[str, Any]] = None):
         launch_kwargs = launch_kwargs or self.launch_kwargs
-        self.provider.launch(self, launch_kwargs)
+        self.provider.launch(self.model, launch_kwargs)
 
     def kill(self, launch_kwargs: Optional[Dict[str, Any]] = None):
         launch_kwargs = launch_kwargs or self.launch_kwargs
-        self.provider.kill(self, launch_kwargs)
+        self.provider.kill(self.model, launch_kwargs)
 
     def finetune(
         self,
@@ -226,6 +199,8 @@ class LM(BaseLM):
         return Provider()
 
     def infer_adapter(self) -> Adapter:
+        import dspy
+
         if dspy.settings.adapter:
             return dspy.settings.adapter
 
@@ -252,78 +227,8 @@ class LM(BaseLM):
         return new_instance
 
 
-def request_cache(maxsize: Optional[int] = None):
-    """
-    A threadsafe decorator to create an in-memory LRU cache for LM inference functions that accept
-    a dictionary-like LM request. An in-memory cache for LM calls is critical for ensuring
-    good performance when optimizing and evaluating DSPy LMs (disk caching alone is too slow).
-
-    Args:
-        maxsize: The maximum size of the cache. If unspecified, no max size is enforced (cache is unbounded).
-
-    Returns:
-        A decorator that wraps the target function with caching.
-    """
-
-    def cache_key(request: Dict[str, Any]) -> str:
-        """
-        Obtain a unique cache key for the given request dictionary by hashing its JSON
-        representation. For request fields having types that are known to be JSON-incompatible,
-        convert them to a JSON-serializable format before hashing.
-
-        Note: Values that cannot be converted to JSON should *not* be ignored / discarded, since
-        that would potentially lead to cache collisions. For example, consider request A
-        containing only JSON-convertible values and request B containing the same JSON-convertible
-        values in addition to one unconvertible value. Discarding the unconvertible value would
-        lead to a cache collision between requests A and B, even though they are semantically
-        different.
-        """
-
-        def transform_value(value):
-            if isinstance(value, type) and issubclass(value, pydantic.BaseModel):
-                return value.model_json_schema()
-            elif isinstance(value, pydantic.BaseModel):
-                return value.model_dump()
-            elif callable(value) and hasattr(value, "__code__") and hasattr(value.__code__, "co_code"):
-                return value.__code__.co_code.decode("utf-8")
-            else:
-                # Note: We don't attempt to compute a hash of the value, since the default
-                # implementation of hash() is id(), which may collide if the same memory address
-                # is reused for different objects at different times
-                return value
-
-        params = {k: transform_value(v) for k, v in request.items()}
-        return sha256(ujson.dumps(params, sort_keys=True).encode()).hexdigest()
-
-    def decorator(func):
-        @cached(
-            # NB: cachetools doesn't support maxsize=None; it recommends using float("inf") instead
-            cache=LRUCache(maxsize=maxsize or float("inf")),
-            key=lambda key, request, *args, **kwargs: key,
-            # Use a lock to ensure thread safety for the cache when DSPy LMs are queried
-            # concurrently, e.g. during optimization and evaluation
-            lock=threading.RLock(),
-        )
-        def func_cached(key: str, request: Dict[str, Any], *args, **kwargs):
-            return func(request, *args, **kwargs)
-
-        @functools.wraps(func)
-        def wrapper(request: dict, *args, **kwargs):
-            try:
-                key = cache_key(request)
-            except Exception:
-                # If the cache key cannot be computed (e.g. because it contains a value that cannot
-                # be converted to JSON), bypass the cache and call the target function directly
-                return func(request, *args, **kwargs)
-            return func_cached(key, request, *args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-@request_cache(maxsize=None)
-def cached_litellm_completion(request: Dict[str, Any], num_retries: int):
+@functools.lru_cache(maxsize=None)
+def cached_litellm_completion(request, num_retries: int):
     return litellm_completion(
         request,
         cache={"no-cache": False, "no-store": False},
@@ -331,24 +236,17 @@ def cached_litellm_completion(request: Dict[str, Any], num_retries: int):
     )
 
 
-def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
-    retry_kwargs = dict(
-        retry_policy=_get_litellm_retry_policy(num_retries),
-        # In LiteLLM version 1.55.3 (the first version that supports retry_policy as an argument
-        # to completion()), the default value of max_retries is non-zero for certain providers, and
-        # max_retries is stacked on top of the retry_policy. To avoid this, we set max_retries=0
-        max_retries=0,
-    )
-
+def litellm_completion(request, num_retries: int, cache={"no-cache": True, "no-store": True}):
+    kwargs = ujson.loads(request)
     return litellm.completion(
+        num_retries=num_retries,
         cache=cache,
-        **retry_kwargs,
-        **request,
+        **kwargs,
     )
 
 
-@request_cache(maxsize=None)
-def cached_litellm_text_completion(request: Dict[str, Any], num_retries: int):
+@functools.lru_cache(maxsize=None)
+def cached_litellm_text_completion(request, num_retries: int):
     return litellm_text_completion(
         request,
         num_retries=num_retries,
@@ -356,18 +254,20 @@ def cached_litellm_text_completion(request: Dict[str, Any], num_retries: int):
     )
 
 
-def litellm_text_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
+def litellm_text_completion(request, num_retries: int, cache={"no-cache": True, "no-store": True}):
+    kwargs = ujson.loads(request)
+
     # Extract the provider and model from the model string.
     # TODO: Not all the models are in the format of "provider/model"
-    model = request.pop("model").split("/", 1)
+    model = kwargs.pop("model").split("/", 1)
     provider, model = model[0] if len(model) > 1 else "openai", model[-1]
 
-    # Use the API key and base from the request, or from the environment.
-    api_key = request.pop("api_key", None) or os.getenv(f"{provider}_API_KEY")
-    api_base = request.pop("api_base", None) or os.getenv(f"{provider}_API_BASE")
+    # Use the API key and base from the kwargs, or from the environment.
+    api_key = kwargs.pop("api_key", None) or os.getenv(f"{provider}_API_KEY")
+    api_base = kwargs.pop("api_base", None) or os.getenv(f"{provider}_API_BASE")
 
     # Build the prompt from the messages.
-    prompt = "\n\n".join([x["content"] for x in request.pop("messages")] + ["BEGIN RESPONSE:"])
+    prompt = "\n\n".join([x["content"] for x in kwargs.pop("messages")] + ["BEGIN RESPONSE:"])
 
     return litellm.text_completion(
         cache=cache,
@@ -375,32 +275,6 @@ def litellm_text_completion(request: Dict[str, Any], num_retries: int, cache={"n
         api_key=api_key,
         api_base=api_base,
         prompt=prompt,
-        retry_policy=_get_litellm_retry_policy(num_retries),
-        # In LiteLLM version 1.55.3 (the first version that supports retry_policy as an argument
-        # to completion()), the default value of max_retries is non-zero for certain providers, and
-        # max_retries is stacked on top of the retry_policy. To avoid this, we set max_retries=0
-        max_retries=0,
-        **request,
-    )
-
-
-def _get_litellm_retry_policy(num_retries: int) -> RetryPolicy:
-    """
-    Get a LiteLLM retry policy for retrying requests when transient API errors occur.
-    Args:
-        num_retries: The number of times to retry a request if it fails transiently due to
-                     network error, rate limiting, etc. Requests are retried with exponential
-                     backoff.
-    Returns:
-        A LiteLLM RetryPolicy instance.
-    """
-    return RetryPolicy(
-        TimeoutErrorRetries=num_retries,
-        RateLimitErrorRetries=num_retries,
-        InternalServerErrorRetries=num_retries,
-        ContentPolicyViolationErrorRetries=num_retries,
-        # We don't retry on errors that are unlikely to be transient
-        # (e.g. bad request, invalid auth credentials)
-        BadRequestErrorRetries=0,
-        AuthenticationErrorRetries=0,
+        num_retries=num_retries,
+        **kwargs,
     )

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -5,11 +5,18 @@ import re
 import threading
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Literal, Optional
+from hashlib import sha256
+from typing import Any, Dict, List, Literal, Optional, cast
 
 import litellm
+import pydantic
 import ujson
+from anyio.streams.memory import MemoryObjectSendStream
+from asyncer import syncify
+from cachetools import LRUCache, cached
+from litellm import RetryPolicy
 
+import dspy
 from dspy.adapters.base import Adapter
 from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, TrainingJob
@@ -33,8 +40,9 @@ class LM(BaseLM):
         temperature: float = 0.0,
         max_tokens: int = 1000,
         cache: bool = True,
+        cache_in_memory: bool = True,
         callbacks: Optional[List[BaseCallback]] = None,
-        num_retries: int = 3,
+        num_retries: int = 8,
         provider=None,
         finetuning_model: Optional[str] = None,
         launch_kwargs: Optional[dict[str, Any]] = None,
@@ -51,6 +59,7 @@ class LM(BaseLM):
             max_tokens: The maximum number of tokens to generate per response.
             cache: Whether to cache the model responses for reuse to improve performance
                    and reduce costs.
+            cache_in_memory: To enable additional caching with LRU in memory.
             callbacks: A list of callback functions to run before and after each request.
             num_retries: The number of times to retry a request if it fails transiently due to
                          network error, rate limiting, etc. Requests are retried with exponential
@@ -63,6 +72,7 @@ class LM(BaseLM):
         self.model = model
         self.model_type = model_type
         self.cache = cache
+        self.cache_in_memory = cache_in_memory
         self.provider = provider or self.infer_provider()
         self.callbacks = callbacks or []
         self.history = []
@@ -90,20 +100,39 @@ class LM(BaseLM):
     def __call__(self, prompt=None, messages=None, **kwargs):
         # Build the request.
         cache = kwargs.pop("cache", self.cache)
+        # disable cache will also disable in memory cache
+        cache_in_memory = cache and kwargs.pop("cache_in_memory", self.cache_in_memory)
         messages = messages or [{"role": "user", "content": prompt}]
         kwargs = {**self.kwargs, **kwargs}
 
         # Make the request and handle LRU & disk caching.
-        if self.model_type == "chat":
-            completion = cached_litellm_completion if cache else litellm_completion
-        else:
-            completion = cached_litellm_text_completion if cache else litellm_text_completion
+        if cache_in_memory:
+            completion = cached_litellm_completion if self.model_type == "chat" else cached_litellm_text_completion
 
-        response = completion(
-            request=ujson.dumps(dict(model=self.model, messages=messages, **kwargs)),
-            num_retries=self.num_retries,
-        )
-        outputs = [c.message.content if hasattr(c, "message") else c["text"] for c in response["choices"]]
+            response = completion(
+                request=dict(model=self.model, messages=messages, **kwargs),
+                num_retries=self.num_retries,
+            )
+        else:
+            completion = litellm_completion if self.model_type == "chat" else litellm_text_completion
+
+            response = completion(
+                request=dict(model=self.model, messages=messages, **kwargs),
+                num_retries=self.num_retries,
+                # only leverage LiteLLM cache in this case
+                cache={"no-cache": not cache, "no-store": not cache},
+            )
+
+        if kwargs.get("logprobs"):
+            outputs = [
+                {
+                    "text": c.message.content if hasattr(c, "message") else c["text"],
+                    "logprobs": c.logprobs if hasattr(c, "logprobs") else c["logprobs"],
+                }
+                for c in response["choices"]
+            ]
+        else:
+            outputs = [c.message.content if hasattr(c, "message") else c["text"] for c in response["choices"]]
 
         if dspy.settings.disable_history:
             return outputs
@@ -118,6 +147,7 @@ class LM(BaseLM):
             timestamp=datetime.now().isoformat(),
             uuid=str(uuid.uuid4()),
             model=self.model,
+            response_model=response["model"],
             model_type=self.model_type,
         )
         self.history.append(entry)
@@ -127,11 +157,11 @@ class LM(BaseLM):
 
     def launch(self, launch_kwargs: Optional[Dict[str, Any]] = None):
         launch_kwargs = launch_kwargs or self.launch_kwargs
-        self.provider.launch(self.model, launch_kwargs)
+        self.provider.launch(self, launch_kwargs)
 
     def kill(self, launch_kwargs: Optional[Dict[str, Any]] = None):
         launch_kwargs = launch_kwargs or self.launch_kwargs
-        self.provider.kill(self.model, launch_kwargs)
+        self.provider.kill(self, launch_kwargs)
 
     def finetune(
         self,
@@ -227,8 +257,78 @@ class LM(BaseLM):
         return new_instance
 
 
-@functools.lru_cache(maxsize=None)
-def cached_litellm_completion(request, num_retries: int):
+def request_cache(maxsize: Optional[int] = None):
+    """
+    A threadsafe decorator to create an in-memory LRU cache for LM inference functions that accept
+    a dictionary-like LM request. An in-memory cache for LM calls is critical for ensuring
+    good performance when optimizing and evaluating DSPy LMs (disk caching alone is too slow).
+
+    Args:
+        maxsize: The maximum size of the cache. If unspecified, no max size is enforced (cache is unbounded).
+
+    Returns:
+        A decorator that wraps the target function with caching.
+    """
+
+    def cache_key(request: Dict[str, Any]) -> str:
+        """
+        Obtain a unique cache key for the given request dictionary by hashing its JSON
+        representation. For request fields having types that are known to be JSON-incompatible,
+        convert them to a JSON-serializable format before hashing.
+
+        Note: Values that cannot be converted to JSON should *not* be ignored / discarded, since
+        that would potentially lead to cache collisions. For example, consider request A
+        containing only JSON-convertible values and request B containing the same JSON-convertible
+        values in addition to one unconvertible value. Discarding the unconvertible value would
+        lead to a cache collision between requests A and B, even though they are semantically
+        different.
+        """
+
+        def transform_value(value):
+            if isinstance(value, type) and issubclass(value, pydantic.BaseModel):
+                return value.model_json_schema()
+            elif isinstance(value, pydantic.BaseModel):
+                return value.model_dump()
+            elif callable(value) and hasattr(value, "__code__") and hasattr(value.__code__, "co_code"):
+                return value.__code__.co_code.decode("utf-8")
+            else:
+                # Note: We don't attempt to compute a hash of the value, since the default
+                # implementation of hash() is id(), which may collide if the same memory address
+                # is reused for different objects at different times
+                return value
+
+        params = {k: transform_value(v) for k, v in request.items()}
+        return sha256(ujson.dumps(params, sort_keys=True).encode()).hexdigest()
+
+    def decorator(func):
+        @cached(
+            # NB: cachetools doesn't support maxsize=None; it recommends using float("inf") instead
+            cache=LRUCache(maxsize=maxsize or float("inf")),
+            key=lambda key, request, *args, **kwargs: key,
+            # Use a lock to ensure thread safety for the cache when DSPy LMs are queried
+            # concurrently, e.g. during optimization and evaluation
+            lock=threading.RLock(),
+        )
+        def func_cached(key: str, request: Dict[str, Any], *args, **kwargs):
+            return func(request, *args, **kwargs)
+
+        @functools.wraps(func)
+        def wrapper(request: dict, *args, **kwargs):
+            try:
+                key = cache_key(request)
+            except Exception:
+                # If the cache key cannot be computed (e.g. because it contains a value that cannot
+                # be converted to JSON), bypass the cache and call the target function directly
+                return func(request, *args, **kwargs)
+            return func_cached(key, request, *args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+@request_cache(maxsize=None)
+def cached_litellm_completion(request: Dict[str, Any], num_retries: int):
     return litellm_completion(
         request,
         cache={"no-cache": False, "no-store": False},
@@ -236,17 +336,45 @@ def cached_litellm_completion(request, num_retries: int):
     )
 
 
-def litellm_completion(request, num_retries: int, cache={"no-cache": True, "no-store": True}):
-    kwargs = ujson.loads(request)
-    return litellm.completion(
-        num_retries=num_retries,
-        cache=cache,
-        **kwargs,
+def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
+    retry_kwargs = dict(
+        retry_policy=_get_litellm_retry_policy(num_retries),
+        # In LiteLLM version 1.55.3 (the first version that supports retry_policy as an argument
+        # to completion()), the default value of max_retries is non-zero for certain providers, and
+        # max_retries is stacked on top of the retry_policy. To avoid this, we set max_retries=0
+        max_retries=0,
     )
 
+    stream = dspy.settings.send_stream
+    if stream is None:
+        return litellm.completion(
+            cache=cache,
+            **retry_kwargs,
+            **request,
+        )
 
-@functools.lru_cache(maxsize=None)
-def cached_litellm_text_completion(request, num_retries: int):
+    # The stream is already opened, and will be closed by the caller.
+    stream = cast(MemoryObjectSendStream, stream)
+
+    @syncify
+    async def stream_completion():
+        response = await litellm.acompletion(
+            cache=cache,
+            stream=True,
+            **retry_kwargs,
+            **request,
+        )
+        chunks = []
+        async for chunk in response:
+            chunks.append(chunk)
+            await stream.send(chunk)
+        return litellm.stream_chunk_builder(chunks)
+
+    return stream_completion()
+
+
+@request_cache(maxsize=None)
+def cached_litellm_text_completion(request: Dict[str, Any], num_retries: int):
     return litellm_text_completion(
         request,
         num_retries=num_retries,
@@ -254,20 +382,18 @@ def cached_litellm_text_completion(request, num_retries: int):
     )
 
 
-def litellm_text_completion(request, num_retries: int, cache={"no-cache": True, "no-store": True}):
-    kwargs = ujson.loads(request)
-
+def litellm_text_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
     # Extract the provider and model from the model string.
     # TODO: Not all the models are in the format of "provider/model"
-    model = kwargs.pop("model").split("/", 1)
+    model = request.pop("model").split("/", 1)
     provider, model = model[0] if len(model) > 1 else "openai", model[-1]
 
-    # Use the API key and base from the kwargs, or from the environment.
-    api_key = kwargs.pop("api_key", None) or os.getenv(f"{provider}_API_KEY")
-    api_base = kwargs.pop("api_base", None) or os.getenv(f"{provider}_API_BASE")
+    # Use the API key and base from the request, or from the environment.
+    api_key = request.pop("api_key", None) or os.getenv(f"{provider}_API_KEY")
+    api_base = request.pop("api_base", None) or os.getenv(f"{provider}_API_BASE")
 
     # Build the prompt from the messages.
-    prompt = "\n\n".join([x["content"] for x in kwargs.pop("messages")] + ["BEGIN RESPONSE:"])
+    prompt = "\n\n".join([x["content"] for x in request.pop("messages")] + ["BEGIN RESPONSE:"])
 
     return litellm.text_completion(
         cache=cache,
@@ -275,6 +401,32 @@ def litellm_text_completion(request, num_retries: int, cache={"no-cache": True, 
         api_key=api_key,
         api_base=api_base,
         prompt=prompt,
-        num_retries=num_retries,
-        **kwargs,
+        retry_policy=_get_litellm_retry_policy(num_retries),
+        # In LiteLLM version 1.55.3 (the first version that supports retry_policy as an argument
+        # to completion()), the default value of max_retries is non-zero for certain providers, and
+        # max_retries is stacked on top of the retry_policy. To avoid this, we set max_retries=0
+        max_retries=0,
+        **request,
+    )
+
+
+def _get_litellm_retry_policy(num_retries: int) -> RetryPolicy:
+    """
+    Get a LiteLLM retry policy for retrying requests when transient API errors occur.
+    Args:
+        num_retries: The number of times to retry a request if it fails transiently due to
+                     network error, rate limiting, etc. Requests are retried with exponential
+                     backoff.
+    Returns:
+        A LiteLLM RetryPolicy instance.
+    """
+    return RetryPolicy(
+        TimeoutErrorRetries=num_retries,
+        RateLimitErrorRetries=num_retries,
+        InternalServerErrorRetries=num_retries,
+        ContentPolicyViolationErrorRetries=num_retries,
+        # We don't retry on errors that are unlikely to be transient
+        # (e.g. bad request, invalid auth credentials)
+        BadRequestErrorRetries=0,
+        AuthenticationErrorRetries=0,
     )

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -6,17 +6,14 @@ import threading
 import uuid
 from datetime import datetime
 from hashlib import sha256
-from typing import Any, Dict, List, Literal, Optional, cast
+from typing import Any, Dict, List, Literal, Optional
 
 import litellm
 import pydantic
 import ujson
-from anyio.streams.memory import MemoryObjectSendStream
-from asyncer import syncify
 from cachetools import LRUCache, cached
 from litellm import RetryPolicy
 
-import dspy
 from dspy.adapters.base import Adapter
 from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, TrainingJob
@@ -229,8 +226,6 @@ class LM(BaseLM):
         return Provider()
 
     def infer_adapter(self) -> Adapter:
-        import dspy
-
         if dspy.settings.adapter:
             return dspy.settings.adapter
 
@@ -345,32 +340,11 @@ def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cac
         max_retries=0,
     )
 
-    stream = dspy.settings.send_stream
-    if stream is None:
-        return litellm.completion(
-            cache=cache,
-            **retry_kwargs,
-            **request,
-        )
-
-    # The stream is already opened, and will be closed by the caller.
-    stream = cast(MemoryObjectSendStream, stream)
-
-    @syncify
-    async def stream_completion():
-        response = await litellm.acompletion(
-            cache=cache,
-            stream=True,
-            **retry_kwargs,
-            **request,
-        )
-        chunks = []
-        async for chunk in response:
-            chunks.append(chunk)
-            await stream.send(chunk)
-        return litellm.stream_chunk_builder(chunks)
-
-    return stream_completion()
+    return litellm.completion(
+        cache=cache,
+        **retry_kwargs,
+        **request,
+    )
 
 
 @request_cache(maxsize=None)

--- a/dspy/utils/__init__.py
+++ b/dspy/utils/__init__.py
@@ -1,5 +1,6 @@
 from dspy.utils.callback import BaseCallback, with_callbacks
 from dspy.utils.dummies import DummyLM, DummyVectorizer, dummy_rm
+from dspy.utils.streaming import StatusMessage, StatusMessageProvider, streamify
 
 import os
 import requests
@@ -24,4 +25,7 @@ __all__ = [
     "DummyLM",
     "DummyVectorizer",
     "dummy_rm",
+    "StatusMessage",
+    "StatusMessageProvider",
+    "streamify",
 ]

--- a/dspy/utils/asyncify.py
+++ b/dspy/utils/asyncify.py
@@ -1,9 +1,10 @@
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 import asyncer
 from anyio import CapacityLimiter
 
-from dspy.primitives.program import Module
+if TYPE_CHECKING:
+    from dspy.primitives.program import Module
 
 _limiter = None
 
@@ -26,7 +27,7 @@ def get_limiter():
     return _limiter
 
 
-def asyncify(program: Module) -> Callable[[Any, Any], Awaitable[Any]]:
+def asyncify(program: "Module") -> Callable[[Any, Any], Awaitable[Any]]:
     """
     Wraps a DSPy program so that it can be called asynchronously. This is useful for running a
     program in parallel with another task (e.g., another DSPy program).

--- a/dspy/utils/streaming.py
+++ b/dspy/utils/streaming.py
@@ -26,19 +26,19 @@ class StatusMessage:
 
 
 class StatusMessageProvider:
-    def tool_start_status_message(self, instance: Any):
+    def tool_start_status_message(self, instance: Any, inputs: Dict[str, Any]):
         return f"Calling tool {instance.name}..."
 
     def tool_end_status_message(self, outputs: Any):
         return "Tool calling finished! Querying the LLM with tool calling results..."
 
-    def module_start_status_message(self, instance: Any):
+    def module_start_status_message(self, instance: Any, inputs: Dict[str, Any]):
         pass
 
     def module_end_status_message(self, outputs: Any):
         pass
 
-    def lm_start_status_message(self, instance: Any):
+    def lm_start_status_message(self, instance: Any, inputs: Dict[str, Any]):
         pass
 
     def lm_end_status_message(self, outputs: Any):
@@ -61,7 +61,7 @@ class StatusStreamingCallback(BaseCallback):
 
         @syncify
         async def send_status():
-            status_message = self.status_message_provider.tool_start_status_message(instance)
+            status_message = self.status_message_provider.tool_start_status_message(instance, inputs)
             if status_message:
                 await stream.send(StatusMessage(status_message))
 
@@ -97,7 +97,7 @@ class StatusStreamingCallback(BaseCallback):
 
         @syncify
         async def send_status():
-            status_message = self.status_message_provider.lm_start_status_message(instance)
+            status_message = self.status_message_provider.lm_start_status_message(instance, inputs)
             if status_message:
                 await stream.send(StatusMessage(status_message))
 
@@ -133,7 +133,7 @@ class StatusStreamingCallback(BaseCallback):
 
         @syncify
         async def send_status():
-            status_message = self.status_message_provider.module_start_status_message(instance)
+            status_message = self.status_message_provider.module_start_status_message(instance, inputs)
             if status_message:
                 await stream.send(StatusMessage(status_message))
 
@@ -187,7 +187,14 @@ def streamify(
 
     # Use the program with streaming output
     async def use_streaming():
-        return await program(q="Why did a chicken cross the kitchen?")
+        output = program(q="Why did a chicken cross the kitchen?")
+        return_value = None
+        async for value in output:
+            if isinstance(value, dspy.Prediction):
+                return_value = value
+            else:
+                print(value)
+        return return_value
 
     output = asyncio.run(use_streaming())
     print(output)

--- a/tests/utils/test_streaming.py
+++ b/tests/utils/test_streaming.py
@@ -1,7 +1,7 @@
 import pytest
 
 import dspy
-from dspy.utils.streaming import streaming_response
+from dspy.utils.streaming import StatusMessage, StatusMessageProvider, streaming_response
 from ..test_utils.server import litellm_test_server
 
 
@@ -58,3 +58,67 @@ async def test_streaming_response_yields_expected_response_chunks(litellm_test_s
         assert all(chunk.startswith("data: ") for chunk in output_chunks)
         assert 'data: {"prediction":{"output_text":"Hello!"}}\n\n' in output_chunks
         assert output_chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.anyio
+async def test_default_status_streaming():
+    class MyProgram(dspy.Module):
+        def __init__(self):
+            self.generate_question = dspy.Tool(lambda x: f"What color is the {x}?", name="generate_question")
+            self.predict = dspy.Predict("question->answer")
+
+        def __call__(self, x: str):
+            question = self.generate_question(x=x)
+            return self.predict(question=question)
+
+    lm = dspy.utils.DummyLM([{"answer": "red"}, {"answer": "blue"}])
+    with dspy.context(lm=lm):
+        program = dspy.streamify(MyProgram())
+        output = program("sky")
+
+        status_messages = []
+        async for value in output:
+            if isinstance(value, StatusMessage):
+                status_messages.append(value)
+
+    assert len(status_messages) == 2
+    assert status_messages[0].message == "Calling tool generate_question..."
+    assert status_messages[1].message == "Tool calling finished! Querying the LLM with tool calling results..."
+
+
+@pytest.mark.anyio
+async def test_custom_status_streaming():
+    class MyProgram(dspy.Module):
+        def __init__(self):
+            self.generate_question = dspy.Tool(lambda x: f"What color is the {x}?", name="generate_question")
+            self.predict = dspy.Predict("question->answer")
+
+        def __call__(self, x: str):
+            question = self.generate_question(x=x)
+            return self.predict(question=question)
+
+    class MyStatusMessageProvider(StatusMessageProvider):
+        def tool_start_status_message(self, instance, inputs):
+            return f"Tool starting!"
+
+        def tool_end_status_message(self, outputs):
+            return "Tool finished!"
+
+        def module_start_status_message(self, instance, inputs):
+            if isinstance(instance, dspy.Predict):
+                return "Predict starting!"
+
+    lm = dspy.utils.DummyLM([{"answer": "red"}, {"answer": "blue"}])
+    with dspy.context(lm=lm):
+        program = dspy.streamify(MyProgram(), status_message_provider=MyStatusMessageProvider())
+        output = program("sky")
+
+        status_messages = []
+        async for value in output:
+            if isinstance(value, StatusMessage):
+                status_messages.append(value)
+
+        assert len(status_messages) == 3
+        assert status_messages[0].message == "Tool starting!"
+        assert status_messages[1].message == "Tool finished!"
+        assert status_messages[2].message == "Predict starting!"


### PR DESCRIPTION
One interesting and useful feature is status streaming, e.g., we tell users that "we are running the tool XXX", "we finished running the tool XXX" so that users don't wait endlessly until the final output. With callback system, the implementation is relatively straightforward. 

Below is a testing code:

``` 
import asyncio
from typing import Any

from pydantic import BaseModel

import dspy
from dspy.utils.streaming import StatusMessage, StatusMessageProvider

lm = dspy.LM("openai/gpt-4o-mini")
dspy.settings.configure(lm=lm)


class CalendarEvent(BaseModel):
    name: str
    date: str
    participants: list[str]


def write_invitation_letter(participant_name: str, event_info: CalendarEvent):
    if participant_name not in event_info.participants:
        return None
    return f"It's my honor to invite {participant_name} to event {event_info.name} on {event_info.date}"


class InvitationSignature(dspy.Signature):
    participant_name: str = dspy.InputField(desc="The name of the participant to invite")
    event_info: CalendarEvent = dspy.InputField(desc="The information about the event")
    invitation_letter: str = dspy.OutputField(desc="The invitation letter to be sent to the participant")


class CustomStatusMessageProvider(StatusMessageProvider):
    def lm_start_status_message(self, instance: Any):
        return "I am just calling the LLM!"

    def lm_end_status_message(self, outputs: Any):
        return "I have finished calling the LLM!"

    def module_start_status_message(self, instance: Any):
        if isinstance(instance, dspy.ReAct):
            return "I am calling ReAct!"


react = dspy.ReAct(InvitationSignature, tools=[write_invitation_letter])
stream_react = dspy.streamify(react, status_message_provider=CustomStatusMessageProvider())


async def main():
    output = stream_react(
        participant_name="Alice",
        event_info=CalendarEvent(
            name="Science Fair",
            date="Friday",
            participants=["Alice", "Bob"],
        ),
    )
    return_value = None
    async for value in output:
        if isinstance(value, StatusMessage):
            print(value.message)
        else:
            return_value = value
    return return_value


print(asyncio.run(main()))
```

the console output looks like:

```
(dspy) (base) [streaming-status][~/Documents/mlflow_team/dspy]$ python3 simple_react_tmp.py
/Users/chen.qian/miniconda3/envs/dspy/lib/python3.12/site-packages/pydantic/_internal/_config.py:345: UserWarning: Valid config keys have changed in V2:
* 'fields' has been removed
  warnings.warn(message, UserWarning)
I am calling ReAct!
I am just calling the LLM!
I have finished calling the LLM!
Calling tool write_invitation_letter...
Tool calling finished! Querying the LLM with tool calling results...
I am just calling the LLM!
I have finished calling the LLM!
I am just calling the LLM!
I have finished calling the LLM!
Prediction(
    trajectory={'thought_0': 'I need to write an invitation letter for Alice to the Science Fair event.', 'tool_name_0': 'write_invitation_letter', 'tool_args_0': {'participant_name': 'Alice', 'event_info': {'name': 'Science Fair', 'date': 'Friday', 'participants': ['Alice', 'Bob']}}, 'observation_0': "It's my honor to invite Alice to event Science Fair on Friday", 'thought_1': 'I have successfully written the invitation letter for Alice. Now I can finish the task.', 'tool_name_1': 'finish', 'tool_args_1': {}, 'observation_1': 'Completed.'},
    reasoning='The invitation letter is crafted to formally invite Alice to the Science Fair event, highlighting her participation and the date of the event. It emphasizes the honor of inviting her, which adds a personal touch to the invitation.',
    invitation_letter='Dear Alice,\n\nIt is my honor to invite you to the Science Fair taking place this Friday. Your participation is highly valued, and we look forward to seeing your contributions to this exciting event.\n\nBest regards,\n\n[Your Name]'
)
```