### PR TITLE
Fix inspect_history bug in base_lm.py

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -137,7 +137,7 @@ class BaseLM:
         return new_instance
 
     def inspect_history(self, n: int = 1):
-        return inspect_history(self.history, n)
+        return inspect_history(n)
 
     def update_global_history(self, entry):
         if settings.disable_history:


### PR DESCRIPTION
This was changed two weeks ago, but the global history inspect_history only takes `n`