### PR TITLE
Fix pyproject.toml to include package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["setuptools==62.3.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -51,10 +51,12 @@ dependencies = [
 ]
 
 [tool.setuptools.packages.find]
-include = ["dspy*"]
+where = ["."]
+include = ["dspy", "dspy.*"]
+exclude = ["tests", "tests.*"]
 
-[tool.setuptools]
-include-package-data = true
+[tool.setuptools.package-data]
+dspy = ["primitives/*.js"]
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.18.0,<1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools==62.3.0", "wheel"]
+requires = ["setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This PR fixes #7853 and #7490 without causing #7867.
Confirmed the behavior by running `python -m build` on a clean clone of the DSPy repo.


<img width="865" alt="image" src="https://github.com/user-attachments/assets/e67e3d48-317e-43a0-9231-bf10d05973e4" />
