### PR TITLE
Add usage tracking

### DIFF
--- a/docs/docs/learn/programming/modules.md
+++ b/docs/docs/learn/programming/modules.md
@@ -247,29 +247,33 @@ class Hop(dspy.Module):
 
 ## How do I track LM usage?
 
-!!! info "Version Requirement"
+!!! note "Version Requirement"
     LM usage tracking is available in DSPy version 2.6.16 and later.
 
-DSPy supports tracking LM usage for each module call, and the usage data is accessible from the
-returned `dspy.Prediction`. To enable LM usage tracking, you need to call:
+DSPy provides built-in tracking of language model usage across all module calls. To enable tracking:
 
 ```python
 dspy.settings.configure(track_usage=True)
 ```
 
-Then you can get the usage data from your `dspy.Prediction` instance by calling:
+Once enabled, you can access usage statistics from any `dspy.Prediction` object:
 
-```
+```python
 usage = prediction_instance.get_lm_usage()
 ```
-which returns a dictionary mapping from each `lm` name into the combined usage data in the module call.
-See below for an end to end demo:
+
+The usage data is returned as a dictionary that maps each language model name to its usage statistics. Here's a complete example:
 
 ```python
 import dspy
 
-dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False), track_usage=True)
+# Configure DSPy with tracking enabled
+dspy.settings.configure(
+    lm=dspy.LM("openai/gpt-4o-mini", cache=False),
+    track_usage=True
+)
 
+# Define a simple program that makes multiple LM calls
 class MyProgram(dspy.Module):
     def __init__(self):
         self.predict1 = dspy.ChainOfThought("question -> answer")
@@ -280,48 +284,53 @@ class MyProgram(dspy.Module):
         score = self.predict2(question=question, answer=answer)
         return score
 
+# Run the program and check usage
 program = MyProgram()
 output = program(question="What is the capital of France?")
 print(output.get_lm_usage())
 ```
 
-An example output will look like:
-
-```
-{'openai/gpt-4o-mini': {'completion_tokens': 61, 'prompt_tokens': 260, 'total_tokens': 321, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0, 'text_tokens': None}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0, 'text_tokens': None, 'image_tokens': None}}}
-```
-
-Please note that if you call hit cache, either in-memory cache or the on-disk cache (litellm cache), it will
-be considered as no LM usage. See below for code example:
+This will output usage statistics like:
 
 ```python
-import dspy
+{
+    'openai/gpt-4o-mini': {
+        'completion_tokens': 61,
+        'prompt_tokens': 260,
+        'total_tokens': 321,
+        'completion_tokens_details': {
+            'accepted_prediction_tokens': 0,
+            'audio_tokens': 0,
+            'reasoning_tokens': 0,
+            'rejected_prediction_tokens': 0,
+            'text_tokens': None
+        },
+        'prompt_tokens_details': {
+            'audio_tokens': 0,
+            'cached_tokens': 0,
+            'text_tokens': None,
+            'image_tokens': None
+        }
+    }
+}
+```
 
-dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=True), track_usage=True)
+When using DSPy's caching features (either in-memory or on-disk via litellm), cached responses won't count toward usage statistics. For example:
 
-
-class MyProgram(dspy.Module):
-    def __init__(self):
-        self.predict1 = dspy.ChainOfThought("question -> answer")
-        self.predict2 = dspy.ChainOfThought("question, answer -> score")
-
-    def __call__(self, question: str) -> str:
-        answer = self.predict1(question=question)
-        score = self.predict2(question=question, answer=answer)
-        return score
-
+```python
+# Enable caching
+dspy.settings.configure(
+    lm=dspy.LM("openai/gpt-4o-mini", cache=True),
+    track_usage=True
+)
 
 program = MyProgram()
+
+# First call - will show usage statistics
 output = program(question="What is the capital of Zambia?")
-# Make a second call to test the cache behavior
+print(output.get_lm_usage())  # Shows token usage
+
+# Second call - same question, will use cache
 output = program(question="What is the capital of Zambia?")
-print(output.get_lm_usage())
+print(output.get_lm_usage())  # Shows empty dict: {}
 ```
-
-You should see an empty dict:
-
-```
-{}
-```
-
-

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -13,6 +13,7 @@ from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, en
 from dspy.utils.asyncify import asyncify
 from dspy.utils.saving import load
 from dspy.utils.streaming import streamify
+from dspy.utils.usage_tracker import track_usage
 
 from dspy.dsp.utils.settings import settings
 

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -13,6 +13,14 @@ logger = logging.getLogger(__name__)
 DISK_CACHE_DIR = os.environ.get("DSPY_CACHEDIR") or os.path.join(Path.home(), ".dspy_cache")
 DISK_CACHE_LIMIT = int(os.environ.get("DSPY_CACHE_LIMIT", 3e10))  # 30 GB default
 
+
+def _litellm_track_cache_hit_callback(kwargs, completion_response, start_time, end_time):
+    # Access the cache_hit information
+    completion_response.cache_hit = kwargs.get("cache_hit", False)
+
+
+litellm.success_callback = [_litellm_track_cache_hit_callback]
+
 try:
     # TODO: There's probably value in getting litellm to support FanoutCache and to separate the limit for
     # the LM cache from the embeddings cache. Then we can lower the default 30GB limit.

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -18,6 +18,7 @@ import dspy
 from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, TrainingJob
 from dspy.clients.utils_finetune import TrainDataFormat
+from dspy.dsp.utils.settings import settings
 from dspy.utils.callback import BaseCallback, with_callbacks
 
 from .base_lm import BaseLM
@@ -121,8 +122,9 @@ class LM(BaseLM):
                 # only leverage LiteLLM cache in this case
                 cache={"no-cache": not cache, "no-store": not cache},
             )
+
         if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
-            dspy.settings.usage_tracker.add_usage(self.model, results.usage)
+            settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 
     def launch(self, launch_kwargs: Optional[Dict[str, Any]] = None):

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -265,7 +265,8 @@ def request_cache(maxsize: Optional[int] = None):
             cache_hit = key in func_cached.cache
             output = func_cached(key, request, *args, **kwargs)
             if cache_hit and hasattr(output, "usage"):
-                output.usage = None
+                # Clear the usage data when cache is hit, because no LM call is made
+                output.usage = {}
 
             return func_cached(key, request, *args, **kwargs)
 

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -20,6 +20,7 @@ DEFAULT_CONFIG = dotdict(
     async_max_workers=8,
     send_stream=None,
     disable_history=False,
+    usage_tracker=None,
 )
 
 # Global base configuration and owner tracking

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -20,6 +20,7 @@ DEFAULT_CONFIG = dotdict(
     async_max_workers=8,
     send_stream=None,
     disable_history=False,
+    track_usage=False,
     usage_tracker=None,
 )
 

--- a/dspy/predict/parallel.py
+++ b/dspy/predict/parallel.py
@@ -1,6 +1,5 @@
 import threading
-
-from typing import Tuple, List, Any
+from typing import Any, List, Tuple
 
 from dspy.primitives.example import Example
 from dspy.utils.parallelizer import ParallelExecutor

--- a/dspy/primitives/prediction.py
+++ b/dspy/primitives/prediction.py
@@ -9,6 +9,15 @@ class Prediction(Example):
         del self._input_keys
 
         self._completions = None
+        self._usage = None
+
+    @property
+    def usage(self):
+        return self._usage
+
+    @usage.setter
+    def usage(self, value):
+        self._usage = value
 
     @classmethod
     def from_completions(cls, list_or_dict, signature=None):

--- a/dspy/primitives/prediction.py
+++ b/dspy/primitives/prediction.py
@@ -11,12 +11,10 @@ class Prediction(Example):
         self._completions = None
         self._lm_usage = None
 
-    @property
-    def lm_usage(self):
+    def get_lm_usage(self):
         return self._lm_usage
 
-    @lm_usage.setter
-    def lm_usage(self, value):
+    def set_lm_usage(self, value):
         self._lm_usage = value
 
     @classmethod

--- a/dspy/primitives/prediction.py
+++ b/dspy/primitives/prediction.py
@@ -9,15 +9,15 @@ class Prediction(Example):
         del self._input_keys
 
         self._completions = None
-        self._usage = None
+        self._lm_usage = None
 
     @property
-    def usage(self):
-        return self._usage
+    def lm_usage(self):
+        return self._lm_usage
 
-    @usage.setter
-    def usage(self, value):
-        self._usage = value
+    @lm_usage.setter
+    def lm_usage(self, value):
+        self._lm_usage = value
 
     @classmethod
     def from_completions(cls, list_or_dict, signature=None):
@@ -38,7 +38,7 @@ class Prediction(Example):
 
     def __str__(self):
         return self.__repr__()
-    
+
     def __float__(self):
         if "score" not in self._store:
             raise ValueError("Prediction object does not have a 'score' field to convert to float.")
@@ -50,7 +50,7 @@ class Prediction(Example):
         elif isinstance(other, Prediction):
             return self.__float__() + float(other)
         raise TypeError(f"Unsupported type for addition: {type(other)}")
-    
+
     def __radd__(self, other):
         if isinstance(other, (float, int)):
             return other + self.__float__()
@@ -64,7 +64,7 @@ class Prediction(Example):
         elif isinstance(other, Prediction):
             return self.__float__() / float(other)
         raise TypeError(f"Unsupported type for division: {type(other)}")
-    
+
     def __rtruediv__(self, other):
         if isinstance(other, (float, int)):
             return other / self.__float__()
@@ -78,21 +78,21 @@ class Prediction(Example):
         elif isinstance(other, Prediction):
             return self.__float__() < float(other)
         raise TypeError(f"Unsupported type for comparison: {type(other)}")
-    
+
     def __le__(self, other):
         if isinstance(other, (float, int)):
             return self.__float__() <= other
         elif isinstance(other, Prediction):
             return self.__float__() <= float(other)
         raise TypeError(f"Unsupported type for comparison: {type(other)}")
-    
+
     def __gt__(self, other):
         if isinstance(other, (float, int)):
             return self.__float__() > other
         elif isinstance(other, Prediction):
             return self.__float__() > float(other)
         raise TypeError(f"Unsupported type for comparison: {type(other)}")
-    
+
     def __ge__(self, other):
         if isinstance(other, (float, int)):
             return self.__float__() >= other

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -24,7 +24,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
         if settings.track_usage and settings.usage_tracker is None:
             with track_usage() as usage_tracker:
                 output = self.forward(*args, **kwargs)
-                output.lm_usage = usage_tracker.get_total_tokens()
+                output.set_lm_usage(usage_tracker.get_total_tokens())
                 return output
 
         return self.forward(*args, **kwargs)

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -24,7 +24,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
         if settings.track_usage and settings.usage_tracker is None:
             with track_usage() as usage_tracker:
                 output = self.forward(*args, **kwargs)
-                output.usage = usage_tracker.get_total_tokens()
+                output.lm_usage = usage_tracker.get_total_tokens()
                 return output
 
         return self.forward(*args, **kwargs)

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -1,8 +1,10 @@
 import magicattr
 
+from dspy.dsp.utils.settings import settings
 from dspy.predict.parallel import Parallel
 from dspy.primitives.module import BaseModule
 from dspy.utils.callback import with_callbacks
+from dspy.utils.usage_tracker import track_usage
 
 
 class ProgramMeta(type):
@@ -19,6 +21,12 @@ class Module(BaseModule, metaclass=ProgramMeta):
 
     @with_callbacks
     def __call__(self, *args, **kwargs):
+        if settings.track_usage and settings.usage_tracker is None:
+            with track_usage() as usage_tracker:
+                output = self.forward(*args, **kwargs)
+                output.usage = usage_tracker.get_total_tokens()
+                return output
+
         return self.forward(*args, **kwargs)
 
     def named_predictors(self):

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -87,9 +87,9 @@ class ParallelExecutor:
 
             original = thread_local_overrides.overrides
             thread_local_overrides.overrides = parent_overrides.copy()
-            if original.get("usage_tracker"):
+            if parent_overrides.get("usage_tracker"):
                 # Usage tracker needs to be deep copied across threads so that each thread tracks its own usage
-                thread_local_overrides.overrides["usage_tracker"] = copy.deepcopy(original["usage_tracker"])
+                thread_local_overrides.overrides["usage_tracker"] = copy.deepcopy(parent_overrides["usage_tracker"])
 
             try:
                 return index, function(item)

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -86,10 +86,10 @@ class ParallelExecutor:
             from dspy.dsp.utils.settings import thread_local_overrides
 
             original = thread_local_overrides.overrides
-            thread_local_overrides.overrides = copy.deepcopy(parent_overrides)
-            if "callbacks" in original:
-                # The same callbacks instances should be shared across threads
-                thread_local_overrides.overrides["callbacks"] = original.callbacks
+            thread_local_overrides.overrides = parent_overrides.copy()
+            if original.get("usage_tracker"):
+                # Usage tracker needs to be deep copied across threads so that each thread tracks its own usage
+                thread_local_overrides.overrides["usage_tracker"] = copy.deepcopy(original["usage_tracker"])
 
             try:
                 return index, function(item)

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -1,4 +1,5 @@
 import contextlib
+import copy
 import logging
 import signal
 import sys
@@ -85,8 +86,10 @@ class ParallelExecutor:
             from dspy.dsp.utils.settings import thread_local_overrides
 
             original = thread_local_overrides.overrides
-            # thread_local_overrides.overrides = copy.deepcopy(parent_overrides)
-            thread_local_overrides.overrides = parent_overrides.copy()
+            thread_local_overrides.overrides = copy.deepcopy(parent_overrides)
+            if "callbacks" in original:
+                # The same callbacks instances should be shared across threads
+                thread_local_overrides.overrides["callbacks"] = original.callbacks
 
             try:
                 return index, function(item)

--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -1,6 +1,8 @@
 """Usage tracking utilities for DSPy."""
 
+from collections import defaultdict
 from contextlib import contextmanager
+from typing import Any
 
 from dspy.dsp.utils.settings import settings
 
@@ -9,24 +11,43 @@ class UsageTracker:
     """Tracks LM usage data within a context."""
 
     def __init__(self):
-        self.usage_data = []
+        self.usage_data = defaultdict(list)
 
-    def add_usage(self, usage_entry: dict):
+    def _flatten_usage_entry(self, usage_entry) -> dict[str, dict[str, Any]]:
+        result = dict(usage_entry)
+        result["completion_tokens_details"] = dict(result["completion_tokens_details"])
+        result["prompt_tokens_details"] = dict(result["prompt_tokens_details"])
+        return result
+
+    def _merge_usage_entries(self, usage_entry1, usage_entry2) -> dict[str, dict[str, Any]]:
+        if usage_entry1 is None or len(usage_entry1) == 0:
+            return dict(usage_entry2)
+        if usage_entry2 is None or len(usage_entry2) == 0:
+            return dict(usage_entry1)
+
+        result = dict(usage_entry2)
+        for k, v in usage_entry1.items():
+            if k in result:
+                if isinstance(v, dict):
+                    result[k] = self._merge_usage_entries(result[k], v)
+                else:
+                    result[k] = result[k] or 0
+                    result[k] += v if v else 0
+        return result
+
+    def add_usage(self, lm: str, usage_entry: dict):
         """Add a usage entry to the tracker."""
-        self.usage_data.append(usage_entry)
+        self.usage_data[lm].append(self._flatten_usage_entry(usage_entry))
 
-    @property
-    def total_cost(self) -> float:
-        """Calculate total cost from all tracked usage."""
-        return sum(entry.get("cost", 0) or 0 for entry in self.usage_data)
-
-    @property
-    def total_tokens(self) -> int:
+    def get_total_tokens(self) -> dict[str, dict[str, Any]]:
         """Calculate total tokens from all tracked usage."""
-        return sum(
-            sum(entry.get("usage", {}).get(k, 0) for k in ["prompt_tokens", "completion_tokens"])
-            for entry in self.usage_data
-        )
+        total_usage_by_lm = {}
+        for lm, usage_entries in self.usage_data.items():
+            total_usage = {}
+            for usage_entry in usage_entries:
+                total_usage = self._merge_usage_entries(total_usage, usage_entry)
+            total_usage_by_lm[lm] = total_usage
+        return total_usage_by_lm
 
 
 @contextmanager
@@ -36,4 +57,3 @@ def track_usage():
 
     with settings.context(usage_tracker=tracker):
         yield tracker
-

--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -22,8 +22,10 @@ class UsageTracker:
 
     def _flatten_usage_entry(self, usage_entry) -> dict[str, dict[str, Any]]:
         result = dict(usage_entry)
-        result["completion_tokens_details"] = dict(result["completion_tokens_details"])
-        result["prompt_tokens_details"] = dict(result["prompt_tokens_details"])
+        if "completion_tokens_details" in result:
+            result["completion_tokens_details"] = dict(result["completion_tokens_details"])
+        if "prompt_tokens_details" in result:
+            result["prompt_tokens_details"] = dict(result["prompt_tokens_details"])
         return result
 
     def _merge_usage_entries(self, usage_entry1, usage_entry2) -> dict[str, dict[str, Any]]:
@@ -44,7 +46,8 @@ class UsageTracker:
 
     def add_usage(self, lm: str, usage_entry: dict):
         """Add a usage entry to the tracker."""
-        self.usage_data[lm].append(self._flatten_usage_entry(usage_entry))
+        if len(usage_entry) > 0:
+            self.usage_data[lm].append(self._flatten_usage_entry(usage_entry))
 
     def get_total_tokens(self) -> dict[str, dict[str, Any]]:
         """Calculate total tokens from all tracked usage."""

--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -1,0 +1,39 @@
+"""Usage tracking utilities for DSPy."""
+
+from contextlib import contextmanager
+
+from dspy.dsp.utils.settings import settings
+
+
+class UsageTracker:
+    """Tracks LM usage data within a context."""
+
+    def __init__(self):
+        self.usage_data = []
+
+    def add_usage(self, usage_entry: dict):
+        """Add a usage entry to the tracker."""
+        self.usage_data.append(usage_entry)
+
+    @property
+    def total_cost(self) -> float:
+        """Calculate total cost from all tracked usage."""
+        return sum(entry.get("cost", 0) or 0 for entry in self.usage_data)
+
+    @property
+    def total_tokens(self) -> int:
+        """Calculate total tokens from all tracked usage."""
+        return sum(
+            sum(entry.get("usage", {}).get(k, 0) for k in ["prompt_tokens", "completion_tokens"])
+            for entry in self.usage_data
+        )
+
+
+@contextmanager
+def track_usage():
+    """Context manager for tracking LM usage."""
+    tracker = UsageTracker()
+
+    with settings.context(usage_tracker=tracker):
+        yield tracker
+

--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -11,6 +11,13 @@ class UsageTracker:
     """Tracks LM usage data within a context."""
 
     def __init__(self):
+        # Map of LM name to list of usage entries. For example:
+        # {
+        #     "openai/gpt-4o-mini": [
+        #         {"prompt_tokens": 100, "completion_tokens": 200},
+        #         {"prompt_tokens": 300, "completion_tokens": 400},
+        #     ],
+        # }
         self.usage_data = defaultdict(list)
 
     def _flatten_usage_entry(self, usage_entry) -> dict[str, dict[str, Any]]:

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -177,12 +177,12 @@ def test_single_module_call_with_usage_tracker():
     assert output.usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
     assert output.usage["openai/gpt-4o-mini"]["total_tokens"] > 0
 
-    # # Test no usage being tracked when cache is enabled
-    # dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=True), track_usage=True)
-    # for _ in range(2):
-    #     output = predict(question="What is the capital of France?")
+    # Test no usage being tracked when cache is enabled
+    dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=True), track_usage=True)
+    for _ in range(2):
+        output = predict(question="What is the capital of France?")
 
-    # assert output.usage is None
+    assert len(output.usage) == 0
 
 
 @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="Skip the test if OPENAI_API_KEY is not set.")
@@ -210,3 +210,37 @@ def test_multi_module_call_with_usage_tracker():
     assert output.usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
     assert output.usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
     assert output.usage["openai/gpt-4o-mini"]["total_tokens"] > 0
+
+
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="Skip the test if OPENAI_API_KEY is not set.")
+def test_usage_tracker_in_parallel():
+    class MyProgram(dspy.Module):
+        def __init__(self, lm):
+            self.lm = lm
+            self.predict1 = dspy.ChainOfThought("question -> answer")
+            self.predict2 = dspy.ChainOfThought("question, answer -> score")
+
+        def __call__(self, question: str) -> str:
+            with dspy.settings.context(lm=self.lm):
+                answer = self.predict1(question=question)
+                score = self.predict2(question=question, answer=answer)
+                return score
+
+    dspy.settings.configure(track_usage=True)
+    program1 = MyProgram(lm=dspy.LM("openai/gpt-4o-mini", cache=False))
+    program2 = MyProgram(lm=dspy.LM("openai/gpt-3.5-turbo", cache=False))
+
+    parallelizer = dspy.Parallel()
+
+    results = parallelizer(
+        [
+            (program1, {"question": "What is the meaning of life?"}),
+            (program2, {"question": "why did a chicken cross the kitchen?"}),
+        ]
+    )
+
+    assert results[0].usage is not None
+    assert results[1].usage is not None
+
+    assert results[0].keys() == set(["openai/gpt-4o-mini"])
+    assert results[1].keys() == set(["openai/gpt-3.5-turbo"])

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -172,17 +172,18 @@ def test_single_module_call_with_usage_tracker():
     predict = dspy.ChainOfThought("question -> answer")
     output = predict(question="What is the capital of France?")
 
-    assert output.lm_usage is not None
-    assert output.lm_usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
-    assert output.lm_usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
-    assert output.lm_usage["openai/gpt-4o-mini"]["total_tokens"] > 0
+    lm_usage = output.get_lm_usage()
+    assert len(lm_usage) == 1
+    assert lm_usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
+    assert lm_usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
+    assert lm_usage["openai/gpt-4o-mini"]["total_tokens"] > 0
 
     # Test no usage being tracked when cache is enabled
     dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=True), track_usage=True)
     for _ in range(2):
         output = predict(question="What is the capital of France?")
 
-    assert len(output.usage) == 0
+    assert len(output.get_lm_usage()) == 0
 
 
 @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="Skip the test if OPENAI_API_KEY is not set.")
@@ -202,14 +203,12 @@ def test_multi_module_call_with_usage_tracker():
     program = MyProgram()
     output = program(question="What is the capital of France?")
 
-    assert output.lm_usage is not None
-
-    assert isinstance(output.lm_usage, dict)
-    assert len(output.lm_usage.keys()) == 1
-    assert "openai/gpt-4o-mini" in output.lm_usage
-    assert output.lm_usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
-    assert output.lm_usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
-    assert output.lm_usage["openai/gpt-4o-mini"]["total_tokens"] > 0
+    lm_usage = output.get_lm_usage()
+    assert len(lm_usage) == 1
+    assert lm_usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
+    assert lm_usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
+    assert lm_usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
+    assert lm_usage["openai/gpt-4o-mini"]["total_tokens"] > 0
 
 
 @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="Skip the test if OPENAI_API_KEY is not set.")
@@ -239,8 +238,8 @@ def test_usage_tracker_in_parallel():
         ]
     )
 
-    assert results[0].lm_usage is not None
-    assert results[1].lm_usage is not None
+    assert results[0].get_lm_usage() is not None
+    assert results[1].get_lm_usage() is not None
 
-    assert results[0].lm_usage.keys() == set(["openai/gpt-4o-mini"])
-    assert results[1].lm_usage.keys() == set(["openai/gpt-3.5-turbo"])
+    assert results[0].get_lm_usage().keys() == set(["openai/gpt-4o-mini"])
+    assert results[1].get_lm_usage().keys() == set(["openai/gpt-3.5-turbo"])

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -172,10 +172,10 @@ def test_single_module_call_with_usage_tracker():
     predict = dspy.ChainOfThought("question -> answer")
     output = predict(question="What is the capital of France?")
 
-    assert output.usage is not None
-    assert output.usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
-    assert output.usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
-    assert output.usage["openai/gpt-4o-mini"]["total_tokens"] > 0
+    assert output.lm_usage is not None
+    assert output.lm_usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
+    assert output.lm_usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
+    assert output.lm_usage["openai/gpt-4o-mini"]["total_tokens"] > 0
 
     # Test no usage being tracked when cache is enabled
     dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=True), track_usage=True)
@@ -202,14 +202,14 @@ def test_multi_module_call_with_usage_tracker():
     program = MyProgram()
     output = program(question="What is the capital of France?")
 
-    assert output.usage is not None
+    assert output.lm_usage is not None
 
-    assert isinstance(output.usage, dict)
-    assert len(output.usage.keys()) == 1
-    assert "openai/gpt-4o-mini" in output.usage
-    assert output.usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
-    assert output.usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
-    assert output.usage["openai/gpt-4o-mini"]["total_tokens"] > 0
+    assert isinstance(output.lm_usage, dict)
+    assert len(output.lm_usage.keys()) == 1
+    assert "openai/gpt-4o-mini" in output.lm_usage
+    assert output.lm_usage["openai/gpt-4o-mini"]["prompt_tokens"] > 0
+    assert output.lm_usage["openai/gpt-4o-mini"]["completion_tokens"] > 0
+    assert output.lm_usage["openai/gpt-4o-mini"]["total_tokens"] > 0
 
 
 @pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="Skip the test if OPENAI_API_KEY is not set.")
@@ -239,8 +239,8 @@ def test_usage_tracker_in_parallel():
         ]
     )
 
-    assert results[0].usage is not None
-    assert results[1].usage is not None
+    assert results[0].lm_usage is not None
+    assert results[1].lm_usage is not None
 
-    assert results[0].keys() == set(["openai/gpt-4o-mini"])
-    assert results[1].keys() == set(["openai/gpt-3.5-turbo"])
+    assert results[0].lm_usage.keys() == set(["openai/gpt-4o-mini"])
+    assert results[1].lm_usage.keys() == set(["openai/gpt-3.5-turbo"])

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -1,0 +1,159 @@
+import pytest
+import dspy
+from unittest.mock import Mock, patch, MagicMock
+from dspy.utils.usage_tracker import UsageTracker, track_usage
+from dspy.utils.dummies import DummyLM
+import os
+
+
+def test_add_usage_entry():
+    """Test adding usage entries to the tracker."""
+    tracker = UsageTracker()
+
+    # Test with a single usage entry
+    usage_entry = {
+        "prompt_tokens": 1117,
+        "completion_tokens": 46,
+        "total_tokens": 1163,
+        "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+        "completion_tokens_details": {
+            "reasoning_tokens": 0,
+            "audio_tokens": 0,
+            "accepted_prediction_tokens": 0,
+            "rejected_prediction_tokens": 0,
+        },
+    }
+
+    tracker.add_usage("gpt-4o-mini", usage_entry)
+    assert len(tracker.usage_data["gpt-4o-mini"]) == 1
+    assert tracker.usage_data["gpt-4o-mini"][0] == usage_entry
+
+
+def test_get_total_tokens():
+    """Test calculating total tokens from usage entries."""
+    tracker = UsageTracker()
+
+    # Add multiple usage entries for the same model
+    usage_entries = [
+        {
+            "prompt_tokens": 1117,
+            "completion_tokens": 46,
+            "total_tokens": 1163,
+            "prompt_tokens_details": {"cached_tokens": 200, "audio_tokens": 50},
+            "completion_tokens_details": {
+                "reasoning_tokens": 20,
+                "audio_tokens": 10,
+                "accepted_prediction_tokens": 16,
+                "rejected_prediction_tokens": 0,
+            },
+        },
+        {
+            "prompt_tokens": 800,
+            "completion_tokens": 100,
+            "total_tokens": 900,
+            "prompt_tokens_details": {"cached_tokens": 300, "audio_tokens": 0},
+            "completion_tokens_details": {
+                "reasoning_tokens": 50,
+                "audio_tokens": 0,
+                "accepted_prediction_tokens": 40,
+                "rejected_prediction_tokens": 10,
+            },
+        },
+        {
+            "prompt_tokens": 500,
+            "completion_tokens": 80,
+            "total_tokens": 580,
+            "prompt_tokens_details": {"cached_tokens": 100, "audio_tokens": 25},
+            "completion_tokens_details": {
+                "reasoning_tokens": 30,
+                "audio_tokens": 15,
+                "accepted_prediction_tokens": 25,
+                "rejected_prediction_tokens": 10,
+            },
+        },
+    ]
+
+    for entry in usage_entries:
+        tracker.add_usage("gpt-4o-mini", entry)
+
+    total_usage = tracker.get_total_tokens()
+    assert "gpt-4o-mini" in total_usage
+    assert total_usage["gpt-4o-mini"]["prompt_tokens"] == 2417  # 1117 + 800 + 500
+    assert total_usage["gpt-4o-mini"]["completion_tokens"] == 226  # 46 + 100 + 80
+    assert total_usage["gpt-4o-mini"]["total_tokens"] == 2643  # 1163 + 900 + 580
+    assert total_usage["gpt-4o-mini"]["prompt_tokens_details"]["cached_tokens"] == 600  # 200 + 300 + 100
+    assert total_usage["gpt-4o-mini"]["prompt_tokens_details"]["audio_tokens"] == 75  # 50 + 0 + 25
+    assert total_usage["gpt-4o-mini"]["completion_tokens_details"]["reasoning_tokens"] == 100  # 20 + 50 + 30
+    assert total_usage["gpt-4o-mini"]["completion_tokens_details"]["audio_tokens"] == 25  # 10 + 0 + 15
+    assert total_usage["gpt-4o-mini"]["completion_tokens_details"]["accepted_prediction_tokens"] == 81  # 16 + 40 + 25
+    assert total_usage["gpt-4o-mini"]["completion_tokens_details"]["rejected_prediction_tokens"] == 20  # 0 + 10 + 10
+
+
+def test_track_usage_with_multiple_models():
+    """Test tracking usage across multiple models."""
+    tracker = UsageTracker()
+
+    # Add usage entries for different models
+    usage_entries = [
+        {
+            "model": "gpt-4o-mini",
+            "usage": {
+                "prompt_tokens": 1117,
+                "completion_tokens": 46,
+                "total_tokens": 1163,
+                "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+                "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "audio_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0,
+                },
+            },
+        },
+        {
+            "model": "gpt-3.5-turbo",
+            "usage": {
+                "prompt_tokens": 800,
+                "completion_tokens": 100,
+                "total_tokens": 900,
+                "prompt_tokens_details": {"cached_tokens": 0, "audio_tokens": 0},
+                "completion_tokens_details": {
+                    "reasoning_tokens": 0,
+                    "audio_tokens": 0,
+                    "accepted_prediction_tokens": 0,
+                    "rejected_prediction_tokens": 0,
+                },
+            },
+        },
+    ]
+
+    for entry in usage_entries:
+        tracker.add_usage(entry["model"], entry["usage"])
+
+    total_usage = tracker.get_total_tokens()
+    assert "gpt-4o-mini" in total_usage
+    assert "gpt-3.5-turbo" in total_usage
+    assert total_usage["gpt-4o-mini"]["total_tokens"] == 1163
+    assert total_usage["gpt-3.5-turbo"]["total_tokens"] == 900
+
+
+@pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="Skip the test if OPENAI_API_KEY is not set.",
+)
+def test_track_usage_context_manager():
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+    dspy.settings.configure(lm=lm)
+
+    predict = dspy.ChainOfThought("question -> answer")
+    with track_usage() as tracker:
+        predict(question="What is the capital of France?")
+        predict(question="What is the capital of Italy?")
+
+    assert len(tracker.usage_data) > 0
+    assert len(tracker.usage_data["openai/gpt-4o-mini"]) == 2
+
+    total_usage = tracker.get_total_tokens()
+    assert "openai/gpt-4o-mini" in total_usage
+    assert len(total_usage.keys()) == 1
+    assert isinstance(total_usage["openai/gpt-4o-mini"], dict)


### PR DESCRIPTION
Per community request, we are adding usage tracking for DSPy program. As an overview:

- We track the LM usage in the openai (litellm) format for each program call
- Local cache hit will cause no usage
- If multiple LMs are used in the process, they will be tracked separately. 
- The returned usage is a dictionary from lm name to openai-format usage data. The usage data is the merge result across all LM calls in one single program pass.


To use usage tracking, follow the code example below:

```
import dspy

dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False), track_usage=True)

predict = dspy.ChainOfThought("question -> answer")
output = predict(question="What is the capital of France?")
print(output.get_lm_usage())
```

This usage tracking also works for multi-module program, for example:

```
import dspy

dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False), track_usage=True)

class MyProgram(dspy.Module):
    def __init__(self):
        self.predict1 = dspy.ChainOfThought("question -> answer")
        self.predict2 = dspy.ChainOfThought("question, answer -> score")

    def __call__(self, question: str) -> str:
        answer = self.predict1(question=question)
        score = self.predict2(question=question, answer=answer)
        return score

program = MyProgram()
output = program(question="What is the capital of France?")
print(output.get_lm_usage())
```

The output is the combined output for the end to end program call. 

This usage tracking also works with multithreading:

```
class MyProgram(dspy.Module):
    def __init__(self, lm):
        self.lm = lm
        self.predict1 = dspy.ChainOfThought("question -> answer")
        self.predict2 = dspy.ChainOfThought("question, answer -> score")

    def __call__(self, question: str) -> str:
        with dspy.settings.context(lm=self.lm):
            answer = self.predict1(question=question)
            score = self.predict2(question=question, answer=answer)
            return score

dspy.settings.configure(track_usage=True)
program1 = MyProgram(lm=dspy.LM("openai/gpt-4o-mini", cache=False))
program2 = MyProgram(lm=dspy.LM("openai/gpt-3.5-turbo", cache=False))

parallelizer = dspy.Parallel()

results = parallelizer(
    [
        (program1, {"question": "What is the meaning of life?"}),
        (program2, {"question": "why did a chicken cross the kitchen?"}),
    ]
)
```
it is thread-safe, each program's output will only see the usage of itself. 