### PR TITLE
Support for Service Principal Auth for Databricks Retrieve with DSPy 

### DIFF
--- a/dspy/retrieve/databricks_rm.py
+++ b/dspy/retrieve/databricks_rm.py
@@ -133,9 +133,13 @@ class DatabricksRM(dspy.Retrieve):
         self.databricks_endpoint = (
             databricks_endpoint if databricks_endpoint is not None else os.environ.get("DATABRICKS_HOST")
         )
-        self.databricks_client_id = databricks_client_id if databricks_client_id is not None else os.environ.get("DATABRICKS_CLIENT_ID")
+        self.databricks_client_id = (
+            databricks_client_id if databricks_client_id is not None else os.environ.get("DATABRICKS_CLIENT_ID")
+        )
         self.databricks_client_secret = (
-            databricks_client_secret if databricks_client_secret is not None else os.environ.get("DATABRICKS_CLIENT_SECRET")
+            databricks_client_secret
+            if databricks_client_secret is not None
+            else os.environ.get("DATABRICKS_CLIENT_SECRET")
         )
         if not _databricks_sdk_installed and (self.databricks_token, self.databricks_endpoint).count(None) > 0:
             raise ValueError(


### PR DESCRIPTION
### This PR adds support for authenticating with Databricks Vector Search using service principals. Users can now provide client ID and secret credentials as an alternative to personal access tokens.

### Changes

- Added support for service principal authentication in the DatabricksRM class
- Added two new optional parameters to the constructor:
  - databricks_client_id: Databricks service principal ID
  - databricks_client_secret: Databricks service principal secret
- Updated authentication logic to use service principal credentials when provided
- Added appropriate error handling and validation
- Added clear logging statements to indicate which authentication method is being used
- Updated documentation with new parameter descriptions

### Implementation Details
The implementation prioritizes service principal authentication when both client credentials and tokens are provided. This follows the standard pattern where more specific authentication methods take precedence over more general ones.

### Authentication now follows this logic:

- If client ID and secret are provided, use service principal authentication
- Otherwise, fall back to token-based authentication (existing behavior)

### Testing
Tested with:

- Service principal authentication using client ID and secret
- Token-based authentication (ensuring backward compatibility)
- Various combinations of missing credentials to verify error handling

### Documentation
Updated the docstring to include descriptions of the new parameters and their usage.