### PR TITLE
Add context truncation logic for react

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 
+from litellm import ContextWindowExceededError
+
 from dspy.utils.callback import with_callbacks
+
 
 class Adapter(ABC):
     def __init__(self, callbacks=None):
@@ -40,6 +43,9 @@ class Adapter(ABC):
             return values
 
         except Exception as e:
+            if isinstance(e, ContextWindowExceededError):
+                # On context window exceeded error, we don't want to retry with a different adapter.
+                raise e
             from .json_adapter import JSONAdapter
             if not isinstance(self, JSONAdapter):
                 return JSONAdapter()(lm, lm_kwargs, signature, demos, inputs)


### PR DESCRIPTION
In the current implementation, we are accumulating the trajectory without an end, which in some cases cause context overflow, e.g., the tool is a retriever which fetches long context. With this PR we are providing a default way to truncate trajectory when detecting context window exceeding, and also provide a custom hook `truncate_trajectory` so that users can override to implement their own truncation logic. 