### PR TITLE
Remove branch installation instruction

### DIFF
--- a/docs/docs/tutorials/rl_multihop/index.ipynb
+++ b/docs/docs/tutorials/rl_multihop/index.ipynb
@@ -8,8 +8,6 @@
     "\n",
     "WARNING: This feature is new and extremely EXPERIMENTAL. Unlike almost everything else in DSPy, it's currently in pure proof of concept and development mode, but we release it to encourage community involvement.\n",
     "\n",
-    "If you want to be on the cutting edge even before it's merged, install the `dspy.GRPO` PR via `pip install git+https://github.com/stanfordnlp/dspy.git@refs/pull/8171/head` and follow along.\n",
-    "\n",
     "For this tutorial, you will also need DSPy's Arbor RL server.\n",
     "\n",
     "```bash\n",

--- a/docs/docs/tutorials/rl_papillon/index.ipynb
+++ b/docs/docs/tutorials/rl_papillon/index.ipynb
@@ -8,8 +8,6 @@
     "\n",
     "WARNING: This feature is new and extremely EXPERIMENTAL. Unlike almost everything else in DSPy, it's currently in pure proof of concept and development mode, but we release it to encourage community involvement.\n",
     "\n",
-    "If you want to be on the cutting edge even before it's merged, install the `dspy.GRPO` PR via `pip install git+https://github.com/stanfordnlp/dspy.git@refs/pull/8171/head` and follow along.\n",
-    "\n",
     "In this tutorial, we optimize the LM weights of [PAPILLON](https://dspy.ai/tutorials/papillon/) with `dspy.GRPO`, a generalization of the popular GRPO online RL algorithm of LLMs to sophisticated multi-module LM programs.\n",
     "\n",
     "PAPILLON is a system for privacy-preserving delegation, where we will teach a tiny model (1.7B parameters) to use an \"untrusted\" external LLM, which is more powerful but may save your private data, to balance high-quality and private chat.\n",


### PR DESCRIPTION
Remove the instruction for installing DSPy from the GRPO feature branch since it has been merged.