### PR TITLE
Update chain_of_thought.py

### DIFF
--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -4,17 +4,34 @@ from dspy.signatures.signature import ensure_signature
 
 
 class ChainOfThought(Module):
-    def __init__(self, signature, rationale_type=None, **config):
+    
+    def __init__(
+        self, 
+        signature: Type[dspy.Signature], 
+        rationale_field: Optional[Union[dspy.OutputField, pydantic.fields.FieldInfo]] = None, 
+        rationale_field_type: Type = str,
+        **config
+    ):
+        """
+        A module that reasons step by step in order to predict the output of a task.
+        
+        Args:
+            signature (Type[dspy.Signature]): The signature of the module.
+            rationale_field (Optional[Union[dspy.OutputField, pydantic.fields.FieldInfo]]): The field that will contain the reasoning.
+            rationale_field_type (Type): The type of the rationale field.
+            **config: The configuration for the module.
+        """
         super().__init__()
-
         signature = ensure_signature(signature)
-
         prefix = "Reasoning: Let's think step by step in order to"
         desc = "${reasoning}"
-        rationale_type = rationale_type or dspy.OutputField(prefix=prefix, desc=desc)
-        extended_signature = signature.prepend("reasoning", rationale_type, type_=str)
-        
+        rationale_field_type = rationale_field.annotation if rationale_field else rationale_field_type
+        rationale_field = rationale_field if rationale_field else dspy.OutputField(prefix=prefix, desc=desc)
+        extended_signature = signature.prepend(name="reasoning", field=rationale_field, type_=rationale_field_type)
         self.predict = dspy.Predict(extended_signature, **config)
+
+    def forward(self, **kwargs):
+        return self.predict(**kwargs)
 
     def forward(self, **kwargs):
         return self.predict(**kwargs)

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -1,5 +1,6 @@
 import dspy
 from dspy.primitives.program import Module
+from dspy.signatures.field import OutputField
 from dspy.signatures.signature import ensure_signature, Signature
 from pydantic.fields import FieldInfo
 from typing import Optional, Union, Type
@@ -10,7 +11,7 @@ class ChainOfThought(Module):
     def __init__(
         self, 
         signature: Type[Signature], 
-        rationale_field: Optional[Union[dspy.OutputField, FieldInfo]] = None, 
+        rationale_field: Optional[Union[OutputField, FieldInfo]] = None, 
         rationale_field_type: Type = str,
         **config
     ):

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -1,14 +1,15 @@
 import dspy
 from dspy.primitives.program import Module
 from dspy.signatures.signature import ensure_signature
-
+from pydantic.fields import FieldInfo
+from typing import Optional, Union, Type
 
 class ChainOfThought(Module):
     
     def __init__(
         self, 
         signature: Type[dspy.Signature], 
-        rationale_field: Optional[Union[dspy.OutputField, pydantic.fields.FieldInfo]] = None, 
+        rationale_field: Optional[Union[dspy.OutputField, FieldInfo]] = None, 
         rationale_field_type: Type = str,
         **config
     ):
@@ -29,9 +30,6 @@ class ChainOfThought(Module):
         rationale_field = rationale_field if rationale_field else dspy.OutputField(prefix=prefix, desc=desc)
         extended_signature = signature.prepend(name="reasoning", field=rationale_field, type_=rationale_field_type)
         self.predict = dspy.Predict(extended_signature, **config)
-
-    def forward(self, **kwargs):
-        return self.predict(**kwargs)
 
     def forward(self, **kwargs):
         return self.predict(**kwargs)

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -1,14 +1,15 @@
 import dspy
 from dspy.primitives.program import Module
-from dspy.signatures.signature import ensure_signature
+from dspy.signatures.signature import ensure_signature, Signature
 from pydantic.fields import FieldInfo
 from typing import Optional, Union, Type
+
 
 class ChainOfThought(Module):
     
     def __init__(
         self, 
-        signature: Type[dspy.Signature], 
+        signature: Type[Signature], 
         rationale_field: Optional[Union[dspy.OutputField, FieldInfo]] = None, 
         rationale_field_type: Type = str,
         **config


### PR DESCRIPTION
Allow use of custom CoT representations (e.g., List of strings) instead of forcing CoT be a string output.  Previously, even if the user passed in a custom definition for the reasoning field, the type of the reasoning field output would be a string.  This change ensures that the type of the field is consistent with its annotation, and allows for users to specify a custom type for reasoning without creating a custom field for it.  Also, this change introduces a docstring and type hints into the ChainOfThought module.