### PR TITLE
compute cache key once

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -230,7 +230,7 @@ def request_cache(
 
             # Otherwise, compute and store the result
             # Make a copy of the original request in case it's modified in place, e.g., deleting some fields
-            original_request = dict(modified_request)
+            original_request = copy.deepcopy(modified_request)
             result = fn(*args, **kwargs)
             # `enable_memory_cache` can be provided at call time to avoid indefinite growth.
             cache.put(original_request, result, ignored_args_for_cache_key, enable_memory_cache)
@@ -251,7 +251,7 @@ def request_cache(
 
             # Otherwise, compute and store the result
             # Make a copy of the original request in case it's modified in place, e.g., deleting some fields
-            original_request = dict(modified_request)
+            original_request = copy.deepcopy(modified_request)
             result = await fn(*args, **kwargs)
             cache.put(original_request, result, ignored_args_for_cache_key, enable_memory_cache)
 

--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -30,7 +30,6 @@ class Cache:
         disk_cache_dir: str,
         disk_size_limit_bytes: Optional[int] = 1024 * 1024 * 10,
         memory_max_entries: Optional[int] = 1000000,
-
     ):
         """
         Args:
@@ -230,8 +229,8 @@ def request_cache(
                 return cached_result
 
             # Otherwise, compute and store the result
-            # first, make a copy of original request to compute identical cache key in `put` in case litellm changes request values
-            original_request = copy.deepcopy(modified_request)
+            # Make a copy of the original request in case it's modified in place, e.g., deleting some fields
+            original_request = dict(modified_request)
             result = fn(*args, **kwargs)
             # `enable_memory_cache` can be provided at call time to avoid indefinite growth.
             cache.put(original_request, result, ignored_args_for_cache_key, enable_memory_cache)
@@ -251,8 +250,8 @@ def request_cache(
                 return cached_result
 
             # Otherwise, compute and store the result
-            # first, make a copy of original request to compute identical cache key in `put` in case litellm changes request values
-            original_request = copy.deepcopy(modified_request)
+            # Make a copy of the original request in case it's modified in place, e.g., deleting some fields
+            original_request = dict(modified_request)
             result = await fn(*args, **kwargs)
             cache.put(original_request, result, ignored_args_for_cache_key, enable_memory_cache)
 


### PR DESCRIPTION
Resolves #8393 

Cache key is computed only for incoming request, therefore any modifications made to request by external calls (eg to LiteLLM.completion) does not impact cache.