### PR TITLE
Refactor DSPy adapters to make it more extensible

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -320,8 +320,6 @@ class Adapter:
 
         # Remove the history field from the inputs
         del inputs[history_field_name]
-        # Add the user message for the current input
-        messages.append({"role": "user", "content": self.format_user_message_content(signature, inputs)})
 
         return messages
 

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -292,6 +292,7 @@ class Adapter:
 
         Args:
             signature: The DSPy signature for which to format the conversation history.
+            history_field_name: The name of the history field in the signature.
             inputs: The input arguments to the DSPy module.
 
         Returns:

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -98,7 +98,7 @@ class Adapter(ABC):
 
         for k, v in signature.input_fields.items():
             value = inputs[k]
-            formatted_field_value = format_field_value(field_info=v.info, value=value)
+            formatted_field_value = format_field_value(field_info=v, value=value)
             messages.append(f"[[ ## {k} ## ]]\n{formatted_field_value}")
 
         if include_output_format:
@@ -116,7 +116,7 @@ class Adapter(ABC):
         self,
         signature: Type[Signature],
         outputs: dict[str, Any],
-        missing_field_message=None,
+        missing_field_message: str = None,
     ) -> str:
         raise NotImplementedError
 
@@ -145,11 +145,25 @@ class Adapter(ABC):
             messages.append(
                 {"role": "user", "content": self.format_user_message(signature, demo, prefix=incomplete_demo_prefix)}
             )
-            messages.append({"role": "assistant", "content": self.format_assistant_message(signature, demo)})
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": self.format_assistant_message(
+                        signature, demo, missing_field_message="Not supplied for this particular example. "
+                    ),
+                }
+            )
 
         for demo in complete_demos:
             messages.append({"role": "user", "content": self.format_user_message(signature, demo)})
-            messages.append({"role": "assistant", "content": self.format_assistant_message(signature, demo)})
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": self.format_assistant_message(
+                        signature, demo, missing_field_message="Not supplied for this conversation history message. "
+                    ),
+                }
+            )
 
         return messages
 

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -168,7 +168,6 @@ class ChatAdapter(Adapter):
                     raise ValueError(
                         f"Error parsing field {k}: {e}.\n\n\t\tOn attempting to parse the value\n```\n{v}\n```"
                     )
-
         if fields.keys() != signature.output_fields.keys():
             raise ValueError(f"Expected {signature.output_fields.keys()} but got {fields.keys()}")
 

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -1,9 +1,6 @@
 import re
-import textwrap
-from collections.abc import Mapping
 from typing import Any, Dict, NamedTuple, Optional, Type
 
-import pydantic
 from litellm import ContextWindowExceededError
 from pydantic.fields import FieldInfo
 
@@ -11,8 +8,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.utils import format_field_value, get_annotation_name, parse_value, translate_field_type
 from dspy.clients.lm import LM
-from dspy.signatures.field import OutputField
-from dspy.signatures.signature import Signature, SignatureMeta
+from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback
 
 field_header_pattern = re.compile(r"\[\[ ## (\w+) ## \]\]")
@@ -21,10 +17,6 @@ field_header_pattern = re.compile(r"\[\[ ## (\w+) ## \]\]")
 class FieldInfoWithName(NamedTuple):
     name: str
     info: FieldInfo
-
-
-# Built-in field indicating that a chat turn has been completed.
-BuiltInCompletedOutputFieldInfo = FieldInfoWithName(name="completed", info=OutputField())
 
 
 class ChatAdapter(Adapter):
@@ -42,54 +34,18 @@ class ChatAdapter(Adapter):
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
-            raise e
             if isinstance(e, ContextWindowExceededError):
                 # On context window exceeded error, we don't want to retry with a different adapter.
                 raise e
             # fallback to JSONAdapter
             return JSONAdapter()(lm, lm_kwargs, signature, demos, inputs)
 
-    # def format(
-    #     self, signature: Type[Signature], demos: list[dict[str, Any]], inputs: dict[str, Any]
-    # ) -> list[dict[str, Any]]:
-    #     messages: list[dict[str, Any]] = []
-
-    #     # Extract demos where some of the output_fields are not filled in.
-    #     incomplete_demos = [
-    #         demo for demo in demos if not all(k in demo and demo[k] is not None for k in signature.fields)
-    #     ]
-    #     complete_demos = [demo for demo in demos if demo not in incomplete_demos]
-    #     # Filter out demos that don't have at least one input and one output field.
-    #     incomplete_demos = [
-    #         demo
-    #         for demo in incomplete_demos
-    #         if any(k in demo for k in signature.input_fields) and any(k in demo for k in signature.output_fields)
-    #     ]
-
-    #     demos = incomplete_demos + complete_demos
-    #     prepared_instructions = prepare_instructions(signature)
-    #     messages.append({"role": "system", "content": prepared_instructions})
-
-    #     # Add the few-shot examples
-    #     for demo in demos:
-    #         messages.append(self.format_turn(signature, demo, role="user", incomplete=demo in incomplete_demos))
-    #         messages.append(self.format_turn(signature, demo, role="assistant", incomplete=demo in incomplete_demos))
-
-    #     # Add the chat history after few-shot examples
-    #     if any(field.annotation == History for field in signature.input_fields.values()):
-    #         messages.extend(self.format_conversation_history(signature, inputs))
-    #     else:
-    #         messages.append(self.format_turn(signature, inputs, role="user"))
-
-    #     messages = try_expand_image_tags(messages)
-    #     return messages
-
     def format_field_structure(self, signature: Type[Signature]) -> str:
         parts = []
         parts.append("All interactions will be structured in the following way, with the appropriate values filled in.")
 
         def format_signature_fields_for_instructions(fields: Dict[str, FieldInfo]):
-            return format_fields(
+            return self.format_field_with_value(
                 fields_with_values={
                     FieldInfoWithName(name=field_name, info=field_info): translate_field_type(field_name, field_info)
                     for field_name, field_info in fields.items()
@@ -119,14 +75,12 @@ class ChatAdapter(Adapter):
         outputs: dict[str, Any],
         missing_field_message=None,
     ) -> str:
-        messages = format_fields(
+        return self.format_field_with_value(
             {
                 FieldInfoWithName(name=k, info=v): outputs.get(k, missing_field_message)
                 for k, v in signature.output_fields.items()
             },
         )
-        joined_messages = "\n\n".join(msg for msg in messages)
-        return {"role": "assistant", "content": joined_messages}
 
     def parse(self, signature: Type[Signature], completion: str) -> dict[str, Any]:
         sections = [(None, [])]
@@ -158,6 +112,25 @@ class ChatAdapter(Adapter):
 
         return fields
 
+    def format_field_with_value(self, fields_with_values: Dict[FieldInfoWithName, Any]) -> str:
+        """
+        Formats the values of the specified fields according to the field's DSPy type (input or output),
+        annotation (e.g. str, int, etc.), and the type of the value itself. Joins the formatted values
+        into a single string, which is is a multiline string if there are multiple fields.
+
+        Args:
+        fields_with_values: A dictionary mapping information about a field to its corresponding
+                            value.
+        Returns:
+        The joined formatted values of the fields, represented as a string
+        """
+        output = []
+        for field, field_value in fields_with_values.items():
+            formatted_field_value = format_field_value(field_info=field.info, value=field_value)
+            output.append(f"[[ ## {field.name} ## ]]\n{formatted_field_value}")
+
+        return "\n\n".join(output).strip()
+
     # TODO(PR): Looks ok?
     def format_finetune_data(
         self, signature: Type[Signature], demos: list[dict[str, Any]], inputs: dict[str, Any], outputs: dict[str, Any]
@@ -173,169 +146,3 @@ class ChatAdapter(Adapter):
 
         # Wrap the messages in a dictionary with a "messages" key
         return dict(messages=messages)
-
-    def format_fields(self, signature: Type[Signature], values: dict[str, Any], role: str) -> str:
-        fields_with_values = {
-            FieldInfoWithName(name=field_name, info=field_info): values.get(
-                field_name, "Not supplied for this particular example."
-            )
-            for field_name, field_info in signature.fields.items()
-            if field_name in values
-        }
-        return format_fields(fields_with_values)
-
-    def format_turn(
-        self,
-        signature: Type[Signature],
-        values: dict[str, Any],
-        role: str,
-        incomplete: bool = False,
-        is_conversation_history: bool = False,
-    ) -> dict[str, Any]:
-        return format_turn(signature, values, role, incomplete, is_conversation_history)
-
-
-def format_fields(fields_with_values: Dict[FieldInfoWithName, Any]) -> str:
-    """
-    Formats the values of the specified fields according to the field's DSPy type (input or output),
-    annotation (e.g. str, int, etc.), and the type of the value itself. Joins the formatted values
-    into a single string, which is is a multiline string if there are multiple fields.
-
-    Args:
-      fields_with_values: A dictionary mapping information about a field to its corresponding
-                          value.
-    Returns:
-      The joined formatted values of the fields, represented as a string
-    """
-    output = []
-    for field, field_value in fields_with_values.items():
-        formatted_field_value = format_field_value(field_info=field.info, value=field_value)
-        output.append(f"[[ ## {field.name} ## ]]\n{formatted_field_value}")
-
-    return "\n\n".join(output).strip()
-
-
-def format_turn(
-    signature: Type[Signature], values: dict[str, Any], role: str, incomplete=False, is_conversation_history=False
-):
-    """
-    Constructs a new message ("turn") to append to a chat thread. The message is carefully formatted
-    so that it can instruct an LLM to generate responses conforming to the specified DSPy signature.
-
-    Args:
-        signature: The DSPy signature to which future LLM responses should conform.
-        values: A dictionary mapping field names (from the DSPy signature) to corresponding values
-            that should be included in the message.
-        role: The role of the message, which can be either "user" or "assistant".
-        incomplete: If True, indicates that output field values are present in the set of specified
-            `values`. If False, indicates that `values` only contains input field values. Only used if
-            `is_conversation_history` is False.
-        is_conversation_history: If True, indicates that the message is part of the chat history, otherwise
-            it is a demo (few-shot example).
-
-    Returns:
-        A chat message that can be appended to a chat thread. The message contains two string fields:
-        `role` ("user" or "assistant") and `content` (the message text).
-    """
-    if role == "user":
-        fields = signature.input_fields
-        if incomplete and not is_conversation_history:
-            message_prefix = "This is an example of the task, though some input or output fields are not supplied."
-        else:
-            message_prefix = ""
-    else:
-        # Add the completed field or chat history for the assistant turn
-        fields = {**signature.output_fields}
-        values = {**values}
-        message_prefix = ""
-        if not is_conversation_history:
-            fields.update({BuiltInCompletedOutputFieldInfo.name: BuiltInCompletedOutputFieldInfo.info})
-            values.update({BuiltInCompletedOutputFieldInfo.name: ""})
-
-    if not incomplete and not is_conversation_history and not set(values).issuperset(fields.keys()):
-        raise ValueError(f"Expected {fields.keys()} but got {values.keys()}")
-
-    messages = []
-    if message_prefix:
-        messages.append(message_prefix)
-
-    field_messages = format_fields(
-        {
-            FieldInfoWithName(name=k, info=v): values.get(
-                k,
-                "Not supplied for this conversation history message. "
-                if is_conversation_history
-                else "Not supplied for this particular example. ",
-            )
-            for k, v in fields.items()
-        },
-    )
-    messages.append(field_messages)
-
-    def type_info(v):
-        if v.annotation is not str:
-            return f" (must be formatted as a valid Python {get_annotation_name(v.annotation)})"
-        else:
-            return ""
-
-    # Add output field instructions for user messages
-    if role == "user" and signature.output_fields:
-        field_instructions = (
-            "Respond with the corresponding output fields, starting with the field "
-            + ", then ".join(f"`[[ ## {f} ## ]]`{type_info(v)}" for f, v in signature.output_fields.items())
-            + ", and then ending with the marker for `[[ ## completed ## ]]`."
-        )
-        messages.append(field_instructions)
-    joined_messages = "\n\n".join(msg for msg in messages)
-    return {"role": role, "content": joined_messages}
-
-
-def enumerate_fields(fields: dict) -> str:
-    parts = []
-    for idx, (k, v) in enumerate(fields.items()):
-        parts.append(f"{idx + 1}. `{k}`")
-        parts[-1] += f" ({get_annotation_name(v.annotation)})"
-        parts[-1] += f": {v.json_schema_extra['desc']}" if v.json_schema_extra["desc"] != f"${{{k}}}" else ""
-        parts[-1] += (
-            f"\nConstraints: {v.json_schema_extra['constraints']}" if v.json_schema_extra.get("constraints") else ""
-        )
-    return "\n".join(parts).strip()
-
-
-def move_type_to_front(d):
-    # Move the 'type' key to the front of the dictionary, recursively, for LLM readability/adherence.
-    if isinstance(d, Mapping):
-        return {k: move_type_to_front(v) for k, v in sorted(d.items(), key=lambda item: (item[0] != "type", item[0]))}
-    elif isinstance(d, list):
-        return [move_type_to_front(item) for item in d]
-    return d
-
-
-def prepare_schema(field_type):
-    schema = pydantic.TypeAdapter(field_type).json_schema()
-    schema = move_type_to_front(schema)
-    return schema
-
-
-def prepare_instructions(signature: SignatureMeta):
-    parts = []
-    parts.append("Your input fields are:\n" + enumerate_fields(signature.input_fields))
-    parts.append("Your output fields are:\n" + enumerate_fields(signature.output_fields))
-    parts.append("All interactions will be structured in the following way, with the appropriate values filled in.")
-
-    def format_signature_fields_for_instructions(fields: Dict[str, FieldInfo]):
-        return format_fields(
-            fields_with_values={
-                FieldInfoWithName(name=field_name, info=field_info): translate_field_type(field_name, field_info)
-                for field_name, field_info in fields.items()
-            },
-        )
-
-    parts.append(format_signature_fields_for_instructions(signature.input_fields))
-    parts.append(format_signature_fields_for_instructions(signature.output_fields))
-    parts.append(format_fields({BuiltInCompletedOutputFieldInfo: ""}))
-    instructions = textwrap.dedent(signature.instructions)
-    objective = ("\n" + " " * 8).join([""] + instructions.splitlines())
-    parts.append(f"In adhering to this structure, your objective is: {objective}")
-
-    return "\n\n".join(parts).strip()

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from copy import deepcopy
-from typing import Any, Dict, NamedTuple, Type
+from typing import Any, Dict, Type
 
 import json_repair
 import litellm
@@ -9,7 +9,7 @@ import pydantic
 from pydantic import create_model
 from pydantic.fields import FieldInfo
 
-from dspy.adapters.base import Adapter
+from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
 from dspy.adapters.utils import (
     format_field_value,
     get_annotation_name,
@@ -23,12 +23,7 @@ from dspy.signatures.signature import Signature, SignatureMeta
 logger = logging.getLogger(__name__)
 
 
-class FieldInfoWithName(NamedTuple):
-    name: str
-    info: FieldInfo
-
-
-class JSONAdapter(Adapter):
+class JSONAdapter(ChatAdapter):
     def __call__(
         self,
         lm: LM,

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -78,7 +78,7 @@ class JSONAdapter(Adapter):
         parts.append(format_signature_fields_for_instructions(signature.output_fields))
         return "\n\n".join(parts).strip()
 
-    def get_output_format_in_user_message(self, signature: Type[Signature]) -> str:
+    def user_message_output_requirements(self, signature: Type[Signature]) -> str:
         def type_info(v):
             return (
                 f" (must be formatted as a valid Python {get_annotation_name(v.annotation)})"
@@ -91,7 +91,7 @@ class JSONAdapter(Adapter):
         message += "."
         return message
 
-    def format_assistant_message(
+    def format_assistant_message_content(
         self,
         signature: Type[Signature],
         outputs: dict[str, Any],
@@ -124,10 +124,9 @@ class JSONAdapter(Adapter):
         into a single string, which is is a multiline string if there are multiple fields.
 
         Args:
-        fields_with_values: A dictionary mapping information about a field to its corresponding
-                            value.
+        fields_with_values: A dictionary mapping information about a field to its corresponding value.
         Returns:
-        The joined formatted values of the fields, represented as a string
+            The joined formatted values of the fields, represented as a string
         """
         if role == "user":
             output = []

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,10 +1,7 @@
-import enum
-import inspect
 import json
 import logging
-import textwrap
 from copy import deepcopy
-from typing import Any, Dict, KeysView, Literal, NamedTuple, Type
+from typing import Any, Dict, NamedTuple, Type
 
 import json_repair
 import litellm
@@ -13,12 +10,15 @@ from pydantic import create_model
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.base import Adapter
-from dspy.adapters.types.history import History
-from dspy.adapters.types.image import try_expand_image_tags
-from dspy.adapters.utils import format_field_value, get_annotation_name, parse_value, serialize_for_json
+from dspy.adapters.utils import (
+    format_field_value,
+    get_annotation_name,
+    parse_value,
+    serialize_for_json,
+    translate_field_type,
+)
 from dspy.clients.lm import LM
 from dspy.signatures.signature import Signature, SignatureMeta
-from dspy.signatures.utils import get_dspy_field_type
 
 logger = logging.getLogger(__name__)
 
@@ -29,9 +29,6 @@ class FieldInfoWithName(NamedTuple):
 
 
 class JSONAdapter(Adapter):
-    def __init__(self):
-        pass
-
     def __call__(
         self,
         lm: LM,
@@ -40,70 +37,71 @@ class JSONAdapter(Adapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        inputs = self.format(signature, demos, inputs)
-        inputs = dict(prompt=inputs) if isinstance(inputs, str) else dict(messages=inputs)
+        provider = lm.model.split("/", 1)[0] or "openai"
+        params = litellm.get_supported_openai_params(model=lm.model, custom_llm_provider=provider)
 
+        # If response_format is not supported, use basic call
+        if not params or "response_format" not in params:
+            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+
+        # Try structured output first, fall back to basic json if it fails
         try:
-            provider = lm.model.split("/", 1)[0] or "openai"
-            params = litellm.get_supported_openai_params(model=lm.model, custom_llm_provider=provider)
-            if params and "response_format" in params:
-                try:
-                    response_format = _get_structured_outputs_response_format(signature)
-                    outputs = lm(**inputs, **lm_kwargs, response_format=response_format)
-                except Exception as e:
-                    logger.debug(
-                        f"Failed to obtain response using signature-based structured outputs"
-                        f" response format: Falling back to default 'json_object' response format."
-                        f" Exception: {e}"
-                    )
-                    outputs = lm(**inputs, **lm_kwargs, response_format={"type": "json_object"})
-            else:
-                outputs = lm(**inputs, **lm_kwargs)
+            structured_output_format = self._get_structured_outputs_response_format(signature)
+            lm_kwargs["response_format"] = structured_output_format
+            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+        except Exception as e:
+            logger.warning(f"Failed to use structured output format. Falling back to JSON mode. Error: {e}")
+            try:
+                lm_kwargs["response_format"] = {"type": "json_object"}
+                return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+            except Exception as e:
+                raise RuntimeError(
+                    "Both structured output format and JSON mode failed. Please choose a model that supports "
+                    f"`response_format` argument. Original error: {e}"
+                ) from e
 
-        except litellm.UnsupportedParamsError:
-            outputs = lm(**inputs, **lm_kwargs)
+    def format_field_structure(self, signature: Type[Signature]) -> str:
+        parts = []
+        parts.append("All interactions will be structured in the following way, with the appropriate values filled in.")
 
-        values = []
+        def format_signature_fields_for_instructions(fields: Dict[str, FieldInfo]):
+            return self.format_field_with_value(
+                fields_with_values={
+                    FieldInfoWithName(name=field_name, info=field_info): translate_field_type(field_name, field_info)
+                    for field_name, field_info in fields.items()
+                },
+            )
 
-        for output in outputs:
-            value = self.parse(signature, output)
-            assert set(value.keys()) == set(
-                signature.output_fields.keys()
-            ), f"Expected {signature.output_fields.keys()} but got {value.keys()}"
-            values.append(value)
+        parts.append("Inputs will have the following structure:")
+        parts.append(format_signature_fields_for_instructions(signature.input_fields))
+        parts.append("Outputs will be a JSON object with the following fields.")
+        parts.append(format_signature_fields_for_instructions(signature.output_fields))
+        return "\n\n".join(parts).strip()
 
-        return values
+    def get_output_format_in_user_message(self, signature: Type[Signature]) -> str:
+        def type_info(v):
+            return (
+                f" (must be formatted as a valid Python {get_annotation_name(v.annotation)})"
+                if v.annotation is not str
+                else ""
+            )
 
-    def format(
-        self, signature: Type[Signature], demos: list[dict[str, Any]], inputs: dict[str, Any]
-    ) -> list[dict[str, Any]]:
-        messages = []
+        message = "Respond with a JSON object in the following order of fields: "
+        message += ", then ".join(f"`{f}`{type_info(v)}" for f, v in signature.output_fields.items())
+        message += "."
+        return message
 
-        # Extract demos where some of the output_fields are not filled in.
-        incomplete_demos = [demo for demo in demos if not all(k in demo for k in signature.fields)]
-        complete_demos = [demo for demo in demos if demo not in incomplete_demos]
-        incomplete_demos = [
-            demo
-            for demo in incomplete_demos
-            if any(k in demo for k in signature.input_fields) and any(k in demo for k in signature.output_fields)
-        ]
-
-        demos = incomplete_demos + complete_demos
-
-        messages.append({"role": "system", "content": prepare_instructions(signature)})
-
-        for demo in demos:
-            messages.append(self.format_turn(signature, demo, role="user", incomplete=demo in incomplete_demos))
-            messages.append(self.format_turn(signature, demo, role="assistant", incomplete=demo in incomplete_demos))
-
-        # Add the chat history after few-shot examples
-        if any(field.annotation == History for field in signature.input_fields.values()):
-            messages.extend(self.format_conversation_history(signature, inputs))
-        else:
-            messages.append(self.format_turn(signature, inputs, role="user"))
-
-        messages = try_expand_image_tags(messages)
-        return messages
+    def format_assistant_message(
+        self,
+        signature: Type[Signature],
+        outputs: dict[str, Any],
+        missing_field_message=None,
+    ) -> str:
+        fields_with_values = {
+            FieldInfoWithName(name=k, info=v): outputs.get(k, missing_field_message)
+            for k, v in signature.output_fields.items()
+        }
+        return self.format_field_with_value(fields_with_values, role="assistant")
 
     def parse(self, signature: Type[Signature], completion: str) -> dict[str, Any]:
         fields = json_repair.loads(completion)
@@ -119,25 +117,28 @@ class JSONAdapter(Adapter):
 
         return fields
 
-    def format_fields(self, signature: Type[Signature], values: dict[str, Any], role: str) -> str:
-        fields_with_values = {
-            FieldInfoWithName(name=field_name, info=field_info): values.get(
-                field_name, "Not supplied for this particular example."
-            )
-            for field_name, field_info in signature.fields.items()
-            if field_name in values
-        }
-        return format_fields(role=role, fields_with_values=fields_with_values)
+    def format_field_with_value(self, fields_with_values: Dict[FieldInfoWithName, Any], role: str = "user") -> str:
+        """
+        Formats the values of the specified fields according to the field's DSPy type (input or output),
+        annotation (e.g. str, int, etc.), and the type of the value itself. Joins the formatted values
+        into a single string, which is is a multiline string if there are multiple fields.
 
-    def format_turn(
-        self,
-        signature: Type[Signature],
-        values,
-        role: str,
-        incomplete: bool = False,
-        is_conversation_history: bool = False,
-    ) -> dict[str, Any]:
-        return format_turn(signature, values, role, incomplete, is_conversation_history)
+        Args:
+        fields_with_values: A dictionary mapping information about a field to its corresponding
+                            value.
+        Returns:
+        The joined formatted values of the fields, represented as a string
+        """
+        if role == "user":
+            output = []
+            for field, field_value in fields_with_values.items():
+                formatted_field_value = format_field_value(field_info=field.info, value=field_value)
+                output.append(f"[[ ## {field.name} ## ]]\n{formatted_field_value}")
+            return "\n\n".join(output).strip()
+        else:
+            d = fields_with_values.items()
+            d = {k.name: v for k, v in d}
+            return json.dumps(serialize_for_json(d), indent=2)
 
     def format_finetune_data(
         self, signature: Type[Signature], demos: list[dict[str, Any]], inputs: dict[str, Any], outputs: dict[str, Any]
@@ -145,215 +146,49 @@ class JSONAdapter(Adapter):
         # TODO: implement format_finetune_data method in JSONAdapter
         raise NotImplementedError
 
-
-def format_fields(role: str, fields_with_values: Dict[FieldInfoWithName, Any]) -> str:
-    """
-    Formats the values of the specified fields according to the field's DSPy type (input or output),
-    annotation (e.g. str, int, etc.), and the type of the value itself. Joins the formatted values
-    into a single string, which is a multiline string if there are multiple fields.
-
-    Args:
-      role: The role of the message ('user' or 'assistant')
-      fields_with_values: A dictionary mapping information about a field to its corresponding value.
-
-    Returns:
-      The joined formatted values of the fields, represented as a string.
-    """
-
-    if role == "assistant":
-        d = fields_with_values.items()
-        d = {k.name: v for k, v in d}
-        return json.dumps(serialize_for_json(d), indent=2)
-
-    output = []
-    for field, field_value in fields_with_values.items():
-        formatted_field_value = format_field_value(field_info=field.info, value=field_value)
-        output.append(f"[[ ## {field.name} ## ]]\n{formatted_field_value}")
-
-    return "\n\n".join(output).strip()
-
-
-def format_turn(
-    signature: SignatureMeta,
-    values: Dict[str, Any],
-    role: str,
-    incomplete=False,
-    is_conversation_history=False,
-) -> Dict[str, str]:
-    """
-    Constructs a new message ("turn") to append to a chat thread. The message is carefully formatted
-    so that it can instruct an LLM to generate responses conforming to the specified DSPy signature.
-
-    Args:
-        signature: The DSPy signature to which future LLM responses should conform.
-        values: A dictionary mapping field names (from the DSPy signature) to corresponding values
-            that should be included in the message.
-        role: The role of the message, which can be either "user" or "assistant".
-        incomplete: If True, indicates that output field values are present in the set of specified
-            `values`. If False, indicates that `values` only contains input field values. Only
-            relevant if `is_conversation_history` is False.
-        is_conversation_history: If True, indicates that the message is part of a chat history instead of a
-            few-shot example.
-    Returns:
-        A chat message that can be appended to a chat thread. The message contains two string fields:
-        ``role`` ("user" or "assistant") and ``content`` (the message text).
-    """
-    content = []
-
-    if role == "user":
-        fields: Dict[str, FieldInfo] = signature.input_fields
-        if incomplete and not is_conversation_history:
-            content.append("This is an example of the task, though some input or output fields are not supplied.")
-    else:
-        fields: Dict[str, FieldInfo] = signature.output_fields
-
-    if not incomplete and not is_conversation_history:
-        # For complete few-shot examples, ensure that the values contain all the fields.
-        field_names: KeysView = fields.keys()
-        if not set(values).issuperset(set(field_names)):
-            raise ValueError(f"Expected {field_names} but got {values.keys()}")
-
-    fields_with_values = {}
-    for field_name, field_info in fields.items():
-        if is_conversation_history:
-            fields_with_values[FieldInfoWithName(name=field_name, info=field_info)] = values.get(
-                field_name, "Not supplied for this conversation history message. "
-            )
-        else:
-            fields_with_values[FieldInfoWithName(name=field_name, info=field_info)] = values.get(
-                field_name, "Not supplied for this particular example. "
-            )
-
-    formatted_fields = format_fields(role=role, fields_with_values=fields_with_values)
-    content.append(formatted_fields)
-
-    if role == "user":
-
-        def type_info(v):
-            return (
-                f" (must be formatted as a valid Python {get_annotation_name(v.annotation)})"
-                if v.annotation is not str
-                else ""
-            )
-
-        # TODO: Consider if not incomplete:
-        content.append(
-            "Respond with a JSON object in the following order of fields: "
-            + ", then ".join(f"`{f}`{type_info(v)}" for f, v in signature.output_fields.items())
-            + "."
-        )
-
-    return {"role": role, "content": "\n\n".join(content).strip()}
-
-
-def enumerate_fields(fields):
-    parts = []
-    for idx, (k, v) in enumerate(fields.items()):
-        parts.append(f"{idx+1}. `{k}`")
-        parts[-1] += f" ({get_annotation_name(v.annotation)})"
-        parts[-1] += f": {v.json_schema_extra['desc']}" if v.json_schema_extra["desc"] != f"${{{k}}}" else ""
-        parts[-1] += (
-            f"\nConstraints: {v.json_schema_extra['constraints']}" if v.json_schema_extra.get("constraints") else ""
-        )
-
-    return "\n".join(parts).strip()
-
-
-def prepare_instructions(signature: SignatureMeta):
-    parts = []
-    parts.append("Your input fields are:\n" + enumerate_fields(signature.input_fields))
-    parts.append("Your output fields are:\n" + enumerate_fields(signature.output_fields))
-    parts.append("All interactions will be structured in the following way, with the appropriate values filled in.")
-
-    def field_metadata(field_name, field_info):
-        type_ = field_info.annotation
-
-        if get_dspy_field_type(field_info) == "input" or type_ is str:
-            desc = ""
-        elif type_ is bool:
-            desc = "must be True or False"
-        elif type_ in (int, float):
-            desc = f"must be a single {type_.__name__} value"
-        elif inspect.isclass(type_) and issubclass(type_, enum.Enum):
-            desc = f"must be one of: {'; '.join(type_.__members__)}"
-        elif hasattr(type_, "__origin__") and type_.__origin__ is Literal:
-            desc = f"must be one of: {'; '.join([str(x) for x in type_.__args__])}"
-        else:
-            desc = "must adhere to the JSON schema: "
-            desc += json.dumps(pydantic.TypeAdapter(type_).json_schema())
-
-        desc = (" " * 8) + f"# note: the value you produce {desc}" if desc else ""
-        return f"{{{field_name}}}{desc}"
-
-    def format_signature_fields_for_instructions(role, fields: Dict[str, FieldInfo]):
-        return format_fields(
-            role=role,
-            fields_with_values={
-                FieldInfoWithName(name=field_name, info=field_info): field_metadata(field_name, field_info)
-                for field_name, field_info in fields.items()
-            },
-        )
-
-    parts.append("Inputs will have the following structure:")
-    parts.append(format_signature_fields_for_instructions("user", signature.input_fields))
-    parts.append("Outputs will be a JSON object with the following fields.")
-    parts.append(format_signature_fields_for_instructions("assistant", signature.output_fields))
-    # parts.append(format_fields({BuiltInCompletedOutputFieldInfo: ""}))
-
-    instructions = textwrap.dedent(signature.instructions)
-    objective = ("\n" + " " * 8).join([""] + instructions.splitlines())
-    parts.append(f"In adhering to this structure, your objective is: {objective}")
-
-    # parts.append("You will receive some input fields in each interaction. " +
-    #              "Respond only with the corresponding output fields, starting with the field " +
-    #              ", then ".join(f"`{f}`" for f in signature.output_fields) +
-    #              ", and then ending with the marker for `completed`.")
-
-    return "\n\n".join(parts).strip()
-
-
-def _get_structured_outputs_response_format(signature: SignatureMeta) -> pydantic.BaseModel:
-    """
-    Obtains the LiteLLM / OpenAI `response_format` parameter for generating structured outputs from
-    an LM request, based on the output fields of the specified DSPy signature.
-
-    Args:
-        signature: The DSPy signature for which to obtain the `response_format` request parameter.
-    Returns:
-        A Pydantic model representing the `response_format` parameter for the LM request.
-    """
-
-    def filter_json_schema_extra(field_name: str, field_info: FieldInfo) -> FieldInfo:
+    def _get_structured_outputs_response_format(self, signature: SignatureMeta) -> pydantic.BaseModel:
         """
-        Recursively filter the `json_schema_extra` of a FieldInfo to exclude DSPy internal attributes
-        (e.g. `__dspy_field_type`) and remove descriptions that are placeholders for the field name.
+        Obtains the LiteLLM / OpenAI `response_format` parameter for generating structured outputs from
+        an LM request, based on the output fields of the specified DSPy signature.
+
+        Args:
+            signature: The DSPy signature for which to obtain the `response_format` request parameter.
+        Returns:
+            A Pydantic model representing the `response_format` parameter for the LM request.
         """
-        field_copy = deepcopy(field_info)  # Make a copy to avoid mutating the original
 
-        # Update `json_schema_extra` for the copied field
-        if field_copy.json_schema_extra:
-            field_copy.json_schema_extra = {
-                key: value
-                for key, value in field_info.json_schema_extra.items()
-                if key not in ("desc", "__dspy_field_type")
-            }
-            field_desc = field_info.json_schema_extra.get("desc")
-            if field_desc is not None and field_desc != f"${{{field_name}}}":
-                field_copy.json_schema_extra["desc"] = field_desc
+        def filter_json_schema_extra(field_name: str, field_info: FieldInfo) -> FieldInfo:
+            """
+            Recursively filter the `json_schema_extra` of a FieldInfo to exclude DSPy internal attributes
+            (e.g. `__dspy_field_type`) and remove descriptions that are placeholders for the field name.
+            """
+            field_copy = deepcopy(field_info)  # Make a copy to avoid mutating the original
 
-        # Handle nested fields
-        if hasattr(field_copy.annotation, "__pydantic_model__"):
-            # Recursively update fields of the nested model
-            nested_model = field_copy.annotation.__pydantic_model__
-            updated_fields = {
-                key: filter_json_schema_extra(key, value) for key, value in nested_model.__fields__.items()
-            }
-            # Create a new model with the same name and updated fields
-            field_copy.annotation = create_model(nested_model.__name__, **updated_fields)
+            # Update `json_schema_extra` for the copied field
+            if field_copy.json_schema_extra:
+                field_copy.json_schema_extra = {
+                    key: value
+                    for key, value in field_info.json_schema_extra.items()
+                    if key not in ("desc", "__dspy_field_type")
+                }
+                field_desc = field_info.json_schema_extra.get("desc")
+                if field_desc is not None and field_desc != f"${{{field_name}}}":
+                    field_copy.json_schema_extra["desc"] = field_desc
 
-        return field_copy
+            # Handle nested fields
+            if hasattr(field_copy.annotation, "__pydantic_model__"):
+                # Recursively update fields of the nested model
+                nested_model = field_copy.annotation.__pydantic_model__
+                updated_fields = {
+                    key: filter_json_schema_extra(key, value) for key, value in nested_model.__fields__.items()
+                }
+                # Create a new model with the same name and updated fields
+                field_copy.annotation = create_model(nested_model.__name__, **updated_fields)
 
-    output_pydantic_fields = {
-        key: (value.annotation, filter_json_schema_extra(key, value)) for key, value in signature.output_fields.items()
-    }
-    return create_model("DSPyProgramOutputs", **output_pydantic_fields)
+            return field_copy
+
+        output_pydantic_fields = {
+            key: (value.annotation, filter_json_schema_extra(key, value))
+            for key, value in signature.output_fields.items()
+        }
+        return create_model("DSPyProgramOutputs", **output_pydantic_fields)

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -1,11 +1,16 @@
 import ast
 import enum
+import inspect
 import json
+from collections.abc import Mapping
 from typing import Any, List, Literal, Union, get_args, get_origin
 
 import json_repair
+import pydantic
 from pydantic import TypeAdapter
 from pydantic.fields import FieldInfo
+
+from dspy.signatures.utils import get_dspy_field_type
 
 
 def serialize_for_json(value: Any) -> Any:
@@ -56,6 +61,46 @@ def format_field_value(field_info: FieldInfo, value: Any, assume_text=True) -> U
         return string_value
     else:
         return {"type": "text", "text": string_value}
+
+
+def _get_json_schema(field_type):
+    def move_type_to_front(d):
+        # Move the 'type' key to the front of the dictionary, recursively, for LLM readability/adherence.
+        if isinstance(d, Mapping):
+            return {
+                k: move_type_to_front(v) for k, v in sorted(d.items(), key=lambda item: (item[0] != "type", item[0]))
+            }
+        elif isinstance(d, list):
+            return [move_type_to_front(item) for item in d]
+        return d
+
+    schema = pydantic.TypeAdapter(field_type).json_schema()
+    schema = move_type_to_front(schema)
+    return schema
+
+
+def translate_field_type(field_name, field_info):
+    field_type = field_info.annotation
+
+    if get_dspy_field_type(field_info) == "input" or field_type is str:
+        desc = ""
+    elif field_type is bool:
+        desc = "must be True or False"
+    elif field_type in (int, float):
+        desc = f"must be a single {field_type.__name__} value"
+    elif inspect.isclass(field_type) and issubclass(field_type, enum.Enum):
+        desc = f"must be one of: {'; '.join(field_type.__members__)}"
+    elif hasattr(field_type, "__origin__") and field_type.__origin__ is Literal:
+        desc = (
+            # Strongly encourage the LM to avoid choosing values that don't appear in the
+            # literal or returning a value of the form 'Literal[<selected_value>]'
+            f"must exactly match (no extra characters) one of: {'; '.join([str(x) for x in field_type.__args__])}"
+        )
+    else:
+        desc = f"must adhere to the JSON schema: {json.dumps(_get_json_schema(field_type), ensure_ascii=False)}"
+
+    desc = (" " * 8) + f"# note: the value you produce {desc}" if desc else ""
+    return f"{{{field_name}}}{desc}"
 
 
 def find_enum_member(enum, identifier):

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -170,6 +170,18 @@ def get_annotation_name(annotation):
         args_str = ", ".join(get_annotation_name(a) for a in args)
         return f"{get_annotation_name(origin)}[{args_str}]"
 
+def get_field_description_string(fields: dict) -> str:
+    field_descriptions = []
+    for idx, (k, v) in enumerate(fields.items()):
+        field_message = f"{idx + 1}. `{k}`"
+        field_message += f" ({get_annotation_name(v.annotation)})"
+        field_message += f": {v.json_schema_extra['desc']}" if v.json_schema_extra["desc"] != f"${{{k}}}" else ""
+        field_message += (
+            f"\nConstraints: {v.json_schema_extra['constraints']}" if v.json_schema_extra.get("constraints") else ""
+        )
+        field_descriptions.append(field_message)
+    return "\n".join(field_descriptions).strip()
+
 
 def _format_input_list_field_value(value: List[Any]) -> str:
     """

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -2,15 +2,15 @@ import random
 
 from pydantic import BaseModel
 
+from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.clients.base_lm import BaseLM
 from dspy.clients.lm import LM
+from dspy.dsp.utils import settings
 from dspy.predict.parameter import Parameter
 from dspy.primitives.prediction import Prediction
 from dspy.primitives.program import Module
 from dspy.signatures.signature import ensure_signature
 from dspy.utils.callback import with_callbacks
-from dspy.dsp.utils import settings
-from dspy.adapters.chat_adapter import ChatAdapter
 
 
 class Predict(Module, Parameter):

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -69,7 +69,7 @@ class ReAct(Module):
     def _format_trajectory(self, trajectory: dict[str, Any]):
         adapter = dspy.settings.adapter or dspy.ChatAdapter()
         trajectory_signature = dspy.Signature(f"{', '.join(trajectory.keys())} -> x")
-        return adapter.format_fields(trajectory_signature, trajectory, role="user")
+        return adapter.format_user_message_content(trajectory_signature, trajectory)
 
     def forward(self, **input_args):
         trajectory = {}

--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional
 import ujson
 
 import dspy
-from dspy.adapters.chat_adapter import enumerate_fields
+from dspy.adapters.utils import get_field_description_string
 from dspy.predict.predict import Prediction
 from dspy.signatures import InputField, OutputField, Signature
 
@@ -180,9 +180,9 @@ def inspect_modules(program):
 
         output.append(f"Module {name}")
         output.append("\n\tInput Fields:")
-        output.append(("\n" + "\t" * 2).join([""] + enumerate_fields(signature.input_fields).splitlines()))
+        output.append(("\n" + "\t" * 2).join([""] + get_field_description_string(signature.input_fields).splitlines()))
         output.append("\tOutput Fields:")
-        output.append(("\n" + "\t" * 2).join([""] + enumerate_fields(signature.output_fields).splitlines()))
+        output.append(("\n" + "\t" * 2).join([""] + get_field_description_string(signature.output_fields).splitlines()))
         output.append(f"\tOriginal Instructions: {instructions}")
         output.append(separator)
 

--- a/dspy/teleprompt/simba_utils.py
+++ b/dspy/teleprompt/simba_utils.py
@@ -4,7 +4,7 @@ import inspect
 import logging
 import textwrap
 
-from dspy.adapters.chat_adapter import enumerate_fields
+from dspy.adapters.utils import get_field_description_string
 from dspy.signatures import InputField, OutputField
 from typing import Callable
 
@@ -181,9 +181,9 @@ def inspect_modules(program):
 
         output.append(f"Module {name}")
         output.append("\n\tInput Fields:")
-        output.append(("\n" + "\t" * 2).join([""] + enumerate_fields(signature.input_fields).splitlines()))
+        output.append(("\n" + "\t" * 2).join([""] + get_field_description_string(signature.input_fields).splitlines()))
         output.append("\tOutput Fields:")
-        output.append(("\n" + "\t" * 2).join([""] + enumerate_fields(signature.output_fields).splitlines()))
+        output.append(("\n" + "\t" * 2).join([""] + get_field_description_string(signature.output_fields).splitlines()))
         output.append(f"\tOriginal Instructions: {instructions}")
         output.append(separator)
 

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -269,7 +269,12 @@ def with_callbacks(fn):
         call_id = uuid.uuid4().hex
 
         inputs = inspect.getcallargs(fn, instance, *args, **kwargs)
-        inputs.pop("self")  # Not logging self as input
+
+        # We don't include the instance information in the inpus
+        if "self" in inputs:
+            inputs.pop("self")
+        elif "instance" in inputs:
+            inputs.pop("instance")
 
         for callback in callbacks:
             try:

--- a/dspy/utils/dummies.py
+++ b/dspy/utils/dummies.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Union
 
 import numpy as np
 
-from dspy.adapters.chat_adapter import FieldInfoWithName, field_header_pattern, format_fields
+from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName, field_header_pattern
 from dspy.clients.lm import LM
 from dspy.dsp.utils.utils import dotdict
 from dspy.signatures.field import OutputField
@@ -19,8 +19,7 @@ class DummyLM(LM):
     Mode 1: List of dictionaries
 
     If a list of dictionaries is provided, the dummy model will return the next dictionary
-    in the list for each request, formatted according to the `format_fields` function.
-    from the chat adapter.
+    in the list for each request, formatted according to the `format_field_with_value` function.
 
     Example:
 
@@ -41,7 +40,7 @@ class DummyLM(LM):
 
     If a dictionary of dictionaries is provided, the dummy model will return the value
     corresponding to the key which is contained with the final message of the prompt,
-    formatted according to the `format_fields` function from the chat adapter.
+    formatted according to the `format_field_with_value` function from the chat adapter.
 
     ```
     lm = DummyLM({"What color is the sky?": {"answer": "blue"}})
@@ -95,7 +94,7 @@ class DummyLM(LM):
     @with_callbacks
     def __call__(self, prompt=None, messages=None, **kwargs):
         def format_answer_fields(field_names_and_values: Dict[str, Any]):
-            return format_fields(
+            return ChatAdapter().format_field_with_value(
                 fields_with_values={
                     FieldInfoWithName(name=field_name, info=OutputField()): value
                     for field_name, value in field_names_and_values.items()


### PR DESCRIPTION
We are reworking DSPy adapters for extensibility. For most users this change shouldn't cause backward compatibility issues, but if your workflow explicitly calls child methods of DSPy adapters, you need to make adjustments. 

The goal here is with DSPy 3.0, we want Adapter to be a customizable interface rather than some tribal knowledge. We acknowledge that it will be common for users willing to write their own adapter to adjust to their LLMs and workflows. However, the current adapter doesn't have a decent abstraction, and to write a custom adapter users need to understand the source code, and go through a tedious debugging process without guidelines.

In this PR, we are trying to standardize the dspy Adapters, and open a few hooks for people to override during customization. We are aware that there is no single standard that fits all use cases, but trying to hit a stage where we don't over-simplify or over-engineer the base DSPy Adapter/

In a nutshell, we are making the following breakdown of Adapters:

- Adapter 
  - format(): formats the type-based inputs into LM multiturn messages
    - System messages: The high level description of the task, and LM I/O format.
      - Fields description: `format_field_description()`
      - LM input/output structure description: `format_field_structure()`
      - task description: `format_task_description`
    - Few-shot examples (demo): multiturn few-shot examples
      - user message (inputs of demo): `format_user_message_content()`
      - assistant message (outputs of demo): `format_assistant_message_content()`
    - Conversation history: multiturn conversation history
      - user message (inputs of history message): `format_user_message_content()`
      - assistant message (outputs of history message): `format_assistant_message_content()` 
    - Current input: the actual question/input
      - user message: `format_user_message_content()`
  - parse(): parse the LM response to type-based outputs. No sub-hook for `parse()` because it varies for different adapters.

Note that `format_user_message_content()` and `format_assistant_message_content()` are used in multiple places. Users can override any level of hooks for customization. 

We will publish a guide on how to customize Adapter with concrete use cases after landing this PR. 