### PR TITLE
Support async in DSPy critical paths

### DIFF
--- a/dspy/adapters/two_step_adapter.py
+++ b/dspy/adapters/two_step_adapter.py
@@ -1,13 +1,11 @@
 from typing import Any, Type
 
-from dspy.signatures.signature import Signature
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.utils import get_field_description_string
-from dspy.signatures.field import InputField
-from dspy.signatures.signature import make_signature
 from dspy.clients import LM
-
+from dspy.signatures.field import InputField
+from dspy.signatures.signature import Signature, make_signature
 
 """
 NOTE/TODO/FIMXE:

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -90,7 +90,7 @@ class BaseLM(ABC):
 
         return outputs
 
-    async def a_call(self, prompt=None, messages=None, **kwargs):
+    async def acall(self, prompt=None, messages=None, **kwargs):
         response = await self.aforward(prompt=prompt, messages=messages, **kwargs)
         outputs = self._process_lm_response(response, prompt, messages, **kwargs)
         return outputs
@@ -186,7 +186,7 @@ def _inspect_history(history, n: int = 1):
         print(_green(outputs[0].strip()))
 
         if len(outputs) > 1:
-            choices_text = f" \t (and {len(outputs)-1} other completions)"
+            choices_text = f" \t (and {len(outputs) - 1} other completions)"
             print(_red(choices_text, end=""))
 
     print("\n\n\n")

--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -78,60 +78,83 @@ class Embedder:
         self.caching = caching
         self.default_kwargs = kwargs
 
-    def __call__(self, inputs, batch_size=None, caching=None, **kwargs):
-        """Compute embeddings for the given inputs.
-
-        Args:
-            inputs: The inputs to compute embeddings for, can be a single string or a list of strings.
-            batch_size (int, optional): The batch size for processing inputs. If None, defaults to the batch_size set during initialization.
-            caching (bool, optional): Whether to cache the embedding response when using a hosted model. If None, defaults to the caching setting from initialization.
-            **kwargs: Additional keyword arguments to pass to the embedding model. These will override the default kwargs provided during initialization.
-
-        Returns:
-            numpy.ndarray: If the input is a single string, returns a 1D numpy array representing the embedding.
-            If the input is a list of strings, returns a 2D numpy array of embeddings, one embedding per row.
-        """
-
+    def _preprocess(self, inputs, batch_size=None, caching=None, **kwargs):
         if isinstance(inputs, str):
             is_single_input = True
             inputs = [inputs]
         else:
             is_single_input = False
 
-        assert all(isinstance(inp, str) for inp in inputs), "All inputs must be strings."
+        if not all(isinstance(inp, str) for inp in inputs):
+            raise ValueError("All inputs must be strings.")
 
-        if batch_size is None:
-            batch_size = self.batch_size
-        if caching is None:
-            caching = self.caching
-
+        batch_size = batch_size or self.batch_size
+        caching = caching or self.caching
         merged_kwargs = self.default_kwargs.copy()
         merged_kwargs.update(kwargs)
 
+        input_batches = []
+        for i in range(0, len(inputs), batch_size):
+            input_batches.append(inputs[i : i + batch_size])
+
+        return input_batches, caching, merged_kwargs, is_single_input
+
+    def _postprocess(self, embeddings_list, is_single_input):
+        embeddings = np.array(embeddings_list, dtype=np.float32)
+        if is_single_input:
+            return embeddings[0]
+        else:
+            return np.array(embeddings, dtype=np.float32)
+
+    def __call__(self, inputs, batch_size=None, caching=None, **kwargs):
+        """Compute embeddings for the given inputs.
+
+        Args:
+            inputs: The inputs to compute embeddings for, can be a single string or a list of strings.
+            batch_size (int, optional): The batch size for processing inputs. If None, defaults to the batch_size set
+                during initialization.
+            caching (bool, optional): Whether to cache the embedding response when using a hosted model. If None,
+                defaults to the caching setting from initialization.
+            **kwargs: Additional keyword arguments to pass to the embedding model. These will override the default
+                kwargs provided during initialization.
+
+        Returns:
+            numpy.ndarray: If the input is a single string, returns a 1D numpy array representing the embedding.
+            If the input is a list of strings, returns a 2D numpy array of embeddings, one embedding per row.
+        """
+        input_batches, caching, kwargs, is_single_input = self._preprocess(inputs, batch_size, caching, **kwargs)
+
         embeddings_list = []
 
-        def chunk(inputs_list, size):
-            for i in range(0, len(inputs_list), size):
-                yield inputs_list[i : i + size]
-
-        for batch_inputs in chunk(inputs, batch_size):
+        for batch in input_batches:
             if isinstance(self.model, str):
-                embedding_response = litellm.embedding(
-                    model=self.model, input=batch_inputs, caching=caching, **merged_kwargs
-                )
+                embedding_response = litellm.embedding(model=self.model, input=batch, caching=caching, **kwargs)
                 batch_embeddings = [data["embedding"] for data in embedding_response.data]
             elif callable(self.model):
-                batch_embeddings = self.model(batch_inputs, **merged_kwargs)
+                batch_embeddings = self.model(batch, **kwargs)
             else:
                 raise ValueError(
                     f"`model` in `dspy.Embedder` must be a string or a callable, but got {type(self.model)}."
                 )
 
             embeddings_list.extend(batch_embeddings)
+        return self._postprocess(embeddings_list, is_single_input)
 
-        embeddings = np.array(embeddings_list, dtype=np.float32)
+    async def acall(self, inputs, batch_size=None, caching=None, **kwargs):
+        input_batches, caching, kwargs, is_single_input = self._preprocess(inputs, batch_size, caching, **kwargs)
 
-        if is_single_input:
-            return embeddings[0]
-        else:
-            return embeddings
+        embeddings_list = []
+
+        for batch in input_batches:
+            if isinstance(self.model, str):
+                embedding_response = await litellm.aembedding(model=self.model, input=batch, caching=caching, **kwargs)
+                batch_embeddings = [data["embedding"] for data in embedding_response.data]
+            elif callable(self.model):
+                batch_embeddings = self.model(batch, **kwargs)
+            else:
+                raise ValueError(
+                    f"`model` in `dspy.Embedder` must be a string or a callable, but got {type(self.model)}."
+                )
+
+            embeddings_list.extend(batch_embeddings)
+        return self._postprocess(embeddings_list, is_single_input)

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -89,9 +89,9 @@ class LM(BaseLM):
 
         if model_pattern:
             # Handle OpenAI reasoning models (o1, o3)
-            assert (
-                max_tokens >= 20_000 and temperature == 1.0
-            ), "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 20_000 to `dspy.LM(...)`"
+            assert max_tokens >= 20_000 and temperature == 1.0, (
+                "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 20_000 to `dspy.LM(...)`"
+            )
             self.kwargs = dict(temperature=temperature, max_completion_tokens=max_tokens, **kwargs)
         else:
             self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
@@ -128,7 +128,7 @@ class LM(BaseLM):
         return results
 
     async def aforward(self, prompt=None, messages=None, **kwargs):
-        completion = litellm_completion if self.model_type == "chat" else litellm_text_completion
+        completion = alitellm_completion if self.model_type == "chat" else alitellm_text_completion
 
         results = await completion(
             request=dict(model=self.model, messages=messages, **kwargs),

--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -1,7 +1,9 @@
 from typing import Callable, Optional
 
 import dspy
-from dspy.predict.predict import Module, Prediction
+from dspy.predict.predict import Prediction
+
+from dspy.predict.predict import Module
 
 
 class BestOfN(Module):
@@ -51,7 +53,7 @@ class BestOfN(Module):
         self.N = N
         self.fail_count = fail_count or N  # default to N if fail_count is not provided
 
-    async def forward(self, **kwargs):
+    def forward(self, **kwargs):
         lm = self.module.get_lm() or dspy.settings.lm
         temps = [lm.kwargs["temperature"]] + [0.5 + i * (0.5 / self.N) for i in range(self.N)]
         temps = list(dict.fromkeys(temps))[: self.N]
@@ -64,7 +66,7 @@ class BestOfN(Module):
 
             try:
                 with dspy.context(trace=[]):
-                    pred = await mod(**kwargs)
+                    pred = mod(**kwargs)
                     trace = dspy.settings.trace.copy()
 
                     # NOTE: Not including the trace of reward_fn.

--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -1,9 +1,7 @@
 from typing import Callable, Optional
 
 import dspy
-from dspy.predict.predict import Prediction
-
-from dspy.predict.predict import Module
+from dspy.predict.predict import Module, Prediction
 
 
 class BestOfN(Module):
@@ -53,7 +51,7 @@ class BestOfN(Module):
         self.N = N
         self.fail_count = fail_count or N  # default to N if fail_count is not provided
 
-    def forward(self, **kwargs):
+    async def forward(self, **kwargs):
         lm = self.module.get_lm() or dspy.settings.lm
         temps = [lm.kwargs["temperature"]] + [0.5 + i * (0.5 / self.N) for i in range(self.N)]
         temps = list(dict.fromkeys(temps))[: self.N]
@@ -66,7 +64,7 @@ class BestOfN(Module):
 
             try:
                 with dspy.context(trace=[]):
-                    pred = mod(**kwargs)
+                    pred = await mod(**kwargs)
                     trace = dspy.settings.trace.copy()
 
                     # NOTE: Not including the trace of reward_fn.

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -1,23 +1,24 @@
+from typing import Optional, Type, Union
+
+from pydantic.fields import FieldInfo
+
 import dspy
 from dspy.primitives.program import Module
 from dspy.signatures.field import OutputField
-from dspy.signatures.signature import ensure_signature, Signature
-from pydantic.fields import FieldInfo
-from typing import Optional, Union, Type
+from dspy.signatures.signature import Signature, ensure_signature
 
 
 class ChainOfThought(Module):
-    
     def __init__(
-        self, 
-        signature: Type[Signature], 
-        rationale_field: Optional[Union[OutputField, FieldInfo]] = None, 
+        self,
+        signature: Type[Signature],
+        rationale_field: Optional[Union[OutputField, FieldInfo]] = None,
         rationale_field_type: Type = str,
-        **config
+        **config,
     ):
         """
         A module that reasons step by step in order to predict the output of a task.
-        
+
         Args:
             signature (Type[dspy.Signature]): The signature of the module.
             rationale_field (Optional[Union[dspy.OutputField, pydantic.fields.FieldInfo]]): The field that will contain the reasoning.
@@ -35,3 +36,6 @@ class ChainOfThought(Module):
 
     def forward(self, **kwargs):
         return self.predict(**kwargs)
+
+    async def aforward(self, **kwargs):
+        return await self.predict.acall(**kwargs)

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -38,6 +38,8 @@ class Module(BaseModule, metaclass=ProgramMeta):
                 output.set_lm_usage(usage_tracker.get_total_tokens())
                 return output
 
+        return await self.aforward(*args, **kwargs)
+
     def named_predictors(self):
         from dspy.predict.predict import Predict
 

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -1,5 +1,6 @@
-import magicattr
 from typing import Optional
+
+import magicattr
 
 from dspy.dsp.utils.settings import settings
 from dspy.predict.parallel import Parallel
@@ -29,6 +30,13 @@ class Module(BaseModule, metaclass=ProgramMeta):
                 return output
 
         return self.forward(*args, **kwargs)
+
+    async def acall(self, *args, **kwargs):
+        if settings.track_usage and settings.usage_tracker is None:
+            with track_usage() as usage_tracker:
+                output = await self.aforward(*args, **kwargs)
+                output.set_lm_usage(usage_tracker.get_total_tokens())
+                return output
 
     def named_predictors(self):
         from dspy.predict.predict import Predict

--- a/dspy/utils/dummies.py
+++ b/dspy/utils/dummies.py
@@ -129,6 +129,9 @@ class DummyLM(LM):
 
         return outputs
 
+    async def acall(self, prompt=None, messages=None, **kwargs):
+        return self.__call__(prompt=prompt, messages=messages, **kwargs)
+
     def get_convo(self, index):
         """Get the prompt + answer from the ith message."""
         return self.history[index]["messages"], self.history[index]["outputs"]

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -77,3 +77,20 @@ def test_chat_adapter_quotes_literals_as_expected(
 
     assert expected_input_str in content
     assert expected_output_str in content
+
+
+def test_chat_adapter_sync_call():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+    lm = dspy.utils.DummyLM([{"answer": "Paris"}])
+    result = adapter(lm, {}, signature, [], {"question": "What is the capital of France?"})
+    assert result == [{"answer": "Paris"}]
+
+
+@pytest.mark.asyncio
+async def test_chat_adapter_async_call():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+    lm = dspy.utils.DummyLM([{"answer": "Paris"}])
+    result = await adapter.acall(lm, {}, signature, [], {"question": "What is the capital of France?"})
+    assert result == [{"answer": "Paris"}]

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -93,3 +93,20 @@ def test_json_adapter_with_structured_outputs_does_not_mutate_original_signature
         program(input1="Test input")
 
     assert program.signature.output_fields == TestSignature.output_fields
+
+
+def test_json_adapter_sync_call():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+    lm = dspy.utils.DummyLM([{"answer": "Paris"}])
+    result = adapter(lm, {}, signature, [], {"question": "What is the capital of France?"})
+    assert result == [{"answer": "Paris"}]
+
+
+@pytest.mark.asyncio
+async def test_json_adapter_async_call():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+    lm = dspy.utils.DummyLM([{"answer": "Paris"}])
+    result = await adapter.acall(lm, {}, signature, [], {"question": "What is the capital of France?"})
+    assert result == [{"answer": "Paris"}]

--- a/tests/adapters/test_two_step_adapter.py
+++ b/tests/adapters/test_two_step_adapter.py
@@ -68,6 +68,70 @@ def test_two_step_adapter_call():
     content = call_kwargs["messages"][1]["content"]
     assert "text from main LM" in content
 
+@pytest.mark.asyncio
+async def test_two_step_adapter_async_call():
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField(desc="The math question to solve")
+        solution: str = dspy.OutputField(desc="Step by step solution")
+        answer: float = dspy.OutputField(desc="The final numerical answer")
+    
+    program = dspy.Predict(TestSignature)
+
+    mock_main_lm = mock.MagicMock(spec=dspy.LM)
+    mock_main_lm.acall.return_value = ["text from main LM"]
+    mock_main_lm.kwargs = {"temperature": 1.0}
+
+    mock_extraction_lm = mock.MagicMock(spec=dspy.LM)
+    mock_extraction_lm.acall.return_value = [
+        """
+[[ ## solution ## ]] result
+[[ ## answer ## ]] 12
+[[ ## completed ## ]]
+"""
+    ]
+    mock_extraction_lm.kwargs = {"temperature": 1.0}
+    mock_extraction_lm.model = "openai/gpt-4o"
+
+    dspy.configure(lm=mock_main_lm, adapter=dspy.TwoStepAdapter(extraction_model=mock_extraction_lm))
+
+    result = await program.acall(question="What is 5 + 7?")
+    
+    assert result.answer == 12
+
+    # main LM call
+    mock_main_lm.acall.assert_called_once()
+    _, call_kwargs = mock_main_lm.acall.call_args
+    assert len(call_kwargs["messages"]) == 2
+
+    # assert first message
+    assert call_kwargs["messages"][0]["role"] == "system"
+    content = call_kwargs["messages"][0]["content"]
+    assert "1. `question` (str)" in content
+    assert "1. `solution` (str)" in content
+    assert "2. `answer` (float)" in content
+
+    # assert second message
+    assert call_kwargs["messages"][1]["role"] == "user"
+    content = call_kwargs["messages"][1]["content"]
+    assert "question:" in content.lower()
+    assert "What is 5 + 7?" in content
+
+    # extraction LM call
+    mock_extraction_lm.acall.assert_called_once()
+    _, call_kwargs = mock_extraction_lm.acall.call_args
+    assert len(call_kwargs["messages"]) == 2
+
+    # assert first message
+    assert call_kwargs["messages"][0]["role"] == "system"
+    content = call_kwargs["messages"][0]["content"]
+    assert  "`text` (str)" in content
+    assert  "`solution` (str)" in content
+    assert  "`answer` (float)" in content
+
+    # assert second message
+    assert call_kwargs["messages"][1]["role"] == "user"
+    content = call_kwargs["messages"][1]["content"]
+    assert "text from main LM" in content
 
 def test_two_step_adapter_parse():
     class ComplexSignature(dspy.Signature):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -274,3 +274,12 @@ def test_exponential_backoff_retry():
     # The first retry happens immediately regardless of the configuration
     for i in range(1, len(time_counter) - 1):
         assert time_counter[i + 1] - time_counter[i] >= 2 ** (i - 1)
+
+
+@pytest.mark.asyncio
+async def test_async_lm_call(litellm_test_server):
+    api_base, _ = litellm_test_server
+
+    lm = dspy.LM(model="openai/gpt-4o-mini", api_base=api_base, api_key="fakekey", model_type="chat")
+    result = await lm.acall("question")
+    assert result == "answer"

--- a/tests/predict/test_chain_of_thought.py
+++ b/tests/predict/test_chain_of_thought.py
@@ -2,6 +2,8 @@ import dspy
 from dspy import ChainOfThought
 from dspy.utils import DummyLM
 
+import pytest
+
 
 def test_initialization_with_string_signature():
     lm = DummyLM([{"reasoning": "find the number after 1", "answer": "2"}])
@@ -12,3 +14,12 @@ def test_initialization_with_string_signature():
         "answer",
     ]
     assert predict(question="What is 1+1?").answer == "2"
+
+
+@pytest.mark.asyncio
+async def test_async_chain_of_thought():
+    lm = DummyLM([{"reasoning": "find the number after 1", "answer": "2"}])
+    dspy.settings.configure(lm=lm)
+    program = ChainOfThought("question -> answer")
+    result = await program.acall(question="What is 1+1?")
+    assert result.answer == "2"

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -569,3 +569,11 @@ def test_litellm_cache_initialization_failure():
     # No exception should be raised when litellm.cache is None even if we try to use the cache.
     assert dspy.settings.lm.cache == True
     predictor(question="test")
+
+
+@pytest.mark.asyncio
+async def test_async_predict():
+    program = Predict("question -> answer")
+    dspy.settings.configure(lm=DummyLM([{"answer": "Paris"}]))
+    result = await program.acall(question="What is the capital of France?")
+    assert result.answer == "Paris"


### PR DESCRIPTION
We are working on supporting async in DSPy (true async, i.e., `async def` instead of `asyncio.to_thread`), and in this PR we are supporting async in the critical paths including:
- `dspy.LM`
- `dspy.Embedder`
- `dspy.Adapter`
- `dspy.Module`
- `dspy.Predict` and `dspy.ChainOfThought`

We will roll over the support to more APIs/Classes gradually. 
