### PR TITLE
Pin json-repair for python 3.9 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "magicattr>=0.1.6",
     "litellm>=1.60.3",
     "diskcache>=5.6.0",
-    "json-repair>=0.30.0",
+    "json-repair>=0.30.0,<0.45.0",
     "tenacity>=8.2.3",
     "anyio",
     "asyncer==0.0.8",

--- a/uv.lock
+++ b/uv.lock
@@ -665,7 +665,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "2.6.19"
+version = "2.6.24"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -734,7 +734,7 @@ requires-dist = [
     { name = "datasets", specifier = ">=2.14.6" },
     { name = "diskcache", specifier = ">=5.6.0" },
     { name = "joblib", specifier = "~=1.3" },
-    { name = "json-repair", specifier = ">=0.30.0" },
+    { name = "json-repair", specifier = ">=0.30.0,<0.45.0" },
     { name = "litellm", specifier = ">=1.60.3" },
     { name = "litellm", marker = "sys_platform == 'win32' and extra == 'dev'", specifier = ">=1.60.3" },
     { name = "litellm", extras = ["proxy"], marker = "sys_platform != 'win32' and extra == 'dev'", specifier = ">=1.60.3" },


### PR DESCRIPTION
json-repair dropped the support for python 3.9 since 0.45.0. So we should pin json-repair<0.45.0 until we drop the support for python 3.9
https://github.com/mangiucugna/json_repair/issues/124