### PR TITLE
Fix predict usage tracking

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -11,7 +11,6 @@ from dspy.predict.parameter import Parameter
 from dspy.primitives.prediction import Prediction
 from dspy.primitives.program import Module
 from dspy.signatures.signature import ensure_signature
-from dspy.utils.callback import with_callbacks
 
 logger = logging.getLogger(__name__)
 
@@ -71,13 +70,11 @@ class Predict(Module, Parameter):
 
         return self
 
-    @with_callbacks
     def __call__(self, **kwargs):
-        return self.forward(**kwargs)
+        return super().__call__(**kwargs)
 
-    @with_callbacks
     async def acall(self, **kwargs):
-        return await self.aforward(**kwargs)
+        return await super().acall(**kwargs)
 
     def _forward_preprocess(self, **kwargs):
         # Extract the three privileged keyword arguments.

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -70,10 +70,23 @@ class Predict(Module, Parameter):
 
         return self
 
-    def __call__(self, **kwargs):
+    def __call__(self, *args, **kwargs):
+        if args:
+            raise ValueError(
+                "Positional arguments are not allowed when calling `dspy.Predict`, must use keyword arguments "
+                "that match your signature input fields. For example: "
+                "dspy.Predict('question -> answer')(question='What is the capital of France?')"
+            )
+
         return super().__call__(**kwargs)
 
-    async def acall(self, **kwargs):
+    async def acall(self, *args, **kwargs):
+        if args:
+            raise ValueError(
+                "Positional arguments are not allowed when calling `dspy.Predict`, must use keyword arguments "
+                "that match your signature input fields. For example: "
+                "dspy.Predict('question -> answer').acall(question='What is the capital of France?')"
+            )
         return await super().acall(**kwargs)
 
     def _forward_preprocess(self, **kwargs):

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -507,6 +507,15 @@ def test_lm_usage():
         assert result.get_lm_usage()["openai/gpt-4o-mini"]["total_tokens"] == 10
 
 
+def test_positional_arguments():
+    program = Predict("question -> answer")
+    with pytest.raises(ValueError) as e:
+        program("What is the capital of France?")
+    assert "Positional arguments are not allowed when calling `dspy.Predict`, must use keyword arguments" in str(
+        e.value
+    )
+
+
 @pytest.mark.parametrize("adapter_type", ["chat", "json"])
 def test_field_constraints(adapter_type):
     class SpyLM(dspy.LM):

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -11,6 +11,7 @@ import dspy
 from dspy import Predict, Signature
 from dspy.utils.dummies import DummyLM
 from unittest.mock import patch, MagicMock, Mock
+from litellm import ModelResponse
 
 
 def test_initialization_with_string_signature():
@@ -489,6 +490,21 @@ def test_call_predict_with_chat_history(adapter_type):
     assert "what's the capital of france?" in messages[1]["content"]
     assert "paris" in messages[2]["content"]
     assert "are you sure that's correct" in messages[3]["content"]
+
+
+def test_lm_usage():
+    program = Predict("question -> answer")
+    dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False), track_usage=True)
+    with patch(
+        "dspy.clients.lm.litellm_completion",
+        return_value=ModelResponse(
+            choices=[{"message": {"content": "[[ ## answer ## ]]\nParis"}}],
+            usage={"total_tokens": 10},
+        ),
+    ):
+        result = program(question="What is the capital of France?")
+        assert result.answer == "Paris"
+        assert result.get_lm_usage()["openai/gpt-4o-mini"]["total_tokens"] == 10
 
 
 @pytest.mark.parametrize("adapter_type", ["chat", "json"])


### PR DESCRIPTION
fix #8145 

It actually indicates a bigger problem that our `dspy.Predict`'s `__call__` is not using the `Module.__call__`. We override the `__call__` in `dspy.Predict` to disallow positional args, but it should still utilize the parent's `__call__`.

We also improve the error message on users passing positional args to `dspy.Predict`. 

Before:

```
TypeError: Predict.__call__() takes 1 positional argument but 2 were given
```

After:

```
ValueError: Positional arguments are not allowed when calling `dspy.Predict`, must use keyword arguments that match your signature input fields. For example: dspy.Predict('question -> answer')(question='What is the capital of France?')
```
