### PR TITLE
Move num_threads into global settings

### DIFF
--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -23,6 +23,7 @@ DEFAULT_CONFIG = dotdict(
     track_usage=False,
     usage_tracker=None,
     provide_traceback=False, # Whether to include traceback information in error logs.
+    num_threads=8, # Number of threads to use for parallel processing.
 )
 
 # Global base configuration and owner tracking

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -52,7 +52,7 @@ class Evaluate:
         *,
         devset: List["dspy.Example"],
         metric: Optional[Callable] = None,
-        num_threads: int = 1,
+        num_threads: Optional[int] = None,
         display_progress: bool = False,
         display_table: Union[bool, int] = False,
         max_errors: int = 5,
@@ -66,7 +66,7 @@ class Evaluate:
         Args:
             devset (List[dspy.Example]): the evaluation dataset.
             metric (Callable): The metric function to use for evaluation.
-            num_threads (int): The number of threads to use for parallel evaluation.
+            num_threads (Optional[int]): The number of threads to use for parallel evaluation.
             display_progress (bool): Whether to display progress during evaluation.
             display_table (Union[bool, int]): Whether to display the evaluation results in a table. 
                 If a number is passed, the evaluation results will be truncated to that number before displayed. 
@@ -105,7 +105,7 @@ class Evaluate:
             program (dspy.Module): The DSPy program to evaluate.
             metric (Callable): The metric function to use for evaluation. if not provided, use `self.metric`.
             devset (List[dspy.Example]): the evaluation dataset. if not provided, use `self.devset`.
-            num_threads (int): The number of threads to use for parallel evaluation. if not provided, use
+            num_threads (Optional[int]): The number of threads to use for parallel evaluation. if not provided, use
                 `self.num_threads`.
             display_progress (bool): Whether to display progress during evaluation. if not provided, use
                 `self.display_progress`.

--- a/dspy/predict/parallel.py
+++ b/dspy/predict/parallel.py
@@ -3,12 +3,13 @@ from typing import Any, List, Tuple, Optional
 
 from dspy.primitives.example import Example
 from dspy.utils.parallelizer import ParallelExecutor
+from dspy.dsp.utils.settings import settings
 
 
 class Parallel:
     def __init__(
         self,
-        num_threads: int = 32,
+        num_threads: Optional[int] = None,
         max_errors: int = 10,
         access_examples: bool = True,
         return_failed_examples: bool = False,
@@ -16,7 +17,7 @@ class Parallel:
         disable_progress_bar: bool = False,
     ):
         super().__init__()
-        self.num_threads = num_threads
+        self.num_threads = num_threads or settings.num_threads
         self.max_errors = max_errors
         self.access_examples = access_examples
         self.return_failed_examples = return_failed_examples
@@ -29,7 +30,7 @@ class Parallel:
         self.failed_examples = []
         self.exceptions = []
 
-    def forward(self, exec_pairs: List[Tuple[Any, Example]], num_threads: int = None) -> List[Any]:
+    def forward(self, exec_pairs: List[Tuple[Any, Example]], num_threads: Optional[int] = None) -> List[Any]:
         num_threads = num_threads if num_threads is not None else self.num_threads
 
         executor = ParallelExecutor(

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -93,7 +93,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def batch(
         self,
         examples,
-        num_threads: int = 32,
+        num_threads: Optional[int] = None,
         max_errors: int = 10,
         return_failed_examples: bool = False,
         provide_traceback: Optional[bool] = None,

--- a/dspy/teleprompt/avatar_optimizer.py
+++ b/dspy/teleprompt/avatar_optimizer.py
@@ -120,10 +120,11 @@ class AvatarOptimizer(Teleprompter):
                 return 0
 
 
-    def thread_safe_evaluator(self, devset, actor, return_outputs=False, num_threads=60):
+    def thread_safe_evaluator(self, devset, actor, return_outputs=False, num_threads=None):
         total_score = 0
         total_examples = len(devset)
         results = []
+        num_threads = num_threads or dspy.settings.num_threads
 
         with ThreadPoolExecutor(max_workers=num_threads) as executor:
             futures = [executor.submit(self.process_example, actor, example, return_outputs) for example in devset]

--- a/dspy/teleprompt/infer_rules.py
+++ b/dspy/teleprompt/infer_rules.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class InferRules(BootstrapFewShot):
-    def __init__(self, num_candidates=10, num_rules=10, num_threads=8, teacher_settings=None, **kwargs):
+    def __init__(self, num_candidates=10, num_rules=10, num_threads=None, teacher_settings=None, **kwargs):
         super().__init__(teacher_settings=teacher_settings, **kwargs)
 
         self.num_candidates = num_candidates

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -55,7 +55,7 @@ class MIPROv2(Teleprompter):
         max_labeled_demos: int = 4,
         auto: Optional[Literal["light", "medium", "heavy"]] = "medium",
         num_candidates: int = 10,
-        num_threads: int = 6,
+        num_threads: Optional[int] = None,
         max_errors: int = 10,
         seed: int = 9,
         init_temperature: float = 0.5,

--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -32,7 +32,7 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
         max_labeled_demos=16,
         max_rounds=1,
         num_candidate_programs=16,
-        num_threads=6,
+        num_threads=None,
         max_errors=10,
         stop_at_score=None,
         metric_threshold=None,

--- a/dspy/teleprompt/simba.py
+++ b/dspy/teleprompt/simba.py
@@ -21,7 +21,7 @@ class SIMBA(Teleprompter):
         max_steps=8,
         max_demos=4,
         demo_input_field_maxlen=100_000,
-        num_threads=16,
+        num_threads=None,
         temperature_for_sampling=0.2,
         temperature_for_candidates=0.2,
     ):

--- a/dspy/teleprompt/teleprompt_optuna.py
+++ b/dspy/teleprompt/teleprompt_optuna.py
@@ -15,14 +15,12 @@ class BootstrapFewShotWithOptuna(Teleprompter):
         max_labeled_demos=16,
         max_rounds=1,
         num_candidate_programs=16,
-        num_threads=6,
+        num_threads=None,
     ):
         self.metric = metric
         self.teacher_settings = teacher_settings
         self.max_rounds = max_rounds
-
         self.num_threads = num_threads
-
         self.min_num_samples = 1
         self.max_num_samples = max_bootstrapped_demos
         self.num_candidate_sets = num_candidate_programs

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class ParallelExecutor:
     def __init__(
         self,
-        num_threads,
+        num_threads=None,
         max_errors=5,
         disable_progress_bar=False,
         provide_traceback=None,
@@ -30,7 +30,7 @@ class ParallelExecutor:
         """
         from dspy.dsp.utils.settings import settings
 
-        self.num_threads = num_threads
+        self.num_threads = num_threads or settings.num_threads
         self.max_errors = max_errors
         self.disable_progress_bar = disable_progress_bar
         self.provide_traceback = provide_traceback if provide_traceback is not None else settings.provide_traceback

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -30,7 +30,7 @@ def test_evaluate_initialization():
     )
     assert ev.devset == devset
     assert ev.metric == answer_exact_match
-    assert ev.num_threads == len(devset)
+    assert ev.num_threads is None
     assert ev.display_progress == False
 
 


### PR DESCRIPTION
Currently, many classes have their own thread count settings. It makes it difficult to configure the thread count for all components. This PR introduces a new setting, num_threads, to configure the thread count globally.