### PR TITLE
Performance improvement of evaluate.py

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -176,12 +176,12 @@ class Evaluate:
 
         logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
 
-        # Rename the 'correct' column to the name of the metric object
-        metric_name = metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
-        # Construct a pandas DataFrame from the results
-        result_df = self._construct_result_table(results, metric_name)
-
         if display_table:
+            # Rename the 'correct' column to the name of the metric object
+            metric_name = metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
+            # Construct a pandas DataFrame from the results
+            result_df = self._construct_result_table(results, metric_name)
+            
             self._display_result_table(result_df, display_table, metric_name)
 
         if return_all_scores and return_outputs:


### PR DESCRIPTION
In the evaluation function, a dataframe `result_df` is constructed using the results. 

However, this dataframe is **_only needed_** when the user wants to display the table as output. 
Otherwise, this construction is computed without any further use. 

In this PR, I moved the `metric_name` and `result_df` computations to the `if` clause. 