### PR TITLE
feat(dspy): custom type resolution in Signatures

### DIFF
--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -157,6 +157,46 @@ Prediction(
 )
 ```
 
+## Type Resolution in Signatures
+
+DSPy signatures support various annotation types:
+
+1. **Basic types** like `str`, `int`, `bool`
+2. **Typing module types** like `List[str]`, `Dict[str, int]`, `Optional[float]`
+3. **Custom types** defined in your code
+4. **Dot notation** for nested types with proper configuration
+5. **Special data types** like `dspy.Image`
+
+### Working with Custom Types
+
+```python
+# Simple custom type
+class QueryResult(pydantic.BaseModel):
+    text: str
+    score: float
+
+# Automatic resolution - works in the same scope
+signature = dspy.Signature("query: str -> result: QueryResult")
+
+# Nested types with dot notation
+class Container:
+    class NestedType(pydantic.BaseModel):
+        value: str
+
+# Approach 1: Type aliases (recommended)
+NestedResult = Container.NestedType
+signature = dspy.Signature("query: str -> result: NestedResult")
+
+# Approach 2: Explicit custom_types parameter
+signature = dspy.Signature(
+    "query: str -> result: Container.NestedType",
+    custom_types={
+        "Container": Container,
+        "Container.NestedType": Container.NestedType
+    }
+)
+```
+
 ## Using signatures to build modules & compiling them
 
 While signatures are convenient for prototyping with structured inputs/outputs, that's not the only reason to use them!

--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -32,6 +32,13 @@ Your signatures can also have multiple input/output fields with types:
 
 **Tip:** For fields, any valid variable names work! Field names should be semantically meaningful, but start simple and don't prematurely optimize keywords! Leave that kind of hacking to the DSPy compiler. For example, for summarization, it's probably fine to say `"document -> summary"`, `"text -> gist"`, or `"long_context -> tldr"`.
 
+You can also add instructions to your inline signature, which can use variables at runtime. Use the `instructions` keyword argument to add instructions to your signature.
+
+```python
+toxicity = dspy.Predict(
+    'comment -> toxic: bool',
+    instructions="Mark as 'toxic' if the comment includes insults, harassment, or sarcastic derogatory remarks.")
+```
 
 ### Example A: Sentiment Classification
 
@@ -162,10 +169,10 @@ Prediction(
 DSPy signatures support various annotation types:
 
 1. **Basic types** like `str`, `int`, `bool`
-2. **Typing module types** like `List[str]`, `Dict[str, int]`, `Optional[float]`
+2. **Typing module types** like `List[str]`, `Dict[str, int]`, `Optional[float]`. `Union[str, int]`
 3. **Custom types** defined in your code
 4. **Dot notation** for nested types with proper configuration
-5. **Special data types** like `dspy.Image`
+5. **Special data types** like `dspy.Image, dspy.History`
 
 ### Working with Custom Types
 
@@ -175,26 +182,15 @@ class QueryResult(pydantic.BaseModel):
     text: str
     score: float
 
-# Automatic resolution - works in the same scope
 signature = dspy.Signature("query: str -> result: QueryResult")
 
-# Nested types with dot notation
 class Container:
-    class NestedType(pydantic.BaseModel):
-        value: str
+    class Query(pydantic.BaseModel):
+        text: str
+    class Score(pydantic.BaseModel):
+        score: float
 
-# Approach 1: Type aliases (recommended)
-NestedResult = Container.NestedType
-signature = dspy.Signature("query: str -> result: NestedResult")
-
-# Approach 2: Explicit custom_types parameter
-signature = dspy.Signature(
-    "query: str -> result: Container.NestedType",
-    custom_types={
-        "Container": Container,
-        "Container.NestedType": Container.NestedType
-    }
-)
+signature = dspy.Signature("query: Container.Query -> score: Container.Score")
 ```
 
 ## Using signatures to build modules & compiling them

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -21,6 +21,7 @@ import inspect
 import re
 import types
 import typing
+import sys
 from copy import deepcopy
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
@@ -61,9 +62,6 @@ class SignatureMeta(type(BaseModel)):
         For more reliable custom type resolution, explicitly provide types using the 
         `custom_types` parameter when creating a Signature.
         """
-        import inspect
-        import re
-        import sys
 
         # Extract potential type names from the signature string, including dotted names
         # Match both simple types like 'MyType' and dotted names like 'Module.Type'

--- a/tests/signatures/test_custom_types.py
+++ b/tests/signatures/test_custom_types.py
@@ -34,6 +34,15 @@ def test_type_alias_for_nested_types():
     alias_sig = Signature("input: str -> output: NestedType")
     assert alias_sig.output_fields["output"].annotation == Container.NestedType
 
+    class Container2:
+        class Query(pydantic.BaseModel):
+            text: str
+        class Score(pydantic.BaseModel):
+            score: float
+
+    signature = dspy.Signature("query: Container2.Query -> score: Container2.Score")
+    assert signature.output_fields["score"].annotation == Container2.Score
+
 
 class GlobalCustomType(pydantic.BaseModel):
     """A type defined at module level for testing module-level resolution."""
@@ -83,6 +92,7 @@ def test_recommended_patterns():
     assert sig5.output_fields["output"].annotation == OuterContainer.InnerType
 
 def test_expected_failure():
+    # InnerType DNE when not OuterContainer.InnerTypes, so this type shouldnt be resolved
     with pytest.raises(ValueError):
         sig4 = Signature("input: str -> output: InnerType")
         assert sig4.output_fields["output"].annotation == InnerType

--- a/tests/signatures/test_custom_types.py
+++ b/tests/signatures/test_custom_types.py
@@ -78,7 +78,7 @@ def test_recommended_patterns():
     sig4 = Signature("input: str -> output: InnerTypeAlias")
     assert sig4.output_fields["output"].annotation == InnerTypeAlias
 
-    # PATTERN 5: Nested type with dot notation and alias
+    # PATTERN 5: Nested type with dot notation
     sig5 = Signature("input: str -> output: OuterContainer.InnerType")
     assert sig5.output_fields["output"].annotation == OuterContainer.InnerType
 
@@ -87,7 +87,6 @@ def test_expected_failure():
         sig4 = Signature("input: str -> output: InnerType")
         assert sig4.output_fields["output"].annotation == InnerType
 
-# FROZEN -- DO NOT EDIT THIS TEST
 def test_module_type_resolution():
     class TestModule(dspy.Module):
         def __init__(self):
@@ -100,3 +99,13 @@ def test_module_type_resolution():
     module = TestModule()
     sig = module.predict.signature
     assert sig.output_fields["output"].annotation == OuterContainer.InnerType
+
+def test_basic_custom_type_resolution():
+    class CustomType(pydantic.BaseModel):
+        value: str
+
+    sig = Signature("input: CustomType -> output: str", custom_types={"CustomType": CustomType})
+    assert sig.input_fields["input"].annotation == CustomType
+
+    sig = Signature("input: CustomType -> output: str")
+    assert sig.input_fields["input"].annotation == CustomType

--- a/tests/signatures/test_custom_types.py
+++ b/tests/signatures/test_custom_types.py
@@ -1,0 +1,102 @@
+import pydantic
+import pytest
+from typing import List, Dict, Any
+
+import dspy
+from dspy import Signature
+from dspy.utils.dummies import DummyLM
+
+
+def test_basic_custom_type_resolution():
+    """Test basic custom type resolution with both explicit and automatic mapping."""
+    class CustomType(pydantic.BaseModel):
+        value: str
+
+    # Custom types can be explicitly mapped
+    explicit_sig = Signature(
+        "input: CustomType -> output: str",
+        custom_types={"CustomType": CustomType}
+    )
+    assert explicit_sig.input_fields["input"].annotation == CustomType
+    
+    # Custom types can also be auto-resolved from caller's scope
+    auto_sig = Signature("input: CustomType -> output: str")
+    assert auto_sig.input_fields["input"].annotation == CustomType
+
+
+def test_type_alias_for_nested_types():
+    """Test using type aliases for nested types."""
+    class Container:
+        class NestedType(pydantic.BaseModel):
+            value: str
+    
+    NestedType = Container.NestedType
+    alias_sig = Signature("input: str -> output: NestedType")
+    assert alias_sig.output_fields["output"].annotation == Container.NestedType
+
+
+class GlobalCustomType(pydantic.BaseModel):
+    """A type defined at module level for testing module-level resolution."""
+    value: str
+    notes: str = ""
+
+
+def test_module_level_type_resolution():
+    """Test resolution of types defined at module level."""
+    # Module-level types can be auto-resolved
+    sig = Signature("name: str -> result: GlobalCustomType")
+    assert sig.output_fields["result"].annotation == GlobalCustomType
+
+
+# Create module-level nested class for testing
+class OuterContainer:
+    class InnerType(pydantic.BaseModel):
+        name: str
+        value: int
+
+
+def test_recommended_patterns():
+    """Test recommended patterns for working with custom types in signatures."""
+    
+    # PATTERN 1: Local type with auto-resolution
+    class LocalType(pydantic.BaseModel):
+        value: str
+    
+    sig1 = Signature("input: str -> output: LocalType")
+    assert sig1.output_fields["output"].annotation == LocalType
+    
+    # PATTERN 2: Module-level type with auto-resolution
+    sig2 = Signature("input: str -> output: GlobalCustomType")
+    assert sig2.output_fields["output"].annotation == GlobalCustomType
+    
+    # PATTERN 3: Nested type with dot notation
+    sig3 = Signature("input: str -> output: OuterContainer.InnerType")
+    assert sig3.output_fields["output"].annotation == OuterContainer.InnerType
+
+    # PATTERN 4: Nested type using alias
+    InnerTypeAlias = OuterContainer.InnerType
+    sig4 = Signature("input: str -> output: InnerTypeAlias")
+    assert sig4.output_fields["output"].annotation == InnerTypeAlias
+
+    # PATTERN 5: Nested type with dot notation and alias
+    sig5 = Signature("input: str -> output: OuterContainer.InnerType")
+    assert sig5.output_fields["output"].annotation == OuterContainer.InnerType
+
+def test_expected_failure():
+    with pytest.raises(ValueError):
+        sig4 = Signature("input: str -> output: InnerType")
+        assert sig4.output_fields["output"].annotation == InnerType
+
+# FROZEN -- DO NOT EDIT THIS TEST
+def test_module_type_resolution():
+    class TestModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predict = dspy.Predict("input: str -> output: OuterContainer.InnerType")
+
+        def predict(self, input: str) -> str:
+            return input
+
+    module = TestModule()
+    sig = module.predict.signature
+    assert sig.output_fields["output"].annotation == OuterContainer.InnerType


### PR DESCRIPTION
## 📝 Changes Description
Added support for custom type resolution in Signatures. Allows users to reference their own types in string-based signature definitions.

Added custom_types parameter to make_signature. Uses caller's frame to detect custom types.

## ⚠️ Warnings

Anything we should be aware of ?
