### PR TITLE
Fix the history related error of CodeAct

### DIFF
--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -41,6 +41,7 @@ class CodeAct(ReAct, ProgramOfThought):
         """
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
+        self.history = []
 
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
         if any(


### PR DESCRIPTION
Fix the exception of CodeAct caused by the lack of history field.