### PR TITLE
Wrap langchain tool code example by asyncio runner

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -210,9 +210,9 @@ class Tool(BaseType):
         ```python
         import asyncio
         import dspy
-        from langchain.tools import tool
+        from langchain.tools import tool as lc_tool
 
-        @tool
+        @lc_tool
         def add(x: int, y: int):
             "Add two numbers together."
             return x + y

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -206,17 +206,23 @@ class Tool(BaseType):
             A Tool object.
 
         Example:
+
         ```python
-        from langchain.tools import tool
+        import asyncio
         import dspy
+        from langchain.tools import tool
 
         @tool
         def add(x: int, y: int):
             "Add two numbers together."
             return x + y
 
-        tool = dspy.Tool.from_langchain(add)
-        print(await tool.acall(x=1, y=2))
+        dspy_tool = dspy.Tool.from_langchain(add)
+
+        async def run_tool():
+            return await dspy_tool.acall(x=1, y=2)
+
+        print(asyncio.run(run_tool()))
         # 3
         ```
         """


### PR DESCRIPTION
Two minor fixes:

- Wrap the code by asyncio.run() so that users can copy the code and run.
- Renaming the variable from `tool` to `dspy_tool` to avoid conflicting with the imported langchain `tool`.