### PR TITLE
Simplify dspy.LM

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -16,6 +16,22 @@ class BaseLM(ABC):
     def __call__(self, prompt=None, messages=None, **kwargs):
         pass
 
+    def copy(self, **kwargs):
+        """Returns a copy of the language model with possibly updated parameters."""
+
+        import copy
+
+        new_instance = copy.deepcopy(self)
+        new_instance.history = []
+
+        for key, value in kwargs.items():
+            if hasattr(self, key):
+                setattr(new_instance, key, value)
+            if (key in self.kwargs) or (not hasattr(self, key)):
+                new_instance.kwargs[key] = value
+
+        return new_instance
+
     def inspect_history(self, n: int = 1):
         _inspect_history(self.history, n)
 


### PR DESCRIPTION
We are in an effort of simplifying `dspy.LM` for two goals:

- Make `dspy.BaseLM` more extensible, since we are seeing more request for that.
- Avoid mess when we implement the async call, which will increase our maintenance cost a lot.

This PR includes the following:

- Move `copy` method to `BaseLM`
- Delete the `infer_adapter`, which just defaults to ChatAdapter. 
- Minor cleanups, like the history entry creation. 