### PR TITLE
Fix Enum prompts and add XML adapter

### DIFF
--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -1,6 +1,7 @@
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
+from dspy.adapters.xml_adapter import XMLAdapter
 from dspy.adapters.two_step_adapter import TwoStepAdapter
 from dspy.adapters.types import Audio, BaseType, History, Image, Tool, ToolCalls
 
@@ -12,6 +13,7 @@ __all__ = [
     "Image",
     "Audio",
     "JSONAdapter",
+    "XMLAdapter",
     "TwoStepAdapter",
     "Tool",
     "ToolCalls",

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -90,7 +90,8 @@ def translate_field_type(field_name, field_info):
     elif field_type in (int, float):
         desc = f"must be a single {field_type.__name__} value"
     elif inspect.isclass(field_type) and issubclass(field_type, enum.Enum):
-        desc = f"must be one of: {'; '.join(field_type.__members__)}"
+        enum_vals = '; '.join(str(member.value) for member in field_type)
+        desc = f"must be one of: {enum_vals}"
     elif hasattr(field_type, "__origin__") and field_type.__origin__ is Literal:
         desc = (
             # Strongly encourage the LM to avoid choosing values that don't appear in the

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -1,0 +1,63 @@
+import re
+from typing import Any, Dict, Optional, Type
+
+from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
+from dspy.adapters.utils import format_field_value
+from dspy.clients.lm import LM
+from dspy.signatures.signature import Signature
+from dspy.utils.callback import BaseCallback
+
+
+class XMLAdapter(ChatAdapter):
+    def __init__(self, callbacks: Optional[list[BaseCallback]] = None):
+        super().__init__(callbacks)
+        self.field_pattern = re.compile(r"<(?P<name>\w+)>((?P<content>.*?))</\1>", re.DOTALL)
+
+    def format_field_with_value(self, fields_with_values: Dict[FieldInfoWithName, Any]) -> str:
+        output = []
+        for field, field_value in fields_with_values.items():
+            formatted = format_field_value(field_info=field.info, value=field_value)
+            output.append(f"<{field.name}>\n{formatted}\n</{field.name}>")
+        return "\n\n".join(output).strip()
+
+    def user_message_output_requirements(self, signature: Type[Signature]) -> str:
+        message = "Respond with the corresponding output fields wrapped in XML tags"
+        message += ", then ".join(f"`<{f}>`" for f in signature.output_fields)
+        message += ", and then end with the `<completed>` tag."
+        return message
+
+    def parse(self, signature: Type[Signature], completion: str) -> dict[str, Any]:
+        fields = {}
+        for match in self.field_pattern.finditer(completion):
+            name = match.group("name")
+            content = match.group("content").strip()
+            if name in signature.output_fields and name not in fields:
+                fields[name] = content
+        # Cast values using base class parse_value helper
+        for k, v in fields.items():
+            fields[k] = self._parse_field_value(signature.output_fields[k], v, completion)
+        if fields.keys() != signature.output_fields.keys():
+            from dspy.utils.exceptions import AdapterParseError
+
+            raise AdapterParseError(
+                adapter_name="XMLAdapter",
+                signature=signature,
+                lm_response=completion,
+                parsed_result=fields,
+            )
+        return fields
+
+    def _parse_field_value(self, field_info, raw, completion):
+        from dspy.adapters.utils import parse_value
+        try:
+            return parse_value(raw, field_info.annotation)
+        except Exception as e:
+            from dspy.utils.exceptions import AdapterParseError
+
+            raise AdapterParseError(
+                adapter_name="XMLAdapter",
+                signature=None,
+                lm_response=completion,
+                message=f"Failed to parse field {field_info} with value {raw}: {e}",
+            )
+


### PR DESCRIPTION
## Summary
- show enum values in adapter prompts
- add lightweight XMLAdapter for simple XML prompts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datamodel_code_generator')*

------
https://chatgpt.com/codex/tasks/task_e_683fadf314608329b8b5237911da3f7b