### PR TITLE
SIMBA Improvements: Bug fixes + Adding Trial Logs

### DIFF
--- a/dspy/teleprompt/simba.py
+++ b/dspy/teleprompt/simba.py
@@ -6,7 +6,6 @@ import numpy as np
 from typing import Callable
 from dspy.teleprompt.teleprompt import Teleprompter
 from dspy.teleprompt.simba_utils import prepare_models_for_resampling, wrap_program, append_a_demo, append_a_rule
-from dspy.teleprompt.utils import log_token_usage
 
 logger = logging.getLogger(__name__)
 
@@ -286,8 +285,6 @@ class SIMBA(Teleprompter):
                 sys_scores = [outputs[i]["score"] for i in range(start, end)]
                 register_new_program(cand_sys, sys_scores)
             
-            log_token_usage(trial_logs, batch_idx, {"lm": dspy.settings.lm})
-
         M = len(winning_programs) - 1
         N = self.num_candidates + 1
         if M < 1:

--- a/dspy/teleprompt/simba.py
+++ b/dspy/teleprompt/simba.py
@@ -6,6 +6,7 @@ import numpy as np
 from typing import Callable
 from dspy.teleprompt.teleprompt import Teleprompter
 from dspy.teleprompt.simba_utils import prepare_models_for_resampling, wrap_program, append_a_demo, append_a_rule
+from dspy.teleprompt.utils import log_token_usage
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,10 @@ class SIMBA(Teleprompter):
         self.temperature_for_sampling = temperature_for_sampling
         self.temperature_for_candidates = temperature_for_candidates
 
-        self.strategies = [append_a_demo(demo_input_field_maxlen), append_a_rule]
+        if self.max_demos > 0:
+            self.strategies = [append_a_demo(demo_input_field_maxlen), append_a_rule]
+        else:
+            self.strategies = [append_a_rule]
 
     def compile(self, student: dspy.Module, *, trainset: list[dspy.Example], seed: int = 0):
         # Basic checks
@@ -117,7 +121,10 @@ class SIMBA(Teleprompter):
         # Parallel runner
         run_parallel = dspy.Parallel(access_examples=False, num_threads=self.num_threads)
 
+        trial_logs = {}
         for batch_idx in range(self.max_steps):
+            trial_logs[batch_idx] = {}
+
             logger.info(f"Starting batch {batch_idx+1} of {self.max_steps}.")
 
             # STEP 1: Get next batch
@@ -205,12 +212,14 @@ class SIMBA(Teleprompter):
                 name2predictor = {}
                 num_demos_list = []
 
+                max_demos_tmp = self.max_demos if self.max_demos > 0 else 3
+
                 for name, predictor in system_candidate.named_predictors():
                     name2predictor[name] = predictor
                     num_demos_list.append(len(predictor.demos))
 
                 num_demos = max(num_demos_list) if num_demos_list else 0
-                num_demos_to_drop = max(rng_np.poisson(num_demos / self.max_demos), int(num_demos >= self.max_demos))
+                num_demos_to_drop = max(rng_np.poisson(num_demos / max_demos_tmp), int(num_demos >= max_demos_tmp))
                 num_demos_to_drop = min(num_demos_to_drop, num_demos)
                 demos_to_drop = [rng.randrange(num_demos) for _ in range(num_demos_to_drop)]
 
@@ -268,7 +277,7 @@ class SIMBA(Teleprompter):
             if candidate_scores:
                 best_idx_among_candidates = candidate_scores.index(max(candidate_scores))
                 best_program = system_candidates[best_idx_among_candidates]
-                winning_programs.append(best_program)
+                winning_programs.append(best_program.deepcopy())
 
             # STEP 8: Register all new candidate systems in our global pool
             for idx_cand, cand_sys in enumerate(system_candidates):
@@ -276,6 +285,8 @@ class SIMBA(Teleprompter):
                 end = (idx_cand + 1) * self.bsize
                 sys_scores = [outputs[i]["score"] for i in range(start, end)]
                 register_new_program(cand_sys, sys_scores)
+            
+            log_token_usage(trial_logs, batch_idx, {"lm": dspy.settings.lm})
 
         M = len(winning_programs) - 1
         N = self.num_candidates + 1
@@ -286,7 +297,7 @@ class SIMBA(Teleprompter):
             program_idxs = [round(i * M / (N - 1)) for i in range(N)]
         program_idxs = list(dict.fromkeys(program_idxs))
 
-        candidate_programs = [winning_programs[i] for i in program_idxs]
+        candidate_programs = [winning_programs[i].deepcopy() for i in program_idxs]
         logger.info(f"VALIDATION: Evaluating {len(candidate_programs)} programs on the full trainset.")
         exec_pairs = [(wrap_program(sys, self.metric), ex) for sys in candidate_programs for ex in trainset]
         outputs = run_parallel(exec_pairs)
@@ -298,7 +309,9 @@ class SIMBA(Teleprompter):
             sys_scores = [outputs[i]["score"] for i in range(start, end)]
             avg_score = sum(sys_scores) / len(sys_scores) if sys_scores else 0.0
             scores.append(avg_score)
-
+            if idx_prog != 0:
+                trial_logs[idx_prog-1]["train_score"] = avg_score
+        
         best_idx = scores.index(max(scores)) if scores else 0
         best_program = candidate_programs[best_idx]
         logger.info(
@@ -309,5 +322,6 @@ class SIMBA(Teleprompter):
         # FIXME: Attach all program candidates in decreasing average score to the best program.
         best_program.candidate_programs = candidate_programs
         best_program.winning_programs = winning_programs
+        best_program.trial_logs = trial_logs
 
         return best_program

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -266,8 +266,8 @@ def get_token_usage(model) -> tuple[int, int]:
         input_tokens.append(_input_tokens)
         output_tokens.append(_output_tokens)
 
-    total_input_tokens = np.sum(input_tokens)
-    total_output_tokens = np.sum(output_tokens)
+    total_input_tokens = int(np.sum(input_tokens))
+    total_output_tokens = int(np.sum(output_tokens))
 
     return total_input_tokens, total_output_tokens
 
@@ -280,7 +280,7 @@ def log_token_usage(trial_logs, trial_num, model_dict):
     token_usage_dict = {}
 
     for model_name, model in model_dict.items():
-        in_tokens, out_tokens = extract_token_usage(model)
+        in_tokens, out_tokens = get_token_usage(model)
         token_usage_dict[model_name] = {
             "total_input_tokens": in_tokens,
             "total_output_tokens": out_tokens

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -250,6 +250,23 @@ def setup_logging(log_dir):
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
 
+def log_token_usage(trial_logs, trial_num, model_dict):
+    """
+    Extract total input and output tokens used by each model and log to trial_logs[trial_num]["token_usage"].
+    """
+
+    token_usage_dict = {}
+
+    for model_name, model in model_dict.items():
+        in_tokens, out_tokens = extract_token_usage(model)
+        token_usage_dict[model_name] = {
+            "total_input_tokens": in_tokens,
+            "total_output_tokens": out_tokens
+        }
+
+    # Store token usage info in trial logs
+    trial_logs[trial_num]["token_usage"] = token_usage_dict
+
 
 ### OTHER UTILS ###
 

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -5,7 +5,7 @@ import os
 import random
 import shutil
 import sys
-
+from Typing import Tuple
 import numpy as np
 
 try:
@@ -249,6 +249,29 @@ def setup_logging(log_dir):
     console_formatter = logging.Formatter("%(message)s")
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
+
+def get_token_usage(model) -> Tuple[int, int]:
+    """
+    Extract total input tokens and output tokens from a model's interaction history.
+    Returns (total_input_tokens, total_output_tokens).
+    """
+    if not hasattr(model, "history"):
+        return 0, 0
+
+    input_tokens = []
+    output_tokens = []
+    for interaction in model.history:
+        usage = interaction.get("usage", {})
+        _input_tokens = usage.get("prompt_tokens", 0)
+        _output_tokens = usage.get("completion_tokens", 0)
+        input_tokens.append(_input_tokens)
+        output_tokens.append(_output_tokens)
+
+    total_input_tokens = np.sum(input_tokens)
+    total_output_tokens = np.sum(output_tokens)
+
+    return total_input_tokens, total_output_tokens
+
 
 def log_token_usage(trial_logs, trial_num, model_dict):
     """

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -5,7 +5,6 @@ import os
 import random
 import shutil
 import sys
-from Typing import Tuple
 import numpy as np
 
 try:
@@ -250,7 +249,7 @@ def setup_logging(log_dir):
     console_handler.setFormatter(console_formatter)
     logger.addHandler(console_handler)
 
-def get_token_usage(model) -> Tuple[int, int]:
+def get_token_usage(model) -> tuple[int, int]:
     """
     Extract total input tokens and output tokens from a model's interaction history.
     Returns (total_input_tokens, total_output_tokens).


### PR DESCRIPTION
This PR does the following:

1. Allows SIMBA to run 0-shot - previously this was through a divide by 0 error.
2. Fixes a `maximum recursion depth exceeded` error resulting from saving an optimized SIMBA program with `save_program=True`. This was done by making sure that `winning_programs` and `candidate_programs` are deepcopy(s) of the original programs.
3. Adds in basic `trial_logs` to the optimized program, to allow for post hoc analysis of cost vs. performance

These changes were tested by running a 0-shot optimization run, saving the resulting program with `save_program=True`, and verifying that the returned `trial_logs` were as expected.