### PR TITLE
Use exponential_backoff_retry for completion call

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -278,6 +278,7 @@ def cached_litellm_completion(request: Dict[str, Any], num_retries: int):
 def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
     retry_kwargs = dict(
         retry_policy=_get_litellm_retry_policy(num_retries),
+        retry_strategy="exponential_backoff_retry",
         # In LiteLLM version 1.55.3 (the first version that supports retry_policy as an argument
         # to completion()), the default value of max_retries is non-zero for certain providers, and
         # max_retries is stacked on top of the retry_policy. To avoid this, we set max_retries=0


### PR DESCRIPTION
Some users reported that their programs were stuck due to Rate limit errors. This PR configures exponential backoff retry for LiteLLM completion call since LiteLLM uses constant backoff even for rate limits ([ref](https://github.com/BerriAI/litellm/blob/3ca34a181cae83b8b3c73e5937f07e36509a7f35/litellm/main.py#L3172)), which is ineffective.

One tradeoff here is that we will start using exponential backoff for other types of exceptions (e.g. internal server error) after this change. LiteLLM has a smart logic for async completion that it switches to exponential backoff only for RateLimitError ([ref](https://github.com/BerriAI/litellm/blob/17ad8a04175402b71bbb3f67c9d8e5ff248c5228/litellm/utils.py#L1415)), but this does not exist for sync completion. Therefore, another solution is that we file a PR to LiteLLM side to implement the logic for sync completion to use exponential backoff only to RateLimitError.