### PR TITLE
Add unit tests for ParallelExecutor class in dspy.utils.parallelizer

### DIFF
--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -2,6 +2,7 @@ import time
 import pytest
 from dspy.utils.parallelizer import ParallelExecutor
 
+
 def test_worker_threads_independence():
     def task(item):
         # Each thread maintains its own state by appending to a thread-local list
@@ -12,6 +13,7 @@ def test_worker_threads_independence():
     results = executor.execute(task, data)
 
     assert results == [2, 4, 6, 8, 10]
+
 
 def test_parallel_execution_speed():
     def task(item):
@@ -27,6 +29,7 @@ def test_parallel_execution_speed():
 
     assert end_time - start_time < len(data)
 
+
 def test_max_errors_handling():
     def task(item):
         if item == 3:
@@ -38,6 +41,7 @@ def test_max_errors_handling():
 
     with pytest.raises(Exception, match="Execution cancelled due to errors or interruption."):
         executor.execute(task, data)
+
 
 def test_max_errors_not_met():
     def task(item):
@@ -52,4 +56,4 @@ def test_max_errors_not_met():
     results = executor.execute(task, data)
 
     # Verify that the results exclude the failed task
-    assert results == [1, 2, 4, 5]
+    assert results == [1, 2, None, 4, 5]

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -1,0 +1,40 @@
+import time
+import pytest
+from dspy.utils.parallelizer import ParallelExecutor
+
+def test_worker_threads_independence():
+    def task(item):
+        # Each thread maintains its own state by appending to a thread-local list
+        return item * 2
+
+    data = [1, 2, 3, 4, 5]
+    executor = ParallelExecutor(num_threads=3)
+    results = executor.execute(task, data)
+
+    assert results == [2, 4, 6, 8, 10], "Worker threads did not maintain independence."
+
+def test_parallel_execution_speed():
+    def task(item):
+        time.sleep(1)  # Simulate a time-consuming task
+        return item
+
+    data = [1, 2, 3, 4, 5]
+    executor = ParallelExecutor(num_threads=5)
+
+    start_time = time.time()
+    executor.execute(task, data)
+    end_time = time.time()
+
+    assert end_time - start_time < len(data), "Tasks were not executed in parallel."
+
+def test_max_errors_handling():
+    def task(item):
+        if item == 3:
+            raise ValueError("Intentional error")
+        return item
+
+    data = [1, 2, 3, 4, 5]
+    executor = ParallelExecutor(num_threads=3, max_errors=1)
+
+    with pytest.raises(Exception, match="Execution cancelled due to errors or interruption."):
+        executor.execute(task, data)

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -11,11 +11,11 @@ def test_worker_threads_independence():
     executor = ParallelExecutor(num_threads=3)
     results = executor.execute(task, data)
 
-    assert results == [2, 4, 6, 8, 10], "Worker threads did not maintain independence."
+    assert results == [2, 4, 6, 8, 10]
 
 def test_parallel_execution_speed():
     def task(item):
-        time.sleep(1)  # Simulate a time-consuming task
+        time.sleep(0.1)  # Simulate a time-consuming task
         return item
 
     data = [1, 2, 3, 4, 5]
@@ -25,7 +25,7 @@ def test_parallel_execution_speed():
     executor.execute(task, data)
     end_time = time.time()
 
-    assert end_time - start_time < len(data), "Tasks were not executed in parallel."
+    assert end_time - start_time < len(data)
 
 def test_max_errors_handling():
     def task(item):
@@ -38,3 +38,18 @@ def test_max_errors_handling():
 
     with pytest.raises(Exception, match="Execution cancelled due to errors or interruption."):
         executor.execute(task, data)
+
+def test_max_errors_not_met():
+    def task(item):
+        if item == 3:
+            raise ValueError("Intentional error")
+        return item
+
+    data = [1, 2, 3, 4, 5]
+    executor = ParallelExecutor(num_threads=3, max_errors=2)
+
+    # Ensure that the execution completes without crashing when max_errors is not met
+    results = executor.execute(task, data)
+
+    # Verify that the results exclude the failed task
+    assert results == [1, 2, 4, 5]


### PR DESCRIPTION
This PR adds additional test cases for the ParallelExecutor:
- Ensures worker threads maintain independence.
- Validates parallel execution speed.
- Tests error handling with max_errors.

All tests are passed locally.

Fixes: #8122 