### PR TITLE
Fix default arg when type hints are not available

### DIFF
--- a/dspy/primitives/tool.py
+++ b/dspy/primitives/tool.py
@@ -119,7 +119,7 @@ class Tool:
                 v_json_schema = self._resolve_pydantic_schema(v)
                 args[k] = v_json_schema
             else:
-                args[k] = TypeAdapter(v).json_schema() or "Any"
+                args[k] = TypeAdapter(v).json_schema()
             if default_values[k] is not inspect.Parameter.empty:
                 args[k]["default"] = default_values[k]
             if arg_desc and k in arg_desc:
@@ -137,7 +137,8 @@ class Tool:
                 raise ValueError(f"Arg {k} is not in the tool's args.")
             try:
                 instance = v.model_dump() if hasattr(v, "model_dump") else v
-                if not self.args[k] == "Any":
+                type_str = self.args[k].get("type")
+                if type_str is not None and type_str != "Any":
                     validate(instance=instance, schema=self.args[k])
             except ValidationError as e:
                 raise ValueError(f"Arg {k} is invalid: {e.message}")

--- a/tests/primitives/test_tool.py
+++ b/tests/primitives/test_tool.py
@@ -150,3 +150,12 @@ def test_invalid_function_call():
 def test_parameter_desc():
     tool = Tool(dummy_function, arg_desc={"x": "The x parameter"})
     assert tool.args["x"]["description"] == "The x parameter"
+
+
+def test_tool_with_default_args_without_type_hints():
+    def foo(x=100):
+        return x
+
+    tool = Tool(foo)
+    assert tool.args["x"]["default"] == 100
+    assert not hasattr(tool.args["x"], "type")


### PR DESCRIPTION
resolve #8086 

The standard is mapping `Any` to empty json schema, no need to use a special string identifier `"Any"` to represent the situation where no type hint is provided.