### PR TITLE
Adding unit tests for dspy.retrievers.Embeddings

### DIFF
--- a/tests/retrievers/test_embeddings.py
+++ b/tests/retrievers/test_embeddings.py
@@ -1,0 +1,85 @@
+import numpy as np
+import pytest
+
+from dspy.retrievers.embeddings import Embeddings
+
+@pytest.fixture
+def dummy_corpus():
+    return [
+        "The cat sat on the mat.",
+        "The dog barked at the mailman.",
+        "The sun rises in the east.",
+        "The quick brown fox jumps over the lazy dog.",
+        "An apple a day keeps the doctor away."
+    ]
+
+@pytest.fixture
+def dummy_embedder():
+    def embed(texts):
+        # Simple dummy embedder: convert each character's ASCII values and sum for each string
+        embeddings = []
+        for text in texts:
+            vec = np.array([sum(ord(c) for c in text[i::10]) for i in range(10)], dtype=np.float32)
+            embeddings.append(vec)
+        return np.stack(embeddings)
+    return embed
+
+def test_embeddings_basic_search(dummy_corpus, dummy_embedder):
+    retriever = Embeddings(
+        corpus=dummy_corpus,
+        embedder=dummy_embedder,
+        k=2
+    )
+
+    query = "A fox is quick and brown."
+    prediction = retriever(query)
+
+    assert hasattr(prediction, 'passages')
+    assert hasattr(prediction, 'indices')
+
+    assert isinstance(prediction.passages, list)
+    assert isinstance(prediction.indices, list)
+
+    assert len(prediction.passages) == 2
+    assert len(prediction.indices) == 2
+
+    for passage in prediction.passages:
+        assert isinstance(passage, str)
+        assert passage in dummy_corpus
+
+def test_embeddings_forward_batch(dummy_corpus, dummy_embedder):
+    retriever = Embeddings(
+        corpus=dummy_corpus,
+        embedder=dummy_embedder,
+        k=3
+    )
+
+    queries = ["Healthy habits", "Animals on the move"]
+    batch_results = retriever._batch_forward(queries)
+
+    assert isinstance(batch_results, list)
+    assert len(batch_results) == len(queries)
+
+    for passages, indices in batch_results:
+        assert isinstance(passages, list)
+        assert isinstance(indices, list)
+        assert len(passages) == 3
+        assert len(indices) == 3
+        for p in passages:
+            assert isinstance(p, str)
+            assert p in dummy_corpus
+
+def test_normalization(dummy_embedder):
+    dummy_data = ["text one", "text two"]
+    embeds = dummy_embedder(dummy_data)
+    
+    retriever = Embeddings(
+        corpus=dummy_data,
+        embedder=dummy_embedder,
+        k=1
+    )
+
+    normalized = retriever._normalize(embeds)
+    
+    norms = np.linalg.norm(normalized, axis=1)
+    np.testing.assert_allclose(norms, np.ones_like(norms), atol=1e-5)

--- a/tests/retrievers/test_embeddings.py
+++ b/tests/retrievers/test_embeddings.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 from dspy.retrievers.embeddings import Embeddings
 
+
 def dummy_corpus():
     return [
         "The cat sat on the mat.",
@@ -10,35 +11,30 @@ def dummy_corpus():
         "Birds fly in the sky.",
     ]
 
-def dummy_embedder():
-    def embed(texts):
-        embeddings = []
-        for text in texts:
-            if "cat" in text:
-                embeddings.append(np.array([1, 0, 0], dtype=np.float32))
-            elif "dog" in text:
-                embeddings.append(np.array([0, 1, 0], dtype=np.float32))
-            else:
-                embeddings.append(np.array([0, 0, 1], dtype=np.float32))
-        return np.stack(embeddings)
 
-    return embed
+def dummy_embedder(texts):
+    embeddings = []
+    for text in texts:
+        if "cat" in text:
+            embeddings.append(np.array([1, 0, 0], dtype=np.float32))
+        elif "dog" in text:
+            embeddings.append(np.array([0, 1, 0], dtype=np.float32))
+        else:
+            embeddings.append(np.array([0, 0, 1], dtype=np.float32))
+    return np.stack(embeddings)
+
 
 def test_embeddings_basic_search():
     corpus = dummy_corpus()
-    embedder = dummy_embedder()
+    embedder = dummy_embedder
 
-    retriever = Embeddings(
-        corpus=corpus,
-        embedder=embedder,
-        k=1
-    )
+    retriever = Embeddings(corpus=corpus, embedder=embedder, k=1)
 
     query = "I saw a dog running."
     result = retriever(query)
 
-    assert hasattr(result, 'passages')
-    assert hasattr(result, 'indices')
+    assert hasattr(result, "passages")
+    assert hasattr(result, "indices")
 
     assert isinstance(result.passages, list)
     assert isinstance(result.indices, list)
@@ -51,13 +47,9 @@ def test_embeddings_basic_search():
 
 def test_embeddings_multithreaded_search():
     corpus = dummy_corpus()
-    embedder = dummy_embedder()
+    embedder = dummy_embedder
 
-    retriever = Embeddings(
-        corpus=corpus,
-        embedder=embedder,
-        k=1
-    )
+    retriever = Embeddings(corpus=corpus, embedder=embedder, k=1)
 
     queries = [
         ("A cat is sitting on the mat.", "The cat sat on the mat."),
@@ -72,5 +64,8 @@ def test_embeddings_multithreaded_search():
 
     with ThreadPoolExecutor(max_workers=10) as executor:
         futures = [executor.submit(worker, q, expected) for q, expected in queries]
-        for future in as_completed(futures):
-            assert future.result() in corpus
+        # Results will be in original order
+        results = [f.result() for f in futures]
+        assert results[0] == "The cat sat on the mat."
+        assert results[1] == "The dog barked at the mailman."
+        assert results[2] == "Birds fly in the sky."

--- a/tests/retrievers/test_embeddings.py
+++ b/tests/retrievers/test_embeddings.py
@@ -1,85 +1,76 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
 import numpy as np
 import pytest
-
 from dspy.retrievers.embeddings import Embeddings
 
-@pytest.fixture
 def dummy_corpus():
     return [
         "The cat sat on the mat.",
         "The dog barked at the mailman.",
-        "The sun rises in the east.",
-        "The quick brown fox jumps over the lazy dog.",
-        "An apple a day keeps the doctor away."
+        "Birds fly in the sky.",
     ]
 
-@pytest.fixture
 def dummy_embedder():
     def embed(texts):
-        # Simple dummy embedder: convert each character's ASCII values and sum for each string
         embeddings = []
         for text in texts:
-            vec = np.array([sum(ord(c) for c in text[i::10]) for i in range(10)], dtype=np.float32)
-            embeddings.append(vec)
+            if "cat" in text:
+                embeddings.append(np.array([1, 0, 0], dtype=np.float32))
+            elif "dog" in text:
+                embeddings.append(np.array([0, 1, 0], dtype=np.float32))
+            else:
+                embeddings.append(np.array([0, 0, 1], dtype=np.float32))
         return np.stack(embeddings)
+
     return embed
 
-def test_embeddings_basic_search(dummy_corpus, dummy_embedder):
+def test_embeddings_basic_search():
+    corpus = dummy_corpus()
+    embedder = dummy_embedder()
+
     retriever = Embeddings(
-        corpus=dummy_corpus,
-        embedder=dummy_embedder,
-        k=2
-    )
-
-    query = "A fox is quick and brown."
-    prediction = retriever(query)
-
-    assert hasattr(prediction, 'passages')
-    assert hasattr(prediction, 'indices')
-
-    assert isinstance(prediction.passages, list)
-    assert isinstance(prediction.indices, list)
-
-    assert len(prediction.passages) == 2
-    assert len(prediction.indices) == 2
-
-    for passage in prediction.passages:
-        assert isinstance(passage, str)
-        assert passage in dummy_corpus
-
-def test_embeddings_forward_batch(dummy_corpus, dummy_embedder):
-    retriever = Embeddings(
-        corpus=dummy_corpus,
-        embedder=dummy_embedder,
-        k=3
-    )
-
-    queries = ["Healthy habits", "Animals on the move"]
-    batch_results = retriever._batch_forward(queries)
-
-    assert isinstance(batch_results, list)
-    assert len(batch_results) == len(queries)
-
-    for passages, indices in batch_results:
-        assert isinstance(passages, list)
-        assert isinstance(indices, list)
-        assert len(passages) == 3
-        assert len(indices) == 3
-        for p in passages:
-            assert isinstance(p, str)
-            assert p in dummy_corpus
-
-def test_normalization(dummy_embedder):
-    dummy_data = ["text one", "text two"]
-    embeds = dummy_embedder(dummy_data)
-    
-    retriever = Embeddings(
-        corpus=dummy_data,
-        embedder=dummy_embedder,
+        corpus=corpus,
+        embedder=embedder,
         k=1
     )
 
-    normalized = retriever._normalize(embeds)
-    
-    norms = np.linalg.norm(normalized, axis=1)
-    np.testing.assert_allclose(norms, np.ones_like(norms), atol=1e-5)
+    query = "I saw a dog running."
+    result = retriever(query)
+
+    assert hasattr(result, 'passages')
+    assert hasattr(result, 'indices')
+
+    assert isinstance(result.passages, list)
+    assert isinstance(result.indices, list)
+
+    assert len(result.passages) == 1
+    assert len(result.indices) == 1
+
+    assert result.passages[0] == "The dog barked at the mailman."
+
+
+def test_embeddings_multithreaded_search():
+    corpus = dummy_corpus()
+    embedder = dummy_embedder()
+
+    retriever = Embeddings(
+        corpus=corpus,
+        embedder=embedder,
+        k=1
+    )
+
+    queries = [
+        ("A cat is sitting on the mat.", "The cat sat on the mat."),
+        ("My dog is awesome!", "The dog barked at the mailman."),
+        ("Birds flying high.", "Birds fly in the sky."),
+    ] * 10
+
+    def worker(query_text, expected_passage):
+        result = retriever(query_text)
+        assert result.passages[0] == expected_passage
+        return result.passages[0]
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(worker, q, expected) for q, expected in queries]
+        for future in as_completed(futures):
+            assert future.result() in corpus


### PR DESCRIPTION
Added three unit tests for the embeddings.

1) test_embeddings_basic_search: Verifies that the retriever returns the correct top k relevant passages and their indices for a single query.

2) test_embeddings_forward_batch: Ensures the retriever handles batch queries correctly, returning the top k relevant passages and indices for each query.

3) test_normalization: Confirms that the embeddings are correctly normalized to have a norm close to 1 after processing.