### PR TITLE
Add callback to async methods

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -90,6 +90,7 @@ class BaseLM(ABC):
 
         return outputs
 
+    @with_callbacks
     async def acall(self, prompt=None, messages=None, **kwargs):
         response = await self.aforward(prompt=prompt, messages=messages, **kwargs)
         outputs = self._process_lm_response(response, prompt, messages, **kwargs)

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -75,6 +75,7 @@ class Predict(Module, Parameter):
     def __call__(self, **kwargs):
         return self.forward(**kwargs)
 
+    @with_callbacks
     async def acall(self, **kwargs):
         return await self.aforward(**kwargs)
 

--- a/dspy/primitives/program.py
+++ b/dspy/primitives/program.py
@@ -31,6 +31,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
 
         return self.forward(*args, **kwargs)
 
+    @with_callbacks
     async def acall(self, *args, **kwargs):
         if settings.track_usage and settings.usage_tracker is None:
             with track_usage() as usage_tracker:

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -316,7 +316,7 @@ def with_callbacks(fn):
     
     if inspect.iscoroutinefunction(fn):
         @functools.wraps(fn)
-        async def wapper(instance, *args, **kwargs):
+        async def wrapper(instance, *args, **kwargs):
             generator = wrapper_generator(instance, *args, **kwargs)
             next(generator)
             try:
@@ -330,7 +330,7 @@ def with_callbacks(fn):
                 generator.close()
     else:
         @functools.wraps(fn)
-        def wapper(instance, *args, **kwargs):
+        def wrapper(instance, *args, **kwargs):
             generator = wrapper_generator(instance, *args, **kwargs)
             next(generator)
             try:
@@ -341,7 +341,7 @@ def with_callbacks(fn):
             finally:
                 generator.close()
 
-    return wapper
+    return wrapper
 
 
 def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -> Callable:


### PR DESCRIPTION
While async methods are supported for major parts of DSPy, they don't call callback handlers. This PR enables callbacks to the async methods. To implement the callback wrapper in a general way both for sync and async methods, a generator function is used for common logic.

<img width="913" alt="image" src="https://github.com/user-attachments/assets/16dc1eed-7adc-433e-ac5d-ed0af0033a4d" />
