### PR TITLE
Fix model name error in finetune

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -384,7 +384,7 @@ Given a few tens or hundreds of representative _inputs_ of your task and a _metr
 
         ```python linenums="1"
         import dspy
-        dspy.configure(lm=dspy.LM('gpt-4o-mini-2024-07-18'))
+        dspy.configure(lm=dspy.LM('openai/gpt-4o-mini-2024-07-18'))
         
         # Define the DSPy module for classification. It will use the hint at training time, if available.
         signature = dspy.Signature("text -> label").with_updated_fields('label', type_=Literal[tuple(CLASSES)])
@@ -394,7 +394,7 @@ Given a few tens or hundreds of representative _inputs_ of your task and a _metr
         optimizer = dspy.BootstrapFinetune(metric=(lambda x, y, trace=None: x.label == y.label), num_threads=24)
         optimized = optimizer.compile(classify, trainset=trainset)
 
-        optimized_classifier(text="What does a pending cash withdrawal mean?")
+        optimized(text="What does a pending cash withdrawal mean?")
         ```
 
         **Possible Output (from the last line):**

--- a/dspy/clients/databricks.py
+++ b/dspy/clients/databricks.py
@@ -172,21 +172,21 @@ class DatabricksProvider(Provider):
         train_data_format: Optional[Union[TrainDataFormat, str]] = "chat",
         train_kwargs: Optional[Dict[str, Any]] = None,
     ) -> str:
-        if isinstance(data_format, str):
-            if data_format == "chat":
-                data_format = TrainDataFormat.CHAT
-            elif data_format == "completion":
-                data_format = TrainDataFormat.COMPLETION
+        if isinstance(train_data_format, str):
+            if train_data_format == "chat":
+                train_data_format = TrainDataFormat.CHAT
+            elif train_data_format == "completion":
+                train_data_format = TrainDataFormat.COMPLETION
             else:
                 raise ValueError(
-                    f"String `train_data_format` must be one of 'chat' or 'completion', but received: {data_format}."
+                    f"String `train_data_format` must be one of 'chat' or 'completion', but received: {train_data_format}."
                 )
 
         if "train_data_path" not in train_kwargs:
             raise ValueError("The `train_data_path` must be provided to finetune on Databricks.")
         # Add the file name to the directory path.
         train_kwargs["train_data_path"] = DatabricksProvider.upload_data(
-            train_data, train_kwargs["train_data_path"], data_format
+            train_data, train_kwargs["train_data_path"], train_data_format
         )
 
         try:
@@ -236,7 +236,7 @@ class DatabricksProvider(Provider):
         model_to_deploy = train_kwargs.get("register_to")
         job.endpoint_name = model_to_deploy.replace(".", "_")
         DatabricksProvider.deploy_finetuned_model(
-            model_to_deploy, data_format, databricks_host, databricks_token, deploy_timeout
+            model_to_deploy, train_data_format, databricks_host, databricks_token, deploy_timeout
         )
         job.launch_completed = True
         # The finetuned model name should be in the format: "databricks/<endpoint_name>".

--- a/dspy/clients/lm_local.py
+++ b/dspy/clients/lm_local.py
@@ -12,6 +12,10 @@ from datasets import Dataset
 from typing import Any, Dict, List, Optional
 from dspy.clients.provider import TrainingJob, Provider
 from dspy.clients.utils_finetune import TrainDataFormat, save_data
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dspy.clients.lm import LM
 
 logger = logging.getLogger(__name__)
 
@@ -118,7 +122,7 @@ class LocalProvider(Provider):
 
 
     @staticmethod
-    def kill(lm: 'LM', launch_kwargs: Optional[Dict[str, Any]] = None):
+    def kill(lm: "LM", launch_kwargs: Optional[Dict[str, Any]] = None):
         from sglang.utils import terminate_process
         if not hasattr(lm, "process"):
             logger.info("No running server to kill.")
@@ -227,7 +231,8 @@ def train_sft_locally(model_name, train_data, train_kwargs):
 
     hf_dataset = Dataset.from_list(train_data)
     def tokenize_function(example):
-        return encode_sft_example(example, tokenizer, max_seq_length)
+        nonlocal tokenizer
+        return encode_sft_example(example, tokenizer, train_kwargs["max_seq_length"])
     tokenized_dataset = hf_dataset.map(tokenize_function, batched=False)
     tokenized_dataset.set_format(type="torch")
     tokenized_dataset = tokenized_dataset.filter(lambda example: (example["labels"] != -100).any())

--- a/dspy/clients/lm_local.py
+++ b/dspy/clients/lm_local.py
@@ -231,7 +231,6 @@ def train_sft_locally(model_name, train_data, train_kwargs):
 
     hf_dataset = Dataset.from_list(train_data)
     def tokenize_function(example):
-        nonlocal tokenizer
         return encode_sft_example(example, tokenizer, train_kwargs["max_seq_length"])
     tokenized_dataset = hf_dataset.map(tokenize_function, batched=False)
     tokenized_dataset.set_format(type="torch")

--- a/dspy/clients/provider.py
+++ b/dspy/clients/provider.py
@@ -4,7 +4,10 @@ from threading import Thread
 from typing import Any, Dict, List, Optional, Union
 
 from dspy.clients.utils_finetune import TrainDataFormat
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from dspy.clients.lm import LM
 
 class TrainingJob(Future):
     def __init__(
@@ -44,14 +47,14 @@ class Provider:
         return False
 
     @staticmethod
-    def launch(lm: 'LM', launch_kwargs: Optional[Dict[str, Any]] = None):
+    def launch(lm: "LM", launch_kwargs: Optional[Dict[str, Any]] = None):
         # Note that "launch" and "kill" methods might be called even if there
         # is a launched LM or no launched LM to kill. These methods should be
         # resillient to such cases.
         pass
 
     @staticmethod
-    def kill(lm: 'LM', launch_kwargs: Optional[Dict[str, Any]] = None):
+    def kill(lm: "LM", launch_kwargs: Optional[Dict[str, Any]] = None):
         # We assume that LM.launch_kwargs dictionary will contain the necessary
         # information for a provider to launch and/or kill an LM. This is the
         # reeason why the argument here is named launch_kwargs and not

--- a/dspy/teleprompt/bootstrap_finetune.py
+++ b/dspy/teleprompt/bootstrap_finetune.py
@@ -132,7 +132,7 @@ class BootstrapFinetune(FinetuneTeleprompter):
 
         key_to_job = {}
         for key, finetune_kwargs in finetune_dict.items():
-            lm = finetune_kwargs.pop("lm")
+            lm: LM = finetune_kwargs.pop("lm")
             # TODO: The following line is a hack. We should re-think how to free
             # up resources for fine-tuning. This might mean introducing a new
             # provider method (e.g. prepare_for_finetune) that can be called


### PR DESCRIPTION
While `provider/model` format is used for most methods, this format does not work for fine-tuning user journey, which is confusing. This PR fixes the model name handling and fixes the tutorial for fine-tuning on the top page. Also fixes type/reference errors in the relevant provider codes.
