### PR TITLE
Fix: avoid PythonInterpreter(deno) leak

### DIFF
--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -157,6 +157,9 @@ class ProgramOfThought(Module):
             return code, output, None
         except Exception as e:
             return code, None, str(e)
+        finally:
+            interpreter.shutdown()
+
     def forward(self, **kwargs):
         input_kwargs = {
             field_name: kwargs[field_name] for field_name in self.input_fields


### PR DESCRIPTION
PythonInterpreter(deno) allocated by `ProgramOfThought.execute_code()` never gets closed, leading to memory leak. Simply shut it down.