### PR TITLE
Clean up unnecessary ruff exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,9 +116,7 @@ exclude_lines = [
 include = ["dspy/**/*.py", "tests/**/*.py"]
 exclude = [
   "dspy/__metadata__.py",
-  "dspy/retrieve/*.py",
   "tests/reliability/*.py",
-  "tests/retrieve/*.py",
 ]
 
 


### PR DESCRIPTION
We have removed the retrieve/ directory, no need to exclude them from ruff rules.