### PR TITLE
Restore relaxation of openai version range, lost after refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "backoff>=2.2",
     "joblib~=1.3",
-    "openai>=0.28.1,<=1.61.0",
+    "openai>=0.28.1",
     "pandas>=2.1.1",
     "regex>=2023.10.3",
     "ujson>=5.8.0",


### PR DESCRIPTION
Recently, https://github.com/stanfordnlp/dspy/issues/8075 was opened to note that limiting openai to version 1.61.0 was causing problems.

This was fixed for 2.6.18 in https://github.com/stanfordnlp/dspy/pull/8084 . However that change only changed one of two entries in `pyproject.toml` that defines the openai range, as there were parallel configurations of dependencies for poetry and uv.

Then, just before 2.6.19, this PR removed the poetry-oriented dependencies, including the openai change:
https://github.com/stanfordnlp/dspy/commit/0363c2e72b24c0c0d65ba0d8cdfdef86049591be#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L36-L106

Now, `pyproject.toml` is left with the other copy which still has the version limit of 1.61.0:
https://github.com/stanfordnlp/dspy/blob/main/pyproject.toml#L27

This just completes the intent of the original change by removing the version limit on openai.

CC @okhat @chenmoneygithub 