### PR TITLE
Fix progress bar and tutorial of BootstrapFewShot

### DIFF
--- a/docs/docs/deep-dive/optimizers/bootstrap-fewshot.md
+++ b/docs/docs/deep-dive/optimizers/bootstrap-fewshot.md
@@ -49,12 +49,16 @@ class CoT(dspy.Module):
         return self.prog(question=question)
 ```
 
-Now we need to evaluate this pipeline too!! So we'll use the `Evaluate` class that DSPy provides us, as for the metric we'll use the `gsm8k_metric` that we imported above.
+Now we need to evaluate this pipeline too!! So we'll use the `Evaluate` class that DSPy provides us, as for the metric we'll use the `gsm8k_metric`.
 
 ```python
 from dspy.evaluate import Evaluate
+from dspy.datasets.gsm8k import gsm8k_metric
+import os
 
-evaluate = Evaluate(devset=devset[:], metric=gsm8k_metric, num_threads=NUM_THREADS, display_progress=True, display_table=False)
+NUM_THREADS=os.cpu_count()
+
+evaluate = Evaluate(devset=devset, metric=gsm8k_metric, num_threads=NUM_THREADS, display_progress=True, display_table=False)
 ```
 
 To evaluate the `CoT` pipeline we'll need to create an object of it and pass it as an arg to the `evaluator` call.


### PR DESCRIPTION
The current BootstrapFewShot progress bar has an issue that when there are many training examples compared with necessary demonstrations, the progress bar does not proceed.
This PR updated the progression bar implementation to show two progress bars: one is for the number of bootstrapped examples and another is for the number of training samples processed.
Also fixed the tutorial for BootstrapFewShot.


<img width="1010" alt="image" src="https://github.com/user-attachments/assets/d58ba7e0-2558-4ee9-9e61-637ddf4bfc1f" />




