### PR TITLE
fix: Streaming with Status Message Provider

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -272,6 +272,9 @@ async def streaming_response(streamer: AsyncGenerator) -> AsyncGenerator:
         elif isinstance(value, litellm.ModelResponseStream):
             data = {"chunk": value.json()}
             yield f"data: {ujson.dumps(data)}\n\n"
+        elif isinstance(value, StatusMessage):
+            data = {"status": value.message}
+            yield f"data: {ujson.dumps(data)}\n\n"
         elif isinstance(value, str) and value.startswith("data:"):
             # The chunk value is an OpenAI-compatible streaming chunk value,
             # e.g. "data: {"finish_reason": "stop", "index": 0, "is_finished": True, ...}",

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -3,6 +3,7 @@ import contextvars
 import logging
 import threading
 from asyncio import iscoroutinefunction
+from dataclasses import asdict
 from queue import Queue
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator, List, Optional
 
@@ -14,7 +15,7 @@ from litellm import ModelResponseStream
 
 from dspy.dsp.utils.settings import settings
 from dspy.primitives.prediction import Prediction
-from dspy.streaming.messages import StatusMessage, StatusMessageProvider, StatusStreamingCallback
+from dspy.streaming.messages import StatusMessage, StatusMessageProvider, StatusStreamingCallback, StreamResponse
 from dspy.streaming.streaming_listener import StreamListener, find_predictor_for_stream_listeners
 from dspy.utils.asyncify import asyncify
 
@@ -274,6 +275,9 @@ async def streaming_response(streamer: AsyncGenerator) -> AsyncGenerator:
             yield f"data: {ujson.dumps(data)}\n\n"
         elif isinstance(value, StatusMessage):
             data = {"status": value.message}
+            yield f"data: {ujson.dumps(data)}\n\n"
+        elif isinstance(value, StreamResponse):
+            data = {"chunk": {k: v for k, v in asdict(value).items()}}
             yield f"data: {ujson.dumps(data)}\n\n"
         elif isinstance(value, str) and value.startswith("data:"):
             # The chunk value is an OpenAI-compatible streaming chunk value,


### PR DESCRIPTION
When using a custom `StatusMessageProvider` to stream the intermediate status there are errors in FastAPI. This PR intends to fix it.

```python
class MyStatusMessageProvider(dspy.streaming.StatusMessageProvider):
    def tool_start_status_message(self, instance, inputs):
        return f"`Pythia is using tool {instance.name}...`"
    def tool_end_status_message(self, outputs):
        return ''
    def lm_start_status_message(self, instance, inputs):
        return f"`Pythia is thinking...`"

@router.post("/predict/stream")
def stream(question: Question):
    stream = stream_predict(question=question.text)
    return StreamingResponse(streaming_response(stream), media_type="text/event-stream")


File "/code/.venv/lib/python3.12/site-packages/dspy/streaming/streamify.py", line 270, in streaming_response
2025-05-14T14:34:38.741268688Z     |     raise ValueError(f"Unknown chunk value type: {value}")
2025-05-14T14:34:38.741275938Z     | ValueError: Unknown chunk value type: StatusMessage(message='`Pythia is using tool search_human_ressources_documents...`')
2025-05-14T14:34:38.741305355Z     +------------------------------------

....


File "/code/.venv/lib/python3.12/site-packages/starlette/responses.py", line 246, in stream_response
2025-05-14T14:34:38.743937321Z     async for chunk in self.body_iterator:
2025-05-14T14:34:38.743963404Z   File "/code/.venv/lib/python3.12/site-packages/dspy/streaming/streamify.py", line 270, in streaming_response
2025-05-14T14:34:38.743981321Z     raise ValueError(f"Unknown chunk value type: {value}")
```

Example of output after the PR in FastAPI:

```
data: {"status":"`Pythia is using tool search_human_ressources_documents...`"}
data: {"status":"`Pythia is using tool search_human_ressources_documents...`"}
data: {"status":"`Pythia is using tool search_human_ressources_documents...`"}
data: {"status":"`Pythia is using tool search_human_ressources_documents...`"}
data: {"status":"`Pythia is thinking...`"}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":"\nThe exact"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" number of vacation days"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" for a wedding is"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" not clearly specifie"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":"d in the available documents"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":". It is"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" recommended to:"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":"\n1. Cons"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":"ult directly with your"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" HR department"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":"\n2. Check"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" your"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" specific"}}
data: {"chunk":{"predict_name":"extract.predict","signature_field_name":"answer","chunk":" employment contract\n3. Discuss the details with your manager\nTypically, companies may allow 1-3 days for a wedding, but this can vary widely between organizations."}}

data: {"prediction":{"trajectory":{"thought_0":"I'll search the human resources documents to find the policy regarding vacation days for a wedding, as this is typically covered in HR policies.","tool_name_0":"search_human_ressources_documents","tool_args_0":{},"observation_0":"Dummy Tool Call","thought_1":"I'll carefully review the search results to find specific information about vacation days for a wedding. Typically, companies have policies for personal events like weddings, and I want to find the exact number of days allowed.","tool_name_1":"search_human_ressources_documents","tool_args_1":{},"observation_1":"Dummy Tool Call","thought_2":"I notice that I haven't found a clear answer about the number of vacation days for a wedding yet. I'll continue searching the HR documents, being more specific in my mental query about wedding-related leave or personal event days.","tool_name_2":"search_human_ressources_documents","tool_args_2":{},"observation_2":"Dummy Tool Call","thought_3":"After multiple searches in the HR documents, I still haven't found a definitive answer about the specific number of vacation days allowed for a wedding. I'll try one more search with a broader approach to find information about personal leave or special event days.","tool_name_3":"search_human_ressources_documents","tool_args_3":{},"observation_3":"Dummy Tool Call","thought_4":"After multiple searches in the HR documents, I have not found a clear, definitive answer about the specific number of vacation days allowed for a wedding. This suggests that I might need to broaden my search or conclude that the information may not be readily available in the current document set.","tool_name_4":"finish","tool_args_4":{},"observation_4":"Completed."},"reasoning":"After conducting multiple searches through the human resources documents, I was unable to find a definitive answer about the specific number of vacation days allowed for a wedding. The searches did not yield clear information about wedding-related leave or personal event days. This suggests that the number of vacation days for a wedding may vary depending on the specific company policy, and might require direct consultation with the HR department.","answer":"The exact number of vacation days for a wedding is not clearly specified in the available documents. It is recommended to:\n1. Consult directly with your HR department\n2. Check your specific employment contract\n3. Discuss the details with your manager\nTypically, companies may allow 1-3 days for a wedding, but this can vary widely between organizations.","s3_keys":[]}}

data: [DONE]
```