### PR TITLE
Add pytest-asyncio to deps list of testing before pypi

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           source test_before_testpypi/bin/activate
           # Install the locally built wheel and testing dependencies
-          pip install dist/*.whl pytest
+          pip install dist/*.whl pytest pytest-asyncio
           pytest tests/metadata/test_metadata.py tests/predict
           deactivate
       # Publish to test-PyPI
@@ -100,7 +100,7 @@ jobs:
         run: |
           source test_before_pypi/bin/activate
           # Install the locally built wheel and testing dependencies
-          pip install dist/*.whl pytest
+          pip install dist/*.whl pytest pytest-asyncio
           pytest tests/metadata/test_metadata.py tests/predict
           deactivate
           rm -r test_before_pypi


### PR DESCRIPTION
We are missing requirement for async testing, which didn't throw errors in the past because those tests were skipped in CI. But it's raising error now: https://github.com/stanfordnlp/dspy/actions/runs/15402216730/job/43337294042