### PR TITLE
Fix missing doc link

### DIFF
--- a/docs/docs/tutorials/core_development/index.md
+++ b/docs/docs/tutorials/core_development/index.md
@@ -3,5 +3,6 @@
 - [Saving and Loading](/tutorials/saving/)
 - [Deployment](/tutorials/deployment/)
 - [Debugging & Observability](/tutorials/observability/)
+- [Tracking DSPy Optimizers](/tutorials/optimizer_tracking/)
 - [Streaming](/tutorials/streaming/)
 - [Async](/tutorials/async/)


### PR DESCRIPTION
<img width="781" alt="image" src="https://github.com/user-attachments/assets/5eba89dd-9b10-40f7-a001-9915403b9044" />

Tutorial link on tracking optimizers is missing on the right. 