### PR TITLE
Fix DataLoader input key bug

### DIFF
--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -116,7 +116,7 @@ class DataLoader(Dataset):
         if not fields:
             fields = list(dataset.features)
 
-        return [dspy.Example({field: row[field] for field in fields}).with_inputs(input_keys) for row in dataset]
+        return [dspy.Example({field: row[field] for field in fields}).with_inputs(*input_keys) for row in dataset]
 
     def from_rm(self, num_samples: int, fields: List[str], input_keys: List[str]) -> List[dspy.Example]:
         try:


### PR DESCRIPTION
## Summary
- ensure input keys are expanded when loading parquet data

## Testing
- `pre-commit run --files dspy/datasets/dataloader.py` *(fails: command not found)*