### PR TITLE
Remove Unnecessary Comma in `arbor.yaml`

### DIFF
--- a/docs/docs/tutorials/rl_multihop/index.ipynb
+++ b/docs/docs/tutorials/rl_multihop/index.ipynb
@@ -21,7 +21,7 @@
     "\n",
     "```text\n",
     "inference:\n",
-    "  gpu_ids: '0,'\n",
+    "  gpu_ids: '0'\n",
     "\n",
     "training:\n",
     "  gpu_ids: '1, 2'\n",


### PR DESCRIPTION
We fixed this in the papillon tutorial but not this one