### PR TITLE
Remove special case for dspy.Predict

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -90,12 +90,7 @@ class Predict(Module, Parameter):
         if not all(k in kwargs for k in signature.input_fields):
             present = [k for k in signature.input_fields if k in kwargs]
             missing = [k for k in signature.input_fields if k not in kwargs]
-
-            from dspy.adapters.types import History
-
-            if not all(signature.input_fields[k].annotation == History for k in missing):
-                # We allow missing history fields.
-                print(f"WARNING: Not all input fields were provided to module. Present: {present}. Missing: {missing}.")
+            print(f"WARNING: Not all input fields were provided to module. Present: {present}. Missing: {missing}.")
 
         import dspy
 


### PR DESCRIPTION
In #7851 we allowed history to be missing to avoid warnings during `compile()` call, but in fact we shouldn't do that