### PR TITLE
Break down DSPy tutorials for clarity

### DIFF
--- a/docs/docs/tutorials/build_ai_program/index.md
+++ b/docs/docs/tutorials/build_ai_program/index.md
@@ -1,0 +1,7 @@
+- [Retrieval-Augmented Generation (RAG)](/tutorials/rag/)
+- [Building RAG as Agent](/tutorials/agents/)
+- [Entity Extraction](/tutorials/entity_extraction/)
+- [Classification](/tutorials/classification/)
+- [Multi-Hop RAG](/tutorials/multihop_search/)
+- [Privacy-Conscious Delegation](/tutorials/papillon/)
+- [Image Generation Prompt iteration](/tutorials/image_generation_prompting/)

--- a/docs/docs/tutorials/core_development/index.md
+++ b/docs/docs/tutorials/core_development/index.md
@@ -1,0 +1,5 @@
+- [Use MCP in DSPy](/tutorials/mcp/index.md)
+- [Output Refinement](/tutorials/output_refinement/best-of-n-and-refine/)
+- [Saving and Loading](/tutorials/saving/index.md)
+- [Deployment](/tutorials/deployment/)
+- [Debugging & Observability](/tutorials/observability/)

--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -1,30 +1,38 @@
-* [Retrieval-Augmented Generation](/tutorials/rag/)
+Welcome to DSPy tutorials! We've organized our tutorials into three main categories to help you get started:
 
-* [Agents](/tutorials/agents/)
+- **Build AI Programs with DSPy**: These hands-on tutorials guide you through building production-ready AI
+  applications. From implementing RAG systems to creating intelligent agents, each tutorial demonstrates
+  practical use cases. You'll also learn how to leverage DSPy optimizers to enhance your program's performance.
 
-* [Reasoning](/tutorials/math/)
+- **Optimize AI Programs with DSPy Optimizers**: These tutorials deep dive into DSPy's optimization capabilities. While
+  lighter on programming concepts, they focus on how to systematically improve your AI programs using DSPy
+  optimizers, and showcase how DSPy optimizers help improve the quality automatically.
 
-* [Entity Extraction](/tutorials/entity_extraction/)
+- **DSPy Core Development**: These tutorials cover essential DSPy features and best practices. Learn how to implement
+  key functionalities like streaming, caching, deployment, and monitoring in your DSPy applications.
 
-* [Classification](/tutorials/classification/)
 
-* [Classification Finetuning](/tutorials/classification_finetuning/)
+- Build AI Programs with DSPy
+  - [Retrieval-Augmented Generation (RAG)](/tutorials/rag/)
+  - [Building RAG as Agent](/tutorials/agents/)
+  - [Entity Extraction](/tutorials/entity_extraction/)
+  - [Classification](/tutorials/classification/)
+  - [Multi-Hop RAG](/tutorials/multihop_search/)
+  - [Privacy-Conscious Delegation](/tutorials/papillon/)
+  - [Image Generation Prompt iteration](/tutorials/image_generation_prompting/)
 
-* [Multi-Hop Search](/tutorials/multihop_search/)
 
-* [Advanced Tool Use](/tutorials/tool_use/)
+- Optimize AI Programs with DSPy
+  - [Math Reasoning](/tutorials/math/)
+  - [Classification Finetuning](/tutorials/classification_finetuning/)
+  - [Advanced Tool Use](/tutorials/tool_use/)
+  - [Finetuning Agents](/tutorials/games/)
 
-* [Privacy-Conscious Delegation](/tutorials/papillon/)
+- DSPy Core Development
+  - [Use MCP in DSPy](/tutorials/mcp/index.md)
+  - [Output Refinement](/tutorials/output_refinement/best-of-n-and-refine/)
+  - [Saving and Loading](/tutorials/saving/index.md)
+  - [Deployment](/tutorials/deployment/)
+  - [Debugging & Observability](/tutorials/observability/)
 
-* [Image Generation Prompt iteration](/tutorials/image_generation_prompting/)
-
-* [Output Refinement](/tutorials/output_refinement/best-of-n-and-refine/)
-
-* [Finetuning Agents](/tutorials/games/)
-
-* [Saving and Loading](/tutorials/saving/index.md)
-
-* [Deployment](/tutorials/deployment/)
-
-* [Debugging & Observability](/tutorials/observability/)
 

--- a/docs/docs/tutorials/optimize_ai_program/index.md
+++ b/docs/docs/tutorials/optimize_ai_program/index.md
@@ -1,0 +1,4 @@
+- [Math Reasoning](/tutorials/math/)
+- [Classification Finetuning](/tutorials/classification_finetuning/)
+- [Advanced Tool Use](/tutorials/tool_use/)
+- [Finetuning Agents](/tutorials/games/)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -25,22 +25,28 @@ nav:
             - Optimizers: learn/optimization/optimizers.md
     - Tutorials:
         - Tutorials Overview: tutorials/index.md
-        - Retrieval-Augmented Generation: tutorials/rag/index.ipynb
-        - Agents: tutorials/agents/index.ipynb
-        - Reasoning: tutorials/math/index.ipynb
-        - Entity Extraction: tutorials/entity_extraction/index.ipynb
-        - MCP in DSPy: tutorials/mcp/index.md
-        - Classification: tutorials/classification/index.md
-        - Classification Finetuning: tutorials/classification_finetuning/index.ipynb
-        - Multi-Hop Search: tutorials/multihop_search/index.ipynb
-        - Privacy-Conscious Delegation: tutorials/papillon/index.md
-        - Advanced Tool Use: tutorials/tool_use/index.ipynb
-        - Image Generation Prompt iteration: tutorials/image_generation_prompting/index.ipynb
-        - Output Refinement: tutorials/output_refinement/best-of-n-and-refine.md
-        - Finetuning Agents: tutorials/games/index.ipynb
-        - Saving and Loading: tutorials/saving/index.md
-        - Deployment: tutorials/deployment/index.md
-        - Debugging & Observability: tutorials/observability/index.md
+        - Build AI Programs with DSPy:
+            - Overview: tutorials/build_ai_program/index.md
+            - Retrieval-Augmented Generation (RAG): tutorials/rag/index.ipynb
+            - Building RAG as Agent: tutorials/agents/index.ipynb
+            - Entity Extraction: tutorials/entity_extraction/index.ipynb
+            - Classification: tutorials/classification/index.md
+            - Multi-Hop RAG: tutorials/multihop_search/index.ipynb
+            - Privacy-Conscious Delegation: tutorials/papillon/index.md
+            - Image Generation Prompt iteration: tutorials/image_generation_prompting/index.ipynb
+        - Optimize AI Programs with DSPy:
+            - Overview: tutorials/optimize_ai_program/index.md
+            - Math Reasoning: tutorials/math/index.ipynb
+            - Classification Finetuning: tutorials/classification_finetuning/index.ipynb
+            - Advanced Tool Use: tutorials/tool_use/index.ipynb
+            - Finetuning Agents: tutorials/games/index.ipynb
+        - DSPy Core Development:
+            - Overview: tutorials/core_development/index.md
+            - Use MCP in DSPy: tutorials/mcp/index.md
+            - Output Refinement: tutorials/output_refinement/best-of-n-and-refine.md
+            - Saving and Loading: tutorials/saving/index.md
+            - Deployment: tutorials/deployment/index.md
+            - Debugging & Observability: tutorials/observability/index.md
     - DSPy in Production: production/index.md
     - Community:
         - Community Resources: community/community-resources.md


### PR DESCRIPTION
We have a decent number of tutorials now, and it makes sense to me to break them down into a few sections for easy navigation. I am making 3 categories now:

<img width="1358" alt="image" src="https://github.com/user-attachments/assets/11b9f20f-8746-4cfd-ac3a-848d17edf503" />
