### PR TITLE
Docs: Fix typo in page on MIPROv2

### DIFF
--- a/docs/docs/deep-dive/optimizers/miprov2.md
+++ b/docs/docs/deep-dive/optimizers/miprov2.md
@@ -29,9 +29,9 @@ Now that we have the LM client setup it's time to import the train-dev split in 
 ```python
 from dspy.datasets.gsm8k import GSM8K, gsm8k_metric
 
-gms8k = GSM8K()
+gsm8k = GSM8K()
 
-trainset, devset = gms8k.train, gms8k.dev
+trainset, devset = gsm8k.train, gms8k.dev
 ```
 
 We'll now define a basic QA inline signature i.e. `question->answer` and pass it to `ChainOfThought` module, that applies necessary addition for CoT style prompting to the Signature.


### PR DESCRIPTION
Code sample should read `gsm8k`, not `gms8k`.