### PR TITLE
Increased test coverage for ChatAdapter

### DIFF
--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -120,16 +120,17 @@ def test_chat_adapter_with_pydantic_models():
     program = dspy.Predict(TestSignature)
 
     with mock.patch("litellm.completion") as mock_completion:
-        program(sig_input={"subfield1": True, "nested_field": {"subsubfield1": "Test", "subsubfield2": 11}})
+        program(sig_input=InputField(subfield1=True, nested_field=NestedField(subsubfield1="Test", subsubfield2=10)))
 
     mock_completion.assert_called_once()
     _, call_kwargs = mock_completion.call_args
 
     system_content = call_kwargs["messages"][0]["content"]
     user_content = call_kwargs["messages"][1]["content"]
-
-    assert "InputField" in system_content
-    assert "OutputField" in system_content
+    print(user_content)
+    print(system_content)
+    assert "1. `sig_input` (InputField)" in system_content
+    assert "1. `sig_output` (OutputField)" in system_content
     assert "subfield1" in system_content
     assert "subfield2" in system_content
     assert "subfield3" in system_content

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -131,9 +131,6 @@ def test_chat_adapter_with_pydantic_models():
 
     system_content = call_kwargs["messages"][0]["content"]
     user_content = call_kwargs["messages"][1]["content"]
-    print(system_content)
-    print("\n\n\n\n\n")
-    print(user_content)
     assert "1. `owner` (PetOwner)" in system_content
     assert "2. `question` (str)" in system_content
     assert "1. `output` (Answer)" in system_content

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -99,6 +99,10 @@ async def test_chat_adapter_async_call():
 
 
 def test_chat_adapter_with_pydantic_models():
+    """
+    This test verifies that ChatAdapter can handle different input and output field types, both basic and nested.
+    """
+
     class DogClass(pydantic.BaseModel):
         dog_breeds: list[str] = pydantic.Field(description="List of the breeds of dogs")
         num_dogs: int = pydantic.Field(description="Number of dogs the owner has", ge=0, le=10)
@@ -144,6 +148,10 @@ def test_chat_adapter_with_pydantic_models():
 
 
 def test_chat_adapter_signature_information():
+    """
+    This test ensures that the signature information sent to the LM follows an expected format.
+    """
+
     class TestSignature(dspy.Signature):
         input1: str = dspy.InputField(desc="String Input")
         input2: int = dspy.InputField(desc="Integer Input")
@@ -180,6 +188,9 @@ def test_chat_adapter_signature_information():
 
 
 def test_chat_adapter_exception_raised_on_failure():
+    """
+    This test ensures that on an error, ChatAdapter raises an explicit exception.
+    """
     signature = dspy.make_signature("question->answer")
     adapter = dspy.ChatAdapter()
     invalid_completion = "{'output':'mismatched value'}"

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -194,7 +194,7 @@ def test_chat_adapter_exception_raised_on_failure():
     signature = dspy.make_signature("question->answer")
     adapter = dspy.ChatAdapter()
     invalid_completion = "{'output':'mismatched value'}"
-    with pytest.raises(ValueError) as error:
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="Adapter ChatAdapter failed to parse*"):
         adapter.parse(signature, invalid_completion)
 
 

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -127,8 +127,7 @@ def test_chat_adapter_with_pydantic_models():
 
     system_content = call_kwargs["messages"][0]["content"]
     user_content = call_kwargs["messages"][1]["content"]
-    print(user_content)
-    print(system_content)
+
     assert "1. `sig_input` (InputField)" in system_content
     assert "1. `sig_output` (OutputField)" in system_content
     assert "subfield1" in system_content
@@ -180,8 +179,8 @@ def test_chat_adapter_signature_information():
 def test_chat_adapter_exception_raised_on_failure():
     signature = dspy.make_signature("question->answer")
     adapter = dspy.ChatAdapter()
-    invalid_completion = r'[{"answer": "output"}]'
-    with pytest.raises(ValueError, match=r'[{"answer": "expected"}]'):
+    invalid_completion = "{'output':'mismatched value'}"
+    with pytest.raises(ValueError) as error:
         adapter.parse(signature, invalid_completion)
 
 


### PR DESCRIPTION
Fixes for https://github.com/stanfordnlp/dspy/issues/8120

Adds 3 new tests to ChatAdapter: 

* **test_chat_adapter_with_pydantic_models()**: Validates and ensures that ChatAdapter can use Pydantic models as inputs and outputs, nested or basic

* **test_chat_adapter_signature_information()**: Ensures that the signature information sent with ChatAdapter follows an expected structure and format

* **test_chat_adapter_exception_raised_on_failure()** : Ensures that a specific error is called upon failure

All tests were passed. If there are any changes you'd like me to make, please let me know! More than happy to contribute. 