### PR TITLE
docs: Add multi modal classifier example to documentation

### DIFF
--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -136,6 +136,27 @@ Prediction(
 )
 ```
 
+### Example E: Multi-modal image classification
+
+```python
+class DogPictureSignature(dspy.Signature):
+    """Output the dog breed of the dog in the image."""
+    image_1: dspy.Image = dspy.InputField(desc="An image of a dog")
+    answer: str = dspy.OutputField(desc="The dog breed of the dog in the image")
+
+image_url = "https://picsum.photos/id/237/200/300"
+classify = dspy.Predict(DogPictureSignature)
+classify(image_1=dspy.Image.from_url(image_url))
+```
+
+**Possible Output:**
+
+```text
+Prediction(
+    answer='Labrador Retriever'
+)
+```
+
 ## Using signatures to build modules & compiling them
 
 While signatures are convenient for prototyping with structured inputs/outputs, that's not the only reason to use them!


### PR DESCRIPTION
## Context
This pull request adds an example of multi-modal image input to the signature documentation. It is based on the functionality introduced in https://github.com/stanfordnlp/dspy/pull/1495 

Ideally, it would also be accompanied by the changes introduced in https://github.com/stanfordnlp/dspy/pull/7841, since the existing documentation does not make any references to the functions used in the example.

<img width="999" alt="image" src="https://github.com/user-attachments/assets/355d198f-36d9-4a62-a936-8542cf2b6c10" />
