### PR TITLE
fix version in metadata

### DIFF
--- a/dspy/__metadata__.py
+++ b/dspy/__metadata__.py
@@ -1,7 +1,7 @@
 #replace_package_name_marker
 __name__="dspy"
 #replace_package_version_marker
-__version__="2.6.5"
+__version__="2.6.9rc1"
 __description__="DSPy"
 __url__="https://github.com/stanfordnlp/dspy"
 __author__="Omar Khattab"


### PR DESCRIPTION
I accidentally removed the automatic version updating in the publish workflow, so I am manually updating it now.

After https://github.com/stanfordnlp/dspy/pull/7876, the workflow will handle version update in `__metadata__.py` again.