### PR TITLE
Fix litellm retries

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -40,6 +40,7 @@ class ChatAdapter(Adapter):
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
+            raise e
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -40,7 +40,6 @@ class ChatAdapter(Adapter):
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
-            raise e
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -84,9 +84,9 @@ class LM(BaseLM):
 
         if model_pattern:
             # Handle OpenAI reasoning models (o1, o3)
-            assert max_tokens >= 20_000 and temperature == 1.0, (
-                "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 20_000 to `dspy.LM(...)`"
-            )
+            assert (
+                max_tokens >= 20_000 and temperature == 1.0
+            ), "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 20_000 to `dspy.LM(...)`"
             self.kwargs = dict(temperature=temperature, max_completion_tokens=max_tokens, **kwargs)
         else:
             self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -279,6 +279,7 @@ def litellm_completion(request: Dict[str, Any], num_retries: int, cache={"no-cac
         return litellm.completion(
             cache=cache,
             num_retries=num_retries,
+            retry_strategy="exponential_backoff_retry",
             **request,
         )
 
@@ -305,6 +306,7 @@ def litellm_text_completion(request: Dict[str, Any], num_retries: int, cache={"n
         api_base=api_base,
         prompt=prompt,
         num_retries=num_retries,
+        retry_strategy="exponential_backoff_retry",
         **request,
     )
 
@@ -315,6 +317,7 @@ async def alitellm_completion(request: Dict[str, Any], num_retries: int, cache={
         return await litellm.acompletion(
             cache=cache,
             num_retries=num_retries,
+            retry_strategy="exponential_backoff_retry",
             **request,
         )
 
@@ -341,5 +344,6 @@ async def alitellm_text_completion(
         api_base=api_base,
         prompt=prompt,
         num_retries=num_retries,
+        retry_strategy="exponential_backoff_retry",
         **request,
     )

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -161,79 +161,12 @@ def test_lm_calls_support_pydantic_models(litellm_test_server):
     lm("Query")
 
 
-@pytest.mark.parametrize(
-    ("error_code", "expected_exception", "expected_num_retries"),
-    [
-        ("429", litellm.RateLimitError, 1),
-        ("504", litellm.Timeout, 1),
-        # Don't retry on user errors
-        ("400", litellm.BadRequestError, 0),
-        ("401", litellm.AuthenticationError, 0),
-        # TODO: LiteLLM retry logic isn't implemented properly for internal server errors
-        # and content policy violations, both of which may be transient and should be retried
-        # ("content-policy-violation, litellm.BadRequestError, 1),
-        # ("500", litellm.InternalServerError, 0, 1),
-    ],
-)
-def test_lm_chat_calls_are_retried_for_expected_failures(
-    litellm_test_server,
-    error_code,
-    expected_exception,
-    expected_num_retries,
-):
-    api_base, server_log_file_path = litellm_test_server
-    num_retries = 1
-    openai_lm = dspy.LM(
-        model="openai/dspy-test-model",
-        api_base=api_base,
-        api_key="fakekey",
-        num_retries=num_retries,
-        model_type="chat",
-        cache=False,
-    )
-    with pytest.raises(expected_exception):
-        openai_lm(error_code)
+def test_retry_number_set_correctly():
+    lm = dspy.LM("openai/gpt-4o-mini", num_retries=3)
+    with mock.patch("litellm.completion") as mock_completion:
+        lm("query")
 
-    request_logs = read_litellm_test_server_request_logs(server_log_file_path)
-    # LiteLLM has a strange behavior of two-level retries. If `num_retries=1`, it will retry 1 + 1 times on system
-    # erros, and 1 time on user errors.
-    assert len(request_logs) == num_retries + expected_num_retries + 1
-
-
-@pytest.mark.parametrize(
-    ("error_code", "expected_exception", "expected_num_retries"),
-    [
-        ("429", litellm.RateLimitError, 2),
-        ("504", litellm.Timeout, 3),
-        # Don't retry on user errors
-        ("400", litellm.BadRequestError, 0),
-        ("401", litellm.AuthenticationError, 0),
-        # TODO: LiteLLM retry logic isn't implemented properly for internal server errors
-        # and content policy violations, both of which may be transient and should be retried
-        # ("content-policy-violation, litellm.BadRequestError, 2),
-        # ("500", litellm.InternalServerError, 0, 2),
-    ],
-)
-def test_lm_text_calls_are_retried_for_expected_failures(
-    litellm_test_server,
-    error_code,
-    expected_exception,
-    expected_num_retries,
-):
-    api_base, server_log_file_path = litellm_test_server
-
-    openai_lm = dspy.LM(
-        model="openai/dspy-test-model",
-        api_base=api_base,
-        api_key="fakekey",
-        num_retries=expected_num_retries,
-        model_type="text",
-    )
-    with pytest.raises(expected_exception):
-        openai_lm(error_code)
-
-    request_logs = read_litellm_test_server_request_logs(server_log_file_path)
-    assert len(request_logs) == expected_num_retries + 1  # 1 initial request + 1 retries
+    assert mock_completion.call_args.kwargs["num_retries"] == 3
 
 
 def test_reasoning_model_token_parameter():


### PR DESCRIPTION
`retry_policy` is no longer a useful arg in `litellm.completion`, and we should use `num_retries` instead. 

According to litellm's doc page: 

```
num_retries: int (optional) - The number of times to retry the API call if an APIError, TimeoutError or ServiceUnavailableError occurs
```
so it is sufficient for DSPy need. 