### PR TITLE
Nest default joblib cache dir into .dspy_cache

### DIFF
--- a/dspy/dsp/cache_utils.py
+++ b/dspy/dsp/cache_utils.py
@@ -29,7 +29,7 @@ CacheMemory = dotdict()
 CacheMemory.cache = noop_decorator
 
 if cache_turn_on:
-    cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), 'cachedir_joblib')
+    cachedir = os.environ.get('DSP_CACHEDIR') or os.path.join(Path.home(), '.dspy_cache/cachedir_joblib')
     CacheMemory = Memory(location=cachedir, verbose=0)
 
     cachedir2 = os.environ.get('DSP_NOTEBOOK_CACHEDIR')


### PR DESCRIPTION
This brings the various caching functionality of dspy into one parent dir (by default) and avoids the creation of a non-hidden cachedir_joblib directory in the user's home folder.

Implements #7628.

This is the most minimal change to address the above issue. 

I do believe that there might be a benefit in trying to clean up the organization of the cache directories in a more general sense. Just from doing a closer investigation, it seems that there are three areas within this library where some kind of disk caching occurs:

1. Joblib caching, which seems to be only used in the DSP submodule (after this change it will default to `.dspy_cache/cachedir_joblib`)
2. Finetuning, where by default a `.dspy_cache/finetune` directory is created
3. litellm cacheing, which is also added to `.dspy_cache`

Of these, 1 and 3 both initialize on import of the top level `dspy` module, so even if you aren't doing anything that needs the cache, you are still creating the various directories and such. You also kind of have to go hunting to find out how these caches are configured within the library as they are tucked various similarly named files, e.g. `cache_utils.py` / `utils/caching.py`, etc.

A potentially nice reorganization could do module-level configuration for the "parent" cache directory (which `.dspy_cache` does now, but mostly hardcoded in three different areas within the codebase), and then other components could just build off of this (such as a `from dspy.cache import DSPY_CACHE_PATH`  or something). Something like this would make future components that require caching to continue to maintain it in a centralized location.

If that idea sounds useful at all, I'd be happy to take a closer look at implementing something (otherwise just implementing this PR resolves my original issue, so I'm happy either way :+1: )