### PR TITLE
[update docs] init gsm8k = GSM8K()

### DIFF
--- a/docs/docs/api/optimizers/MIPROv2.md
+++ b/docs/docs/api/optimizers/MIPROv2.md
@@ -42,6 +42,7 @@ teleprompter = MIPROv2(
 
 # Optimize program
 print(f"Optimizing program with MIPROv2...")
+gsm8k = GSM8K()
 optimized_program = teleprompter.compile(
     dspy.ChainOfThought("question -> answer"),
     trainset=gsm8k.train,


### PR DESCRIPTION
missing gsm8k init at repo docs/docs/api/optimizers/MIPROv2.md
docs at https://dspy.ai/api/optimizers/MIPROv2/#optimizing-instructions-only-with-miprov2-0-shot

![image](https://github.com/user-attachments/assets/15fd9a8d-0453-4ee9-b2b5-fcf6e3dc706b)
