### PR TITLE
Handle ReAct tool selection failures more gracefully

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -29,16 +29,17 @@ class ReAct(Module):
 
         instr.extend(
             [
-                f"You are an Agent. In each episode, you will be given {inputs} as input. And you can see your past trajectory so far.",
-                f"Your goal is to use tools to collect any necessary information for producing {outputs}.\n",
-                "To do this, you will interleave next_thought, next_tool_name, and next_tool_args.",
-                "After each tool call, including finishing the task, you receive a resulting observation, appended to your trajectory.\n",
-                "Thought can reason about the current situation and plan for future steps, and the tool must be one of:\n",
+                f"You are an Agent. In each episode, you will be given the fields {inputs} as input. And you can see your past trajectory so far.",
+                f"Your goal is to use one or more of the supplied tools to collect any necessary information for producing {outputs}.\n",
+                "To do this, you will interleave next_thought, next_tool_name, and next_tool_args in each turn, and also when finishing the task.",
+                "After each tool call, you receive a resulting observation, which gets appended to your trajectory.\n",
+                "When writing next_thought, you may reason about the current situation and plan for future steps.",
+                "When selecting the next_tool_name and its next_tool_args, the tool must be one of:\n",
             ]
         )
 
         tools["finish"] = Tool(
-            func=lambda **kwargs: "Completed.",
+            func=lambda: "Completed.",
             name="finish",
             desc=f"Marks the task as complete. That is, signals that all infomration for producing the outputs, i.e. {outputs}, are now available to be extracted.",
             args={},

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -29,16 +29,18 @@ class ReAct(Module):
 
         instr.extend(
             [
-                f"You will be given {inputs} and your goal is to finish with {outputs}.\n",
-                "To do this, you will interleave Thought, Tool Name, and Tool Args, and receive a resulting Observation.\n",
-                "Thought can reason about the current situation, and Tool Name can be the following types:\n",
+                f"You are an Agent. In each episode, you will be given {inputs} as input. And you can see your past trajectory so far.",
+                f"Your goal is to use tools to collect any necessary information for producing {outputs}.\n",
+                "To do this, you will interleave next_thought, next_tool_name, and next_tool_args.",
+                "After each tool call, including finishing the task, you receive a resulting observation, appended to your trajectory.\n",
+                "Thought can reason about the current situation and plan for future steps, and the tool must be one of:\n",
             ]
         )
 
         tools["finish"] = Tool(
             func=lambda **kwargs: "Completed.",
             name="finish",
-            desc=f"Signals that the final outputs, i.e. {outputs}, are now available and marks the task as complete.",
+            desc=f"Marks the task as complete. That is, signals that all infomration for producing the outputs, i.e. {outputs}, are now available to be extracted.",
             args={},
         )
 
@@ -132,9 +134,8 @@ def _fmt_exc(err: BaseException, *, limit: int = 5) -> str:
     """
 
     import traceback
-    return '\n' + "".join(
-        traceback.format_exception(type(err), err, err.__traceback__, limit=limit)
-    ).strip()
+
+    return "\n" + "".join(traceback.format_exception(type(err), err, err.__traceback__, limit=limit)).strip()
 
 
 """

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -275,11 +275,6 @@ def test_trajectory_truncation():
     assert result.output_text == "Final output"
 
 
-import re
-import dspy
-from dspy.testing import DummyLM
-
-
 def test_error_retry():
     # --- a tiny tool that always fails -------------------------------------
     def foo(a, b):  # noqa: D401, ANN001

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -1,8 +1,10 @@
 from pydantic import BaseModel
 
+import re
 import dspy
-from dspy.utils.dummies import DummyLM
 import litellm
+
+from dspy.utils.dummies import DummyLM
 
 # def test_example_no_tools():
 #     # Create a simple dataset which the model will use with the Retrieve tool.

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -275,36 +275,54 @@ def test_trajectory_truncation():
     assert result.output_text == "Final output"
 
 
+import re
+import dspy
+from dspy.testing import DummyLM
+
+
 def test_error_retry():
-    def foo(a, b):
+    # --- a tiny tool that always fails -------------------------------------
+    def foo(a, b):  # noqa: D401, ANN001
         raise Exception("tool error")
 
+    # --- program under test -------------------------------------------------
     react = dspy.ReAct("a, b -> c:int", tools=[foo])
-    max_iters = 2
     lm = DummyLM(
         [
-            {"next_thought": "I need to add two numbers.", "next_tool_name": "foo", "next_tool_args": {"a": 1, "b": 2}},
-            {"next_thought": "I need to add two numbers.", "next_tool_name": "foo", "next_tool_args": {"a": 1, "b": 2}},
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "foo",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "foo",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            # (The model *would* succeed on the 3rd turn, but max_iters=2 stops earlier.)
             {"reasoning": "I added the numbers successfully", "c": 3},
         ]
     )
     dspy.settings.configure(lm=lm)
 
-    outputs = react(a=1, b=2, max_iters=max_iters)
-    expected_trajectory = {
+    outputs = react(a=1, b=2, max_iters=2)
+    traj = outputs.trajectory
+
+    # --- exact-match checks (thoughts + tool calls) -------------------------
+    control_expected = {
         "thought_0": "I need to add two numbers.",
         "tool_name_0": "foo",
-        "tool_args_0": {
-            "a": 1,
-            "b": 2,
-        },
-        'observation_0': 'Failed to execute: tool error',
-        'thought_1': 'I need to add two numbers.',
-        'tool_name_1': 'foo',
-        "tool_args_1": {
-            "a": 1,
-            "b": 2,
-        },
-        'observation_1': 'Failed to execute: tool error',
+        "tool_args_0": {"a": 1, "b": 2},
+        "thought_1": "I need to add two numbers.",
+        "tool_name_1": "foo",
+        "tool_args_1": {"a": 1, "b": 2},
     }
-    assert outputs.trajectory == expected_trajectory
+    for k, v in control_expected.items():
+        assert traj[k] == v, f"{k} mismatch"
+
+    # --- flexible checks for observations ----------------------------------
+    # We only care that each observation mentions our error string; we ignore
+    # any extra traceback detail or differing prefixes.
+    for i in range(2):
+        obs = traj[f"observation_{i}"]
+        assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"


### PR DESCRIPTION
We've accumulated a few reports, sometimes with Google models (Gemma, Gemini) but also with Qwen, that when the model wants to `finish`, it fails to format that properly. This results in an unnecessary exception, instead of ending execution gracefully.

This PR refines the base instructions for `dspy.ReAct` and handles mid-trajectory failures more gracefully. The final extraction step is still responsible for processing. This results in better respect for the ReAct contract.