### PR TITLE
Support default args in dspy.Tool

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -40,14 +40,14 @@ class ReAct(Module):
             func=lambda **kwargs: "Completed.",
             name="finish",
             desc=f"Signals that the final outputs, i.e. {outputs}, are now available and marks the task as complete.",
-            arg_schema={},
+            args={},
         )
 
         for idx, tool in enumerate(tools.values()):
-            arg_schema = getattr(tool, "arg_schema")
+            args = getattr(tool, "args")
             desc = (f", whose description is <desc>{tool.desc}</desc>." if tool.desc else ".").replace("\n", "  ")
-            desc += f" It takes arguments {arg_schema} in JSON format."
-            instr.append(f"({idx+1}) {tool.name}{desc}")
+            desc += f" It takes arguments {args} in JSON format."
+            instr.append(f"({idx + 1}) {tool.name}{desc}")
 
         react_signature = (
             dspy.Signature({**signature.input_fields}, "\n".join(instr))

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -40,13 +40,13 @@ class ReAct(Module):
             func=lambda **kwargs: "Completed.",
             name="finish",
             desc=f"Signals that the final outputs, i.e. {outputs}, are now available and marks the task as complete.",
-            args={},
+            arg_schema={},
         )
 
         for idx, tool in enumerate(tools.values()):
-            args = getattr(tool, "args")
+            arg_schema = getattr(tool, "arg_schema")
             desc = (f", whose description is <desc>{tool.desc}</desc>." if tool.desc else ".").replace("\n", "  ")
-            desc += f" It takes arguments {args} in JSON format."
+            desc += f" It takes arguments {arg_schema} in JSON format."
             instr.append(f"({idx+1}) {tool.name}{desc}")
 
         react_signature = (

--- a/dspy/primitives/tool.py
+++ b/dspy/primitives/tool.py
@@ -19,13 +19,13 @@ class Tool:
         func: Callable,
         name: Optional[str] = None,
         desc: Optional[str] = None,
-        arg_schema: Optional[dict[str, Any]] = None,
+        args: Optional[dict[str, Any]] = None,
         arg_types: Optional[dict[str, Any]] = None,
         arg_desc: Optional[dict[str, str]] = None,
     ):
         """Initialize the Tool class.
 
-        Users can choose to specify the `name`, `desc`, `arg_schema`, and `arg_types`, or let the `dspy.Tool`
+        Users can choose to specify the `name`, `desc`, `args`, and `arg_types`, or let the `dspy.Tool`
         automatically infer the values from the function. For values that are specified by the user, automatic inference
         will not be performed on them.
 
@@ -33,7 +33,7 @@ class Tool:
             func (Callable): The actual function that is being wrapped by the tool.
             name (Optional[str], optional): The name of the tool. Defaults to None.
             desc (Optional[str], optional): The description of the tool. Defaults to None.
-            arg_schema (Optional[dict[str, Any]], optional): The args and their schema of the tool, represented as a
+            args (Optional[dict[str, Any]], optional): The args and their schema of the tool, represented as a
                 dictionary from arg name to arg's json schema. Defaults to None.
             arg_types (Optional[dict[str, Any]], optional): The argument types of the tool, represented as a dictionary
                 from arg name to the type of the argument. Defaults to None.
@@ -47,14 +47,14 @@ class Tool:
             return str(x) + y
 
         tool = Tool(foo)
-        print(tool.arg_schema)
+        print(tool.args)
         # Expected output: {'x': {'type': 'integer'}, 'y': {'type': 'string', 'default': 'hello'}}
         ```
         """
         self.func = func
         self.name = name
         self.desc = desc
-        self.arg_schema = arg_schema
+        self.args = args
         self.arg_types = arg_types
         self.arg_desc = arg_desc
 
@@ -96,7 +96,7 @@ class Tool:
         annotations_func = func if inspect.isfunction(func) or inspect.ismethod(func) else func.__call__
         name = getattr(func, "__name__", type(func).__name__)
         desc = getattr(func, "__doc__", None) or getattr(annotations_func, "__doc__", "")
-        arg_schema = {}
+        args = {}
         arg_types = {}
 
         # Use inspect.signature to get all arg names
@@ -117,28 +117,28 @@ class Tool:
             if isinstance(origin, type) and issubclass(origin, BaseModel):
                 # Get json schema, and replace $ref with the actual schema
                 v_json_schema = self._resolve_pydantic_schema(v)
-                arg_schema[k] = v_json_schema
+                args[k] = v_json_schema
             else:
-                arg_schema[k] = TypeAdapter(v).json_schema() or "Any"
+                args[k] = TypeAdapter(v).json_schema() or "Any"
             if default_values[k] is not inspect.Parameter.empty:
-                arg_schema[k]["default"] = default_values[k]
+                args[k]["default"] = default_values[k]
             if arg_desc and k in arg_desc:
-                arg_schema[k]["description"] = arg_desc[k]
+                args[k]["description"] = arg_desc[k]
 
         self.name = self.name or name
         self.desc = self.desc or desc
-        self.arg_schema = self.arg_schema or arg_schema
+        self.args = self.args or args
         self.arg_types = self.arg_types or arg_types
 
     @with_callbacks
     def __call__(self, **kwargs):
         for k, v in kwargs.items():
-            if k not in self.arg_schema:
+            if k not in self.args:
                 raise ValueError(f"Arg {k} is not in the tool's args.")
             try:
                 instance = v.model_dump() if hasattr(v, "model_dump") else v
-                if not self.arg_schema[k] == "Any":
-                    validate(instance=instance, schema=self.arg_schema[k])
+                if not self.args[k] == "Any":
+                    validate(instance=instance, schema=self.args[k])
             except ValidationError as e:
                 raise ValueError(f"Arg {k} is invalid: {e.message}")
         return self.func(**kwargs)

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -127,32 +127,6 @@ import litellm
 #     assert react.react[0].signature.instructions.startswith("You are going to generate output based on input.")
 
 
-def test_tool_from_function():
-    def foo(a: int, b: int) -> int:
-        """Add two numbers."""
-        return a + b
-
-    tool = react.Tool(foo)
-    assert tool.name == "foo"
-    assert tool.desc == "Add two numbers."
-    assert tool.args == {"a": {"type": "integer"}, "b": {"type": "integer"}}
-
-
-def test_tool_from_class():
-    class Foo:
-        def __init__(self, user_id: str):
-            self.user_id = user_id
-
-        def foo(self, a: int, b: int) -> int:
-            """Add two numbers."""
-            return a + b
-
-    tool = react.Tool(Foo("123").foo)
-    assert tool.name == "foo"
-    assert tool.desc == "Add two numbers."
-    assert tool.args == {"a": {"type": "integer"}, "b": {"type": "integer"}}
-
-
 def test_tool_calling_with_pydantic_args():
     class CalendarEvent(BaseModel):
         name: str

--- a/tests/primitives/test_tool.py
+++ b/tests/primitives/test_tool.py
@@ -68,10 +68,10 @@ def complex_dummy_function(profile: UserProfile, priority: int, notes: Optional[
 
 
 def test_basic_initialization():
-    tool = Tool(name="test_tool", desc="A test tool", arg_schema={"param1": {"type": "string"}}, func=lambda x: x)
+    tool = Tool(name="test_tool", desc="A test tool", args={"param1": {"type": "string"}}, func=lambda x: x)
     assert tool.name == "test_tool"
     assert tool.desc == "A test tool"
-    assert tool.arg_schema == {"param1": {"type": "string"}}
+    assert tool.args == {"param1": {"type": "string"}}
     assert callable(tool.func)
 
 
@@ -80,11 +80,11 @@ def test_tool_from_function():
 
     assert tool.name == "dummy_function"
     assert "A dummy function for testing" in tool.desc
-    assert "x" in tool.arg_schema
-    assert "y" in tool.arg_schema
-    assert tool.arg_schema["x"]["type"] == "integer"
-    assert tool.arg_schema["y"]["type"] == "string"
-    assert tool.arg_schema["y"]["default"] == "hello"
+    assert "x" in tool.args
+    assert "y" in tool.args
+    assert tool.args["x"]["type"] == "integer"
+    assert tool.args["y"]["type"] == "string"
+    assert tool.args["y"]["default"] == "hello"
 
 
 def test_tool_from_class():
@@ -99,33 +99,33 @@ def test_tool_from_class():
     tool = Tool(Foo("123"))
     assert tool.name == "Foo"
     assert tool.desc == "Add two numbers."
-    assert tool.arg_schema == {"a": {"type": "integer"}, "b": {"type": "integer"}}
+    assert tool.args == {"a": {"type": "integer"}, "b": {"type": "integer"}}
 
 
 def test_tool_from_function_with_pydantic():
     tool = Tool(dummy_with_pydantic)
 
     assert tool.name == "dummy_with_pydantic"
-    assert "model" in tool.arg_schema
-    assert tool.arg_schema["model"]["type"] == "object"
-    assert "field1" in tool.arg_schema["model"]["properties"]
-    assert "field2" in tool.arg_schema["model"]["properties"]
-    assert tool.arg_schema["model"]["properties"]["field1"]["default"] == "hello"
+    assert "model" in tool.args
+    assert tool.args["model"]["type"] == "object"
+    assert "field1" in tool.args["model"]["properties"]
+    assert "field2" in tool.args["model"]["properties"]
+    assert tool.args["model"]["properties"]["field1"]["default"] == "hello"
 
 
 def test_tool_from_function_with_pydantic_nesting():
     tool = Tool(complex_dummy_function)
 
     assert tool.name == "complex_dummy_function"
-    assert "profile" in tool.arg_schema
-    assert "priority" in tool.arg_schema
-    assert "notes" in tool.arg_schema
-    assert tool.arg_schema["profile"]["type"] == "object"
-    assert tool.arg_schema["profile"]["properties"]["user_id"]["type"] == "integer"
-    assert tool.arg_schema["profile"]["properties"]["name"]["type"] == "string"
-    assert tool.arg_schema["profile"]["properties"]["age"]["anyOf"] == [{"type": "integer"}, {"type": "null"}]
-    assert tool.arg_schema["profile"]["properties"]["contact"]["type"] == "object"
-    assert tool.arg_schema["profile"]["properties"]["contact"]["properties"]["email"]["type"] == "string"
+    assert "profile" in tool.args
+    assert "priority" in tool.args
+    assert "notes" in tool.args
+    assert tool.args["profile"]["type"] == "object"
+    assert tool.args["profile"]["properties"]["user_id"]["type"] == "integer"
+    assert tool.args["profile"]["properties"]["name"]["type"] == "string"
+    assert tool.args["profile"]["properties"]["age"]["anyOf"] == [{"type": "integer"}, {"type": "null"}]
+    assert tool.args["profile"]["properties"]["contact"]["type"] == "object"
+    assert tool.args["profile"]["properties"]["contact"]["properties"]["email"]["type"] == "string"
 
 
 def test_tool_callable():
@@ -149,4 +149,4 @@ def test_invalid_function_call():
 
 def test_parameter_desc():
     tool = Tool(dummy_function, arg_desc={"x": "The x parameter"})
-    assert tool.arg_schema["x"]["description"] == "The x parameter"
+    assert tool.args["x"]["description"] == "The x parameter"


### PR DESCRIPTION
Before this PR default arg information is lost when we convert functions to `dspy.Tool`. with this PR we are resolving the issue. 