### PR TITLE
Disable disk cache

### DIFF
--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -2,20 +2,22 @@ from dspy.clients.lm import LM
 from dspy.clients.provider import Provider, TrainingJob
 from dspy.clients.base_lm import BaseLM, inspect_history
 from dspy.clients.embedding import Embedder
+from dspy.utils.caching import DSPY_CACHEDIR
 import litellm
 import os
 from pathlib import Path
 from litellm.caching import Cache
 
-DISK_CACHE_DIR = os.environ.get("DSPY_CACHEDIR") or os.path.join(Path.home(), ".dspy_cache")
+DISK_CACHE_DIR = DSPY_CACHEDIR
 DISK_CACHE_LIMIT = int(os.environ.get("DSPY_CACHE_LIMIT", 3e10))  # 30 GB default
 
-# TODO: There's probably value in getting litellm to support FanoutCache and to separate the limit for
-# the LM cache from the embeddings cache. Then we can lower the default 30GB limit.
-litellm.cache = Cache(disk_cache_dir=DISK_CACHE_DIR, type="disk")
+if os.environ.get("DSP_CACHEBOOL", "True").lower() != "false":
+  # TODO: There's probably value in getting litellm to support FanoutCache and to separate the limit for
+  # the LM cache from the embeddings cache. Then we can lower the default 30GB limit.
+  litellm.cache = Cache(disk_cache_dir=DISK_CACHE_DIR, type="disk")
 
-if litellm.cache.cache.disk_cache.size_limit != DISK_CACHE_LIMIT:
-    litellm.cache.cache.disk_cache.reset("size_limit", DISK_CACHE_LIMIT)
+  if litellm.cache.cache.disk_cache.size_limit != DISK_CACHE_LIMIT:
+      litellm.cache.cache.disk_cache.reset("size_limit", DISK_CACHE_LIMIT)
 
 litellm.telemetry = False
 

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -2,7 +2,7 @@ from dspy.clients.lm import LM
 from dspy.clients.provider import Provider, TrainingJob
 from dspy.clients.base_lm import BaseLM, inspect_history
 from dspy.clients.embedding import Embedder
-from dspy.utils.caching import DSPY_CACHEDIR
+from dspy.utils.caching import DSPY_CACHEDIR, USE_FILE_CACHE
 import litellm
 import os
 from pathlib import Path
@@ -11,7 +11,7 @@ from litellm.caching import Cache
 DISK_CACHE_DIR = DSPY_CACHEDIR
 DISK_CACHE_LIMIT = int(os.environ.get("DSPY_CACHE_LIMIT", 3e10))  # 30 GB default
 
-if os.environ.get("DSP_CACHEBOOL", "True").lower() != "false":
+if USE_FILE_CACHE:
   # TODO: There's probably value in getting litellm to support FanoutCache and to separate the limit for
   # the LM cache from the embeddings cache. Then we can lower the default 30GB limit.
   litellm.cache = Cache(disk_cache_dir=DISK_CACHE_DIR, type="disk")

--- a/dspy/dsp/cache_utils.py
+++ b/dspy/dsp/cache_utils.py
@@ -5,9 +5,11 @@ from pathlib import Path
 from joblib import Memory
 
 from dspy.dsp.utils import dotdict
+from dspy.utils.caching import USE_FILE_CACHE
 
 cache_turn_on = os.environ.get('DSP_CACHEBOOL', 'True').lower() != 'false'
-
+if cache_turn_on:
+  cache_turn_on = USE_FILE_CACHE
 
 def noop_decorator(arg=None, *noop_args, **noop_kwargs):
     def decorator(func):

--- a/dspy/utils/caching.py
+++ b/dspy/utils/caching.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 _DEFAULT_CACHE_DIR = os.path.join(Path.home(), ".dspy_cache")
 DSPY_CACHEDIR = os.environ.get("DSPY_CACHEDIR") or _DEFAULT_CACHE_DIR
-
+USE_FILE_CACHE = os.environ.get("DSPY_FILE_CACHE", "True").lower() != "false"
 
 def create_subdir_in_cachedir(subdir: str) -> str:
     """Create a subdirectory in the DSPy cache directory."""

--- a/tests/caching/test_caching.py
+++ b/tests/caching/test_caching.py
@@ -14,6 +14,7 @@ from tests.test_utils.server import litellm_test_server, read_litellm_test_serve
 def temporary_blank_cache_dir(monkeypatch):
     with tempfile.TemporaryDirectory() as cache_dir_path:
         monkeypatch.setenv("DSPY_CACHEDIR", cache_dir_path)
+        importlib.reload(dspy.utils.caching)
         importlib.reload(dspy.clients)
         yield cache_dir_path
 
@@ -30,6 +31,7 @@ def temporary_populated_cache_dir(monkeypatch):
     with tempfile.TemporaryDirectory() as cache_dir_path:
         shutil.copytree(populated_cache_path, cache_dir_path, dirs_exist_ok=True)
         monkeypatch.setenv("DSPY_CACHEDIR", cache_dir_path)
+        importlib.reload(dspy.utils.caching)
         importlib.reload(dspy.clients)
         yield cache_dir_path
 


### PR DESCRIPTION
Adding an env bool, `DSPY_FILE_CACHE `, to disable the construction of a disk cache for the litellm client.

My use case is that I would like to be able to use DSPy in an environment where file access is read only. There a couple places in the code I've encountered where file access is happening at module load time. I'm trying to organize a single bool that can disable this