### PR TITLE
Add 'DSPy in Production' page

### DIFF
--- a/docs/docs/production/index.md
+++ b/docs/docs/production/index.md
@@ -6,7 +6,7 @@
 
     ---
 
-    DSPy is deployed in production by many enterprises and startups. Explore real-world case studies that demonstrate its impact.
+    DSPy is deployed in production by many enterprises and startups. Explore real-world case studies.
 
     [:octicons-arrow-right-24: Use Cases](../dspy-usecases.md)
 
@@ -14,7 +14,7 @@
 
     ---
 
-    Leveraging **MLflow Tracing**, an OpenTelemetry based tracing solution, DSPy offers a comprehensive monitoring and observability framework for your DSPy applications.
+    Monitor your DSPy programs using **MLflow Tracing**, based on OpenTelemetry.
 
     [:octicons-arrow-right-24: Set Up Observability](../tutorials/observability/#tracing)
 
@@ -22,7 +22,7 @@
 
     ---
 
-    Ensuring reproducibility is critical when transitioning models from research to production. With native MLflow integration, you can log programs, metrics, configs, and environments for full reproducibility.
+    Log programs, metrics, configs, and environments for full reproducibility with DSPy's native MLflow integration.
 
     [:octicons-arrow-right-24: MLflow Integration](https://mlflow.org/docs/latest/llms/dspy/index.html)
 
@@ -30,7 +30,7 @@
 
     ---
 
-    Enjoy a seamless deployment experience with DSPy's integration with MLflow Model Serving. Refer to the guide below to launch your application into production.
+    When it's time to productionize, deploy your application easily with DSPy's integration with MLflow Model Serving.
 
     [:octicons-arrow-right-24: Deployment Guide](../tutorials/deployment)
 
@@ -38,7 +38,7 @@
 
     ---
 
-    DSPy is built to scale. DSPy is designed with thread-safety in mind and offers native asynchronous execution support, ensuring optimal performance in high-throughput environments.
+    DSPy is designed with thread-safety in mind and offers native asynchronous execution support for high-throughput environments.
 
     [:octicons-arrow-right-24: Async Program](../api/utils/asyncify.md)
 
@@ -46,7 +46,7 @@
 
     ---
 
-    Controlling LLM behavior in production is both critical and challenging. DSPy's core design includes the **Signature** feature—a powerful tool to manage and regulate LLM outputs.
+    DSPy's **Signatures**, **Modules**, and **Optimizers** help you control and guide LM outputs.
 
     [:octicons-arrow-right-24: Learn Signature](../learn/programming/signatures.md)
 

--- a/docs/docs/production/index.md
+++ b/docs/docs/production/index.md
@@ -1,0 +1,53 @@
+# Using DSPy in Production
+
+<div class="grid cards" style="text-align: left;" markdown>
+
+- :material-earth:{ .lg .middle } __Real-World Use Cases__
+
+    ---
+
+    DSPy is deployed in production by many enterprises and startups. Explore real-world case studies that demonstrate its impact.
+
+    [:octicons-arrow-right-24: Use Cases](../dspy-usecases.md)
+
+- :material-magnify-expand:{ .lg .middle } __Monitoring & Observability__
+
+    ---
+
+    Leveraging **MLflow Tracing**, an OpenTelemetry based tracing solution, DSPy offers a comprehensive monitoring and observability framework for your DSPy applications.
+
+    [:octicons-arrow-right-24: Set Up Observability](../tutorials/observability/#tracing)
+
+- :material-ab-testing: __Reproducibility__
+
+    ---
+
+    Ensuring reproducibility is critical when transitioning models from research to production. With native MLflow integration, you can log programs, metrics, configs, and environments for full reproducibility.
+
+    [:octicons-arrow-right-24: MLflow Integration](https://mlflow.org/docs/latest/llms/dspy/index.html)
+
+- :material-rocket-launch: __Deployment__
+
+    ---
+
+    Enjoy a seamless deployment experience with DSPy's integration with MLflow Model Serving. Refer to the guide below to launch your application into production.
+
+    [:octicons-arrow-right-24: Deployment Guide](../tutorials/deployment)
+
+- :material-arrow-up-right-bold: __Scalability__
+
+    ---
+
+    DSPy is built to scale. DSPy is designed with thread-safety in mind and offers native asynchronous execution support, ensuring optimal performance in high-throughput environments.
+
+    [:octicons-arrow-right-24: Async Program](../api/utils/asyncify.md)
+
+- :material-alert-rhombus: __Guardrails & Controllability__
+
+    ---
+
+    Controlling LLM behavior in production is both critical and challenging. DSPy's core design includes the **Signature** feature—a powerful tool to manage and regulate LLM outputs.
+
+    [:octicons-arrow-right-24: Learn Signature](../learn/programming/signatures.md)
+
+</div>

--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -51,6 +51,10 @@
     text-align: justify;
 }
 
+/* Left-aligned text for grid cards */
+.md-content__inner .grid.cards p {
+    text-align: left;
+}
 
 /* Base styling for the output area */
 .jp-Cell-outputWrapper .jp-OutputArea-output pre {

--- a/docs/docs/tutorials/observability/index.md
+++ b/docs/docs/tutorials/observability/index.md
@@ -4,7 +4,7 @@ This guide demonstrates how to debug problems and improve observability in DSPy.
 
 However, as systems grow more sophisticated, the ability to **understand what your system is doing** becomes critical. Without transparency, the prediction process can easily become a black box, making failures or quality issues difficult to diagnose and production maintenance challenging.
 
-By the end of this tutorial, you'll understand how to debug an issue and improve observability using [MLflow Tracing](#mlflow-tracing). You'll also explore how to build a custom logging solution using callbacks.
+By the end of this tutorial, you'll understand how to debug an issue and improve observability using [MLflow Tracing](#tracing). You'll also explore how to build a custom logging solution using callbacks.
 
 
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -127,6 +127,8 @@ nav:
             - load: api/utils/load.md
             - streamify: api/utils/streamify.md
 
+    - DSPy in Production: production/index.md
+
 theme:
     name: material
     custom_dir: overrides
@@ -235,6 +237,7 @@ markdown_extensions:
     - pymdownx.superfences
     - pymdownx.mark
     - attr_list
+    - md_in_html
     - pymdownx.emoji:
         emoji_index: !!python/name:material.extensions.emoji.twemoji
         emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
As discussed offline, adding a new page describes the production related topics about DSPy.

![Screenshot 2025-02-05 at 11 02 08](https://github.com/user-attachments/assets/b90639b0-400d-49a1-819a-ae30849e4aba)
