### PR TITLE
Fix ChainOfThoughtWithHint

### DIFF
--- a/dspy/predict/chain_of_thought_with_hint.py
+++ b/dspy/predict/chain_of_thought_with_hint.py
@@ -5,6 +5,31 @@ from .predict import Module
 
 class ChainOfThoughtWithHint(Module):
     def __init__(self, signature, rationale_field_type=None, **config):
+        """
+
+        A module that reasons step by step in order to predict the output of a task, with optional hint support.
+
+        
+
+        This module extends ChainOfThought by allowing an optional "hint" parameter that can be provided
+
+        during inference to guide the reasoning process.
+
+        
+
+        Args:
+
+        signature (Type[dspy.Signature]): The signature of the module.
+
+        rationale_field (Optional[Union[dspy.OutputField, pydantic.fields.FieldInfo]]): The field that will contain the reasoning.
+
+        rationale_field_type (Type): The type of the rationale field.
+
+        hint: The hint to provide to the module.
+
+        **config: The configuration for the module.
+
+        """
         self.signature = dspy.ensure_signature(signature)
         self.module = dspy.ChainOfThought(signature, rationale_field_type=rationale_field_type, **config)
 

--- a/dspy/predict/chain_of_thought_with_hint.py
+++ b/dspy/predict/chain_of_thought_with_hint.py
@@ -4,9 +4,9 @@ from .predict import Module
 
 
 class ChainOfThoughtWithHint(Module):
-    def __init__(self, signature, rationale_type=None, **config):
+    def __init__(self, signature, rationale_field_type=None, **config):
         self.signature = dspy.ensure_signature(signature)
-        self.module = dspy.ChainOfThought(signature, rationale_type=rationale_type, **config)
+        self.module = dspy.ChainOfThought(signature, rationale_field_type=rationale_field_type, **config)
 
     def forward(self, **kwargs):
         if kwargs.get("hint"):

--- a/tests/predict/test_chain_of_thought_with_hint.py
+++ b/tests/predict/test_chain_of_thought_with_hint.py
@@ -1,8 +1,8 @@
-# import textwrap
+import textwrap
 
-# import dspy
-# from dspy import ChainOfThoughtWithHint
-# from dspy.utils import DummyLM
+import dspy
+from dspy import ChainOfThoughtWithHint
+from dspy.utils import DummyLM
 
 
 # def test_cot_with_no_hint():
@@ -18,13 +18,13 @@
 #     assert predict(question="What is 1+1?").answer == "2"
 
 
-# def test_cot_with_hint():
-#     lm = DummyLM([{"rationale": "find the number after 1", "hint": "Is it helicopter?", "answer": "2"}])
-#     dspy.settings.configure(lm=lm)
-#     predict = ChainOfThoughtWithHint("question -> answer")
-#     assert list(predict.extended_signature2.output_fields.keys()) == [
-#         "rationale",
-#         "hint",
-#         "answer",
-#     ]
-#     assert predict(question="What is 1+1?", hint="think small").answer == "2"
+def test_cot_with_hint():
+    lm = DummyLM([{"rationale": "find the number after 1", "hint": "Is it helicopter?", "answer": "2"}])
+    dspy.settings.configure(lm=lm)
+    predict = ChainOfThoughtWithHint("question -> answer")
+    assert list(predict.extended_signature2.output_fields.keys()) == [
+        "rationale",
+        "hint",
+        "answer",
+    ]
+    assert predict(question="What is 1+1?", hint="think small").answer == "2"


### PR DESCRIPTION
## Why
Resolve https://github.com/stanfordnlp/dspy/issues/8205. The community reported that `ChainOfThoughtWithHint` is broken. By manual verification, it's indeed broken with basic usage as below 

```
class BasicQA(dspy.Signature):
    """Answer questions with short factoid answers."""
    question = dspy.InputField()
    answer = dspy.OutputField(desc="often between 1 and 5 words")

#Pass signature to ChainOfThought module
generate_answer = dspy.ChainOfThoughtWithHint(BasicQA)

# Call the predictor on a particular input alongside a hint.
question='What is the color of the sky?'
hint = "It's what you often see during a sunny day."
pred = generate_answer(question=question, hint=hint)

print(f"Question: {question}")
print(f"Predicted Answer: {pred.answer}")
```

## What 
1. Fix the module  
2. Uncomment the unit test for the ChainOfThoughtWithHint module 

## Testing 
1. Manual Verification with the `BasicQA` above 
2. Unit test 


