### PR TITLE
Fix wrong comments in predict.py

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,16 +1,19 @@
+import logging
 import random
 
 from pydantic import BaseModel
 
+from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.clients.base_lm import BaseLM
 from dspy.clients.lm import LM
+from dspy.dsp.utils import settings
 from dspy.predict.parameter import Parameter
 from dspy.primitives.prediction import Prediction
 from dspy.primitives.program import Module
 from dspy.signatures.signature import ensure_signature
 from dspy.utils.callback import with_callbacks
-from dspy.dsp.utils import settings
-from dspy.adapters.chat_adapter import ChatAdapter
+
+logger = logging.getLogger(__name__)
 
 
 class Predict(Module, Parameter):
@@ -83,9 +86,8 @@ class Predict(Module, Parameter):
         lm = kwargs.pop("lm", self.lm) or settings.lm
         assert isinstance(lm, BaseLM), "No LM is loaded."
 
-        # If temperature is 0.0 but its n > 1, set temperature to 0.7.
-        temperature = config.get("temperature")
-        temperature = lm.kwargs["temperature"] if temperature is None else temperature
+        # If temperature is unset or <=0.15, and n > 1, set temperature to 0.7 to keep randomness.
+        temperature = config.get("temperature") or lm.kwargs.get("temperature")
         num_generations = config.get("n") or lm.kwargs.get("n") or lm.kwargs.get("num_generations") or 1
 
         if (temperature is None or temperature <= 0.15) and num_generations > 1:
@@ -94,7 +96,11 @@ class Predict(Module, Parameter):
         if not all(k in kwargs for k in signature.input_fields):
             present = [k for k in signature.input_fields if k in kwargs]
             missing = [k for k in signature.input_fields if k not in kwargs]
-            print(f"WARNING: Not all input fields were provided to module. Present: {present}. Missing: {missing}.")
+            logger.warning(
+                "Not all input fields were provided to module. Present: %s. Missing: %s.",
+                present,
+                missing,
+            )
 
         adapter = settings.adapter or ChatAdapter()
         completions = adapter(


### PR DESCRIPTION
There is a wrong comment in predict.py, we are fixing it with this PR.

Also replace `print` by `logging` for consistency across DSPy modules, and I made a mistake of using f-string for logging earlier, which is supposed to use formatted string: https://google.github.io/styleguide/pyguide.html#3101-logging