### PR TITLE
Fix: Make sure Base LM builds on self.kwargs

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -49,11 +49,32 @@ class BaseLM(ABC):
         self.history = []
 
     def _process_lm_response(self, response, prompt, messages, **kwargs):
-        if kwargs.get("logprobs"):
+        if self.kwargs.get("logprobs"):
+            # If logprobs is set, we need to extract the logprobs from the response
+            # and format them according to the OpenAI API response format.
+            # This is a workaround for the fact that the OpenAI API does not return
+            # logprobs in the same format as the response.
+            # We need to check if the response is a list of choices or a single choice.
             outputs = [
                 {
                     "text": c.message.content if hasattr(c, "message") else c["text"],
-                    "logprobs": c.logprobs if hasattr(c, "logprobs") else c["logprobs"],
+                    "logprobs": {
+                        "content": [
+                            {
+                                "token": token_logprob.token,
+                                "bytes": token_logprob.bytes,
+                                "logprob": token_logprob.logprob,
+                                "top_logprobs": [
+                                    {
+                                        "token": top_logprob.token,
+                                        "bytes": top_logprob.bytes,
+                                        "logprob": top_logprob.logprob,
+                                    } for top_logprob in (token_logprob.top_logprobs or [])
+                                ],
+                            } for token_logprob in (c.logprobs.content if hasattr(c.logprobs, "content") else [])
+                        ],
+                        "refusal": c.logprobs.refusal if hasattr(c.logprobs, "refusal") else None,
+                    } if hasattr(c, "logprobs") else c["logprobs"],
                 }
                 for c in response.choices
             ]


### PR DESCRIPTION
Fix for https://github.com/stanfordnlp/dspy/issues/8101
logprobs = True should return the log probabilities of the output tokens but they are missing.

This has been implemented in #1895 and looks like it worked in the past.
There is also a more recent feature request for it: #7967