### PR TITLE
Remove upper bound on datasets version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "regex",
     "ujson",
     "tqdm",
-    "datasets>=2.14.6,<3.0.0",
+    "datasets>=2.14.6",
     "requests",
     "optuna",
     "pydantic~=2.0",


### PR DESCRIPTION
In May 2024, the following request was made to loosen the versioning requirements: https://github.com/stanfordnlp/dspy/pull/971

`datasets` 3 was released later that year in September 2024. Can we increase the upper bound accordingly?