### PR TITLE
Fix a bug in Teleprompter.get_params

### DIFF
--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -27,4 +27,4 @@ class Teleprompter:
         Returns:
             The parameters of the teleprompter.
         """
-        return self.__dict__()
+        return self.__dict__

--- a/tests/teleprompt/test_teleprompt.py
+++ b/tests/teleprompt/test_teleprompt.py
@@ -9,9 +9,6 @@ class DummyTeleprompter(Teleprompter):
     def compile(self, student, *, trainset, teacher=None, valset=None, **kwargs):
         return student
 
-    def get_params(self):
-        return self.__dict__
-
 
 def test_get_params():
     teleprompter = DummyTeleprompter(param1=1, param2="test")


### PR DESCRIPTION
Fix the bug in `get-params` method and change the test to capture the issue.