### PR TITLE
Remove unnecessary LM callback

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -19,7 +19,7 @@ from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, TrainingJob
 from dspy.clients.utils_finetune import TrainDataFormat
 from dspy.dsp.utils.settings import settings
-from dspy.utils.callback import BaseCallback, with_callbacks
+from dspy.utils.callback import BaseCallback
 
 from .base_lm import BaseLM
 
@@ -96,7 +96,6 @@ class LM(BaseLM):
         else:
             self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
 
-    @with_callbacks
     def forward(self, prompt=None, messages=None, **kwargs):
         # Build the request.
         cache = kwargs.pop("cache", self.cache)


### PR DESCRIPTION
Currently, `LM.__call__` calls callback handlers twice since we apply with_callbacks to both `BaseLM.__call__ ` and `LM.forward`, which is confusing. This PR removes the decorator from `LM.forward`.