### PR TITLE
docs: Add support for class methods in API reference

### DIFF
--- a/docs/docs/api/adapters/ChatAdapter.md
+++ b/docs/docs/api/adapters/ChatAdapter.md
@@ -8,7 +8,6 @@
             - format
             - format_fields
             - format_finetune_data
-            - format_turn
             - parse
         show_source: true
         show_undocumented_members: true

--- a/docs/docs/api/primitives/Image.md
+++ b/docs/docs/api/primitives/Image.md
@@ -4,14 +4,11 @@
     handler: python
     options:
         members:
-            - copy
-            - dict
-            - json
-            - model_copy
-            - model_dump
-            - model_dump_json
-            - model_post_init
+            - from_PIL
+            - from_file
+            - from_url
             - serialize_model
+            - validate_input
         show_source: true
         show_undocumented_members: true
         show_root_heading: true

--- a/docs/docs/api/primitives/Prediction.md
+++ b/docs/docs/api/primitives/Prediction.md
@@ -5,6 +5,7 @@
     options:
         members:
             - copy
+            - from_completions
             - get
             - inputs
             - items

--- a/docs/docs/api/signatures/Signature.md
+++ b/docs/docs/api/signatures/Signature.md
@@ -4,13 +4,14 @@
     handler: python
     options:
         members:
-            - copy
-            - dict
-            - json
-            - model_copy
-            - model_dump
-            - model_dump_json
-            - model_post_init
+            - append
+            - dump_state
+            - equals
+            - insert
+            - load_state
+            - prepend
+            - with_instructions
+            - with_updated_fields
         show_source: true
         show_undocumented_members: true
         show_root_heading: true


### PR DESCRIPTION
## Context
This pull request adds support for class methods in the api documentation by replacing calls to `inspect.isfunction()` with the more inclusive `inspect.isroutine()`. In particular, the `Image`, `Prediction` and `Signature` primitives have several relevant functions that were not being captured by the previous method. 

It also excludes functions defined by external modules (e.g. Pydantic), but it seems there is some other mechanism that also filters them out somewhere, since they do not appear in the existing documentation despite being present in the generated markdown. 

## Before
<img width="948" alt="image" src="https://github.com/user-attachments/assets/d4c11b4e-90e2-455b-b33a-5ecdb420fb2a" />


## After

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/dabb29dc-513d-4d25-b324-90e39f2bb912" />
