### PR TITLE
Change tutorial order in the section "Build AI Programs with DSPy"

### DIFF
--- a/docs/docs/tutorials/build_ai_program/index.md
+++ b/docs/docs/tutorials/build_ai_program/index.md
@@ -1,6 +1,6 @@
+- [Build AI Agents with DSPy](/tutorials/customer_service_agent/)
 - [Retrieval-Augmented Generation (RAG)](/tutorials/rag/)
 - [Building RAG as Agent](/tutorials/agents/)
-- [Build AI Agents with DSPy](/tutorials/customer_service_agent/)
 - [Entity Extraction](/tutorials/entity_extraction/)
 - [Classification](/tutorials/classification/)
 - [Multi-Hop RAG](/tutorials/multihop_search/)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -27,8 +27,8 @@ nav:
         - Tutorials Overview: tutorials/index.md
         - Build AI Programs with DSPy:
             - Overview: tutorials/build_ai_program/index.md
-            - Retrieval-Augmented Generation (RAG): tutorials/rag/index.ipynb
             - Build AI Agents with DSPy: tutorials/customer_service_agent/index.ipynb
+            - Retrieval-Augmented Generation (RAG): tutorials/rag/index.ipynb
             - Building RAG as Agent: tutorials/agents/index.ipynb
             - Entity Extraction: tutorials/entity_extraction/index.ipynb
             - Classification: tutorials/classification/index.md


### PR DESCRIPTION
Currently the first tutorial on RAG is too complex: https://dspy.ai/tutorials/rag/, we should have a simpler one as the tutorial #1. 