### PR TITLE
Use json_repair.load in chat_adapter

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -146,7 +146,7 @@ def parse_value(value, annotation):
         return find_enum_member(annotation, value)
     elif isinstance(value, str):
         parsed_value = json_repair.loads(value)
-        if parsed_value ==  '':
+        if parsed_value == '':
             try:
                 parsed_value = ast.literal_eval(value)
             except (ValueError, SyntaxError):

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -9,6 +9,7 @@ from itertools import chain
 
 from typing import Any, Dict, Literal, NamedTuple
 
+import json_repair
 import pydantic
 from pydantic import TypeAdapter
 from pydantic.fields import FieldInfo
@@ -144,9 +145,8 @@ def parse_value(value, annotation):
     if isinstance(annotation, enum.EnumMeta):
         return find_enum_member(annotation, value)
     elif isinstance(value, str):
-        try:
-            parsed_value = json.loads(value)
-        except json.JSONDecodeError:
+        parsed_value = json_repair.loads(value)
+        if parsed_value ==  '':
             try:
                 parsed_value = ast.literal_eval(value)
             except (ValueError, SyntaxError):


### PR DESCRIPTION
json_adapter is already using json_repair for parsing. I'd like to update chat_adapter to do the same.

This will fix cases where markdown notations sneak into the output and cause trouble for `json.load`.
