### PR TITLE
Remove jinja2 from dependency list

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -8510,4 +8510,4 @@ weaviate = ["weaviate-client"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "7ea3925c451e193b6b580d230293e3f62617040e1d9615ba13db7d2d1f3e3b13"
+content-hash = "86bb0a2eed4844f0e3babf32f63d955420d4913fc4c658894aefacf944af7054"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "requests",
     "optuna",
     "pydantic~=2.0",
-    "jinja2",
     "magicattr~=0.1.6",
     "litellm>=1.59.8,<2.0.0",
     "diskcache",
@@ -140,7 +139,6 @@ rich = "^13.7.1"
 psycopg2 = { version = "^2.9.9", optional = true }
 pgvector = { version = "^0.2.5", optional = true }
 llama-index = { version = "^0.10.30", optional = true }
-jinja2 = "^3.1.3"
 magicattr = "^0.1.6"
 litellm = [
     { version = ">=1.59.8,<2.0.0", markers = "sys_platform == 'win32'" },

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cloudpickle
 datasets
 diskcache
 httpx
-jinja2
 joblib~=1.3
 json-repair
 litellm[proxy]>=1.59.8,<2.0.0


### PR DESCRIPTION
As part of making the DSPy package lighter, we can remove jinja2 from the dependency list.
```
$ git grep jinja2 dspy
-> no result
```