### PR TITLE
Fix the custom type extraction in dspy.BaseType

### DIFF
--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -41,15 +41,12 @@ class BaseType(pydantic.BaseModel):
         This is used to extract all custom types from the annotation of a field, while the annotation can
         have arbitrary level of nesting. For example, we detect `Tool` is in `list[dict[str, Tool]]`.
         """
-        # Direct match. Some typing constructs (like `typing.Any`, `TypeAlias`, or weird internals) may pass
-        # `isinstance(..., type)` but are not valid classes for `issubclass`. We defensively guard against this by
-        # using `inspect.isclass` and wrapping the call in a try/except block.
+        # Direct match. Nested type like `list[dict[str, Event]]` passes `isinstance(annotation, type)` in python 3.10
+        # while fails in python 3.11. To accomodate users using python 3.10, we need to capture the error and ignore it.
         try:
             if isinstance(annotation, type) and issubclass(annotation, cls):
                 return [annotation]
         except TypeError:
-            # `issubclass` can raise `TypeError` if the argument is not actually a class (even if `inspect.isclass`
-            # thought otherwise). In these cases we ignore this check.
             pass
 
         origin = get_origin(annotation)

--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -1,6 +1,6 @@
+import inspect
 import json
 import re
-import inspect
 from typing import Any, Union, get_args, get_origin
 
 import json_repair
@@ -42,18 +42,16 @@ class BaseType(pydantic.BaseModel):
         This is used to extract all custom types from the annotation of a field, while the annotation can
         have arbitrary level of nesting. For example, we detect `Tool` is in `list[dict[str, Tool]]`.
         """
-        # Direct match. Some typing constructs (like `typing.Any`, `TypeAlias`,
-        # or weird internals) may pass `isinstance(..., type)` but are not
-        # valid classes for `issubclass`. We defensively guard against this by
+        # Direct match. Some typing constructs (like `typing.Any`, `TypeAlias`, or weird internals) may pass
+        # `isinstance(..., type)` but are not valid classes for `issubclass`. We defensively guard against this by
         # using `inspect.isclass` and wrapping the call in a try/except block.
         try:
-            if inspect.isclass(annotation) and issubclass(annotation, cls):
+            if isinstance(annotation, type) and issubclass(annotation, cls):
                 return [annotation]
         except TypeError:
-            # `issubclass` can raise `TypeError` if the argument is not actually
-            # a class (even if `inspect.isclass` thought otherwise). In these
-            # cases we just ignore the annotation.
-            return []
+            # `issubclass` can raise `TypeError` if the argument is not actually a class (even if `inspect.isclass`
+            # thought otherwise). In these cases we ignore this check.
+            pass
 
         origin = get_origin(annotation)
         if origin is None:

--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 import re
 from typing import Any, Union, get_args, get_origin

--- a/tests/adapters/test_base_type.py
+++ b/tests/adapters/test_base_type.py
@@ -1,0 +1,53 @@
+import dspy
+from typing import Optional
+import pydantic
+
+
+def test_basic_extract_custom_type_from_annotation():
+    class Event(dspy.BaseType):
+        event_name: str
+        start_date_time: str
+        end_date_time: Optional[str]
+        location: Optional[str]
+
+    class ExtractEvent(dspy.Signature):
+        """Extract all events from the email content."""
+
+        email: str = dspy.InputField()
+        event: Event = dspy.OutputField()
+
+    assert dspy.BaseType.extract_custom_type_from_annotation(ExtractEvent.output_fields["event"].annotation) == [Event]
+
+    class ExtractEvents(dspy.Signature):
+        """Extract all events from the email content."""
+
+        email: str = dspy.InputField()
+        events: list[Event] = dspy.OutputField()
+
+    assert dspy.BaseType.extract_custom_type_from_annotation(ExtractEvents.output_fields["events"].annotation) == [
+        Event
+    ]
+
+
+def test_extract_custom_type_from_annotation_with_nested_type():
+    class Event(dspy.BaseType):
+        event_name: str
+        start_date_time: str
+        end_date_time: Optional[str]
+        location: Optional[str]
+
+    class EventIdentifier(dspy.BaseType):
+        model_config = pydantic.ConfigDict(frozen=True)  # Make it hashable
+        event_id: str
+        event_name: str
+
+    class ExtractEvents(dspy.Signature):
+        """Extract all events from the email content."""
+
+        email: str = dspy.InputField()
+        events: list[dict[EventIdentifier, Event]] = dspy.OutputField()
+
+    assert dspy.BaseType.extract_custom_type_from_annotation(ExtractEvents.output_fields["events"].annotation) == [
+        EventIdentifier,
+        Event,
+    ]


### PR DESCRIPTION
Following up with #8318, this PR handles extracting custom field type from annotations like `list[MyPydanticType]`.

The unit tests passed on both on python 3.10 and 3.12. The original error results from the diff between python 3.10 and python 3.12

On python 3.12:

```
>>> isinstance(list[str], type)
False
```

but on python 3.10:

```
>>> isinstance(list[str], type)
True
```