### PR TITLE
Improve `dspy.Tool`

### DIFF
--- a/dspy/predict/__init__.py
+++ b/dspy/predict/__init__.py
@@ -5,7 +5,7 @@ from dspy.predict.knn import KNN
 from dspy.predict.multi_chain_comparison import MultiChainComparison
 from dspy.predict.predict import Predict
 from dspy.predict.program_of_thought import ProgramOfThought
-from dspy.predict.react import ReAct, Tool
+from dspy.predict.react import ReAct
 from dspy.predict.parallel import Parallel
 
 __all__ = [
@@ -17,6 +17,5 @@ __all__ = [
     "Predict",
     "ProgramOfThought",
     "ReAct",
-    "Tool",
     "Parallel",
 ]

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -40,11 +40,11 @@ class ReAct(Module):
             func=lambda **kwargs: "Completed.",
             name="finish",
             desc=finish_desc,
-            parameters=finish_args,
+            args=finish_args,
         )
 
         for idx, tool in enumerate(tools.values()):
-            args = getattr(tool, "parameters")
+            args = getattr(tool, "args")
             desc = (f", whose description is <desc>{tool.desc}</desc>." if tool.desc else ".").replace("\n", "  ")
             desc += f" It takes arguments {args} in JSON format."
             instr.append(f"({idx+1}) {tool.name}{desc}")

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -4,7 +4,7 @@ from dspy.primitives.module import BaseModule
 from dspy.primitives.prediction import Prediction, Completions
 from dspy.primitives.program import Program, Module
 from dspy.primitives.python_interpreter import PythonInterpreter
-
+from dspy.primitives.tool import Tool
 
 __all__ = [
     "assertions",
@@ -15,4 +15,5 @@ __all__ = [
     "Program",
     "Module",
     "PythonInterpreter",
+    "Tool",
 ]

--- a/dspy/primitives/tool.py
+++ b/dspy/primitives/tool.py
@@ -119,7 +119,8 @@ class Tool:
                 raise ValueError(f"Arg {k} is not in the tool's args.")
             try:
                 instance = v.model_dump() if hasattr(v, "model_dump") else v
-                validate(instance=instance, schema=self.args[k])
+                if not self.args[k] == "Any":
+                    validate(instance=instance, schema=self.args[k])
             except ValidationError as e:
                 raise ValueError(f"Arg {k} is invalid: {e.message}")
         return self.func(**kwargs)

--- a/dspy/primitives/tool.py
+++ b/dspy/primitives/tool.py
@@ -1,0 +1,111 @@
+import inspect
+from typing import Any, Callable, Optional, get_origin, get_type_hints
+
+from jsonschema import ValidationError, validate
+from pydantic import BaseModel, TypeAdapter
+
+from dspy.utils.callback import with_callbacks
+
+
+class Tool:
+    """Tool class.
+
+    This class is used to simplify the creation of tools for tool calling (function calling) in LLMs. Only supports
+    functions for now.
+    """
+
+    def __init__(
+        self,
+        func: Callable,
+        name: Optional[str] = None,
+        desc: Optional[str] = None,
+        args: Optional[dict[str, Any]] = None,
+        arg_types: Optional[dict[str, Any]] = None,
+        arg_desc: Optional[dict[str, str]] = None,
+    ):
+        """Initialize the Tool class.
+
+        Args:
+            func (Callable): The actual function that is being wrapped by the tool.
+            name (Optional[str], optional): The name of the tool. Defaults to None.
+            desc (Optional[str], optional): The description of the tool. Defaults to None.
+            args (Optional[dict[str, Any]], optional): The args of the tool, represented as a dictionary
+                from arg name to arg's json schema. Defaults to None.
+            arg_types (Optional[dict[str, Any]], optional): The argument types of the tool, represented as a dictionary
+                from arg name to the type of the argument. Defaults to None.
+            arg_desc (Optional[dict[str, str]], optional): Descriptions for each arg, represented as a
+                dictionary from arg name to description string. Defaults to None.
+        """
+        self.func = func
+        self.name = name
+        self.desc = desc
+        self.args = args
+        self.arg_types = arg_types
+        self.arg_desc = arg_desc
+
+        self._parse_function(func, arg_desc)
+
+    def _parse_function(self, func: Callable, arg_desc: dict[str, str] = None):
+        """Helper method that parses a function to extract the name, description, and args.
+
+        This is a helper function that automatically infers the name, description, and args of the tool from the
+        provided function. In order to make the inference work, the function must have valid type hints.
+        """
+        annotations_func = func if inspect.isfunction(func) or inspect.ismethod(func) else func.__call__
+        name = getattr(func, "__name__", type(func).__name__)
+        desc = getattr(func, "__doc__", None) or getattr(annotations_func, "__doc__", "")
+        args = {}
+        arg_types = {}
+
+        # Use inspect.signature to get all arg names
+        sig = inspect.signature(annotations_func)
+        # Get available type hints
+        available_hints = get_type_hints(annotations_func)
+        # Build a dictionary of arg name -> type (defaulting to Any when missing)
+        hints = {param_name: available_hints.get(param_name, Any) for param_name in sig.parameters.keys()}
+
+        # Process each argument's type to generate its JSON schema.
+        for k, v in hints.items():
+            self.arg_types[k] = v
+            if k == "return":
+                continue
+            # Check if the type (or its origin) is a subclass of Pydantic's BaseModel
+            origin = get_origin(v) or v
+            if isinstance(origin, type) and issubclass(origin, BaseModel):
+                args[k] = v.model_json_schema(ref_template=None)
+            else:
+                args[k] = TypeAdapter(v).json_schema() or "Any"
+            if arg_desc and k in arg_desc:
+                args[k]["description"] = arg_desc[k]
+
+        self.name = self.name or name
+        self.desc = self.desc or desc
+        self.args = self.args or args
+        self.arg_types = self.arg_types or arg_types
+
+    def convert_to_litellm_tool_format(self):
+        """Converts the tool to the format required by litellm for tool calling."""
+        args = {
+            "type": "object",
+            "properties": self.args,
+            "required": list(self.args.keys()),
+            "additionalProperties": False,
+        }
+
+        tool_dict = {
+            "type": "function",
+            "function": {"name": self.name, "description": self.desc, "args": args},
+        }
+        return tool_dict
+
+    @with_callbacks
+    def __call__(self, **kwargs):
+        for k, v in kwargs.items():
+            if k not in self.args:
+                raise ValueError(f"Arg {k} is not in the tool's args.")
+            try:
+                instance = v.model_dump() if hasattr(v, "model_dump") else v
+                validate(instance=instance, schema=self.args[k])
+            except ValidationError as e:
+                raise ValueError(f"Arg {k} is invalid: {e.message}")
+        return self.func(**kwargs)

--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -204,8 +204,8 @@ def test_tool_calls():
             self.tools = [dspy.Tool(tool_1), dspy.Tool(tool_2)]
 
         def forward(self, query: str) -> str:
-            query = self.tools[0](query)
-            return self.tools[1](query)
+            query = self.tools[0](query=query)
+            return self.tools[1](query=query)
 
     module = MyModule()
     result = module("query")

--- a/tests/primitives/test_tool.py
+++ b/tests/primitives/test_tool.py
@@ -68,10 +68,10 @@ def complex_dummy_function(profile: UserProfile, priority: int, notes: Optional[
 
 
 def test_basic_initialization():
-    tool = Tool(name="test_tool", desc="A test tool", parameters={"param1": {"type": "string"}}, func=lambda x: x)
+    tool = Tool(name="test_tool", desc="A test tool", args={"param1": {"type": "string"}}, func=lambda x: x)
     assert tool.name == "test_tool"
     assert tool.desc == "A test tool"
-    assert tool.parameters == {"param1": {"type": "string"}}
+    assert tool.args == {"param1": {"type": "string"}}
     assert callable(tool.func)
 
 
@@ -80,10 +80,10 @@ def test_tool_from_function():
 
     assert tool.name == "dummy_function"
     assert "A dummy function for testing" in tool.desc
-    assert "x" in tool.parameters
-    assert "y" in tool.parameters
-    assert tool.parameters["x"]["type"] == "integer"
-    assert tool.parameters["y"]["type"] == "string"
+    assert "x" in tool.args
+    assert "y" in tool.args
+    assert tool.args["x"]["type"] == "integer"
+    assert tool.args["y"]["type"] == "string"
 
 
 def test_tool_from_class():
@@ -98,28 +98,17 @@ def test_tool_from_class():
     tool = Tool(Foo("123"))
     assert tool.name == "Foo"
     assert tool.desc == "Add two numbers."
-    assert tool.parameters == {"a": {"type": "integer"}, "b": {"type": "integer"}}
+    assert tool.args == {"a": {"type": "integer"}, "b": {"type": "integer"}}
 
 
 def test_tool_from_function_with_pydantic():
     tool = Tool(dummy_with_pydantic)
 
     assert tool.name == "dummy_with_pydantic"
-    assert "model" in tool.parameters
-    assert tool.parameters["model"]["type"] == "object"
-    assert "field1" in tool.parameters["model"]["properties"]
-    assert "field2" in tool.parameters["model"]["properties"]
-
-
-def test_convert_to_litellm_tool_format():
-    tool = Tool(dummy_function)
-    litellm_format = tool.convert_to_litellm_tool_format()
-
-    assert litellm_format["type"] == "function"
-    assert litellm_format["function"]["name"] == "dummy_function"
-    assert "parameters" in litellm_format["function"]
-    assert litellm_format["function"]["parameters"]["required"] == ["x", "y"]
-    assert not litellm_format["function"]["parameters"]["additionalProperties"]
+    assert "model" in tool.args
+    assert tool.args["model"]["type"] == "object"
+    assert "field1" in tool.args["model"]["properties"]
+    assert "field2" in tool.args["model"]["properties"]
 
 
 def test_tool_callable():
@@ -142,93 +131,5 @@ def test_invalid_function_call():
 
 
 def test_parameter_desc():
-    tool = Tool(dummy_function, parameter_desc={"x": "The x parameter"})
-    assert tool.parameters["x"]["description"] == "The x parameter"
-
-
-def test_complex_nested_schema():
-    tool = Tool(complex_dummy_function, parameter_desc={"profile": "The user ultimate profile"})
-
-    assert tool.name == "complex_dummy_function"
-    assert "profile" in tool.parameters
-
-    profile_schema = tool.parameters["profile"]
-    assert profile_schema["type"] == "object"
-    assert profile_schema["description"] == "The user ultimate profile"
-
-    # Check nested structure
-    properties = profile_schema["properties"]
-    assert "contact" in properties
-    assert properties["contact"]["type"] == "object"
-
-    contact_properties = properties["contact"]["properties"]
-    assert "addresses" in contact_properties
-    assert contact_properties["addresses"]["type"] == "array"
-    assert contact_properties["addresses"]["items"]["type"] == "object"
-
-    # Check converted litellm format
-    expected_litellm_format = {
-        "type": "function",
-        "function": {
-            "name": "complex_dummy_function",
-            "description": (
-                "Process user profile with complex nested structure.\n\n    Args:\n        profile: User "
-                "profile containing nested contact and address information\n        priority: Priority "
-                "level of the processing\n        notes: Optional processing notes\n    "
-            ),
-            "parameters": {
-                "type": "object",
-                "properties": {
-                    "profile": {
-                        "properties": {
-                            "user_id": {"title": "User Id", "type": "integer"},
-                            "name": {"title": "Name", "type": "string"},
-                            "age": {"anyOf": [{"type": "integer"}, {"type": "null"}], "default": None, "title": "Age"},
-                            "contact": {
-                                "properties": {
-                                    "email": {"title": "Email", "type": "string"},
-                                    "phone": {
-                                        "anyOf": [{"type": "string"}, {"type": "null"}],
-                                        "default": None,
-                                        "title": "Phone",
-                                    },
-                                    "addresses": {
-                                        "items": {
-                                            "properties": {
-                                                "street": {"title": "Street", "type": "string"},
-                                                "city": {"title": "City", "type": "string"},
-                                                "zip_code": {"title": "Zip Code", "type": "string"},
-                                                "is_primary": {
-                                                    "default": False,
-                                                    "title": "Is Primary",
-                                                    "type": "boolean",
-                                                },
-                                            },
-                                            "required": ["street", "city", "zip_code"],
-                                            "title": "Address",
-                                            "type": "object",
-                                        },
-                                        "title": "Addresses",
-                                        "type": "array",
-                                    },
-                                },
-                                "required": ["email", "addresses"],
-                                "title": "ContactInfo",
-                                "type": "object",
-                            },
-                            "tags": {"default": [], "items": {"type": "string"}, "title": "Tags", "type": "array"},
-                        },
-                        "required": ["user_id", "name", "contact"],
-                        "title": "UserProfile",
-                        "description": "The user ultimate profile",
-                        "type": "object",
-                    },
-                    "priority": {"type": "integer"},
-                    "notes": {"anyOf": [{"type": "string"}, {"type": "null"}]},
-                },
-                "required": ["profile", "priority", "notes"],
-                "additionalProperties": False,
-            },
-        },
-    }
-    assert tool.convert_to_litellm_tool_format() == expected_litellm_format
+    tool = Tool(dummy_function, arg_desc={"x": "The x parameter"})
+    assert tool.args["x"]["description"] == "The x parameter"

--- a/tests/primitives/test_tool.py
+++ b/tests/primitives/test_tool.py
@@ -1,0 +1,234 @@
+import pytest
+from pydantic import BaseModel
+from dspy.primitives.tool import Tool
+from typing import Any, Optional
+
+
+# Test fixtures
+def dummy_function(x: int, y: str) -> str:
+    """A dummy function for testing.
+
+    Args:
+        x: An integer parameter
+        y: A string parameter
+    """
+    return f"{y} {x}"
+
+
+class DummyModel(BaseModel):
+    field1: str
+    field2: int
+
+
+def dummy_with_pydantic(model: DummyModel) -> str:
+    """A dummy function that accepts a Pydantic model."""
+    return f"{model.field1} {model.field2}"
+
+
+class Address(BaseModel):
+    street: str
+    city: str
+    zip_code: str
+    is_primary: bool = False
+
+
+class ContactInfo(BaseModel):
+    email: str
+    phone: Optional[str] = None
+    addresses: list[Address]
+
+
+class UserProfile(BaseModel):
+    user_id: int
+    name: str
+    age: Optional[int] = None
+    contact: ContactInfo
+    tags: list[str] = []
+
+
+def complex_dummy_function(profile: UserProfile, priority: int, notes: Optional[str] = None) -> dict[str, Any]:
+    """Process user profile with complex nested structure.
+
+    Args:
+        profile: User profile containing nested contact and address information
+        priority: Priority level of the processing
+        notes: Optional processing notes
+    """
+    primary_address = next(
+        (addr for addr in profile.contact.addresses if addr.is_primary), profile.contact.addresses[0]
+    )
+
+    return {
+        "user_id": profile.user_id,
+        "name": profile.name,
+        "priority": priority,
+        "primary_address": primary_address.model_dump(),
+        "notes": notes,
+    }
+
+
+def test_basic_initialization():
+    tool = Tool(name="test_tool", desc="A test tool", parameters={"param1": {"type": "string"}}, func=lambda x: x)
+    assert tool.name == "test_tool"
+    assert tool.desc == "A test tool"
+    assert tool.parameters == {"param1": {"type": "string"}}
+    assert callable(tool.func)
+
+
+def test_tool_from_function():
+    tool = Tool(dummy_function)
+
+    assert tool.name == "dummy_function"
+    assert "A dummy function for testing" in tool.desc
+    assert "x" in tool.parameters
+    assert "y" in tool.parameters
+    assert tool.parameters["x"]["type"] == "integer"
+    assert tool.parameters["y"]["type"] == "string"
+
+
+def test_tool_from_class():
+    class Foo:
+        def __init__(self, user_id: str):
+            self.user_id = user_id
+
+        def __call__(self, a: int, b: int) -> int:
+            """Add two numbers."""
+            return a + b
+
+    tool = Tool(Foo("123"))
+    assert tool.name == "Foo"
+    assert tool.desc == "Add two numbers."
+    assert tool.parameters == {"a": {"type": "integer"}, "b": {"type": "integer"}}
+
+
+def test_tool_from_function_with_pydantic():
+    tool = Tool(dummy_with_pydantic)
+
+    assert tool.name == "dummy_with_pydantic"
+    assert "model" in tool.parameters
+    assert tool.parameters["model"]["type"] == "object"
+    assert "field1" in tool.parameters["model"]["properties"]
+    assert "field2" in tool.parameters["model"]["properties"]
+
+
+def test_convert_to_litellm_tool_format():
+    tool = Tool(dummy_function)
+    litellm_format = tool.convert_to_litellm_tool_format()
+
+    assert litellm_format["type"] == "function"
+    assert litellm_format["function"]["name"] == "dummy_function"
+    assert "parameters" in litellm_format["function"]
+    assert litellm_format["function"]["parameters"]["required"] == ["x", "y"]
+    assert not litellm_format["function"]["parameters"]["additionalProperties"]
+
+
+def test_tool_callable():
+    tool = Tool(dummy_function)
+    result = tool(x=42, y="hello")
+    assert result == "hello 42"
+
+
+def test_tool_with_pydantic_callable():
+    tool = Tool(dummy_with_pydantic)
+    model = DummyModel(field1="test", field2=123)
+    result = tool(model=model)
+    assert result == "test 123"
+
+
+def test_invalid_function_call():
+    tool = Tool(dummy_function)
+    with pytest.raises(ValueError):
+        tool(x="not an integer", y="hello")
+
+
+def test_parameter_desc():
+    tool = Tool(dummy_function, parameter_desc={"x": "The x parameter"})
+    assert tool.parameters["x"]["description"] == "The x parameter"
+
+
+def test_complex_nested_schema():
+    tool = Tool(complex_dummy_function, parameter_desc={"profile": "The user ultimate profile"})
+
+    assert tool.name == "complex_dummy_function"
+    assert "profile" in tool.parameters
+
+    profile_schema = tool.parameters["profile"]
+    assert profile_schema["type"] == "object"
+    assert profile_schema["description"] == "The user ultimate profile"
+
+    # Check nested structure
+    properties = profile_schema["properties"]
+    assert "contact" in properties
+    assert properties["contact"]["type"] == "object"
+
+    contact_properties = properties["contact"]["properties"]
+    assert "addresses" in contact_properties
+    assert contact_properties["addresses"]["type"] == "array"
+    assert contact_properties["addresses"]["items"]["type"] == "object"
+
+    # Check converted litellm format
+    expected_litellm_format = {
+        "type": "function",
+        "function": {
+            "name": "complex_dummy_function",
+            "description": (
+                "Process user profile with complex nested structure.\n\n    Args:\n        profile: User "
+                "profile containing nested contact and address information\n        priority: Priority "
+                "level of the processing\n        notes: Optional processing notes\n    "
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "profile": {
+                        "properties": {
+                            "user_id": {"title": "User Id", "type": "integer"},
+                            "name": {"title": "Name", "type": "string"},
+                            "age": {"anyOf": [{"type": "integer"}, {"type": "null"}], "default": None, "title": "Age"},
+                            "contact": {
+                                "properties": {
+                                    "email": {"title": "Email", "type": "string"},
+                                    "phone": {
+                                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                                        "default": None,
+                                        "title": "Phone",
+                                    },
+                                    "addresses": {
+                                        "items": {
+                                            "properties": {
+                                                "street": {"title": "Street", "type": "string"},
+                                                "city": {"title": "City", "type": "string"},
+                                                "zip_code": {"title": "Zip Code", "type": "string"},
+                                                "is_primary": {
+                                                    "default": False,
+                                                    "title": "Is Primary",
+                                                    "type": "boolean",
+                                                },
+                                            },
+                                            "required": ["street", "city", "zip_code"],
+                                            "title": "Address",
+                                            "type": "object",
+                                        },
+                                        "title": "Addresses",
+                                        "type": "array",
+                                    },
+                                },
+                                "required": ["email", "addresses"],
+                                "title": "ContactInfo",
+                                "type": "object",
+                            },
+                            "tags": {"default": [], "items": {"type": "string"}, "title": "Tags", "type": "array"},
+                        },
+                        "required": ["user_id", "name", "contact"],
+                        "title": "UserProfile",
+                        "description": "The user ultimate profile",
+                        "type": "object",
+                    },
+                    "priority": {"type": "integer"},
+                    "notes": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                },
+                "required": ["profile", "priority", "notes"],
+                "additionalProperties": False,
+            },
+        },
+    }
+    assert tool.convert_to_litellm_tool_format() == expected_litellm_format


### PR DESCRIPTION
Some changes to `dspy.Tool`:

1. Move it under `primitives` to separate it from `dspy.ReAct` definition.
2. Resolve relative model json schema with absolute schema, i.e., expanding all those `$ref`s. 
3. Provide a way for users to specify parameter description, which is proved to be useful for improving function calling quality. 