### PR TITLE
Prompt users to run pre-commit when detecting ruff failures

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -35,6 +35,15 @@ jobs:
       - name: Ruff Fix Attempt
         id: ruff_fix
         run: ruff check --fix-only --diff --exit-non-zero-on-fix
+      - name: Suggest pre-commit run if Ruff fails
+        if: failure() && steps.ruff_fix.outcome == "failure"
+        run: |
+          echo "❌ Ruff found issues that can be fixed automatically."
+          echo "💡 To fix them locally, run:"
+          echo ""
+          echo "    pre-commit run"
+          echo ""
+          echo "Then commit and push the changes."
 
   test:
     name: Run Tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,17 +33,17 @@ jobs:
       - name: Install dependencies
         run: uv sync --dev -p .venv --extra dev
       - name: Ruff Fix Attempt
-        id: ruff_fix
-        run: ruff check --fix-only --diff --exit-non-zero-on-fix
-      - name: Suggest pre-commit run if Ruff fails
-        if: failure() && steps.ruff_fix.outcome == "failure"
         run: |
-          echo "❌ Ruff found issues that can be fixed automatically."
-          echo "💡 To fix them locally, run:"
-          echo ""
-          echo "    pre-commit run"
-          echo ""
-          echo "Then commit and push the changes."
+          ruff check --fix-only --diff --exit-non-zero-on-fix || (
+            echo ""
+            echo "❌ Ruff found issues that can be fixed automatically."
+            echo "💡 To fix them locally, run:"
+            echo ""
+            echo "    pre-commit run --all-files"
+            echo ""
+            echo "Then commit and push the changes."
+            exit 1
+          )
 
   test:
     name: Run Tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,7 +32,7 @@ jobs:
           echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: uv sync --dev -p .venv --extra dev
-      - name: Ruff Fix Attempt
+      - name: Ruff Check
         run: |
           ruff check --fix-only --diff --exit-non-zero-on-fix || (
             echo ""

--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -30,7 +30,7 @@ class Cache:
         disk_cache_dir: str,
         disk_size_limit_bytes: Optional[int] = 1024 * 1024 * 10,
         memory_max_entries: Optional[int] = 1000000,
-        
+
     ):
         """
         Args:

--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -30,6 +30,7 @@ class Cache:
         disk_cache_dir: str,
         disk_size_limit_bytes: Optional[int] = 1024 * 1024 * 10,
         memory_max_entries: Optional[int] = 1000000,
+        
     ):
         """
         Args:


### PR DESCRIPTION
On ruff failures it will show:
<img width="1305" alt="image" src="https://github.com/user-attachments/assets/5c6022ef-61e4-4f23-a4cc-ccc7edf9efcf" />

To prompt users to run `pre-commit run --all-files`