### PR TITLE
Change the output interface of evaluate

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -112,7 +112,7 @@ class Evaluate:
             
             - all_scores: a list of float scores for each example in devset
             
-            - return_outputs: a list of (example, prediction, score) tuples for each example in devset
+            - all_outputs: a list of (example, prediction, score) tuples for each example in devset
 
             - result_table: a pandas DataFrame containing the evaluation results.
 

--- a/dspy/primitives/prediction.py
+++ b/dspy/primitives/prediction.py
@@ -90,6 +90,13 @@ class Prediction(Example):
         elif isinstance(other, Prediction):
             return self.__float__() >= float(other)
         raise TypeError(f"Unsupported type for comparison: {type(other)}")
+    
+    def __eq__(self, other):
+        if isinstance(other, (float, int)):
+            return self.__float__() == other
+        elif isinstance(other, Prediction):
+            return self.__float__() == float(other)
+        raise TypeError(f"Unsupported type for comparison: {type(other)}")
 
     @property
     def completions(self):

--- a/dspy/teleprompt/bootstrap_finetune.py
+++ b/dspy/teleprompt/bootstrap_finetune.py
@@ -211,7 +211,6 @@ def bootstrap_trace_data(
         devset=dataset,
         num_threads=num_threads,
         display_progress=True,
-        return_outputs=True,
         provide_traceback=True,  # TODO(check with team)
     )
 
@@ -223,7 +222,7 @@ def bootstrap_trace_data(
         with dspy.context(trace=[]):
             return program(**kwargs), dspy.settings.trace.copy()
 
-    _, outputs = evaluator(wrapped_program, metric=wrapped_metric)
+    outputs = evaluator(wrapped_program, metric=wrapped_metric).all_outputs
 
     data = []
     for example_ind, (example, prediction, score) in enumerate(outputs):

--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -225,7 +225,7 @@ class COPRO(Teleprompter):
                         f"At Depth {d+1}/{self.depth}, Evaluating Prompt Candidate #{c_i+1}/{len(candidates_)} for "
                         f"Predictor {p_i+1} of {len(module.predictors())}.",
                     )
-                    score = evaluate(module_clone, devset=trainset, **eval_kwargs)
+                    score = evaluate(module_clone, devset=trainset, **eval_kwargs).score
                     if self.prompt_model:
                         logger.debug(f"prompt_model.inspect_history(n=1) {self.prompt_model.inspect_history(n=1)}")
                     total_calls += 1

--- a/dspy/teleprompt/infer_rules.py
+++ b/dspy/teleprompt/infer_rules.py
@@ -118,7 +118,7 @@ class InferRules(BootstrapFewShot):
             display_progress=True,
             return_all_scores=True,
         )
-        score, _ = evaluate(program, metric=self.metric)
+        score = evaluate(program, metric=self.metric).score
         return score
 
 

--- a/dspy/teleprompt/infer_rules.py
+++ b/dspy/teleprompt/infer_rules.py
@@ -116,7 +116,6 @@ class InferRules(BootstrapFewShot):
             max_errors=self.max_errors,
             display_table=False,
             display_progress=True,
-            return_all_scores=True,
         )
         score = evaluate(program, metric=self.metric).score
         return score

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -467,8 +467,8 @@ class MIPROv2(Teleprompter):
         adjusted_num_trials = (num_trials + num_trials // minibatch_full_eval_steps + 1) if minibatch else num_trials
         logger.info(f"== Trial {1} / {adjusted_num_trials} - Full Evaluation of Default Program ==")
 
-        default_score, _ = eval_candidate_program(
-            len(valset), valset, program, evaluate, self.rng, return_all_scores=True
+        default_score = eval_candidate_program(
+            len(valset), valset, program, evaluate, self.rng
         )
         logger.info(f"Default program score: {default_score}\n")
 
@@ -750,7 +750,7 @@ class MIPROv2(Teleprompter):
             param_score_dict, fully_evaled_param_combos
         )
         logger.info(f"Doing full eval on next top averaging program (Avg Score: {mean_score}) from minibatch trials...")
-        full_eval_score = eval_candidate_program(len(valset), valset, highest_mean_program, evaluate, self.rng)
+        full_eval_score = eval_candidate_program(len(valset), valset, highest_mean_program, evaluate, self.rng).score
         score_data.append({"score": full_eval_score, "program": highest_mean_program, "full_eval": True})
 
         # Log full eval as a trial so that optuna can learn from the new results

--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -116,7 +116,9 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
                 display_progress=True,
             )
 
-            score, subscores = evaluate(program, return_all_scores=True)
+            result = evaluate(program)
+
+            score, subscores = result.score, result.all_scores
 
             all_subscores.append(subscores)
 

--- a/dspy/teleprompt/teleprompt_optuna.py
+++ b/dspy/teleprompt/teleprompt_optuna.py
@@ -52,7 +52,7 @@ class BootstrapFewShotWithOptuna(Teleprompter):
             display_table=False,
             display_progress=True,
         )
-        result = evaluate(program2, return_all_scores=False)
+        result = evaluate(program2)
         trial.set_user_attr("program", program2)
         return result.score
 

--- a/dspy/teleprompt/teleprompt_optuna.py
+++ b/dspy/teleprompt/teleprompt_optuna.py
@@ -54,7 +54,7 @@ class BootstrapFewShotWithOptuna(Teleprompter):
         )
         score = evaluate(program2, return_all_scores=False)
         trial.set_user_attr("program", program2)
-        return score
+        return float(score)
 
     def compile(self, student, *, teacher=None, max_demos, trainset, valset=None):
         self.trainset = trainset

--- a/dspy/teleprompt/teleprompt_optuna.py
+++ b/dspy/teleprompt/teleprompt_optuna.py
@@ -52,9 +52,9 @@ class BootstrapFewShotWithOptuna(Teleprompter):
             display_table=False,
             display_progress=True,
         )
-        score = evaluate(program2, return_all_scores=False)
+        result = evaluate(program2, return_all_scores=False)
         trial.set_user_attr("program", program2)
-        return float(score)
+        return result.score
 
     def compile(self, student, *, teacher=None, max_demos, trainset, valset=None):
         self.trainset = trainset

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -43,7 +43,7 @@ def create_minibatch(trainset, batch_size=50, rng=None):
     return minibatch
 
 
-def eval_candidate_program(batch_size, trainset, candidate_program, evaluate, rng=None, return_all_scores=False):
+def eval_candidate_program(batch_size, trainset, candidate_program, evaluate, rng=None):
     """Evaluate a candidate program on the trainset, using the specified batch size."""
 
     try:

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -49,20 +49,18 @@ def eval_candidate_program(batch_size, trainset, candidate_program, evaluate, rn
     try:
         # Evaluate on the full trainset
         if batch_size >= len(trainset):
-            return evaluate(candidate_program, devset=trainset, return_all_scores=return_all_scores, callback_metadata={"metric_key": "eval_full"})
+            return evaluate(candidate_program, devset=trainset, callback_metadata={"metric_key": "eval_full"})
         # Or evaluate on a minibatch
         else:
             return evaluate(
                 candidate_program,
                 devset=create_minibatch(trainset, batch_size, rng),
-                return_all_scores=return_all_scores,
                 callback_metadata={"metric_key": "eval_minibatch"}
             )
     except Exception:
         logger.error("An exception occurred during evaluation", exc_info=True)
-        if return_all_scores:
-            return 0.0, [0.0] * len(trainset)
-        return 0.0  # TODO: Handle this better, as -ve scores are possible
+        # TODO: Handle this better, as -ve scores are possible
+        return dspy.Prediction(score=0.0, all_scores=[0.0] * len(trainset))
 
 def eval_candidate_program_with_pruning(
     trial, trial_logs, trainset, candidate_program, evaluate, trial_num, batch_size=100,

--- a/tests/teleprompt/test_utils.py
+++ b/tests/teleprompt/test_utils.py
@@ -1,5 +1,4 @@
 from unittest.mock import Mock
-import pytest
 
 import dspy
 from dspy.teleprompt.utils import eval_candidate_program
@@ -40,16 +39,12 @@ def test_eval_candidate_program_minibatch():
     assert called_kwargs['callback_metadata'] == {"metric_key": "eval_minibatch"}
     assert result == 0
 
-@pytest.mark.parametrize("return_all_scores", [True, False])
-def test_eval_candidate_program_failure(return_all_scores):
+def test_eval_candidate_program_failure():
     trainset = [1, 2, 3, 4, 5]
     candidate_program = DummyModule()
     evaluate = Mock(side_effect=ValueError("Error"))
     batch_size = 3
 
-    result = eval_candidate_program(batch_size, trainset, candidate_program, evaluate, return_all_scores=return_all_scores)
+    result = eval_candidate_program(batch_size, trainset, candidate_program, evaluate)
 
-    if return_all_scores:
-        assert result == (0.0, [0.0]*len(trainset))
-    else:
-        assert result == 0.0
+    assert result == 0.0


### PR DESCRIPTION
In this PR, we change the output interface of `Evaluate.__call__`.
Instead of returning either score, (score, outputs), (score, scores, outputs) based on arguments, it will always return dspy.Prediction containing the following fields:

- score: A float percentage score (e.g., 67.30) representing overall performance
- all_scores: a list of float scores for each example in devset
- all_outputs: a list of (example, prediction, score) tuples for each example in devset
- result_table: a pandas DataFrame containing the evaluation results.