### PR TITLE
Replacing json.loads with json_repair.loads

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -129,7 +129,7 @@ def parse_value(value, annotation):
         parsed_value = find_enum_member(annotation, value)
     elif isinstance(value, str):
         try:
-            parsed_value = json.loads(value)
+            parsed_value = json_repair.loads(value)
         except json.JSONDecodeError:
             try:
                 parsed_value = ast.literal_eval(value)


### PR DESCRIPTION
Pull request to implement solution to #1968 . in json_adapter.py , the parse_value function uses json_repair.loads() to load the structured output, so if theres slight errors or formatting issues, json_repair tries to fix it.
