### PR TITLE
dspy.Image allows gs://image_urls

### DIFF
--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -78,7 +78,7 @@ def is_url(string: str) -> bool:
     """Check if a string is a valid URL."""
     try:
         result = urlparse(string)
-        return all([result.scheme in ("http", "https"), result.netloc])
+        return all([result.scheme in ("http", "https", "gs"), result.netloc])
     except ValueError:
         return False
 


### PR DESCRIPTION
Allows dspy.Image to have a gs_url that get's passed through and correctly ingested by LiteLLM.

Code Pointer to LiteLLM usage: https://github.com/BerriAI/litellm/blob/e9b7059af4d0aa0ad3da418628f34c1bd02251fa/litellm/llms/vertex_ai/gemini/transformation.py#L72

Example usage:

```python
class GsImageUrl(dspy.Signature):
    """Extract the leadership principles."""

    image: dspy.Image = dspy.InputField(desc="image of page")
    leadership_principles: list[str] = dspy.OutputField(desc="list of leadership principles")

module = dspy.Predict(GsImageUrl)
image_url = "gs://some_bucket/AmazonLeadershipPrinciplesPage1.png"
image = dspy.Image.from_url(image_url, False)
response = module(image=image)

print(response.leadership_principles)
```

Output: 
```
['Customer Obsession', 'Ownership', 'Invent and Simplify', 'Are Right, A Lot', 'Learn and Be Curious', 'Hire and Develop the Best', 'Insist on the Highest Standards']
```