### PR TITLE
bundle files with dspy installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dependencies = [
 [tool.setuptools.packages.find]
 include = ["dspy*"]
 
+[tool.setuptools]
+include-package-data = true
+
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.18.0,<1.0.0"]
 chromadb = ["chromadb~=0.4.14"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,11 +50,11 @@ dependencies = [
     "cloudpickle",
 ]
 
-[tool.setuptools.packages.find]
-include = ["dspy*"]
-
 [tool.setuptools]
-include-package-data = true
+packages = ["dspy"]
+
+[tool.setuptools.package-data]
+"dspy" = ["primitives/*.js"]
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.18.0,<1.0.0"]


### PR DESCRIPTION
fix for #7853  and #7490 

ensures all github files are in the dspy installation package so `runner.js` can be recognized. 

Tagging @chenmoneygithub for review on the proper pypi package installation. 