### PR TITLE
[DO NOT MERGE] enable style check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,31 +237,54 @@ exclude_lines = [
 ]
 
 [tool.ruff]
+include = ["dspy/**/*.py", "tests/**/*.py"]
+
+
 line-length = 120
 indent-width = 4
 target-version = "py39"
 
 [tool.ruff.lint]
-# Select a minimal set of rules
 select = [
-    "F", # Pyflakes
-    "E", # Pycodestyle
-    "TID252", # Absolute imports
-
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "C",   # flake8-comprehensions
+    "B",   # flake8-bugbear
+    "UP",  # ≈
+    "N",   # pep8-naming
+    "RUF", # ruff-specific rules
 ]
+
 ignore = [
-    "E501", # Line too long
-
+    "B027",  # Allow non-abstract empty methods in abstract base classes
+    "FBT003",# Allow boolean positional values in function calls
+    "C901",  # Ignore complexity checking
+    "E501",  # Ignore line length errors (handled by formatter)
 ]
+
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []
 
 [tool.ruff.format]
 docstring-code-format = false
+quote-style = "double"
 indent-style = "space"
+skip-magic-trailing-comma = false
 line-ending = "auto"
 
+[tool.ruff.lint.isort]
+known-first-party = ["dspy"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
 [tool.ruff.lint.per-file-ignores]
-"**/{tests,testing,docs}/*" = ["ALL"]
-"**__init__.py" = ["ALL"]
+"tests/**/*.py" = [
+    "S101",    # Allow assert statements in tests
+    "TID252",  # Allow relative imports in tests
+    "ARG001",  # Allow unused arguments in tests (like pytest fixtures)
+]
+"__init__.py" = ["F401"]  # Init files can be empty


### PR DESCRIPTION
As one step towards stable package (DSPy 3.0), we will enforce the python style for easy maintenance and scalability. 

This PR just contains the desired ruff rules, and we will make separate PRs to fix files according to the rule. After everything is fixed we will check in this PR and enable style check and pre-commit hook.