### PR TITLE
Standardize coding style in dspy/clients

### DIFF
--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -1,14 +1,16 @@
-from dspy.clients.lm import LM
-from dspy.clients.provider import Provider, TrainingJob
-from dspy.clients.base_lm import BaseLM, inspect_history
-from dspy.clients.embedding import Embedder
-import litellm
+import logging
 import os
 from pathlib import Path
-from dspy.clients.cache import Cache
-import logging
 from typing import Optional
+
+import litellm
 from litellm.caching.caching import Cache as LitellmCache
+
+from dspy.clients.base_lm import BaseLM, inspect_history
+from dspy.clients.cache import Cache
+from dspy.clients.embedding import Embedder
+from dspy.clients.lm import LM
+from dspy.clients.provider import Provider, TrainingJob
 
 logger = logging.getLogger(__name__)
 

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,6 +1,5 @@
 import datetime
 import uuid
-from abc import ABC
 
 from dspy.dsp.utils import settings
 from dspy.utils.callback import with_callbacks
@@ -9,7 +8,7 @@ MAX_HISTORY_SIZE = 10_000
 GLOBAL_HISTORY = []
 
 
-class BaseLM(ABC):
+class BaseLM:
     """Base class for handling LLM calls.
 
     Most users can directly use the `dspy.LM` class, which is a subclass of `BaseLM`. Users can also implement their
@@ -178,7 +177,10 @@ def _inspect_history(history, n: int = 1):
                             image_str = ""
                             if "base64" in c["image_url"].get("url", ""):
                                 len_base64 = len(c["image_url"]["url"].split("base64,")[1])
-                                image_str = f"<{c['image_url']['url'].split('base64,')[0]}base64,<IMAGE BASE 64 ENCODED({str(len_base64)})>"
+                                image_str = (
+                                    f"<{c['image_url']['url'].split('base64,')[0]}base64,"
+                                    f"<IMAGE BASE 64 ENCODED({len_base64!s})>"
+                                )
                             else:
                                 image_str = f"<image_url: {c['image_url']['url']}>"
                             print(_blue(image_str.strip()))

--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -83,7 +83,7 @@ class Cache:
                 try:
                     # For regular functions, we can get the source code
                     return f"<callable_source:{inspect.getsource(value)}>"
-                except (TypeError, OSError, IOError):
+                except (TypeError, OSError):
                     # For lambda functions or other callables where source isn't available,
                     # use a string representation
                     return f"<callable:{value.__name__ if hasattr(value, '__name__') else 'lambda'}>"
@@ -170,7 +170,7 @@ class Cache:
 
 def request_cache(
     cache_arg_name: Optional[str] = None,
-    ignored_args_for_cache_key: Optional[list[str]] = ["api_key", "api_base", "base_url"],
+    ignored_args_for_cache_key: Optional[list[str]] = None,
     enable_memory_cache: bool = True,
     *,  # everything after this is keyword-only
     maxsize: Optional[int] = None,  # legacy / no-op
@@ -185,7 +185,7 @@ def request_cache(
         enable_memory_cache: Whether to enable in-memory cache at call time. If False, the memory cache will not be
             written to on new data.
     """
-
+    ignored_args_for_cache_key = ignored_args_for_cache_key or ["api_key", "api_base", "base_url"]
     # Deprecation notice
     if maxsize is not None:
         logger.warning(

--- a/dspy/clients/openai.py
+++ b/dspy/clients/openai.py
@@ -5,50 +5,49 @@ from typing import Any, Dict, List, Optional
 
 import openai
 
-from dspy.clients.provider import TrainingJob, Provider
+from dspy.clients.provider import Provider, TrainingJob
 from dspy.clients.utils_finetune import TrainDataFormat, TrainingStatus, save_data
 
-
 _OPENAI_MODELS = [
-  'gpt-4-turbo',
-  'gpt-4-turbo-2024-04-09',
-  'tts-1',
-  'tts-1-1106',
-  'chatgpt-4o-latest',
-  'dall-e-2',
-  'whisper-1',
-  'gpt-3.5-turbo-instruct',
-  'gpt-3.5-turbo',
-  'gpt-3.5-turbo-0125',
-  'babbage-002',
-  'davinci-002',
-  'gpt-4o-mini-2024-07-18',
-  'gpt-4o',
-  'dall-e-3',
-  'gpt-4o-mini',
-  'gpt-4o-2024-08-06',
-  'gpt-4o-2024-05-13',
-  'o1-preview',
-  'gpt-4o-audio-preview-2024-10-01',
-  'o1-mini-2024-09-12',
-  'gpt-4o-audio-preview',
-  'tts-1-hd',
-  'tts-1-hd-1106',
-  'o1-preview-2024-09-12',
-  'o1-mini',
-  'gpt-4-1106-preview',
-  'text-embedding-ada-002',
-  'gpt-3.5-turbo-16k',
-  'text-embedding-3-small',
-  'text-embedding-3-large',
-  'gpt-4o-realtime-preview-2024-10-01',
-  'gpt-4o-realtime-preview',
-  'gpt-3.5-turbo-1106',
-  'gpt-4-0613',
-  'gpt-4-turbo-preview',
-  'gpt-4-0125-preview',
-  'gpt-4',
-  'gpt-3.5-turbo-instruct-0914'
+    "gpt-4-turbo",
+    "gpt-4-turbo-2024-04-09",
+    "tts-1",
+    "tts-1-1106",
+    "chatgpt-4o-latest",
+    "dall-e-2",
+    "whisper-1",
+    "gpt-3.5-turbo-instruct",
+    "gpt-3.5-turbo",
+    "gpt-3.5-turbo-0125",
+    "babbage-002",
+    "davinci-002",
+    "gpt-4o-mini-2024-07-18",
+    "gpt-4o",
+    "dall-e-3",
+    "gpt-4o-mini",
+    "gpt-4o-2024-08-06",
+    "gpt-4o-2024-05-13",
+    "o1-preview",
+    "gpt-4o-audio-preview-2024-10-01",
+    "o1-mini-2024-09-12",
+    "gpt-4o-audio-preview",
+    "tts-1-hd",
+    "tts-1-hd-1106",
+    "o1-preview-2024-09-12",
+    "o1-mini",
+    "gpt-4-1106-preview",
+    "text-embedding-ada-002",
+    "gpt-3.5-turbo-16k",
+    "text-embedding-3-small",
+    "text-embedding-3-large",
+    "gpt-4o-realtime-preview-2024-10-01",
+    "gpt-4o-realtime-preview",
+    "gpt-3.5-turbo-1106",
+    "gpt-4-0613",
+    "gpt-4-turbo-preview",
+    "gpt-4-0125-preview",
+    "gpt-4",
+    "gpt-3.5-turbo-instruct-0914",
 ]
 
 
@@ -84,7 +83,6 @@ class TrainingJobOpenAI(TrainingJob):
 
 
 class OpenAIProvider(Provider):
-    
     def __init__(self):
         super().__init__()
         self.finetunable = True
@@ -113,7 +111,7 @@ class OpenAIProvider(Provider):
             return True
 
         return False
-    
+
     @staticmethod
     def _remove_provider_prefix(model: str) -> str:
         provider_prefix = "openai/"
@@ -179,7 +177,6 @@ class OpenAIProvider(Provider):
         except Exception:
             return False
 
-
     @staticmethod
     def is_terminal_training_status(status: TrainingStatus) -> bool:
         return status in [
@@ -187,7 +184,7 @@ class OpenAIProvider(Provider):
             TrainingStatus.failed,
             TrainingStatus.cancelled,
         ]
-    
+
     @staticmethod
     def get_training_status(job_id: str) -> TrainingStatus:
         provider_status_to_training_status = {
@@ -234,11 +231,7 @@ class OpenAIProvider(Provider):
         return provider_file.id
 
     @staticmethod
-    def _start_remote_training(
-        train_file_id: str,
-        model: str,
-        train_kwargs: Optional[Dict[str, Any]] = None
-    ) -> str:
+    def _start_remote_training(train_file_id: str, model: str, train_kwargs: Optional[Dict[str, Any]] = None) -> str:
         train_kwargs = train_kwargs or {}
         provider_job = openai.fine_tuning.jobs.create(
             model=model,

--- a/dspy/clients/provider.py
+++ b/dspy/clients/provider.py
@@ -1,13 +1,13 @@
 from abc import abstractmethod
 from concurrent.futures import Future
 from threading import Thread
-from typing import Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from dspy.clients.utils_finetune import TrainDataFormat
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from dspy.clients.lm import LM
+
 
 class TrainingJob(Future):
     def __init__(

--- a/dspy/clients/utils_finetune.py
+++ b/dspy/clients/utils_finetune.py
@@ -62,12 +62,12 @@ def save_data(
 
 
 def validate_data_format(
-        data: List[Dict[str, Any]],
-        data_format: TrainDataFormat,
-    ):
+    data: List[Dict[str, Any]],
+    data_format: TrainDataFormat,
+):
     find_err_funcs = {
         TrainDataFormat.CHAT: find_data_error_chat,
-        TrainDataFormat.COMPLETION: find_data_errors_completion
+        TrainDataFormat.COMPLETION: find_data_errors_completion,
     }
     err = f"Data format {data_format} is not supported."
     assert data_format in find_err_funcs, err
@@ -83,7 +83,7 @@ def validate_data_format(
         if isinstance(data_dict, dict):
             err = find_err_func(data_dict)
         if err:
-            err_dict = dict(index=ind, error=err)
+            err_dict = {"index": ind, "error": err}
             data_dict_errors.append(err_dict)
 
     if data_dict_errors:
@@ -96,9 +96,7 @@ def validate_data_format(
         raise ValueError(err)
 
 
-def find_data_errors_completion(
-        data_dict: Dict[str, str]
-    ) -> Optional[str]:
+def find_data_errors_completion(data_dict: Dict[str, str]) -> Optional[str]:
     keys = ["prompt", "completion"]
 
     assert isinstance(data_dict, dict)
@@ -106,7 +104,7 @@ def find_data_errors_completion(
     found_keys = sorted(data_dict.keys())
     if set(expected_keys) != set(found_keys):
         return f"Expected Keys: {expected_keys}; Found Keys: {found_keys}"
-    
+
     for key in keys:
         if not isinstance(data_dict[key], str):
             return f"Expected `{key}` to be of type `str`. Found: {type(data_dict[key])}"
@@ -114,9 +112,7 @@ def find_data_errors_completion(
 
 # Following functions are modified from the OpenAI cookbook:
 # https://cookbook.openai.com/examples/chat_finetuning_data_prep
-def find_data_error_chat(
-        messages: Dict[str, Any]
-    ) -> Optional[str]:
+def find_data_error_chat(messages: Dict[str, Any]) -> Optional[str]:
     assert isinstance(messages, dict)
 
     expected_keys = ["messages"]
@@ -133,9 +129,7 @@ def find_data_error_chat(
             return f"Error in message at index {ind}: {err}"
 
 
-def find_data_error_chat_message(
-        message: Dict[str, Any]
-    ) -> Optional[str]:
+def find_data_error_chat_message(message: Dict[str, Any]) -> Optional[str]:
     assert isinstance(message, dict)
 
     message_keys = sorted(["role", "content"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,58 +109,27 @@ exclude_lines = [
 ]
 
 [tool.ruff]
-include = ["dspy/**/*.py", "tests/**/*.py"]
-
-
 line-length = 120
 indent-width = 4
 target-version = "py39"
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "C",   # flake8-comprehensions
-    "B",   # flake8-bugbear
-    "UP",  # ≈
-    "N",   # pep8-naming
-    "RUF", # ruff-specific rules
+    "F", # Pyflakes
+    "E", # Pycodestyle
+    "TID252", # Absolute imports
 ]
-
 ignore = [
-    "B027",  # Allow non-abstract empty methods in abstract base classes
-    "FBT003",# Allow boolean positional values in function calls
-    "C901",  # Ignore complexity checking
-    "E501",  # Ignore line length errors (handled by formatter)
-    "UP006", # Allow python typing modules
-    "UP035", # Allow python typing modules
-    "RUF005", # Allow using + operator to concatenate collections
-    "B904", # Allow raise custom exceptions in except blocks
+    "E501", # Line too long
 ]
-
-# Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []
 
 [tool.ruff.format]
 docstring-code-format = false
-quote-style = "double"
 indent-style = "space"
-skip-magic-trailing-comma = false
 line-ending = "auto"
 
-[tool.ruff.lint.isort]
-known-first-party = ["dspy"]
-
-[tool.ruff.lint.flake8-tidy-imports]
-ban-relative-imports = "all"
-
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = [
-    "S101",    # Allow assert statements in tests
-    "TID252",  # Allow relative imports in tests
-    "ARG001",  # Allow unused arguments in tests (like pytest fixtures)
-]
-"__init__.py" = ["F401"]  # Init files can be empty
+"**/{tests,testing,docs}/*" = ["ALL"]
+"**__init__.py" = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,27 +109,54 @@ exclude_lines = [
 ]
 
 [tool.ruff]
+include = ["dspy/**/*.py", "tests/**/*.py"]
+
+
 line-length = 120
 indent-width = 4
 target-version = "py39"
 
 [tool.ruff.lint]
 select = [
-    "F", # Pyflakes
-    "E", # Pycodestyle
-    "TID252", # Absolute imports
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "C",   # flake8-comprehensions
+    "B",   # flake8-bugbear
+    "UP",  # ≈
+    "N",   # pep8-naming
+    "RUF", # ruff-specific rules
 ]
+
 ignore = [
-    "E501", # Line too long
+    "B027",  # Allow non-abstract empty methods in abstract base classes
+    "FBT003",# Allow boolean positional values in function calls
+    "C901",  # Ignore complexity checking
+    "E501",  # Ignore line length errors (handled by formatter)
 ]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = []
 
 [tool.ruff.format]
 docstring-code-format = false
+quote-style = "double"
 indent-style = "space"
+skip-magic-trailing-comma = false
 line-ending = "auto"
 
+[tool.ruff.lint.isort]
+known-first-party = ["dspy"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
 [tool.ruff.lint.per-file-ignores]
-"**/{tests,testing,docs}/*" = ["ALL"]
-"**__init__.py" = ["ALL"]
+"tests/**/*.py" = [
+    "S101",    # Allow assert statements in tests
+    "TID252",  # Allow relative imports in tests
+    "ARG001",  # Allow unused arguments in tests (like pytest fixtures)
+]
+"__init__.py" = ["F401"]  # Init files can be empty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,10 @@ ignore = [
     "FBT003",# Allow boolean positional values in function calls
     "C901",  # Ignore complexity checking
     "E501",  # Ignore line length errors (handled by formatter)
+    "UP006", # Allow python typing modules
+    "UP035", # Allow python typing modules
+    "RUF005", # Allow using + operator to concatenate collections
+    "B904", # Allow raise custom exceptions in except blocks
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
We are standardizing the coding style rules in https://github.com/stanfordnlp/dspy/pull/7885. Before checking in https://github.com/stanfordnlp/dspy/pull/7885, we are running through our directories to fix all broken rules. Afterwards we can turn on strict style checking in github actions.

This PR handles `dspy/clients`. `lm.py` is not touched in this PR to avoid merging conflict with other pending PRs. 