### PR TITLE
MIPROv2 Updates: New defaults, fixed Trial # Logging

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -493,7 +493,6 @@ class MIPROv2(Teleprompter):
             nonlocal program, best_program, best_score, trial_logs, total_eval_calls, score_data
 
             trial_num = trial.number + 1
-            print(f"AT START: trial_num {trial_num} | trial.number {trial.number} | adjusted_num_trials {adjusted_num_trials}")
             if minibatch:
                 logger.info(f"== Trial {trial_num} / {adjusted_num_trials} - Minibatch ==")
             else:
@@ -569,7 +568,6 @@ class MIPROv2(Teleprompter):
             )
 
             # If minibatch, perform full evaluation at intervals (and at the very end)
-            print(f"BEFORE PERFORM FULL EVAL: trial_num {trial_num} | trial.number {trial.number} | adjusted_num_trials {adjusted_num_trials}")
             if minibatch and ((trial_num % (minibatch_full_eval_steps+1) == 0) or (trial_num == (adjusted_num_trials-1))):
                 best_score, best_program, total_eval_calls = self._perform_full_evaluation(
                     trial_num,

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -52,8 +52,8 @@ class MIPROv2(Teleprompter):
         task_model: Optional[Any] = None,
         teacher_settings: Dict = {},
         max_bootstrapped_demos: int = 4,
-        max_labeled_demos: int = 16,
-        auto: Optional[Literal["light", "medium", "heavy"]] = None,
+        max_labeled_demos: int = 4,
+        auto: Optional[Literal["light", "medium", "heavy"]] = "medium",
         num_candidates: int = 10,
         num_threads: int = 6,
         max_errors: int = 10,
@@ -101,8 +101,8 @@ class MIPROv2(Teleprompter):
         max_labeled_demos: Optional[int] = None,
         seed: Optional[int] = None,
         minibatch: bool = True,
-        minibatch_size: int = 25,
-        minibatch_full_eval_steps: int = 10,
+        minibatch_size: int = 35,
+        minibatch_full_eval_steps: int = 5,
         program_aware_proposer: bool = True,
         data_aware_proposer: bool = True,
         view_data_batch_size: int = 10,
@@ -464,7 +464,8 @@ class MIPROv2(Teleprompter):
         )
 
         # Compute the adjusted total trials that we will run (including full evals)
-        adjusted_num_trials = (num_trials + num_trials // minibatch_full_eval_steps + 1) if minibatch else num_trials
+        run_additional_full_eval_at_end = 1 if num_trials % minibatch_full_eval_steps != 0 else 0
+        adjusted_num_trials = (num_trials + num_trials // minibatch_full_eval_steps + 1 + run_additional_full_eval_at_end) if minibatch else num_trials
         logger.info(f"== Trial {1} / {adjusted_num_trials} - Full Evaluation of Default Program ==")
 
         default_score, _ = eval_candidate_program(
@@ -473,11 +474,11 @@ class MIPROv2(Teleprompter):
         logger.info(f"Default program score: {default_score}\n")
 
         trial_logs = {}
-        trial_logs[-1] = {}
-        trial_logs[-1]["full_eval_program_path"] = save_candidate_program(program, self.log_dir, -1)
-        trial_logs[-1]["full_eval_score"] = default_score
-        trial_logs[-1]["total_eval_calls_so_far"] = len(valset)
-        trial_logs[-1]["full_eval_program"] = program.deepcopy()
+        trial_logs[1] = {}
+        trial_logs[1]["full_eval_program_path"] = save_candidate_program(program, self.log_dir, -1)
+        trial_logs[1]["full_eval_score"] = default_score
+        trial_logs[1]["total_eval_calls_so_far"] = len(valset)
+        trial_logs[1]["full_eval_program"] = program.deepcopy()
 
         # Initialize optimization variables
         best_score = default_score
@@ -492,6 +493,7 @@ class MIPROv2(Teleprompter):
             nonlocal program, best_program, best_score, trial_logs, total_eval_calls, score_data
 
             trial_num = trial.number + 1
+            print(f"AT START: trial_num {trial_num} | trial.number {trial.number} | adjusted_num_trials {adjusted_num_trials}")
             if minibatch:
                 logger.info(f"== Trial {trial_num} / {adjusted_num_trials} - Minibatch ==")
             else:
@@ -567,7 +569,8 @@ class MIPROv2(Teleprompter):
             )
 
             # If minibatch, perform full evaluation at intervals (and at the very end)
-            if minibatch and ((trial_num % minibatch_full_eval_steps == 0) or (trial_num == (adjusted_num_trials - 1))):
+            print(f"BEFORE PERFORM FULL EVAL: trial_num {trial_num} | trial.number {trial.number} | adjusted_num_trials {adjusted_num_trials}")
+            if minibatch and ((trial_num % (minibatch_full_eval_steps+1) == 0) or (trial_num == (adjusted_num_trials-1))):
                 best_score, best_program, total_eval_calls = self._perform_full_evaluation(
                     trial_num,
                     adjusted_num_trials,
@@ -601,7 +604,7 @@ class MIPROv2(Teleprompter):
             value=default_score,
         )
         study.add_trial(trial)
-        study.optimize(objective, n_trials=num_trials - 1)
+        study.optimize(objective, n_trials=num_trials)
 
         # Attach logs to best program
         if best_program is not None and self.track_stats:
@@ -767,15 +770,16 @@ class MIPROv2(Teleprompter):
             "score": full_eval_score,
         }
         total_eval_calls += len(valset)
-        trial_logs[trial_num]["total_eval_calls_so_far"] = total_eval_calls
-        trial_logs[trial_num]["full_eval_program_path"] = save_candidate_program(
+        trial_logs[trial_num + 1] = {}
+        trial_logs[trial_num + 1]["total_eval_calls_so_far"] = total_eval_calls
+        trial_logs[trial_num + 1]["full_eval_program_path"] = save_candidate_program(
             program=highest_mean_program,
             log_dir=self.log_dir,
-            trial_num=trial_num,
+            trial_num=trial_num + 1,
             note="full_eval",
         )
-        trial_logs[trial_num]["full_eval_program"] = highest_mean_program
-        trial_logs[trial_num]["full_eval_score"] = full_eval_score
+        trial_logs[trial_num + 1]["full_eval_program"] = highest_mean_program
+        trial_logs[trial_num + 1]["full_eval_score"] = full_eval_score
 
         # Update best score and program if necessary
         if full_eval_score > best_score:


### PR DESCRIPTION
This PR includes the following changes:

1. **New defaults for running MIPROv2**. The specific changes included here are: `minibatch_size` 25 -> 35, `minibatch_full_eval_steps` 10 -> 5, `auto` default from `None` to `medium`, `max_labeled_demos` 14 -> 4. These are defaults that we've found to work better out of the box from experimentation overtime.
2.  **Fixing trial # logging.** There were previously a few off by one, etc. errors in tracking the current trial # and the total trial #s. This came from a past change in which we reported the scores from full evals as a trial, in addition to the mini batch trials. This should now be fixed, and was tested in a number of different settings (`auto=light, medium`, `minibatch=True, False`, etc.)