### PR TITLE
fix: broken full optimizers hyperlink in docs

### DIFF
--- a/docs/docs/learn/optimization/optimizers.md
+++ b/docs/docs/learn/optimization/optimizers.md
@@ -85,7 +85,7 @@ That being said, here's the general guidance on getting started:
 
 ## How do I use an optimizer?
 
-They all share this general interface, with some differences in the keyword arguments (hyperparameters). Detailed documentation for key optimizers can be found [here](/deep-dive/optimizers/vfrs), and a full list can be found [here](/cheatsheet).
+They all share this general interface, with some differences in the keyword arguments (hyperparameters). Detailed documentation for key optimizers can be found [here](/deep-dive/optimizers/vfrs), and a full list can be found [here](https://dspy.ai/api/optimizers/BetterTogether/).
 
 Let's see this with the most common one, `BootstrapFewShotWithRandomSearch`.
 


### PR DESCRIPTION
fixes #8036, small docs fix:

### What happened?

getting a 404 on the optimizer deep-dive links

https://github.com/stanfordnlp/dspy/blob/281e1f3be73f3529ef888196923295d86d79a392/docs/docs/learn/optimization/optimizers.md?plain=1#L88

### Steps to reproduce

docs link [here](https://dspy.ai/learn/optimization/optimizers/) - see "`how to use an optimizer`"

> Detailed documentation for key optimizers can be found [here](https://dspy.ai/deep-dive/optimizers/vfrs),

direct link 404's and points to:

https://dspy.ai/deep-dive/optimizers/vfrs

### DSPy version

NA