### PR TITLE
Fix Pydantic Deprecation warning

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -195,7 +195,7 @@ def _get_structured_outputs_response_format(signature: SignatureMeta) -> type[py
     Model = pydantic.create_model("DSPyProgramOutputs", **fields, __config__=type("Config", (), {"extra": "forbid"}))
 
     # Generate the initial schema.
-    schema = Model.schema()
+    schema = Model.model_json_schema()
 
     # Remove any DSPy-specific metadata.
     for prop in schema.get("properties", {}).values():


### PR DESCRIPTION
Currently, there is this deprecation warning message:

```
/opt/venv/lib/python3.12/site-packages/dspy/adapters/json_adapter.py:198: PydanticDeprecatedSince20: The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/

  schema = Model.schema()
```

Updated the file with the warning