### PR TITLE
Update lm_local.py

### DIFF
--- a/dspy/clients/lm_local.py
+++ b/dspy/clients/lm_local.py
@@ -48,6 +48,8 @@ class LocalProvider(Provider):
             model = model[7:]
         if model.startswith("local:"):
             model = model[6:]
+        if model.startswith("huggingface/"):
+            model = model[len("huggingface/"):]
 
         logger.info(f"Grabbing a free port to launch an SGLang server for model {model}")
         logger.info(


### PR DESCRIPTION
Without ignoring the "hugggingface/" prefix during launch, the model is not properly recognized within the huggingface hub. This change fixes that error.