### PR TITLE
Don't suppress exception in eval_candidate_program

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -467,7 +467,7 @@ class MIPROv2(Teleprompter):
         adjusted_num_trials = (num_trials + num_trials // minibatch_full_eval_steps + 1) if minibatch else num_trials
         logger.info(f"== Trial {1} / {adjusted_num_trials} - Full Evaluation of Default Program ==")
 
-        default_score, baseline_results = eval_candidate_program(
+        default_score, _ = eval_candidate_program(
             len(valset), valset, program, evaluate, self.rng, return_all_scores=True
         )
         logger.info(f"Default program score: {default_score}\n")

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -44,21 +44,14 @@ def create_minibatch(trainset, batch_size=50, rng=None):
 
 def eval_candidate_program(batch_size, trainset, candidate_program, evaluate, rng=None, return_all_scores=False):
     """Evaluate a candidate program on the trainset, using the specified batch size."""
-
-    try:
-        # Evaluate on the full trainset
-        if batch_size >= len(trainset):
-            return evaluate(candidate_program, devset=trainset, return_all_scores=return_all_scores)
-        # Or evaluate on a minibatch
-        else:
-            return evaluate(
-                candidate_program,
-                devset=create_minibatch(trainset, batch_size, rng),
-                return_all_scores=return_all_scores
-            )
-    except Exception as e:
-        print(f"Exception occurred: {e}")
-        return 0.0  # TODO: Handle this better, as -ve scores are possible
+    # Evaluate on the full trainset
+    if batch_size >= len(trainset):
+        return evaluate(candidate_program, devset=trainset, return_all_scores=return_all_scores)
+    return evaluate(
+        candidate_program,
+        devset=create_minibatch(trainset, batch_size, rng),
+        return_all_scores=return_all_scores
+    )
 
 def eval_candidate_program_with_pruning(
     trial, trial_logs, trainset, candidate_program, evaluate, trial_num, batch_size=100,

--- a/tests/teleprompt/test_utils.py
+++ b/tests/teleprompt/test_utils.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+import pytest
+
+import dspy
+from dspy.teleprompt.utils import eval_candidate_program
+
+class DummyModule(dspy.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, **kwargs):
+        pass
+
+
+def test_eval_candidate_program_full_trainset():
+    trainset = [1, 2, 3, 4, 5]
+    candidate_program = DummyModule()
+    evaluate = Mock(return_value=0)
+    batch_size = 10
+
+    result = eval_candidate_program(batch_size, trainset, candidate_program, evaluate)
+
+    evaluate.assert_called_once()
+    _, called_kwargs = evaluate.call_args
+    assert len(called_kwargs['devset']) == len(trainset)
+    assert result == 0
+
+def test_eval_candidate_program_minibatch():
+    trainset = [1, 2, 3, 4, 5]
+    candidate_program = DummyModule()
+    evaluate = Mock(return_value=0)
+    batch_size = 3
+
+    result = eval_candidate_program(batch_size, trainset, candidate_program, evaluate)
+
+    evaluate.assert_called_once()
+    _, called_kwargs = evaluate.call_args
+    assert len(called_kwargs['devset']) == batch_size
+    assert result == 0
+
+def test_eval_candidate_program_failure():
+    trainset = [1, 2, 3, 4, 5]
+    candidate_program = DummyModule()
+    evaluate = Mock(side_effect=ValueError("Error"))
+    batch_size = 3
+
+    with pytest.raises(ValueError, match="Error"):
+        eval_candidate_program(batch_size, trainset, candidate_program, evaluate)


### PR DESCRIPTION
Currently, eval_candidate_program method suppresses any exception from evaluation and returns 0. The behavior is confusing since users cannot notice their evaluation metric is not correct and see the suboptimal result without realizing the optimizer actually fails to optimize a given metric. This PR stops suppressing exceptions and adds unit tests to this util.