### PR TITLE
Run test before publishing to pypi

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -35,7 +35,7 @@ jobs:
         id: check_version  
         run: |  
           VERSION=${{ needs.extract-tag.outputs.version }}  
-          PACKAGE_NAME="dspy-test-chenmoney"
+          PACKAGE_NAME="dspy-ai-test"
           echo "Checking if $VERSION for $PACKAGE_NAME exists on TestPyPI"  
           NEW_VERSION=$(python3 .github/workflows/build_utils/test_version.py $PACKAGE_NAME $VERSION)  
           echo "Version to be used for TestPyPI release: $NEW_VERSION"  
@@ -43,7 +43,7 @@ jobs:
       - name: Update version in pyproject.toml
         run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ steps.check_version.outputs.version }}"/;}' pyproject.toml  
       - name: Update package name in pyproject.toml
-        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-test-chenmoney"/;}' pyproject.toml  
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-test"/;}' pyproject.toml  
       - name: Build a binary wheel
         run: python3 -m build
       # Test the locally built wheel

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -35,7 +35,7 @@ jobs:
         id: check_version  
         run: |  
           VERSION=${{ needs.extract-tag.outputs.version }}  
-          PACKAGE_NAME="dspy-ai-test"
+          PACKAGE_NAME="dspy-test-chenmoney"
           echo "Checking if $VERSION for $PACKAGE_NAME exists on TestPyPI"  
           NEW_VERSION=$(python3 .github/workflows/build_utils/test_version.py $PACKAGE_NAME $VERSION)  
           echo "Version to be used for TestPyPI release: $NEW_VERSION"  
@@ -43,7 +43,7 @@ jobs:
       - name: Update version in pyproject.toml
         run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ steps.check_version.outputs.version }}"/;}' pyproject.toml  
       - name: Update package name in pyproject.toml
-        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-test"/;}' pyproject.toml  
+        run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-test-chenmoney"/;}' pyproject.toml  
       - name: Build a binary wheel
         run: python3 -m build
       # Test the locally built wheel
@@ -54,7 +54,7 @@ jobs:
           source test_before_testpypi/bin/activate
           # Install the locally built wheel and testing dependencies
           pip install dist/*.whl pytest
-          python -c "import dspy; print(dspy.__version__)"
+          pytest tests/metadata/test_metadata.py tests/predict
           deactivate
       # Publish to test-PyPI
       - name: Publish distribution 📦 to test-PyPI

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -48,10 +48,10 @@ jobs:
         run: python3 -m build
       # Test the locally built wheel
       - name: Create test environment
-        run: python -m venv test_env
+        run: python -m venv test_before_testpypi
       - name: Test package installation and functionality
         run: |
-          source test_env/bin/activate
+          source test_before_testpypi/bin/activate
           # Install the locally built wheel and testing dependencies
           pip install dist/*.whl pytest
           python -c "import dspy; print(dspy.__version__)"
@@ -93,6 +93,16 @@ jobs:
         run: sed -i '/#replace_package_name_marker/{n;s/__name__ *= *"[^"]*"/__name__="dspy"/;}' ./dspy/__metadata__.py
       - name: Build a binary wheel
         run: python3 -m build
+      # Test the locally built wheel before publishing to pypi
+      - name: Create test environment
+        run: python -m venv test_before_pypi
+      - name: Test package installation and functionality
+        run: |
+          source test_before_pypi/bin/activate
+          # Install the locally built wheel and testing dependencies
+          pip install dist/*.whl pytest
+          pytest tests/metadata/test_metadata.py tests/predict
+          deactivate
       - name: Publish distribution 📦 to PyPI (dspy)
         uses: pypa/gh-action-pypi-publish@release/v1
         with: 

--- a/dspy/utils/saving.py
+++ b/dspy/utils/saving.py
@@ -3,17 +3,19 @@ import sys
 from pathlib import Path
 
 import cloudpickle
-import importlib_metadata
 import ujson
 
 logger = logging.getLogger(__name__)
 
 
 def get_dependency_versions():
-    cloudpickle_version = '.'.join(cloudpickle.__version__.split('.')[:2])
+    import dspy
+
+    cloudpickle_version = ".".join(cloudpickle.__version__.split(".")[:2])
+
     return {
         "python": f"{sys.version_info.major}.{sys.version_info.minor}",
-        "dspy": importlib_metadata.version("dspy"),
+        "dspy": dspy.__version__,
         "cloudpickle": cloudpickle_version,
     }
 

--- a/tests/metadata/test_metadata.py
+++ b/tests/metadata/test_metadata.py
@@ -1,0 +1,11 @@
+import dspy
+import re
+
+
+def test_metadata():
+    assert dspy.__name__ == "dspy"
+    assert re.match(r"\d+\.\d+\.\d+", dspy.__version__)
+    assert dspy.__author__ == "Omar Khattab"
+    assert dspy.__author_email__ == "okhattab@stanford.edu"
+    assert dspy.__url__ == "https://github.com/stanfordnlp/dspy"
+    assert dspy.__description__ == "DSPy"


### PR DESCRIPTION
We've been messing up releases between 2.6.6 and 2.6.9, which could've been prevented with a decent test before publishing to pypi. This PR adds the following check before publishing to pypi:

- Check the metadata is valid after the release.
- All tests in tests/predict should pass, which has a decent coverage over primitives, predict, adapters and LM.


See screenshot below for an example run (testpypi only) from my fork:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f2ba1307-a463-4f39-872b-9908f6424de8" />

