### PR TITLE
Allow tool async to sync conversion

### DIFF
--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -27,6 +27,8 @@ DEFAULT_CONFIG = dotdict(
     provide_traceback=False,  # Whether to include traceback information in error logs.
     num_threads=8,  # Number of threads to use for parallel processing.
     max_errors=10,  # Maximum errors before halting operations.
+    # If true, async tools can be called in sync mode by getting converted to sync.
+    allow_tool_async_sync_conversion=False,
 )
 
 # Global base configuration and owner tracking

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -5,6 +5,7 @@ import pytest
 from pydantic import BaseModel
 
 from dspy.adapters.types.tool import Tool
+import dspy
 
 
 # Test fixtures
@@ -363,3 +364,14 @@ async def test_async_concurrent_calls():
     # Check that it ran concurrently (should take ~0.1s, not ~0.5s)
     # We use 0.3s as threshold to account for some overhead
     assert end_time - start_time < 0.3
+
+
+def test_async_tool_call_in_sync_mode():
+    tool = Tool(async_dummy_function)
+    with dspy.context(allow_tool_async_sync_conversion=False):
+        with pytest.raises(ValueError):
+            result = tool(x=1, y="hello")
+
+    with dspy.context(allow_tool_async_sync_conversion=True):
+        result = tool(x=1, y="hello")
+        assert result == "hello 1"


### PR DESCRIPTION
Because DSPy evaluator and optimizer doesn't support async yet, we provide a backdoor to execute async tools in sync mode so that optimizer and evaluator can still work. 

We make a specific flag `allow_tool_async_sync_conversion` to enable the conversion to avoid unintended conversion happens for the user.

With this PR the following code works:

```
import asyncio

import dspy
from dspy.datasets import HotPotQA

dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"), allow_tool_async_sync_conversion=True)


async def search_wikipedia(query: str) -> list[str]:
    await asyncio.sleep(0.01)
    results = dspy.ColBERTv2(url="http://20.102.90.50:2017/wiki17_abstracts")(query, k=3)
    return [x["text"] for x in results]


trainset = [x.with_inputs("question") for x in HotPotQA(train_seed=2024, train_size=500).train]
react = dspy.ReAct("question -> answer", tools=[search_wikipedia])

tp = dspy.MIPROv2(metric=dspy.evaluate.answer_exact_match, auto="light", num_threads=24)
optimized_react = tp.compile(react, trainset=trainset)
```