### PR TITLE
Add cache to async LM call

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import logging
 import threading
 from functools import wraps
@@ -119,14 +120,20 @@ class Cache:
             response.usage = {}
         return response
 
-    def put(self, request: Dict[str, Any], value: Any, ignored_args_for_cache_key: Optional[list[str]] = None) -> None:
+    def put(
+        self,
+        request: Dict[str, Any],
+        value: Any,
+        ignored_args_for_cache_key: Optional[list[str]] = None,
+        enable_memory_cache: bool = True,
+    ) -> None:
         try:
             key = self.cache_key(request, ignored_args_for_cache_key)
         except Exception:
             logger.debug(f"Failed to generate cache key for request: {request}")
             return
 
-        if self.enable_memory_cache:
+        if self.enable_memory_cache and enable_memory_cache:
             with self._lock:
                 self.memory_cache[key] = value
 
@@ -164,6 +171,7 @@ class Cache:
 def request_cache(
     cache_arg_name: Optional[str] = None,
     ignored_args_for_cache_key: Optional[list[str]] = ["api_key", "api_base", "base_url"],
+    enable_memory_cache: bool = True,
     *,  # everything after this is keyword-only
     maxsize: Optional[int] = None,  # legacy / no-op
 ):
@@ -174,6 +182,8 @@ def request_cache(
         cache_arg_name: The name of the argument that contains the request. If not provided, the entire kwargs is used
             as the request.
         ignored_args_for_cache_key: A list of arguments to ignore when computing the cache key from the request.
+        enable_memory_cache: Whether to enable in-memory cache at call time. If False, the memory cache will not be
+            written to on new data.
     """
 
     # Deprecation notice
@@ -186,10 +196,7 @@ def request_cache(
 
     def decorator(fn):
         @wraps(fn)
-        def wrapper(*args, **kwargs):
-            import dspy
-
-            cache = dspy.cache
+        def process_request(args, kwargs):
             # Use fully qualified function name for uniqueness
             fn_identifier = f"{fn.__module__}.{fn.__qualname__}"
 
@@ -206,6 +213,15 @@ def request_cache(
                     modified_request[f"positional_arg_{i}"] = arg
             modified_request["_fn_identifier"] = fn_identifier
 
+            return modified_request
+
+        @wraps(fn)
+        def sync_wrapper(*args, **kwargs):
+            import dspy
+
+            cache = dspy.cache
+            modified_request = process_request(args, kwargs)
+
             # Retrieve from cache if available
             cached_result = cache.get(modified_request, ignored_args_for_cache_key)
 
@@ -214,10 +230,32 @@ def request_cache(
 
             # Otherwise, compute and store the result
             result = fn(*args, **kwargs)
-            cache.put(modified_request, result, ignored_args_for_cache_key)
+            # `enable_memory_cache` can be provided at call time to avoid indefinite growth.
+            cache.put(modified_request, result, ignored_args_for_cache_key, enable_memory_cache)
 
             return result
 
-        return wrapper
+        @wraps(fn)
+        async def async_wrapper(*args, **kwargs):
+            import dspy
+
+            cache = dspy.cache
+            modified_request = process_request(args, kwargs)
+
+            # Retrieve from cache if available
+            cached_result = cache.get(modified_request, ignored_args_for_cache_key)
+            if cached_result is not None:
+                return cached_result
+
+            # Otherwise, compute and store the result
+            result = await fn(*args, **kwargs)
+            cache.put(modified_request, result, ignored_args_for_cache_key, enable_memory_cache)
+
+            return result
+
+        if inspect.iscoroutinefunction(fn):
+            return async_wrapper
+        else:
+            return sync_wrapper
 
     return decorator

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -311,6 +311,22 @@ def litellm_text_completion(request: Dict[str, Any], num_retries: int, cache={"n
     )
 
 
+@request_cache(cache_arg_name="request", ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
+async def cached_alitellm_completion(request: Dict[str, Any], num_retries: int):
+    import litellm
+
+    if litellm.cache:
+        litellm_cache_args = {"no-cache": False, "no-store": False}
+    else:
+        litellm_cache_args = {"no-cache": True, "no-store": True}
+
+    return await alitellm_completion(
+        request,
+        cache=litellm_cache_args,
+        num_retries=num_retries,
+    )
+
+
 async def alitellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
     retry_kwargs = dict(
         retry_policy=_get_litellm_retry_policy(num_retries),
@@ -325,6 +341,22 @@ async def alitellm_completion(request: Dict[str, Any], num_retries: int, cache={
         cache=cache,
         **retry_kwargs,
         **request,
+    )
+
+
+@request_cache(cache_arg_name="request", ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
+async def cached_alitellm_text_completion(request: Dict[str, Any], num_retries: int):
+    import litellm
+
+    if litellm.cache:
+        litellm_cache_args = {"no-cache": False, "no-store": False}
+    else:
+        litellm_cache_args = {"no-cache": True, "no-store": True}
+
+    return await alitellm_text_completion(
+        request,
+        num_retries=num_retries,
+        cache=litellm_cache_args,
     )
 
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -54,7 +54,7 @@ class LM(BaseLM):
             max_tokens: The maximum number of tokens to generate per response.
             cache: Whether to cache the model responses for reuse to improve performance
                    and reduce costs.
-            cache_in_memory: To enable additional caching with LRU in memory.
+            cache_in_memory (deprecated): To enable additional caching with LRU in memory.
             callbacks: A list of callback functions to run before and after each request.
             num_retries: The number of times to retry a request if it fails transiently due to
                          network error, rate limiting, etc. Requests are retried with exponential
@@ -92,44 +92,67 @@ class LM(BaseLM):
         else:
             self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
 
+    def _get_cached_completion_fn(self, completion_fn, cache, enable_memory_cache):
+        ignored_args_for_cache_key = ["api_key", "api_base", "base_url"]
+        if cache and enable_memory_cache:
+            completion_fn = request_cache(
+                cache_arg_name="request",
+                ignored_args_for_cache_key=ignored_args_for_cache_key,
+            )(completion_fn)
+        elif cache:
+            completion_fn = request_cache(
+                cache_arg_name="request",
+                ignored_args_for_cache_key=ignored_args_for_cache_key,
+                enable_memory_cache=False,
+            )(completion_fn)
+        else:
+            completion_fn = completion_fn
+
+        if not cache or litellm.cache is None:
+            litellm_cache_args = {"no-cache": True, "no-store": True}
+
+        return completion_fn, litellm_cache_args
+
     def forward(self, prompt=None, messages=None, **kwargs):
         # Build the request.
         cache = kwargs.pop("cache", self.cache)
-        # disable cache will also disable in memory cache
-        cache_in_memory = cache and kwargs.pop("cache_in_memory", self.cache_in_memory)
+        enable_memory_cache = kwargs.pop("cache_in_memory", self.cache_in_memory)
+
         messages = messages or [{"role": "user", "content": prompt}]
         kwargs = {**self.kwargs, **kwargs}
 
-        # Make the request and handle LRU & disk caching.
-        if cache_in_memory:
-            completion = cached_litellm_completion if self.model_type == "chat" else cached_litellm_text_completion
+        completion = litellm_completion if self.model_type == "chat" else litellm_text_completion
+        completion, litellm_cache_args = self._get_cached_completion_fn(completion, cache, enable_memory_cache)
 
-            results = completion(
-                request=dict(model=self.model, messages=messages, **kwargs),
-                num_retries=self.num_retries,
-            )
-        else:
-            completion = litellm_completion if self.model_type == "chat" else litellm_text_completion
-
-            results = completion(
-                request=dict(model=self.model, messages=messages, **kwargs),
-                num_retries=self.num_retries,
-                # only leverage LiteLLM cache in this case
-                cache={"no-cache": not cache, "no-store": not cache},
-            )
+        results = completion(
+            request=dict(model=self.model, messages=messages, **kwargs),
+            num_retries=self.num_retries,
+            cache=litellm_cache_args,
+        )
 
         if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
             settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 
     async def aforward(self, prompt=None, messages=None, **kwargs):
-        completion = alitellm_completion if self.model_type == "chat" else alitellm_text_completion
+        # Build the request.
+        cache = kwargs.pop("cache", self.cache)
+        enable_memory_cache = kwargs.pop("cache_in_memory", self.cache_in_memory)
 
         messages = messages or [{"role": "user", "content": prompt}]
+        kwargs = {**self.kwargs, **kwargs}
+
+        completion = alitellm_completion if self.model_type == "chat" else alitellm_text_completion
+        completion, litellm_cache_args = self._get_cached_completion_fn(completion, cache, enable_memory_cache)
+
         results = await completion(
             request=dict(model=self.model, messages=messages, **kwargs),
             num_retries=self.num_retries,
+            cache=litellm_cache_args,
         )
+
+        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
+            settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 
     def launch(self, launch_kwargs: Optional[Dict[str, Any]] = None):
@@ -206,22 +229,6 @@ class LM(BaseLM):
         return {key: getattr(self, key) for key in state_keys} | self.kwargs
 
 
-@request_cache(cache_arg_name="request", ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
-def cached_litellm_completion(request: Dict[str, Any], num_retries: int):
-    import litellm
-
-    if litellm.cache:
-        litellm_cache_args = {"no-cache": False, "no-store": False}
-    else:
-        litellm_cache_args = {"no-cache": True, "no-store": True}
-
-    return litellm_completion(
-        request,
-        cache=litellm_cache_args,
-        num_retries=num_retries,
-    )
-
-
 def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
     retry_kwargs = dict(
         retry_policy=_get_litellm_retry_policy(num_retries),
@@ -267,22 +274,6 @@ def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cac
     return stream_completion()
 
 
-@request_cache(cache_arg_name="request", ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
-def cached_litellm_text_completion(request: Dict[str, Any], num_retries: int):
-    import litellm
-
-    if litellm.cache:
-        litellm_cache_args = {"no-cache": False, "no-store": False}
-    else:
-        litellm_cache_args = {"no-cache": True, "no-store": True}
-
-    return litellm_text_completion(
-        request,
-        num_retries=num_retries,
-        cache=litellm_cache_args,
-    )
-
-
 def litellm_text_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
     # Extract the provider and model from the model string.
     # TODO: Not all the models are in the format of "provider/model"
@@ -311,22 +302,6 @@ def litellm_text_completion(request: Dict[str, Any], num_retries: int, cache={"n
     )
 
 
-@request_cache(cache_arg_name="request", ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
-async def cached_alitellm_completion(request: Dict[str, Any], num_retries: int):
-    import litellm
-
-    if litellm.cache:
-        litellm_cache_args = {"no-cache": False, "no-store": False}
-    else:
-        litellm_cache_args = {"no-cache": True, "no-store": True}
-
-    return await alitellm_completion(
-        request,
-        cache=litellm_cache_args,
-        num_retries=num_retries,
-    )
-
-
 async def alitellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cache": True, "no-store": True}):
     retry_kwargs = dict(
         retry_policy=_get_litellm_retry_policy(num_retries),
@@ -341,22 +316,6 @@ async def alitellm_completion(request: Dict[str, Any], num_retries: int, cache={
         cache=cache,
         **retry_kwargs,
         **request,
-    )
-
-
-@request_cache(cache_arg_name="request", ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
-async def cached_alitellm_text_completion(request: Dict[str, Any], num_retries: int):
-    import litellm
-
-    if litellm.cache:
-        litellm_cache_args = {"no-cache": False, "no-store": False}
-    else:
-        litellm_cache_args = {"no-cache": True, "no-store": True}
-
-    return await alitellm_text_completion(
-        request,
-        num_retries=num_retries,
-        cache=litellm_cache_args,
     )
 
 


### PR DESCRIPTION
Support DSPy cache on the async LM call, and also simplify the code to avoid the redundant methods like `cached_litellm_completion`. 