### PR TITLE
Fix ReinforceJob LM reference

### DIFF
--- a/dspy/clients/provider.py
+++ b/dspy/clients/provider.py
@@ -37,7 +37,7 @@ class TrainingJob(Future):
 
 class ReinforceJob:
     def __init__(self, lm: "LM", train_kwargs: Optional[Dict[str, Any]] = None):
-        self.lm = LM
+        self.lm = lm
         self.train_kwargs = train_kwargs or {}
         self.checkpoints = {}
         self.last_checkpoint = None


### PR DESCRIPTION
## Summary
- correctly assign the LM instance in `ReinforceJob.__init__`

## Testing
- `ruff check dspy/clients/provider.py`
- `pytest -q` *(fails: command not found)*