### PR TITLE
Fix reference to undefined dsp.passages2text

### DIFF
--- a/dspy/propose/instruction_proposal.py
+++ b/dspy/propose/instruction_proposal.py
@@ -120,7 +120,6 @@ class GenerateInstructionGivenAttempts(dspy.Signature):
 
 Your task is to propose a new instruction that will lead a good language model to perform the task even better. Don't be afraid to be creative."""
 
-        attempted_instructions = dspy.InputField(format=dsp.passages2text)
-        # attempted_instructions = dspy.InputField(desc="Previously attempted task instructions, along with their resulting validation score, and an example of the instruction in use on a sample from our dataset.")
+        attempted_instructions = dspy.InputField(desc="Previously attempted task instructions, along with their resulting validation score, and an example of the instruction in use on a sample from our dataset.")
         proposed_instruction = dspy.OutputField(desc="The improved instructions for the language model")
         proposed_prefix_for_output_field = dspy.OutputField(desc="The string at the end of the prompt, which will help the model start solving the task")

--- a/tests/propose/test_instruction_proposal.py
+++ b/tests/propose/test_instruction_proposal.py
@@ -1,0 +1,23 @@
+import dspy
+from dspy.propose.instruction_proposal import GenerateInstructionGivenAttempts
+from dspy.utils.dummies import DummyLM
+
+
+def test_generate_instruction_given_attempts_minimal():
+    """Test that the GenerateInstructionGivenAttempts signature initializes correctly"""
+    
+    dummy_lm = DummyLM([{
+        "proposed_instruction": "Better instruction",
+        "proposed_prefix_for_output_field": "Result:",
+    }])
+    dspy.settings.configure(lm=dummy_lm)
+    
+    # Create a predictor with the signature
+    predictor = dspy.Predict(GenerateInstructionGivenAttempts)
+    
+    # Basic test - just ensure we can call it without errors
+    result = predictor(attempted_instructions=["Instruction #1: Test", "Score #1: 0.5"])
+    
+    # Verify structure of the result
+    assert hasattr(result, "proposed_instruction")
+    assert hasattr(result, "proposed_prefix_for_output_field")


### PR DESCRIPTION
Fixes a missing import bug in GenerateInstructionGivenAttempts (instruction_proposal.py), where dsp.passages2text was referenced but not defined. This breaks the COPRO optimizer (copro_optimizer.py). Replaced with a descriptive InputField definition to restore functionality without changing behavior.