### PR TITLE
Improve error message on invalid lm setup

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -99,7 +99,22 @@ class Predict(Module, Parameter):
 
         # Get the right LM to use.
         lm = kwargs.pop("lm", self.lm) or settings.lm
-        assert isinstance(lm, BaseLM), "No LM is loaded."
+
+        if lm is None:
+            raise ValueError(
+                "No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, "
+                "`dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`"
+            )
+
+        if isinstance(lm, str):
+            # Many users mistakenly use `dspy.configure(lm="openai/gpt-4o-mini")` instead of
+            # `dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))`, so we are providing a specific error message.
+            raise ValueError(
+                f"LM must be an instance of `dspy.BaseLM`, not a string. Instead of using a string like "
+                f"'dspy.configure(lm=\"{lm}\")', please configure the LM like 'dspy.configure(lm=dspy.LM(\"{lm}\"))'"
+            )
+        elif not isinstance(lm, BaseLM):
+            raise ValueError(f"LM must be an instance of `dspy.BaseLM`, not {type(lm)}. Received `lm={lm}`.")
 
         # If temperature is unset or <=0.15, and n > 1, set temperature to 0.7 to keep randomness.
         temperature = config.get("temperature") or lm.kwargs.get("temperature")

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -582,6 +582,28 @@ def test_positional_arguments():
     )
 
 
+def test_error_message_on_invalid_lm_setup():
+    # No LM is loaded.
+    with pytest.raises(ValueError, match="No LM is loaded"):
+        Predict("question -> answer")(question="Why did a chicken cross the kitchen?")
+
+    # LM is a string.
+    dspy.configure(lm="openai/gpt-4o-mini")
+    with pytest.raises(ValueError) as e:
+        Predict("question -> answer")(question="Why did a chicken cross the kitchen?")
+
+    assert "LM must be an instance of `dspy.BaseLM`, not a string." in str(e.value)
+
+    def dummy_lm():
+        pass
+
+    # LM is not an instance of dspy.BaseLM.
+    dspy.configure(lm=dummy_lm)
+    with pytest.raises(ValueError) as e:
+        Predict("question -> answer")(question="Why did a chicken cross the kitchen?")
+    assert "LM must be an instance of `dspy.BaseLM`, not <class 'function'>." in str(e.value)
+
+
 @pytest.mark.parametrize("adapter_type", ["chat", "json"])
 def test_field_constraints(adapter_type):
     class SpyLM(dspy.LM):


### PR DESCRIPTION
To have more explicit prompt for users on different cases of invalid LM setup. 

Specifically, we prompt users to wrap the string by dspy.LM when they use string as the LM. This is a common case, ironically I still occasionally get trapped by this. 