### PR TITLE
Fix unrecognized api mkdoc options

### DIFF
--- a/docs/docs/api/adapters/Adapter.md
+++ b/docs/docs/api/adapters/Adapter.md
@@ -12,11 +12,10 @@
             - format_turn
             - parse
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/adapters/ChatAdapter.md
+++ b/docs/docs/api/adapters/ChatAdapter.md
@@ -12,11 +12,10 @@
             - format_turn
             - parse
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/adapters/JSONAdapter.md
+++ b/docs/docs/api/adapters/JSONAdapter.md
@@ -12,11 +12,10 @@
             - format_turn
             - parse
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/evaluation/CompleteAndGrounded.md
+++ b/docs/docs/api/evaluation/CompleteAndGrounded.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/evaluation/Evaluate.md
+++ b/docs/docs/api/evaluation/Evaluate.md
@@ -6,11 +6,10 @@
         members:
             - __call__
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/evaluation/SemanticF1.md
+++ b/docs/docs/api/evaluation/SemanticF1.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/evaluation/answer_exact_match.md
+++ b/docs/docs/api/evaluation/answer_exact_match.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/evaluation/answer_passage_match.md
+++ b/docs/docs/api/evaluation/answer_passage_match.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/models/Embedder.md
+++ b/docs/docs/api/models/Embedder.md
@@ -6,11 +6,10 @@
         members:
             - __call__
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/models/LM.md
+++ b/docs/docs/api/models/LM.md
@@ -15,11 +15,10 @@
             - launch
             - update_global_history
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/BestOfN.md
+++ b/docs/docs/api/modules/BestOfN.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/ChainOfThought.md
+++ b/docs/docs/api/modules/ChainOfThought.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/ChainOfThoughtWithHint.md
+++ b/docs/docs/api/modules/ChainOfThoughtWithHint.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/Module.md
+++ b/docs/docs/api/modules/Module.md
@@ -21,11 +21,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/MultiChainComparison.md
+++ b/docs/docs/api/modules/MultiChainComparison.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/Parallel.md
+++ b/docs/docs/api/modules/Parallel.md
@@ -7,11 +7,10 @@
             - __call__
             - forward
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/Predict.md
+++ b/docs/docs/api/modules/Predict.md
@@ -25,11 +25,10 @@
             - set_lm
             - update_config
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/Program.md
+++ b/docs/docs/api/modules/Program.md
@@ -21,11 +21,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/ProgramOfThought.md
+++ b/docs/docs/api/modules/ProgramOfThought.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/ReAct.md
+++ b/docs/docs/api/modules/ReAct.md
@@ -23,11 +23,10 @@
             - set_lm
             - truncate_trajectory
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/modules/Refine.md
+++ b/docs/docs/api/modules/Refine.md
@@ -22,11 +22,10 @@
             - save
             - set_lm
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/BetterTogether.md
+++ b/docs/docs/api/optimizers/BetterTogether.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/BootstrapFewShot.md
+++ b/docs/docs/api/optimizers/BootstrapFewShot.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/BootstrapFewShotWithRandomSearch.md
+++ b/docs/docs/api/optimizers/BootstrapFewShotWithRandomSearch.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/BootstrapFinetune.md
+++ b/docs/docs/api/optimizers/BootstrapFinetune.md
@@ -9,11 +9,10 @@
             - finetune_lms
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/BootstrapRS.md
+++ b/docs/docs/api/optimizers/BootstrapRS.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/COPRO.md
+++ b/docs/docs/api/optimizers/COPRO.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/Ensemble.md
+++ b/docs/docs/api/optimizers/Ensemble.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/InferRules.md
+++ b/docs/docs/api/optimizers/InferRules.md
@@ -12,11 +12,10 @@
             - induce_natural_language_rules
             - update_program_instructions
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/KNN.md
+++ b/docs/docs/api/optimizers/KNN.md
@@ -6,11 +6,10 @@
         members:
             - __call__
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/KNNFewShot.md
+++ b/docs/docs/api/optimizers/KNNFewShot.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/LabeledFewShot.md
+++ b/docs/docs/api/optimizers/LabeledFewShot.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/optimizers/MIPROv2.md
+++ b/docs/docs/api/optimizers/MIPROv2.md
@@ -7,11 +7,10 @@
             - compile
             - get_params
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/primitives/Example.md
+++ b/docs/docs/api/primitives/Example.md
@@ -15,11 +15,10 @@
             - with_inputs
             - without
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/primitives/History.md
+++ b/docs/docs/api/primitives/History.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/primitives/Image.md
+++ b/docs/docs/api/primitives/Image.md
@@ -10,11 +10,10 @@
             - serialize_model
             - validate_input
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/primitives/Prediction.md
+++ b/docs/docs/api/primitives/Prediction.md
@@ -7,20 +7,21 @@
             - copy
             - from_completions
             - get
+            - get_lm_usage
             - inputs
             - items
             - keys
             - labels
+            - set_lm_usage
             - toDict
             - values
             - with_inputs
             - without
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/primitives/Tool.md
+++ b/docs/docs/api/primitives/Tool.md
@@ -6,11 +6,10 @@
         members:
             - __call__
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/signatures/InputField.md
+++ b/docs/docs/api/signatures/InputField.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/signatures/OutputField.md
+++ b/docs/docs/api/signatures/OutputField.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/signatures/Signature.md
+++ b/docs/docs/api/signatures/Signature.md
@@ -14,11 +14,10 @@
             - with_instructions
             - with_updated_fields
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/tools/ColBERTv2.md
+++ b/docs/docs/api/tools/ColBERTv2.md
@@ -6,11 +6,10 @@
         members:
             - __call__
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/tools/Embeddings.md
+++ b/docs/docs/api/tools/Embeddings.md
@@ -7,11 +7,10 @@
             - __call__
             - forward
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/tools/PythonInterpreter.md
+++ b/docs/docs/api/tools/PythonInterpreter.md
@@ -8,11 +8,10 @@
             - execute
             - shutdown
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/StatusMessage.md
+++ b/docs/docs/api/utils/StatusMessage.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/StatusMessageProvider.md
+++ b/docs/docs/api/utils/StatusMessageProvider.md
@@ -11,11 +11,10 @@
             - tool_end_status_message
             - tool_start_status_message
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/asyncify.md
+++ b/docs/docs/api/utils/asyncify.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/disable_litellm_logging.md
+++ b/docs/docs/api/utils/disable_litellm_logging.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/disable_logging.md
+++ b/docs/docs/api/utils/disable_logging.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/enable_litellm_logging.md
+++ b/docs/docs/api/utils/enable_litellm_logging.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/enable_logging.md
+++ b/docs/docs/api/utils/enable_logging.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/inspect_history.md
+++ b/docs/docs/api/utils/inspect_history.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/load.md
+++ b/docs/docs/api/utils/load.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/docs/api/utils/streamify.md
+++ b/docs/docs/api/utils/streamify.md
@@ -4,11 +4,10 @@
     handler: python
     options:
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -243,7 +243,7 @@ markdown_extensions:
     - md_in_html
     - pymdownx.emoji:
         emoji_index: !!python/name:material.extensions.emoji.twemoji
-        emoji_generator: !!python/name:materialx.emoji.to_svg
+        emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 copyright: |
     &copy; 2024 <a href="https://github.com/stanfordnlp"  target="_blank" rel="noopener">Stanford NLP</a>

--- a/docs/scripts/generate_api_docs.py
+++ b/docs/scripts/generate_api_docs.py
@@ -138,14 +138,13 @@ def generate_doc_page(name: str, module_path: str, obj: Any, is_root: bool = Fal
     handler: python
     options:{members_config}
         show_source: true
-        show_undocumented_members: true
         show_root_heading: true
-        show_inherited_members: true
         heading_level: 2
         docstring_style: google
         show_root_full_path: true
         show_object_full_path: false
         separate_signature: false
+        inherited_members: true
 """
 
 


### PR DESCRIPTION
When running `mkdoc serve`, the following warning appears many times. Also, inherited methods don't appear in the DSPy api doc as the `show_inherited_members` option is not recognized. This PR fixes the issue by updating the mkdoc options.

```
DeprecationWarning: Passing extra options directly under options is deprecated. Instead, pass them under options.extra, and
           update your templates. Current extra (unrecognized) options: show_inherited_members, show_undocumented_members?
```