### PR TITLE
Make it easier to do sync streaming

### DIFF
--- a/docs/docs/tutorials/streaming/index.md
+++ b/docs/docs/tutorials/streaming/index.md
@@ -393,3 +393,57 @@ Final output:  Prediction(
     sum='9'
 )
 ```
+
+## Synchronous Streaming
+
+By default calling a streamified DSPy program produces an async generator. In order to get back
+a sync generator, you can set the flag `async_streaming=False`:
+
+```
+import os
+
+import dspy
+
+os.environ["OPENAI_API_KEY"] = "your_api_key"
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+
+predict = dspy.Predict("question->answer")
+
+# Enable streaming for the 'answer' field
+stream_predict = dspy.streamify(
+    predict,
+    stream_listeners=[dspy.streaming.StreamListener(signature_field_name="answer")],
+)
+```
+
+To consume the streamed output:
+
+```python
+import os
+
+import dspy
+
+os.environ["OPENAI_API_KEY"] = "your_api_key"
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+
+predict = dspy.Predict("question->answer")
+
+# Enable streaming for the 'answer' field
+stream_predict = dspy.streamify(
+    predict,
+    stream_listeners=[dspy.streaming.StreamListener(signature_field_name="answer")],
+    async_streaming=False,
+)
+
+output = stream_predict(question="why did a chicken cross the kitchen?")
+
+program_output = None
+for chunk in output:
+    if isinstance(chunk, dspy.streaming.StreamResponse):
+        print(chunk)
+    elif isinstance(chunk, dspy.Prediction):
+        program_output = chunk
+print(f"Program output: {program_output}")
+```

--- a/docs/docs/tutorials/streaming/index.md
+++ b/docs/docs/tutorials/streaming/index.md
@@ -399,25 +399,6 @@ Final output:  Prediction(
 By default calling a streamified DSPy program produces an async generator. In order to get back
 a sync generator, you can set the flag `async_streaming=False`:
 
-```
-import os
-
-import dspy
-
-os.environ["OPENAI_API_KEY"] = "your_api_key"
-
-dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
-
-predict = dspy.Predict("question->answer")
-
-# Enable streaming for the 'answer' field
-stream_predict = dspy.streamify(
-    predict,
-    stream_listeners=[dspy.streaming.StreamListener(signature_field_name="answer")],
-)
-```
-
-To consume the streamed output:
 
 ```python
 import os

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -249,11 +249,11 @@ def test_sync_streaming():
             dspy.streaming.StreamListener(signature_field_name="judgement"),
         ],
         include_final_prediction_in_output_stream=False,
+        async_streaming=False,
     )
     output = program(x="why did a chicken cross the kitchen?")
-    sync_output = dspy.streaming.apply_sync_streaming(output)
     all_chunks = []
-    for value in sync_output:
+    for value in output:
         if isinstance(value, dspy.streaming.StreamResponse):
             all_chunks.append(value)
 


### PR DESCRIPTION
Introduce a bool flag `async_streaming` to `dspy.streamify` so that users can switch easily between sync and async streaming.