### PR TITLE
[WIP] support for OpenAI Responses API and image gen

### DIFF
--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -28,6 +28,10 @@ class BaseType(pydantic.BaseModel):
 
     def format(self) -> list[dict[str, Any]]:
         raise NotImplementedError
+    
+    @classmethod
+    def parse(cls, raw: Any) -> "BaseType":
+        return cls(**raw)
 
     @pydantic.model_serializer()
     def serialize_model(self):

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -41,10 +41,26 @@ def pretty_print_history(history, n: int = 1):
                             else:
                                 image_str = f"<image_url: {c['image_url']['url']}>"
                             print(_blue(image_str.strip()))
+                        elif c["type"] == "input_audio":
+                            audio_format = c["input_audio"]["format"]
+                            len_audio = len(c["input_audio"]["data"])
+                            audio_str = f"<audio format='{audio_format}' base64-encoded, length={len_audio}>"
+                            print(_blue(audio_str.strip()))
             print("\n")
 
         print(_red("Response:"))
-        print(_green(outputs[0].strip()))
+        out = outputs[0]
+        if isinstance(out, str):
+            print(_green(out.strip()))
+        elif hasattr(out, "result") and isinstance(out.result, str):
+            b64 = out.result
+            if b64.startswith("data:"):
+                head, b64data = b64.split(",", 1)
+                print(_green(f"<Image output: {head}base64,<IMAGE_BASE_64_ENCODED({len(b64data)})>>"))
+            else:
+                print(_green(f"<Image output: base64,<IMAGE_BASE_64_ENCODED({len(b64)})>>"))
+        else:
+            print(_green(f"<Non-string output: {repr(out)}>"))
 
         if len(outputs) > 1:
             choices_text = f" \t (and {len(outputs) - 1} other completions)"

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -219,7 +219,7 @@ def test_chat_adapter_formats_image():
     assert user_message_content[2]["type"] == "text"
 
     # Assert that the image is formatted correctly
-    expected_image_content = {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+    expected_image_content = {"type": "input_image", "image_url": "https://example.com/image.jpg"}
     assert expected_image_content in user_message_content
 
 
@@ -245,9 +245,10 @@ def test_chat_adapter_formats_image_with_few_shot_examples():
     # 1 system message, 2 few shot examples (1 user and assistant message for each example), 1 user message
     assert len(messages) == 6
 
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}} in messages[1]["content"]
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}} in messages[3]["content"]
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image3.jpg"}} in messages[5]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image1.jpg"} in messages[1]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image2.jpg"} in messages[3]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image3.jpg"} in messages[5]["content"]
+
 
 
 def test_chat_adapter_formats_image_with_nested_images():
@@ -268,9 +269,11 @@ def test_chat_adapter_formats_image_with_nested_images():
     adapter = dspy.ChatAdapter()
     messages = adapter.format(MySignature, [], {"image": image_wrapper})
 
-    expected_image1_content = {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}}
-    expected_image2_content = {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}}
-    expected_image3_content = {"type": "image_url", "image_url": {"url": "https://example.com/image3.jpg"}}
+    expected_image1_content = {"type": "input_image", "image_url": "https://example.com/image1.jpg"}
+    expected_image2_content = {"type": "input_image", "image_url": "https://example.com/image2.jpg"}
+    expected_image3_content = {"type": "input_image", "image_url": "https://example.com/image3.jpg"}
+
+
 
     assert expected_image1_content in messages[1]["content"]
     assert expected_image2_content in messages[1]["content"]
@@ -305,12 +308,14 @@ def test_chat_adapter_formats_image_with_few_shot_examples_with_nested_images():
     assert len(messages) == 4
 
     # Image information in the few-shot example's user message
-    expected_image1_content = {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}}
-    expected_image2_content = {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}}
-    expected_image3_content = {"type": "image_url", "image_url": {"url": "https://example.com/image3.jpg"}}
+    expected_image1_content = {"type": "input_image", "image_url": "https://example.com/image1.jpg"}
+    expected_image2_content = {"type": "input_image", "image_url": "https://example.com/image2.jpg"}
+    expected_image3_content = {"type": "input_image", "image_url": "https://example.com/image3.jpg"}
+
+
     assert expected_image1_content in messages[1]["content"]
     assert expected_image2_content in messages[1]["content"]
     assert expected_image3_content in messages[1]["content"]
 
     # The query image is formatted in the last user message
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image4.jpg"}} in messages[-1]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image4.jpg"} in messages[-1]["content"]

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -242,7 +242,7 @@ def test_json_adapter_formats_image():
     assert user_message_content[2]["type"] == "text"
 
     # Assert that the image is formatted correctly
-    expected_image_content = {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+    expected_image_content = {"type": "input_image", "image_url": "https://example.com/image.jpg"}
     assert expected_image_content in user_message_content
 
 
@@ -268,9 +268,10 @@ def test_json_adapter_formats_image_with_few_shot_examples():
     # 1 system message, 2 few shot examples (1 user and assistant message for each example), 1 user message
     assert len(messages) == 6
 
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}} in messages[1]["content"]
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}} in messages[3]["content"]
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image3.jpg"}} in messages[5]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image1.jpg"} in messages[1]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image2.jpg"} in messages[3]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image3.jpg"} in messages[5]["content"]
+
 
 
 def test_json_adapter_formats_image_with_nested_images():
@@ -291,9 +292,9 @@ def test_json_adapter_formats_image_with_nested_images():
     adapter = dspy.JSONAdapter()
     messages = adapter.format(MySignature, [], {"image": image_wrapper})
 
-    expected_image1_content = {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}}
-    expected_image2_content = {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}}
-    expected_image3_content = {"type": "image_url", "image_url": {"url": "https://example.com/image3.jpg"}}
+    expected_image1_content = {"type": "input_image", "image_url": "https://example.com/image1.jpg"}
+    expected_image2_content = {"type": "input_image", "image_url": "https://example.com/image2.jpg"}
+    expected_image3_content = {"type": "input_image", "image_url": "https://example.com/image3.jpg"}
 
     assert expected_image1_content in messages[1]["content"]
     assert expected_image2_content in messages[1]["content"]
@@ -328,12 +329,12 @@ def test_json_adapter_formats_image_with_few_shot_examples_with_nested_images():
     assert len(messages) == 4
 
     # Image information in the few-shot example's user message
-    expected_image1_content = {"type": "image_url", "image_url": {"url": "https://example.com/image1.jpg"}}
-    expected_image2_content = {"type": "image_url", "image_url": {"url": "https://example.com/image2.jpg"}}
-    expected_image3_content = {"type": "image_url", "image_url": {"url": "https://example.com/image3.jpg"}}
+    expected_image1_content = {"type": "input_image", "image_url": "https://example.com/image1.jpg"}
+    expected_image2_content = {"type": "input_image", "image_url": "https://example.com/image2.jpg"}
+    expected_image3_content = {"type": "input_image", "image_url": "https://example.com/image3.jpg"}
     assert expected_image1_content in messages[1]["content"]
     assert expected_image2_content in messages[1]["content"]
     assert expected_image3_content in messages[1]["content"]
 
     # The query image is formatted in the last user message
-    assert {"type": "image_url", "image_url": {"url": "https://example.com/image4.jpg"}} in messages[-1]["content"]
+    assert {"type": "input_image", "image_url": "https://example.com/image4.jpg"} in messages[-1]["content"]


### PR DESCRIPTION
Supports [OpenAI Responses API](https://platform.openai.com/docs/api-reference/introduction) 
This also supports image generation in DSPy through native calls through [OpenAI Responses](https://platform.openai.com/docs/guides/image-generation?image-generation-model=gpt-image-1&api=responses) (Note that you can do this through `gpt-image-1` or through models like `gpt-4.1-nano`, `gpt-4.1-mini, `gpt-4.1`, etc. which call `gpt-image-1` under the hood) 

Example usage of DSPy image gen:

```
import base64

lm = dspy.LM(model = 'gpt-4.1-nano', model_type = 'responses', tools=[{
        "type": "image_generation",
        "quality": "low", 
        "size": "1024x1024", 
        "background": "opaque"
    }])
   
dspy.settings.configure(lm=lm)

class DogImageSignature(dspy.Signature):
    """Generate an image of a dog based on the given breed."""
    breed: str = dspy.InputField(desc="The breed of the dog")
    image: dspy.Image = dspy.OutputField(desc="A small image of the dog")

generate_dog = dspy.Predict(DogImageSignature)

response = generate_dog(breed="corgi")

img_obj = response.image

if hasattr(img_obj, "url") and img_obj.url.startswith("data:image/"):
    header, b64data = img_obj.url.split(",", 1)
    with open("corgi.png", "wb") as f:
        f.write(base64.b64decode(b64data))
    print("Image saved to corgi.png")
```

(For further [reference](https://platform.openai.com/docs/guides/image-generation?image-generation-model=gpt-image-1&api=responses) on image gen parameters for OpenAI LMs) 

