### PR TITLE
Make doc site search bar able to identify the API references

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -160,7 +160,18 @@ extra_css:
 
 plugins:
     - social
-    - search
+    - search:
+        lang: en
+        separator: '[\s\-\.]+'
+        min_search_length: 2
+        prebuild_index: true
+        indexing: 'full'
+        properties:
+            - title
+            - tags
+            - content
+            - sections
+        search_index_only: false
     - mkdocstrings:
         handlers:
             python:


### PR DESCRIPTION
Earlier our search bar doesn't identify the API references, this PR fixes it. 

See screenshots for the effect:

<img width="1412" alt="image" src="https://github.com/user-attachments/assets/6d86b6b6-8b5f-4a50-8567-5266404f48db" />

<img width="1592" alt="image" src="https://github.com/user-attachments/assets/b32e37f0-c76b-48ed-98f5-18ef376cbd0b" />
