### PR TITLE
Allow state management of tools

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -1,4 +1,5 @@
 import logging
+from copy import deepcopy
 from typing import Any, Callable, Literal
 
 from litellm import ContextWindowExceededError
@@ -76,6 +77,7 @@ class ReAct(Module):
     def forward(self, **input_args):
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
+        tools = deepcopy(self.tools)
         for idx in range(max_iters):
             try:
                 pred = self._call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
@@ -88,7 +90,7 @@ class ReAct(Module):
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
             try:
-                trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](**pred.next_tool_args)
+                trajectory[f"observation_{idx}"] = tools[pred.next_tool_name](**pred.next_tool_args)
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
 
@@ -101,6 +103,7 @@ class ReAct(Module):
     async def aforward(self, **input_args):
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
+        tools = deepcopy(self.tools)
         for idx in range(max_iters):
             try:
                 pred = await self._async_call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
@@ -113,7 +116,7 @@ class ReAct(Module):
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
             try:
-                trajectory[f"observation_{idx}"] = await self.tools[pred.next_tool_name].acall(**pred.next_tool_args)
+                trajectory[f"observation_{idx}"] = await tools[pred.next_tool_name].acall(**pred.next_tool_args)
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
 
@@ -211,9 +214,4 @@ TOPIC 04: Default behavior when the trajectory gets too long.
 TOPIC 05: Adding more structure around how the instruction is formatted.
     * Concretely, it's now a string, so an optimizer can and does rewrite it freely.
     * An alternative would be to add more structure, such that a certain template is fixed but values are variable?
-
-
-TOPIC 06: Idiomatically allowing tools that maintain state across iterations, but not across different `forward` calls.
-    * So the tool would be newly initialized at the start of each `forward` call, but maintain state across iterations.
-    * This is pretty useful for allowing the agent to keep notes or count certain things, etc.
 """

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -332,3 +332,61 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_tool_call_state_management():
+    # Create a tool class that maintains state
+    class Counter():
+        def __init__(self):
+            self.count = 0
+
+        def __call__(self, i: int):
+            self.count += i
+            return self.count
+    
+    counter = Counter()
+
+    react = dspy.ReAct("max -> sum:int", tools=[counter])
+    lm = DummyLM(
+        [
+            {"next_thought": "I need to add 1", "next_tool_name": "Counter", "next_tool_args": {"i": 1}},
+            {"next_thought": "I need to add 2", "next_tool_name": "Counter", "next_tool_args": {"i": 2}},
+            {"next_thought": "I need to add 3", "next_tool_name": "Counter", "next_tool_args": {"i": 3}},
+            {"next_thought": "I have the sum, now I can finish.", "next_tool_name": "finish", "next_tool_args": {}},
+            {"reasoning": "I added the numbers successfully", "sum": 6},
+        ]
+    )
+    dspy.settings.configure(lm=lm)
+
+    outputs = react(call_count=3) 
+    
+    assert outputs.sum == 6
+    # Verify the state is not changed after the forward call
+    assert counter.count == 0
+
+    # Check the state is managed during the forward call
+    expected_trajectory = {
+        "thought_0": "I need to add 1",
+        "tool_name_0": "Counter",
+        "tool_args_0": {
+            "i": 1,
+        },
+        "observation_0": 1,
+        "thought_1": "I need to add 2",
+        "tool_name_1": "Counter",
+        "tool_args_1": {
+            "i": 2,
+        },
+        "observation_1": 3,
+        "thought_2": "I need to add 3",
+        "tool_name_2": "Counter",
+        "tool_args_2": {
+            "i": 3,
+        },
+        "observation_2": 6,
+        "thought_3": "I have the sum, now I can finish.",
+        "tool_name_3": "finish",
+        "tool_args_3": {},
+        "observation_3": "Completed.",
+    }
+    assert outputs.trajectory == expected_trajectory


### PR DESCRIPTION
This PR allows tools to maintain states during the lifespan of each `ReAct.forward` without affecting other executions by making the copies of tool objects. Users can create a tool class that mutates instance variables. 

```python
class Counter():
    def __init__(self):
        self.count = 0

    def __call__(self, i: int):
        self.count += i
        return self.count

counter = Counter()

react = dspy.ReAct("max -> sum:int", tools=[counter])
```