### PR TITLE
Revert uv.lock changes

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -43,6 +43,8 @@ class UsageTracker:
                 else:
                     result[k] = result[k] or 0
                     result[k] += v if v else 0
+            else:
+                result[k] = dict(v) if isinstance(v, dict) else v
         return result
 
     def add_usage(self, lm: str, usage_entry: dict):

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -157,3 +157,16 @@ def test_track_usage_context_manager():
     assert "openai/gpt-4o-mini" in total_usage
     assert len(total_usage.keys()) == 1
     assert isinstance(total_usage["openai/gpt-4o-mini"], dict)
+
+
+def test_merge_usage_entries_with_new_keys():
+    """Ensure merging usage entries preserves unseen keys."""
+    tracker = UsageTracker()
+
+    tracker.add_usage("model-x", {"prompt_tokens": 5})
+    tracker.add_usage("model-x", {"completion_tokens": 2})
+
+    total_usage = tracker.get_total_tokens()
+
+    assert total_usage["model-x"]["prompt_tokens"] == 5
+    assert total_usage["model-x"]["completion_tokens"] == 2


### PR DESCRIPTION
I *think* there's an error here where the entries are not being merged symmetrically. Before the fix, the function only handled keys already present in usage_entry2. Any key that existed solely in usage_entry1 was ignored. 