### PR TITLE
Use context instead of settings for streamify

### DIFF
--- a/dspy/utils/streaming.py
+++ b/dspy/utils/streaming.py
@@ -266,10 +266,9 @@ def streamify(
     status_streaming_callback = StatusStreamingCallback(status_message_provider)
     if not any(isinstance(c, StatusStreamingCallback) for c in callbacks):
         callbacks.append(status_streaming_callback)
-    settings.configure(callbacks=callbacks)
 
     async def generator(args, kwargs, stream: MemoryObjectSendStream):
-        with settings.context(send_stream=stream):
+        with settings.context(send_stream=stream, callbacks=callbacks):
             prediction = await program(*args, **kwargs)
 
         await stream.send(prediction)


### PR DESCRIPTION
It's uncommon but possible that "streamify" is called in a child thread, especially at model serving, e.g., MLflow serving. So in order to avoid errors we are using `dspy.context` instead of changing the global `dspy.settings`.