### PR TITLE
Support args of custom types in dspy mcp tool

### DIFF
--- a/tests/utils/resources/mcp_server.py
+++ b/tests/utils/resources/mcp_server.py
@@ -1,6 +1,17 @@
 from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel
 
 mcp = FastMCP("test")
+
+
+class Profile(BaseModel):
+    name: str
+    age: int
+
+
+class Account(BaseModel):
+    profile: Profile
+    account_id: str
 
 
 @mcp.tool()
@@ -14,10 +25,18 @@ def hello(names: list[str]) -> str:
     """Greet people"""
     return [f"Hello, {name}!" for name in names]
 
+
 @mcp.tool()
 def wrong_tool():
     """This tool raises an error"""
     raise ValueError("error!")
+
+
+@mcp.tool()
+def get_account_name(account: Account):
+    """This extracts the name from account"""
+    return account.profile.name
+
 
 if __name__ == "__main__":
     mcp.run()


### PR DESCRIPTION
Currently if an MCP tool's arg is of custom type, then the `tool.args` doesn't reflect the json schema correctly. For example:

```
from mcp.server.fastmcp import FastMCP
from pydantic import BaseModel

mcp = FastMCP("test")


class Profile(BaseModel):
    name: str
    age: int


class Account(BaseModel):
    profile: Profile
    account_id: str

@mcp.tool()
def get_account_name(account: Account):
    """This extracts the name from account"""
    return account.profile.name


if __name__ == "__main__":
    mcp.run()
```

will have the args be like `{'account': {'$ref': '#/$defs/Account'}}`, which doesn't have sufficient information for the LM to generate right args. This PR fixes it by explicitly resolving the refs. 