### PR TITLE
Fix Pydantic v2 deprecation warning in json_adapter

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -210,7 +210,7 @@ def _get_structured_outputs_response_format(signature: SignatureMeta) -> type[py
     pydantic_model = pydantic.create_model(
         "DSPyProgramOutputs",
         **fields,
-        __config__=type("Config", (), {"extra": "forbid"}),
+        model_config={"extra": "forbid"},
     )
 
     # Generate the initial schema.


### PR DESCRIPTION
Replace deprecated `__config__` parameter with model_config in pydantic.create_model() to remove one case of the `PydanticDeprecatedSince20` warning.

The warning was:
```
.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:323
  /Users/brian/Programming/dspy/.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:323: PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
    warnings.warn(DEPRECATION_MESSAGE, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

This change updates the code to use the Pydantic v2 approach.