### PR TITLE
Simplify the RAG tutorial

### DIFF
--- a/docs/docs/tutorials/rag/index.ipynb
+++ b/docs/docs/tutorials/rag/index.ipynb
@@ -16,7 +16,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "## Configuring the DSPy environment.\n",
+    "## Configuring the DSPy Environment\n",
     "\n",
     "Let's tell DSPy that we will use OpenAI's `gpt-4o-mini` in our modules. To authenticate, DSPy will look into your `OPENAI_API_KEY`. You can easily swap this out for [other providers or local models](https://github.com/stanfordnlp/dspy/blob/main/examples/migration.ipynb).\n"
    ]
@@ -67,13 +67,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
     "import dspy\n",
+    "import os\n",
     "\n",
-    "lm = dspy.LM('openai/gpt-4o-mini')\n",
+    "os.environ[\"OPENAI_API_KEY\"] = \"{your_openai_api_key}\"\n",
+    "\n",
+    "lm = dspy.LM(\"openai/gpt-4o-mini\")\n",
     "dspy.configure(lm=lm)"
    ]
   },
@@ -81,48 +84,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Exploring some basic DSPy Modules.\n",
+    "## Basic Retrieval-Augmented Generation (RAG)\n",
     "\n",
-    "You can always prompt the LM directly via `lm(prompt=\"prompt\")` or `lm(messages=[...])`. However, DSPy gives you `Modules` as a better way to define your LM functions.\n",
-    "\n",
-    "The simplest module is `dspy.Predict`. It takes a [DSPy Signature](/learn/programming/signatures), i.e. a structured input/output schema, and gives you back a callable function for the behavior you specified. Let's use the \"in-line\" notation for signatures to declare a module that takes a `question` (of type `str`) as input and produces a `response` as an output."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "In Linux, \"high memory\" and \"low memory\" refer to different regions of the system's memory address space, particularly in the context of 32-bit architectures.\n",
-      "\n",
-      "- **Low Memory**: This typically refers to the memory that is directly accessible by the kernel. In a 32-bit system, this is usually the first 896 MB of RAM (from 0 to 896 MB). The kernel can directly map this memory, making it faster for the kernel to access and manage. Low memory is used for kernel data structures and for user processes that require direct access to memory.\n",
-      "\n",
-      "- **High Memory**: This refers to the memory above the low memory limit, which is not directly accessible by the kernel in a 32-bit system. This area is typically above 896 MB. The kernel cannot directly access this memory without using special mechanisms, such as mapping it into the kernel's address space when needed. High memory is used for user processes that require more memory than what is available in low memory.\n",
-      "\n",
-      "In summary, low memory is directly accessible by the kernel, while high memory requires additional steps for the kernel to access it, especially in 32-bit systems. In 64-bit systems, this distinction is less significant as the kernel can address a much larger memory space directly.\n"
-     ]
-    }
-   ],
-   "source": [
-    "qa = dspy.Predict('question: str -> response: str')\n",
-    "response = qa(question=\"what are high memory and low memory on linux?\")\n",
-    "\n",
-    "print(response.response)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Notice how the variable names we specified in the signature defined our input and output argument names and their role.\n",
-    "\n",
-    "Now, what did DSPy do to build this `qa` module? Nothing fancy in this example, yet. The module passed your signature, LM, and inputs to an Adapter, which is a layer that handles structuring the inputs and parsing structured outputs to fit your signature.\n",
-    "\n",
-    "Let's see it directly. You can inspect the `n` last prompts sent by DSPy easily. Alternatively, if you enabled MLflow Tracing above, you can see the full LLM interactions for each program execution in a tree view.\n"
+    "First, let's download the corpus data that we will use for RAG search. An older version of this tutorial used the full (650,000 document) corpus. To make this very fast and cheap to run, we've downsampled the corpus to just 28,000 documents."
    ]
   },
   {
@@ -134,681 +98,43 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\u001b[34m[2024-11-23T23:16:35.966534]\u001b[0m\n",
-      "\n",
-      "\u001b[31mSystem message:\u001b[0m\n",
-      "\n",
-      "Your input fields are:\n",
-      "1. `question` (str)\n",
-      "\n",
-      "Your output fields are:\n",
-      "1. `response` (str)\n",
-      "\n",
-      "All interactions will be structured in the following way, with the appropriate values filled in.\n",
-      "\n",
-      "[[ ## question ## ]]\n",
-      "{question}\n",
-      "\n",
-      "[[ ## response ## ]]\n",
-      "{response}\n",
-      "\n",
-      "[[ ## completed ## ]]\n",
-      "\n",
-      "In adhering to this structure, your objective is: \n",
-      "        Given the fields `question`, produce the fields `response`.\n",
-      "\n",
-      "\n",
-      "\u001b[31mUser message:\u001b[0m\n",
-      "\n",
-      "[[ ## question ## ]]\n",
-      "what are high memory and low memory on linux?\n",
-      "\n",
-      "Respond with the corresponding output fields, starting with the field `[[ ## response ## ]]`, and then ending with the marker for `[[ ## completed ## ]]`.\n",
-      "\n",
-      "\n",
-      "\u001b[31mResponse:\u001b[0m\n",
-      "\n",
-      "\u001b[32m[[ ## response ## ]]\n",
-      "In Linux, \"high memory\" and \"low memory\" refer to different regions of the system's memory address space, particularly in the context of 32-bit architectures.\n",
-      "\n",
-      "- **Low Memory**: This typically refers to the memory that is directly accessible by the kernel. In a 32-bit system, this is usually the first 896 MB of RAM (from 0 to 896 MB). The kernel can directly map this memory, making it faster for the kernel to access and manage. Low memory is used for kernel data structures and for user processes that require direct access to memory.\n",
-      "\n",
-      "- **High Memory**: This refers to the memory above the low memory limit, which is not directly accessible by the kernel in a 32-bit system. This area is typically above 896 MB. The kernel cannot directly access this memory without using special mechanisms, such as mapping it into the kernel's address space when needed. High memory is used for user processes that require more memory than what is available in low memory.\n",
-      "\n",
-      "In summary, low memory is directly accessible by the kernel, while high memory requires additional steps for the kernel to access it, especially in 32-bit systems. In 64-bit systems, this distinction is less significant as the kernel can address a much larger memory space directly.\n",
-      "\n",
-      "[[ ## completed ## ]]\u001b[0m\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n"
+      "Downloading 'ragqa_arena_tech_corpus.jsonl'...\n"
      ]
     }
    ],
    "source": [
-    "dspy.inspect_history(n=1)"
+    "dspy.utils.download(\"https://huggingface.co/dspy/cache/resolve/main/ragqa_arena_tech_corpus.jsonl\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "DSPy has various built-in modules, e.g. `dspy.ChainOfThought`, `dspy.ProgramOfThought`, and `dspy.ReAct`. These are interchangeable with basic `dspy.Predict`: they take your signature, which is specific to your task, and they apply general-purpose prompting techniques and inference-time strategies to it.\n",
+    "## Setting Up Your Retriever\n",
     "\n",
-    "For example, `dspy.ChainOfThought` is an easy way to elicit `reasoning` out of your LM before it commits to the outputs requested in your signature.\n",
+    "As far as DSPy is concerned, you can plug in any Python code for calling tools or retrievers. Here, we'll just use OpenAI Embeddings and do top-K search locally for convenience. We will use a vector index based on FAISS (https://github.com/facebookresearch/faiss), so please install it via:\n",
     "\n",
-    "In the example below, we'll omit `str` types (as the default type is string). You should feel free to experiment with other fields and types, e.g. try `topics: list[str]` or `is_realistic: bool`.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Prediction(\n",
-       "    reasoning='The placement of curly braces on their own line depends on the coding style and conventions being followed. In some programming languages and style guides, such as the Allman style, curly braces are placed on their own line to enhance readability. In contrast, other styles, like K&R style, place the opening brace on the same line as the control statement. Ultimately, it is a matter of personal or team preference, and consistency within a project is key.',\n",
-       "    response='Curly braces can appear on their own line depending on the coding style you are following. If you prefer a style that enhances readability, such as the Allman style, then yes, they should be on their own line. However, if you are following a different style, like K&R, they may not need to be. Consistency is important, so choose a style and stick with it.'\n",
-       ")"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "cot = dspy.ChainOfThought('question -> response')\n",
-    "cot(question=\"should curly braces appear on their own line?\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "\n",
-    "Interestingly, asking for reasoning can make the output `response` shorter in this case. Is this a good thing or a bad thing? It depends on what you need: there's no free lunch, but DSPy gives you the tools to experiment with different strategies extremely quickly.\n",
-    "\n",
-    "By the way, `dspy.ChainOfThought` is implemented in DSPy, using `dspy.Predict`. This is a good place to `dspy.inspect_history` if you're curious.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Using DSPy well involves evaluation and iterative development.\n",
-    "\n",
-    "You already know a lot about DSPy at this point. If all you want is quick scripting, this much of DSPy already enables a lot. Sprinkling DSPy signatures and modules into your Python control flow is a pretty ergonomic way to just get stuff done with LMs.\n",
-    "\n",
-    "That said, you're likely here because you want to build a high-quality system and improve it over time. The way to do that in DSPy is to iterate fast by evaluating the quality of your system and using DSPy's powerful tools, e.g. Optimizers.\n",
-    "\n",
-    "## Manipulating Examples in DSPy.\n",
-    "\n",
-    "To measure the quality of your DSPy system, you need (1) a bunch of input values, like `question`s for example, and (2) a `metric` that can score the quality of an output from your system. Metrics vary widely. Some metrics need ground-truth labels of ideal outputs, e.g. for classification or question answering. Other metrics are self-supervised, e.g. checking faithfulness or lack of hallucination, perhaps using a DSPy program as a judge of these qualities.\n",
-    "\n",
-    "Let's load a dataset of questions and their (pretty long) gold answers. Since we started this notebook with the goal of building **a system for answering Tech questions**, we obtained a bunch of StackExchange-based questions and their correct answers from the [RAG-QA Arena](https://arxiv.org/abs/2407.13998) dataset.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import ujson\n",
-    "from dspy.utils import download\n",
-    "\n",
-    "# Download question--answer pairs from the RAG-QA Arena \"Tech\" dataset.\n",
-    "download(\"https://huggingface.co/dspy/cache/resolve/main/ragqa_arena_tech_examples.jsonl\")\n",
-    "\n",
-    "with open(\"ragqa_arena_tech_examples.jsonl\") as f:\n",
-    "    data = [ujson.loads(line) for line in f]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'question': 'why igp is used in mpls?',\n",
-       " 'response': \"An IGP exchanges routing prefixes between gateways/routers.  \\nWithout a routing protocol, you'd have to configure each route on every router and you'd have no dynamic updates when routes change because of link failures. \\nFuthermore, within an MPLS network, an IGP is vital for advertising the internal topology and ensuring connectivity for MP-BGP inside the network.\",\n",
-       " 'gold_doc_ids': [2822, 2823]}"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Inspect one datapoint.\n",
-    "data[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "\n",
-    "Given a simple dict like this, let's create a list of `dspy.Example`s, which is the datatype that carries training (or test) datapoints in DSPy.\n",
-    "\n",
-    "When you build a `dspy.Example`, you should generally specify `.with_inputs(\"field1\", \"field2\", ...)` to indicate which fields are inputs. The other fields are treated as labels or metadata.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Example({'question': 'why are my text messages coming up as maybe?', 'response': 'This is part of the Proactivity features new with iOS 9: It looks at info in emails to see if anyone with this number sent you an email and if it finds the phone number associated with a contact from your email, it will show you \"Maybe\". \\n\\nHowever, it has been suggested there is a bug in iOS 11.2 that can result in \"Maybe\" being displayed even when \"Find Contacts in Other Apps\" is disabled.', 'gold_doc_ids': [3956, 3957, 8034]}) (input_keys={'question'})"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "data = [dspy.Example(**d).with_inputs('question') for d in data]\n",
-    "\n",
-    "# Let's pick an `example` here from the data.\n",
-    "example = data[2]\n",
-    "example"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "Now, let's divide the data into:\n",
-    "\n",
-    "- Training (and with it Validation) set:\n",
-    "    - These are the splits you typically give to DSPy optimizers.\n",
-    "    - Optimizers typically learn directly from the training examples and check their progress using the validation examples.\n",
-    "    - It's good to have 30--300 examples for training and validation each.\n",
-    "    - For prompt optimizers in particular, it's often better to pass _more_ validation than training.\n",
-    "    - Below, we'll use 200 in total. MIPROv2 will split them into 20% training and 80% validation if you don't pass a valset.\n",
-    "\n",
-    "- Development and Test sets: The rest, typically on the order of 30--1000, can be used for:\n",
-    "    - development (i.e., you can inspect them as you iterate on your system) and\n",
-    "    - testing (final held-out evaluation).\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(200, 300, 500)"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import random\n",
-    "\n",
-    "random.Random(0).shuffle(data)\n",
-    "trainset, devset, testset = data[:200], data[200:500], data[500:1000]\n",
-    "\n",
-    "len(trainset), len(devset), len(testset)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Evaluation in DSPy.\n",
-    "\n",
-    "What kind of metric can suit our question-answering task? There are many choices, but since the answers are long, we may ask: How well does the system response _cover_ all key facts in the gold response? And the other way around, how well is the system response _not saying things_ that aren't in the gold response?\n",
-    "\n",
-    "That metric is essentially a **semantic F1**, so let's load a `SemanticF1` metric from DSPy. This metric is actually implemented as a [very simple DSPy module](https://github.com/stanfordnlp/dspy/blob/main/dspy/evaluate/auto_evaluation.py#L21) using whatever LM we're working with."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Question: \t why are my text messages coming up as maybe?\n",
-      "\n",
-      "Gold Response: \t This is part of the Proactivity features new with iOS 9: It looks at info in emails to see if anyone with this number sent you an email and if it finds the phone number associated with a contact from your email, it will show you \"Maybe\". \n",
-      "\n",
-      "However, it has been suggested there is a bug in iOS 11.2 that can result in \"Maybe\" being displayed even when \"Find Contacts in Other Apps\" is disabled.\n",
-      "\n",
-      "Predicted Response: \t Your text messages are showing up as \"maybe\" because your messaging app is uncertain about the sender's identity. This typically occurs when the sender's number is not saved in your contacts or if the message is from an unknown number. To resolve this, you can save the contact in your address book or check the message settings in your app.\n",
-      "\n",
-      "Semantic F1 Score: 0.33\n"
-     ]
-    }
-   ],
-   "source": [
-    "from dspy.evaluate import SemanticF1\n",
-    "\n",
-    "# Instantiate the metric.\n",
-    "metric = SemanticF1(decompositional=True)\n",
-    "\n",
-    "# Produce a prediction from our `cot` module, using the `example` above as input.\n",
-    "pred = cot(**example.inputs())\n",
-    "\n",
-    "# Compute the metric score for the prediction.\n",
-    "score = metric(example, pred)\n",
-    "\n",
-    "print(f\"Question: \\t {example.question}\\n\")\n",
-    "print(f\"Gold Response: \\t {example.response}\\n\")\n",
-    "print(f\"Predicted Response: \\t {pred.response}\\n\")\n",
-    "print(f\"Semantic F1 Score: {score:.2f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "\n",
-    "The final DSPy module call above actually happens inside `metric`. You might be curious how it measured the semantic F1 for this example.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\u001b[34m[2024-11-23T23:16:36.149518]\u001b[0m\n",
-      "\n",
-      "\u001b[31mSystem message:\u001b[0m\n",
-      "\n",
-      "Your input fields are:\n",
-      "1. `question` (str)\n",
-      "2. `ground_truth` (str)\n",
-      "3. `system_response` (str)\n",
-      "\n",
-      "Your output fields are:\n",
-      "1. `reasoning` (str)\n",
-      "2. `ground_truth_key_ideas` (str): enumeration of key ideas in the ground truth\n",
-      "3. `system_response_key_ideas` (str): enumeration of key ideas in the system response\n",
-      "4. `discussion` (str): discussion of the overlap between ground truth and system response\n",
-      "5. `recall` (float): fraction (out of 1.0) of ground truth covered by the system response\n",
-      "6. `precision` (float): fraction (out of 1.0) of system response covered by the ground truth\n",
-      "\n",
-      "All interactions will be structured in the following way, with the appropriate values filled in.\n",
-      "\n",
-      "[[ ## question ## ]]\n",
-      "{question}\n",
-      "\n",
-      "[[ ## ground_truth ## ]]\n",
-      "{ground_truth}\n",
-      "\n",
-      "[[ ## system_response ## ]]\n",
-      "{system_response}\n",
-      "\n",
-      "[[ ## reasoning ## ]]\n",
-      "{reasoning}\n",
-      "\n",
-      "[[ ## ground_truth_key_ideas ## ]]\n",
-      "{ground_truth_key_ideas}\n",
-      "\n",
-      "[[ ## system_response_key_ideas ## ]]\n",
-      "{system_response_key_ideas}\n",
-      "\n",
-      "[[ ## discussion ## ]]\n",
-      "{discussion}\n",
-      "\n",
-      "[[ ## recall ## ]]\n",
-      "{recall}        # note: the value you produce must be a single float value\n",
-      "\n",
-      "[[ ## precision ## ]]\n",
-      "{precision}        # note: the value you produce must be a single float value\n",
-      "\n",
-      "[[ ## completed ## ]]\n",
-      "\n",
-      "In adhering to this structure, your objective is: \n",
-      "        Compare a system's response to the ground truth to compute recall and precision of key ideas.\n",
-      "        You will first enumerate key ideas in each response, discuss their overlap, and then report recall and precision.\n",
-      "\n",
-      "\n",
-      "\u001b[31mUser message:\u001b[0m\n",
-      "\n",
-      "[[ ## question ## ]]\n",
-      "why are my text messages coming up as maybe?\n",
-      "\n",
-      "[[ ## ground_truth ## ]]\n",
-      "This is part of the Proactivity features new with iOS 9: It looks at info in emails to see if anyone with this number sent you an email and if it finds the phone number associated with a contact from your email, it will show you \"Maybe\". \n",
-      "\n",
-      "However, it has been suggested there is a bug in iOS 11.2 that can result in \"Maybe\" being displayed even when \"Find Contacts in Other Apps\" is disabled.\n",
-      "\n",
-      "[[ ## system_response ## ]]\n",
-      "Your text messages are showing up as \"maybe\" because your messaging app is uncertain about the sender's identity. This typically occurs when the sender's number is not saved in your contacts or if the message is from an unknown number. To resolve this, you can save the contact in your address book or check the message settings in your app.\n",
-      "\n",
-      "Respond with the corresponding output fields, starting with the field `[[ ## reasoning ## ]]`, then `[[ ## ground_truth_key_ideas ## ]]`, then `[[ ## system_response_key_ideas ## ]]`, then `[[ ## discussion ## ]]`, then `[[ ## recall ## ]]` (must be formatted as a valid Python float), then `[[ ## precision ## ]]` (must be formatted as a valid Python float), and then ending with the marker for `[[ ## completed ## ]]`.\n",
-      "\n",
-      "\n",
-      "\u001b[31mResponse:\u001b[0m\n",
-      "\n",
-      "\u001b[32m[[ ## reasoning ## ]]\n",
-      "The system response provides a general explanation for why text messages may show up as \"maybe,\" focusing on the uncertainty of the sender's identity. However, it does not mention the specific iOS features or the potential bug in iOS 11.2 that are highlighted in the ground truth. The ground truth explains that this feature is part of iOS 9's Proactivity features and mentions a specific bug in iOS 11.2, which is not addressed in the system response.\n",
-      "\n",
-      "[[ ## ground_truth_key_ideas ## ]]\n",
-      "1. Proactivity features introduced in iOS 9.\n",
-      "2. The system checks emails to associate phone numbers with contacts.\n",
-      "3. \"Maybe\" is displayed if the number is not saved in contacts.\n",
-      "4. Mention of a bug in iOS 11.2 causing \"Maybe\" to appear incorrectly.\n",
-      "\n",
-      "[[ ## system_response_key_ideas ## ]]\n",
-      "1. Text messages show up as \"maybe\" due to uncertainty about the sender's identity.\n",
-      "2. Occurs when the sender's number is not saved in contacts or is from an unknown number.\n",
-      "3. Suggests saving the contact or checking message settings.\n",
-      "\n",
-      "[[ ## discussion ## ]]\n",
-      "There is some overlap between the ground truth and the system response regarding the uncertainty of the sender's identity and the suggestion to save the contact. However, the system response lacks specific details about the iOS features and the bug mentioned in the ground truth. The ground truth provides a more comprehensive explanation of the \"maybe\" feature, while the system response is more general and does not address the iOS version specifics.\n",
-      "\n",
-      "[[ ## recall ## ]]\n",
-      "0.25\n",
-      "\n",
-      "[[ ## precision ## ]]\n",
-      "0.5\n",
-      "\n",
-      "[[ ## completed ## ]]\u001b[0m\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "dspy.inspect_history(n=1)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For evaluation, you could use the metric above in a simple loop and just average the score. But for nice parallelism and utilities, we can rely on `dspy.Evaluate`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Average Metric: 125.68 / 300 (41.9%): 100%|██████████| 300/300 [00:00<00:00, 666.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024/11/23 23:16:36 INFO dspy.evaluate.evaluate: Average Metric: 125.68228336477591 / 300 (41.9%)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>question</th>\n",
-       "      <th>example_response</th>\n",
-       "      <th>gold_doc_ids</th>\n",
-       "      <th>reasoning</th>\n",
-       "      <th>pred_response</th>\n",
-       "      <th>SemanticF1</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>when to use c over c++, and c++ over c?</td>\n",
-       "      <td>If you are equally familiar with both C++ and C, it's advisable to...</td>\n",
-       "      <td>[733]</td>\n",
-       "      <td>C and C++ are both powerful programming languages, but they serve ...</td>\n",
-       "      <td>Use C when you need low-level access to memory, require high perfo...</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>should images be stored in a git repository?</td>\n",
-       "      <td>One viewpoint expresses that there is no significant downside, esp...</td>\n",
-       "      <td>[6253, 6254, 6275, 6278, 8215]</td>\n",
-       "      <td>Storing images in a Git repository can be beneficial for version c...</td>\n",
-       "      <td>Images can be stored in a Git repository, but it's important to co...</td>\n",
-       "      <td>✔️ [0.444]</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                       question  \\\n",
-       "0       when to use c over c++, and c++ over c?   \n",
-       "1  should images be stored in a git repository?   \n",
-       "\n",
-       "                                                        example_response  \\\n",
-       "0  If you are equally familiar with both C++ and C, it's advisable to...   \n",
-       "1  One viewpoint expresses that there is no significant downside, esp...   \n",
-       "\n",
-       "                     gold_doc_ids  \\\n",
-       "0                           [733]   \n",
-       "1  [6253, 6254, 6275, 6278, 8215]   \n",
-       "\n",
-       "                                                               reasoning  \\\n",
-       "0  C and C++ are both powerful programming languages, but they serve ...   \n",
-       "1  Storing images in a Git repository can be beneficial for version c...   \n",
-       "\n",
-       "                                                           pred_response  \\\n",
-       "0  Use C when you need low-level access to memory, require high perfo...   \n",
-       "1  Images can be stored in a Git repository, but it's important to co...   \n",
-       "\n",
-       "   SemanticF1  \n",
-       "0              \n",
-       "1  ✔️ [0.444]  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "                <div style='\n",
-       "                    text-align: center;\n",
-       "                    font-size: 16px;\n",
-       "                    font-weight: bold;\n",
-       "                    color: #555;\n",
-       "                    margin: 10px 0;'>\n",
-       "                    ... 298 more rows not displayed ...\n",
-       "                </div>\n",
-       "                "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "41.89"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Define an evaluator that we can re-use.\n",
-    "evaluate = dspy.Evaluate(devset=devset, metric=metric, num_threads=24,\n",
-    "                         display_progress=True, display_table=2)\n",
-    "\n",
-    "# Evaluate the Chain-of-Thought program.\n",
-    "evaluate(cot)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<details>\n",
-    "<summary>Tracking Evaluation Results in MLflow Experiment</summary>\n",
-    "\n",
-    "<br/>\n",
-    "\n",
-    "To track and visualize the evaluation results over time, you can record the results in MLflow Experiment.\n",
-    "\n",
-    "\n",
-    "```python\n",
-    "import mlflow\n",
-    "\n",
-    "with mlflow.start_run(run_name=\"rag_evaluation\"):\n",
-    "    evaluate = dspy.Evaluate(\n",
-    "        devset=devset,\n",
-    "        metric=metric,\n",
-    "        num_threads=24,\n",
-    "        display_progress=True,\n",
-    "        # To record the outputs and detailed scores to MLflow\n",
-    "        return_all_scores=True,\n",
-    "        return_outputs=True,\n",
-    "    )\n",
-    "\n",
-    "    # Evaluate the program as usual\n",
-    "    aggregated_score, outputs, all_scores = evaluate(cot)\n",
-    "\n",
-    "\n",
-    "    # Log the aggregated score\n",
-    "    mlflow.log_metric(\"semantic_f1_score\", aggregated_score)\n",
-    "    # Log the detailed evaluation results as a table\n",
-    "    mlflow.log_table(\n",
-    "        {\n",
-    "            \"Question\": [example.question for example in eval_set],\n",
-    "            \"Gold Response\": [example.response for example in eval_set],\n",
-    "            \"Predicted Response\": outputs,\n",
-    "            \"Semantic F1 Score\": all_scores,\n",
-    "        },\n",
-    "        artifact_file=\"eval_results.json\",\n",
-    "    )\n",
+    "```bash\n",
+    "pip insall -U faiss-cpu\n",
     "```\n",
     "\n",
-    "To learn more about the integration, visit [MLflow DSPy Documentation](https://mlflow.org/docs/latest/llms/dspy/index.html) as well.\n",
+    "Or if you have GPU in your runtime:\n",
     "\n",
-    "</details>"
+    "```bash\n",
+    "pip install -U faiss-gpu\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "So far, we built a very simple chain-of-thought module for question answering and evaluated it on a small dataset.\n",
-    "\n",
-    "Can we do better? In the rest of this guide, we will build a retrieval-augmented generation (RAG) program in DSPy for the same task. We'll see how this can boost the score substantially, then we'll use one of the DSPy Optimizers to _compile_ our RAG program to higher-quality prompts, raising our scores even more."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Basic Retrieval-Augmented Generation (RAG).\n",
-    "\n",
-    "First, let's download the corpus data that we will use for RAG search. An older version of this tutorial used the full (650,000 document) corpus. To make this very fast and cheap to run, we've downsampled the corpus to just 28,000 documents."
+    "Now let's create the `retriever` (vector index) for our RAG application. We will use the `dspy.retrievers.Embeddings` API, which indexes data via an embedding model and FAISS, and at query time, it fetches the closest data to the query in the embedding space."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "download(\"https://huggingface.co/dspy/cache/resolve/main/ragqa_arena_tech_corpus.jsonl\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Set up your system's retriever.\n",
-    "\n",
-    "As far as DSPy is concerned, you can plug in any Python code for calling tools or retrievers. Here, we'll just use OpenAI Embeddings and do top-K search locally, just for convenience.\n",
-    "\n",
-    "**Note:** The step below will require that you either do `pip install -U faiss-cpu` or pass `brute_force_threshold=30_000` to `dspy.retrievers.Embeddings` to avoid faiss."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# %pip install -U faiss-cpu  # or faiss-gpu if you have a GPU"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -821,15 +147,17 @@
     }
    ],
    "source": [
+    "import ujson\n",
+    "\n",
     "max_characters = 6000  # for truncating >99th percentile of documents\n",
     "topk_docs_to_retrieve = 5  # number of documents to retrieve per search query\n",
     "\n",
     "with open(\"ragqa_arena_tech_corpus.jsonl\") as f:\n",
-    "    corpus = [ujson.loads(line)['text'][:max_characters] for line in f]\n",
+    "    corpus = [ujson.loads(line)[\"text\"][:max_characters] for line in f]\n",
     "    print(f\"Loaded {len(corpus)} documents. Will encode them below.\")\n",
     "\n",
-    "embedder = dspy.Embedder('openai/text-embedding-3-small', dimensions=512)\n",
-    "search = dspy.retrievers.Embeddings(embedder=embedder, corpus=corpus, k=topk_docs_to_retrieve)"
+    "embedder = dspy.Embedder(\"openai/text-embedding-3-small\", dimensions=512)\n",
+    "retriever = dspy.retrievers.Embeddings(embedder=embedder, corpus=corpus, k=topk_docs_to_retrieve)"
    ]
   },
   {
@@ -837,27 +165,25 @@
    "metadata": {},
    "source": [
     "\n",
-    "## Build your first RAG Module.\n",
+    "## Building Your RAG Application\n",
     "\n",
-    "In the previous guide, we looked at individual DSPy modules in isolation, e.g. `dspy.Predict(\"question -> answer\")`.\n",
+    "Now it's time to build the RAG application! As covered in the tutorial [Building AI Applications by Customizing DSPy Modules](https://dspy.ai/tutorials/custom_module/), we will put our RAG's logic into a custom DSPy module.\n",
     "\n",
-    "What if we want to build a DSPy _program_ that has multiple steps? The syntax below with `dspy.Module` allows you to connect a few pieces together, in this case, our retriever and a generation module, so the whole system can be optimized.\n",
-    "\n",
-    "Concretely, in the `__init__` method, you declare any sub-module you'll need, which in this case is just a `dspy.ChainOfThought('context, question -> response')` module that takes retrieved context, a question, and produces a response. In the `forward` method, you simply express any Python control flow you like, possibly using your modules. In this case, we first invoke the `search` function defined earlier and then invoke the `self.respond` ChainOfThought module.\n"
+    "Our RAG takes a very simple structure - we query the retriever to get relevant context, then generate answer based on the question and fetched context."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
     "class RAG(dspy.Module):\n",
     "    def __init__(self):\n",
-    "        self.respond = dspy.ChainOfThought('context, question -> response')\n",
+    "        self.respond = dspy.ChainOfThought(\"context, question -> response\")\n",
     "\n",
-    "    def forward(self, question):\n",
-    "        context = search(question).passages\n",
+    "    def forward(self, question, **kwargs):\n",
+    "        context = retriever(question).passages\n",
     "        return self.respond(context=context, question=question)"
    ]
   },
@@ -865,25 +191,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "\n",
-    "Let's use the RAG module.\n"
+    "Let's create a RAG instance and call it with some random technical question.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "Prediction(\n",
-       "    reasoning=\"High Memory and Low Memory in Linux refer to two segments of the kernel's memory space. Low Memory is the portion of memory that the kernel can access directly and is statically mapped at boot time. This area is typically used for kernel data structures and is always accessible to the kernel. High Memory, on the other hand, is not permanently mapped in the kernel's address space, meaning that the kernel cannot access it directly without first mapping it into its address space. High Memory is used for user-space applications and temporary data buffers. The distinction allows for better memory management and security, as user-space applications cannot directly access kernel-space memory.\",\n",
-       "    response=\"In Linux, High Memory refers to the segment of memory that is not permanently mapped in the kernel's address space, which means the kernel must map it temporarily to access it. This area is typically used for user-space applications and temporary data buffers. Low Memory, in contrast, is the portion of memory that the kernel can access directly and is statically mapped at boot time. It is used for kernel data structures and is always accessible to the kernel. This separation enhances security by preventing user-space applications from accessing kernel-space memory directly.\"\n",
+       "    reasoning=\"High memory and low memory in Linux refer to two distinct segments of the kernel's memory space. Low memory is the portion of memory that the kernel can access directly and is statically mapped at boot time, allowing for efficient access. High memory, on the other hand, is not permanently mapped in the kernel's address space, meaning that the kernel must map it temporarily when it needs to access it. This distinction is crucial for managing memory in a 32-bit architecture, where the kernel needs to handle more memory than it can directly address. High memory is typically used for temporary data buffers, while low memory is used for kernel operations.\",\n",
+       "    response=\"In Linux, high memory refers to the segment of memory that is not permanently mapped in the kernel's address space, requiring the kernel to map it temporarily for access. Low memory, conversely, is the portion that the kernel can access directly and is statically mapped at boot time. This separation allows user-space applications to operate in their own memory space without directly accessing kernel memory, enhancing system stability and security.\"\n",
        ")"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -895,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -906,18 +231,16 @@
       "\n",
       "\n",
       "\n",
-      "\u001b[34m[2024-11-23T23:16:49.175612]\u001b[0m\n",
+      "\u001b[34m[2025-06-17T16:19:13.986128]\u001b[0m\n",
       "\n",
       "\u001b[31mSystem message:\u001b[0m\n",
       "\n",
       "Your input fields are:\n",
-      "1. `context` (str)\n",
-      "2. `question` (str)\n",
-      "\n",
+      "1. `context` (str): \n",
+      "2. `question` (str):\n",
       "Your output fields are:\n",
-      "1. `reasoning` (str)\n",
-      "2. `response` (str)\n",
-      "\n",
+      "1. `reasoning` (str): \n",
+      "2. `response` (str):\n",
       "All interactions will be structured in the following way, with the appropriate values filled in.\n",
       "\n",
       "[[ ## context ## ]]\n",
@@ -933,7 +256,6 @@
       "{response}\n",
       "\n",
       "[[ ## completed ## ]]\n",
-      "\n",
       "In adhering to this structure, your objective is: \n",
       "        Given the fields `context`, `question`, produce the fields `response`.\n",
       "\n",
@@ -945,7 +267,7 @@
       "[2] «HIGHMEM is a range of kernels memory space, but it is NOT memory you access but its a place where you put what you want to access. A typical 32bit Linux virtual memory map is like: 0x00000000-0xbfffffff: user process (3GB) 0xc0000000-0xffffffff: kernel space (1GB) (CPU-specific vector and whatsoever are ignored here). Linux splits the 1GB kernel space into 2 pieces, LOWMEM and HIGHMEM. The split varies from installation to installation. If an installation chooses, say, 512MB-512MB for LOW and HIGH mems, the 512MB LOWMEM (0xc0000000-0xdfffffff) is statically mapped at the kernel boot time; usually the first so many bytes of the physical memory is used for this so that virtual and physical addresses in this range have a constant offset of, say, 0xc0000000. On the other hand, the latter 512MB (HIGHMEM) has no static mapping (although you could leave pages semi-permanently mapped there, but you must do so explicitly in your driver code). Instead, pages are temporarily mapped and unmapped here so that virtual and physical addresses in this range have no consistent mapping. Typical uses of HIGHMEM include single-time data buffers.»\n",
       "[3] «This is relevant to the Linux kernel; Im not sure how any Unix kernel handles this. The High Memory is the segment of memory that user-space programs can address. It cannot touch Low Memory. Low Memory is the segment of memory that the Linux kernel can address directly. If the kernel must access High Memory, it has to map it into its own address space first. There was a patch introduced recently that lets you control where the segment is. The tradeoff is that you can take addressable memory away from user space so that the kernel can have more memory that it does not have to map before using. Additional resources: http://tldp.org/HOWTO/KernelAnalysis-HOWTO-7.html http://linux-mm.org/HighMemory»\n",
       "[4] «The first reference to turn to is Linux Device Drivers (available both online and in book form), particularly chapter 15 which has a section on the topic. In an ideal world, every system component would be able to map all the memory it ever needs to access. And this is the case for processes on Linux and most operating systems: a 32-bit process can only access a little less than 2^32 bytes of virtual memory (in fact about 3GB on a typical Linux 32-bit architecture). It gets difficult for the kernel, which needs to be able to map the full memory of the process whose system call its executing, plus the whole physical memory, plus any other memory-mapped hardware device. So when a 32-bit kernel needs to map more than 4GB of memory, it must be compiled with high memory support. High memory is memory which is not permanently mapped in the kernels address space. (Low memory is the opposite: it is always mapped, so you can access it in the kernel simply by dereferencing a pointer.) When you access high memory from kernel code, you need to call kmap first, to obtain a pointer from a page data structure (struct page). Calling kmap works whether the page is in high or low memory. There is also kmap_atomic which has added constraints but is more efficient on multiprocessor machines because it uses finer-grained locking. The pointer obtained through kmap is a resource: it uses up address space. Once youve finished with it, you must call kunmap (or kunmap_atomic) to free that resource; then the pointer is no longer valid, and the contents of the page cant be accessed until you call kmap again.»\n",
-      "[5] «/proc/meminfo will tell you how free works, but /proc/kcore can tell you what the kernel uses. From the same page: /proc/kcore This file represents the physical memory of the system and is stored in the ELF core file format. With this pseudo-file, and an unstripped kernel (/usr/src/linux/vmlinux) binary, GDB can be used to examine the current state of any kernel data structures. The total length of the file is the size of physical memory (RAM) plus 4KB. /proc/meminfo This file reports statistics about memory usage on the system. It is used by free(1) to report the amount of free and used memory (both physical and swap) on the system as well as the shared memory and buffers used by the kernel. Each line of the file consists of a parameter name, followed by a colon, the value of the parameter, and an option unit of measurement (e.g., kB). The list below describes the parameter names and the format specifier required to read the field value. Except as noted below, all of the fields have been present since at least Linux 2.6.0. Some fileds are displayed only if the kernel was configured with various options; those dependencies are noted in the list. MemTotal %lu Total usable RAM (i.e., physical RAM minus a few reserved bits and the kernel binary code). MemFree %lu The sum of LowFree+HighFree. Buffers %lu Relatively temporary storage for raw disk blocks that shouldnt get tremendously large (20MB or so). Cached %lu In-memory cache for files read from the disk (the page cache). Doesnt include SwapCached. SwapCached %lu Memory that once was swapped out, is swapped back in but still also is in the swap file. (If memory pressure is high, these pages dont need to be swapped out again because they are already in the swap file. This saves I/O.) Active %lu Memory that has been used more recently and usually not reclaimed unless absolutely necessary. Inactive %lu Memory which has been less recently used. It is more eligible to be reclaimed for other purposes. Active(anon) %lu (since Linux 2.6.28) [To be documented.] Inactive(anon) %lu (since Linux 2.6.28) [To be documented.] Active(file) %lu (since Linux 2.6.28) [To be documented.] Inactive(file) %lu (since Linux 2.6.28) [To be documented.] Unevictable %lu (since Linux 2.6.28) (From Linux 2.6.28 to 2.6.30, CONFIG_UNEVICTABLE_LRU was required.) [To be documented.] Mlocked %lu (since Linux 2.6.28) (From Linux 2.6.28 to 2.6.30, CONFIG_UNEVICTABLE_LRU was required.) [To be documented.] HighTotal %lu (Starting with Linux 2.6.19, CONFIG_HIGHMEM is required.) Total amount of highmem. Highmem is all memory above ~860MB of physical memory. Highmem areas are for use by user-space programs, or for the page cache. The kernel must use tricks to access this memory, making it slower to access than lowmem. HighFree %lu (Starting with Linux 2.6.19, CONFIG_HIGHMEM is required.) Amount of free highmem. LowTotal %lu (Starting with Linux 2.6.19, CONFIG_HIGHMEM is required.) Total amount of lowmem. Lowmem is memory which can be used for everything that highmem can be used for, but it is also available for the kernels use for its own data structures. Among many other things, it is where everything from Slab is allocated. Bad things happen when youre out of lowmem. LowFree %lu (Starting with Linux 2.6.19, CONFIG_HIGHMEM is required.) Amount of free lowmem. MmapCopy %lu (since Linux 2.6.29) (CONFIG_MMU is required.) [To be documented.] SwapTotal %lu Total amount of swap space available. SwapFree %lu Amount of swap space that is currently unused. Dirty %lu Memory which is waiting to get written back to the disk. Writeback %lu Memory which is actively being written back to the disk. AnonPages %lu (since Linux 2.6.18) Non-file backed pages mapped into user-space page tables. Mapped %lu Files which have been mmaped, such as libraries. Shmem %lu (since Linux 2.6.32) [To be documented.] Slab %lu In-kernel data structures cache. SReclaimable %lu (since Linux 2.6.19) Part of Slab, that might be reclaimed, such as caches. SUnreclaim %lu (since Linux 2.6.19) Part of Slab, that cannot be reclaimed on memory pressure. KernelStack %lu (since Linux 2.6.32) Amount of memory allocated to kernel stacks. PageTables %lu (since Linux 2.6.18) Amount of memory dedicated to the lowest level of page tables. Quicklists %lu (since Linux 2.6.27) (CONFIG_QUICKLIST is required.) [To be documented.] NFS_Unstable %lu (since Linux 2.6.18) NFS pages sent to the server, but not yet committed to stable storage. Bounce %lu (since Linux 2.6.18) Memory used for block device bounce buffers. WritebackTmp %lu (since Linux 2.6.26) Memory used by FUSE for temporary writeback buffers. CommitLimit %lu (since Linux 2.6.10) Based on the overcommit ratio (vm.overcommit_ratio), this is the total amount of memory currently available to be allocated on the system. This limit is adhered to only if strict overcommit accounting is enabled (mode 2 in /proc/sys/vm/overcommit_ratio). The CommitLimit is calculated using the following formula: CommitLimit = ([total RAM pages] - [total huge TLB pages]) * overcommit_ratio / 100 + [total swap pages] For example, on a system with 1GB of physical RAM and 7GB of swap with a overcommit_ratio of 30, this formula yields a CommitLimit of 7.3GB. For more details, see the memory overcommit documentation in the kernel source file Documentation/vm/overcommit-accounting. Committed_AS %lu The amount of memory presently allocated on the system. The committed memory is a sum of all of the memory which has been allocated by processes, even if it has not been used by them as of yet. A process which allocates 1GB of memory (using malloc(3) or similar), but touches only 300MB of that memory will show up as using only 300MB of memory even if it has the address space allocated for the entire 1GB. This 1GB is memory which has been committed to by the VM and can be used at any time by the allocating application. With strict overcommit enabled on the system (mode 2 /proc/sys/vm/overcommit_memory), allocations w»\n",
+      "[5] «Since you dont mention, Im assuming this is on Linux. Any of the following should show you (with root): dmidecode -t memory dmidecode -t 16 lshw -class memory»\n",
       "\n",
       "[[ ## question ## ]]\n",
       "what are high memory and low memory on linux?\n",
@@ -956,10 +278,10 @@
       "\u001b[31mResponse:\u001b[0m\n",
       "\n",
       "\u001b[32m[[ ## reasoning ## ]]\n",
-      "High Memory and Low Memory in Linux refer to two segments of the kernel's memory space. Low Memory is the portion of memory that the kernel can access directly and is statically mapped at boot time. This area is typically used for kernel data structures and is always accessible to the kernel. High Memory, on the other hand, is not permanently mapped in the kernel's address space, meaning that the kernel cannot access it directly without first mapping it into its address space. High Memory is used for user-space applications and temporary data buffers. The distinction allows for better memory management and security, as user-space applications cannot directly access kernel-space memory.\n",
+      "High memory and low memory in Linux refer to two distinct segments of the kernel's memory space. Low memory is the portion of memory that the kernel can access directly and is statically mapped at boot time, allowing for efficient access. High memory, on the other hand, is not permanently mapped in the kernel's address space, meaning that the kernel must map it temporarily when it needs to access it. This distinction is crucial for managing memory in a 32-bit architecture, where the kernel needs to handle more memory than it can directly address. High memory is typically used for temporary data buffers, while low memory is used for kernel operations.\n",
       "\n",
       "[[ ## response ## ]]\n",
-      "In Linux, High Memory refers to the segment of memory that is not permanently mapped in the kernel's address space, which means the kernel must map it temporarily to access it. This area is typically used for user-space applications and temporary data buffers. Low Memory, in contrast, is the portion of memory that the kernel can access directly and is statically mapped at boot time. It is used for kernel data structures and is always accessible to the kernel. This separation enhances security by preventing user-space applications from accessing kernel-space memory directly.\n",
+      "In Linux, high memory refers to the segment of memory that is not permanently mapped in the kernel's address space, requiring the kernel to map it temporarily for access. Low memory, conversely, is the portion that the kernel can access directly and is statically mapped at boot time. This separation allows user-space applications to operate in their own memory space without directly accessing kernel memory, enhancing system stability and security.\n",
       "\n",
       "[[ ## completed ## ]]\u001b[0m\n",
       "\n",
@@ -978,26 +300,122 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Earlier with a CoT module, we got around 40% in terms of semantic F1 on our `devset`. Would this `RAG` module score better?"
+    "## Using a DSPy Optimizer to Improve Your RAG Prompt\n",
+    "\n",
+    "You can stop reading if you just want to build a RAG application with DSPy, in this section we are going to show how to use DSPy optimizer to improve the program's quality."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's first evaluate the RAG we built. In order to evaluate a RAG application, we need a dataset along with an evaluation metric. For this purpose, we will use the [RAG-QA dataset](https://arxiv.org/abs/2407.13998) as the evaluation dataset, and [SemanticF1](https://karmake2.github.io/files/Publications/2022/SEM_F1.pdf) as the evaluation metric. Let's download the dataset and import the evaluation metric."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Average Metric: 166.54 / 300 (55.5%): 100%|██████████| 300/300 [00:04<00:00, 61.40it/s] "
+      "Downloading 'ragqa_arena_tech_examples.jsonl'...\n"
+     ]
+    }
+   ],
+   "source": [
+    "import ujson\n",
+    "from dspy.utils import download\n",
+    "\n",
+    "# Download question--answer pairs from the RAG-QA Arena \"Tech\" dataset.\n",
+    "download(\"https://huggingface.co/dspy/cache/resolve/main/ragqa_arena_tech_examples.jsonl\")\n",
+    "\n",
+    "with open(\"ragqa_arena_tech_examples.jsonl\") as f:\n",
+    "    data = [ujson.loads(line) for line in f]\n",
+    "\n",
+    "# Convert the data into a list of `dspy.Example` objects so that we can use them for `dspy.Evaluate`.\n",
+    "data = [dspy.Example(**d).with_inputs(\"question\") for d in data]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look at a sample data record and some metadata of the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data size: 2064\n",
+      "Example({'question': 'why igp is used in mpls?', 'response': \"An IGP exchanges routing prefixes between gateways/routers.  \\nWithout a routing protocol, you'd have to configure each route on every router and you'd have no dynamic updates when routes change because of link failures. \\nFuthermore, within an MPLS network, an IGP is vital for advertising the internal topology and ensuring connectivity for MP-BGP inside the network.\", 'gold_doc_ids': [2822, 2823]}) (input_keys={'question'})\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Data size: {len(data)}\")\n",
+    "print(data[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each data has 3 fields:\n",
+    "\n",
+    "- question\n",
+    "- response\n",
+    "- gold_doc_ids\n",
+    "\n",
+    "For our evaluation purpose, we only use the question and response field.\n",
+    "\n",
+    "Let's take some slices of the dataset to be the training and validation dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "\n",
+    "random.Random(0).shuffle(data)\n",
+    "trainset, devset = data[:200], data[200:500]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's evaluate our RAG application to get a sense of how it performs. For a complete guide on how to evaluate a DSPy program, please refer to the [evaluation guide](https://dspy.ai/learn/evaluation/overview/)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average Metric: 163.55 / 300 (54.5%): 100%|██████████| 300/300 [03:17<00:00,  1.52it/s]"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024/11/23 23:16:54 INFO dspy.evaluate.evaluate: Average Metric: 166.53601368289284 / 300 (55.5%)\n"
+      "2025/06/17 19:43:05 INFO dspy.evaluate.evaluate: Average Metric: 163.5533565284151 / 300 (54.5%)\n"
      ]
     },
     {
@@ -1042,47 +460,167 @@
        "      <td>when to use c over c++, and c++ over c?</td>\n",
        "      <td>If you are equally familiar with both C++ and C, it's advisable to...</td>\n",
        "      <td>[733]</td>\n",
-       "      <td>C should be used over C++ primarily in scenarios where simplicity ...</td>\n",
+       "      <td>C should be used over C++ primarily in scenarios where simplicity,...</td>\n",
        "      <td>Use C over C++ when working on embedded systems, requiring low-lev...</td>\n",
-       "      <td>✔️ [0.500]</td>\n",
+       "      <td>✔️ [0.364]</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>should images be stored in a git repository?</td>\n",
        "      <td>One viewpoint expresses that there is no significant downside, esp...</td>\n",
        "      <td>[6253, 6254, 6275, 6278, 8215]</td>\n",
-       "      <td>Storing images in a Git repository is generally not recommended du...</td>\n",
+       "      <td>Storing images in a Git repository can be problematic due to Git's...</td>\n",
        "      <td>While it is technically possible to store images in a Git reposito...</td>\n",
        "      <td>✔️ [0.444]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>how to chmod without /usr/bin/chmod?</td>\n",
+       "      <td>Run the loader directly, and pass it the command you want to run: ...</td>\n",
+       "      <td>[3252, 3254, 3270, 1964, 4222, 8050]</td>\n",
+       "      <td>To change file permissions without using the `/usr/bin/chmod` comm...</td>\n",
+       "      <td>You can change file permissions without using `/usr/bin/chmod` by ...</td>\n",
+       "      <td>✔️ [0.500]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>how to show the filesystem type via the terminal?</td>\n",
+       "      <td>To determine the type of file system used, you can employ the moun...</td>\n",
+       "      <td>[8248]</td>\n",
+       "      <td>To show the filesystem type via the terminal, you can use several ...</td>\n",
+       "      <td>You can show the filesystem type via the terminal using the follow...</td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>can i get the cpu temperature and fan speed from the command line ...</td>\n",
+       "      <td>The iStats ruby gem allows you to monitor the CPU temperature with...</td>\n",
+       "      <td>[4354, 4784]</td>\n",
+       "      <td>Yes, you can get the CPU temperature and fan speed from the comman...</td>\n",
+       "      <td>Yes, you can get the CPU temperature using the command `sudo power...</td>\n",
+       "      <td>✔️ [0.667]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>how can i see my home folder in the finder?</td>\n",
+       "      <td>To navigate to your home folder on a Mac, you can use the keyboard...</td>\n",
+       "      <td>[6416, 6423, 6424, 2591]</td>\n",
+       "      <td>To see your home folder in Finder, you can use several methods. On...</td>\n",
+       "      <td>You can see your home folder in Finder by looking for it in the si...</td>\n",
+       "      <td>✔️ [0.500]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>can you see when someone is looking at your location?</td>\n",
+       "      <td>When using Find My Friends, your friends will not be aware if you ...</td>\n",
+       "      <td>[1951, 1954]</td>\n",
+       "      <td>Based on the provided context, when someone is using location-shar...</td>\n",
+       "      <td>No, you cannot see when someone is looking at your location. When ...</td>\n",
+       "      <td>✔️ [0.797]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>is a zip code considered pii?</td>\n",
+       "      <td>On one hand, some argue that by itself, a zip code cannot be class...</td>\n",
+       "      <td>[4775, 4777, 4779, 5541]</td>\n",
+       "      <td>A zip code can be considered personally identifiable information (...</td>\n",
+       "      <td>Yes, a zip code can be considered PII, especially when combined wi...</td>\n",
+       "      <td>✔️ [0.600]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>why is my message not delivered imessage?</td>\n",
+       "      <td>\"Not Delivered\" implies an error of some kind, perhaps because the...</td>\n",
+       "      <td>[7645, 4712]</td>\n",
+       "      <td>Your message may not be delivered in iMessage for several reasons....</td>\n",
+       "      <td>Your message may not be delivered due to several factors, such as ...</td>\n",
+       "      <td>✔️ [0.381]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>how to buy an app for a friend?</td>\n",
+       "      <td>Google Play Gift Cards have become widely accessible in numerous c...</td>\n",
+       "      <td>[383]</td>\n",
+       "      <td>To buy an app for a friend, you can use the gifting feature availa...</td>\n",
+       "      <td>To buy an app for a friend, you can gift the app directly through ...</td>\n",
+       "      <td></td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                       question  \\\n",
-       "0       when to use c over c++, and c++ over c?   \n",
-       "1  should images be stored in a git repository?   \n",
+       "                                                                question  \\\n",
+       "0                                when to use c over c++, and c++ over c?   \n",
+       "1                           should images be stored in a git repository?   \n",
+       "2                                   how to chmod without /usr/bin/chmod?   \n",
+       "3                      how to show the filesystem type via the terminal?   \n",
+       "4  can i get the cpu temperature and fan speed from the command line ...   \n",
+       "5                            how can i see my home folder in the finder?   \n",
+       "6                  can you see when someone is looking at your location?   \n",
+       "7                                          is a zip code considered pii?   \n",
+       "8                              why is my message not delivered imessage?   \n",
+       "9                                        how to buy an app for a friend?   \n",
        "\n",
        "                                                        example_response  \\\n",
        "0  If you are equally familiar with both C++ and C, it's advisable to...   \n",
        "1  One viewpoint expresses that there is no significant downside, esp...   \n",
+       "2  Run the loader directly, and pass it the command you want to run: ...   \n",
+       "3  To determine the type of file system used, you can employ the moun...   \n",
+       "4  The iStats ruby gem allows you to monitor the CPU temperature with...   \n",
+       "5  To navigate to your home folder on a Mac, you can use the keyboard...   \n",
+       "6  When using Find My Friends, your friends will not be aware if you ...   \n",
+       "7  On one hand, some argue that by itself, a zip code cannot be class...   \n",
+       "8  \"Not Delivered\" implies an error of some kind, perhaps because the...   \n",
+       "9  Google Play Gift Cards have become widely accessible in numerous c...   \n",
        "\n",
-       "                     gold_doc_ids  \\\n",
-       "0                           [733]   \n",
-       "1  [6253, 6254, 6275, 6278, 8215]   \n",
+       "                           gold_doc_ids  \\\n",
+       "0                                 [733]   \n",
+       "1        [6253, 6254, 6275, 6278, 8215]   \n",
+       "2  [3252, 3254, 3270, 1964, 4222, 8050]   \n",
+       "3                                [8248]   \n",
+       "4                          [4354, 4784]   \n",
+       "5              [6416, 6423, 6424, 2591]   \n",
+       "6                          [1951, 1954]   \n",
+       "7              [4775, 4777, 4779, 5541]   \n",
+       "8                          [7645, 4712]   \n",
+       "9                                 [383]   \n",
        "\n",
        "                                                               reasoning  \\\n",
-       "0  C should be used over C++ primarily in scenarios where simplicity ...   \n",
-       "1  Storing images in a Git repository is generally not recommended du...   \n",
+       "0  C should be used over C++ primarily in scenarios where simplicity,...   \n",
+       "1  Storing images in a Git repository can be problematic due to Git's...   \n",
+       "2  To change file permissions without using the `/usr/bin/chmod` comm...   \n",
+       "3  To show the filesystem type via the terminal, you can use several ...   \n",
+       "4  Yes, you can get the CPU temperature and fan speed from the comman...   \n",
+       "5  To see your home folder in Finder, you can use several methods. On...   \n",
+       "6  Based on the provided context, when someone is using location-shar...   \n",
+       "7  A zip code can be considered personally identifiable information (...   \n",
+       "8  Your message may not be delivered in iMessage for several reasons....   \n",
+       "9  To buy an app for a friend, you can use the gifting feature availa...   \n",
        "\n",
        "                                                           pred_response  \\\n",
        "0  Use C over C++ when working on embedded systems, requiring low-lev...   \n",
        "1  While it is technically possible to store images in a Git reposito...   \n",
+       "2  You can change file permissions without using `/usr/bin/chmod` by ...   \n",
+       "3  You can show the filesystem type via the terminal using the follow...   \n",
+       "4  Yes, you can get the CPU temperature using the command `sudo power...   \n",
+       "5  You can see your home folder in Finder by looking for it in the si...   \n",
+       "6  No, you cannot see when someone is looking at your location. When ...   \n",
+       "7  Yes, a zip code can be considered PII, especially when combined wi...   \n",
+       "8  Your message may not be delivered due to several factors, such as ...   \n",
+       "9  To buy an app for a friend, you can gift the app directly through ...   \n",
        "\n",
        "   SemanticF1  \n",
-       "0  ✔️ [0.500]  \n",
-       "1  ✔️ [0.444]  "
+       "0  ✔️ [0.364]  \n",
+       "1  ✔️ [0.444]  \n",
+       "2  ✔️ [0.500]  \n",
+       "3              \n",
+       "4  ✔️ [0.667]  \n",
+       "5  ✔️ [0.500]  \n",
+       "6  ✔️ [0.797]  \n",
+       "7  ✔️ [0.600]  \n",
+       "8  ✔️ [0.381]  \n",
+       "9              "
       ]
      },
      "metadata": {},
@@ -1092,15 +630,15 @@
      "data": {
       "text/html": [
        "\n",
-       "                <div style='\n",
-       "                    text-align: center;\n",
-       "                    font-size: 16px;\n",
-       "                    font-weight: bold;\n",
-       "                    color: #555;\n",
-       "                    margin: 10px 0;'>\n",
-       "                    ... 298 more rows not displayed ...\n",
-       "                </div>\n",
-       "                "
+       "            <div style='\n",
+       "                text-align: center;\n",
+       "                font-size: 16px;\n",
+       "                font-weight: bold;\n",
+       "                color: #555;\n",
+       "                margin: 10px 0;'>\n",
+       "                ... 290 more rows not displayed ...\n",
+       "            </div>\n",
+       "            "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -1112,63 +650,747 @@
     {
      "data": {
       "text/plain": [
-       "55.51"
+       "54.52"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "evaluate(RAG())"
+    "from dspy.evaluate import SemanticF1\n",
+    "\n",
+    "# Instantiate the metric.\n",
+    "metric = SemanticF1(decompositional=True)\n",
+    "\n",
+    "# Define an evaluator that we can re-use.\n",
+    "evaluate = dspy.Evaluate(\n",
+    "    devset=devset,\n",
+    "    metric=metric,\n",
+    "    num_threads=24,\n",
+    "    display_progress=True,\n",
+    "    display_table=10,\n",
+    ")\n",
+    "\n",
+    "# Evaluate the rag application we just built.\n",
+    "evaluate(rag)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using a DSPy Optimizer to improve your RAG prompt.\n",
+    "Off the shelf, our `RAG` module scores ~54.5%. What are our options to make it stronger? You may think about prompt engineering, like making the instruction more comprehensive or provide a few examples. DSPy provides another option to use DSPy optimizers to automatically optimize our RAG's prompt.\n",
     "\n",
-    "Off the shelf, our `RAG` module scores 55%. What are our options to make it stronger? One of the various choices DSPy offers is optimizing the prompts in our pipeline.\n",
-    "\n",
-    "If there are many sub-modules in your program, all of them will be optimized together. In this case, there's only one: `self.respond = dspy.ChainOfThought('context, question -> response')`\n",
-    "\n",
-    "Let's set up and use DSPy's MIPRO (v2) optimizer. The run below has a cost around $1.5 (for the `medium` auto setting) and may take some 20-30 minutes depending on your number of threads."
+    "Let's set up and use DSPy's MIPRO (v2) optimizer. The run below has a cost around $0.5 (for the `light` auto setting) and may take some 10-20 minutes depending on your number of threads."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:17:43 INFO dspy.teleprompt.mipro_optimizer_v2: \n",
+      "RUNNING WITH THE FOLLOWING LIGHT AUTO RUN SETTINGS:\n",
+      "num_trials: 10\n",
+      "minibatch: True\n",
+      "num_fewshot_candidates: 6\n",
+      "num_instruct_candidates: 3\n",
+      "valset size: 100\n",
+      "\n",
+      "2025/06/17 20:17:43 INFO dspy.teleprompt.mipro_optimizer_v2: \n",
+      "==> STEP 1: BOOTSTRAP FEWSHOT EXAMPLES <==\n",
+      "2025/06/17 20:17:43 INFO dspy.teleprompt.mipro_optimizer_v2: These will be used as few-shot example candidates for our program and for creating instructions.\n",
+      "\n",
+      "2025/06/17 20:17:43 INFO dspy.teleprompt.mipro_optimizer_v2: Bootstrapping N=6 sets of demonstrations...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bootstrapping set 1/6\n",
+      "Bootstrapping set 2/6\n",
+      "Bootstrapping set 3/6\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 10%|█         | 4/40 [00:00<00:05,  6.29it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bootstrapped 2 full traces after 4 examples for up to 1 rounds, amounting to 4 attempts.\n",
+      "Bootstrapping set 4/6\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  5%|▌         | 2/40 [00:26<08:19, 13.14s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bootstrapped 1 full traces after 2 examples for up to 1 rounds, amounting to 2 attempts.\n",
+      "Bootstrapping set 5/6\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 10%|█         | 4/40 [01:11<10:45, 17.93s/it]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bootstrapped 2 full traces after 4 examples for up to 1 rounds, amounting to 4 attempts.\n",
+      "Bootstrapping set 6/6\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  5%|▌         | 2/40 [00:36<11:28, 18.13s/it]\n",
+      "2025/06/17 20:19:58 INFO dspy.teleprompt.mipro_optimizer_v2: \n",
+      "==> STEP 2: PROPOSE INSTRUCTION CANDIDATES <==\n",
+      "2025/06/17 20:19:58 INFO dspy.teleprompt.mipro_optimizer_v2: We will use the few-shot examples from the previous step, a generated dataset summary, a summary of the program code, and a randomly selected prompting tip to propose instructions.\n",
+      "2025/06/17 20:19:58 INFO dspy.teleprompt.mipro_optimizer_v2: \n",
+      "Proposing N=3 instructions...\n",
+      "\n",
+      "2025/06/17 20:19:58 WARNING dspy.primitives.program: Calling GenerateModuleInstruction.forward() directly is discouraged. Please use GenerateModuleInstruction() instead.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bootstrapped 2 full traces after 2 examples for up to 1 rounds, amounting to 2 attempts.\n",
+      "Error getting source code: unhashable type: 'dict'.\n",
+      "\n",
+      "Running without program aware proposer.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:19:59 WARNING dspy.primitives.program: Calling GenerateModuleInstruction.forward() directly is discouraged. Please use GenerateModuleInstruction() instead.\n",
+      "2025/06/17 20:20:02 WARNING dspy.primitives.program: Calling GenerateModuleInstruction.forward() directly is discouraged. Please use GenerateModuleInstruction() instead.\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: Proposed Instructions for Predictor 0:\n",
+      "\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: 0: Given the fields `context`, `question`, produce the fields `response`.\n",
+      "\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: 1: Imagine you are a technical support specialist tasked with resolving urgent user issues related to macOS and command line environments. A user has reached out in a panic because they cannot find their account pictures and need them for an important presentation in just a few hours. Your job is to provide a clear, step-by-step response to the following question: \"Where does macOS store account pictures?\" Ensure your response is thorough, includes all relevant locations, and is accessible to users of varying skill levels.\n",
+      "\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: 2: Given the context provided, answer the following question with a detailed and clear response: {question}\n",
+      "\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: \n",
+      "\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: ==> STEP 3: FINDING OPTIMAL PROMPT PARAMETERS <==\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: We will evaluate the program over a series of trials with different combinations of instructions and few-shot examples to find the optimal combination using Bayesian Optimization.\n",
+      "\n",
+      "2025/06/17 20:20:03 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 1 / 13 - Full Evaluation of Default Program ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average Metric: 52.24 / 100 (52.2%): 100%|██████████| 100/100 [00:03<00:00, 32.08it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:20:06 INFO dspy.evaluate.evaluate: Average Metric: 52.240583970223014 / 100 (52.2%)\n",
+      "2025/06/17 20:20:06 INFO dspy.teleprompt.mipro_optimizer_v2: Default program score: 52.24\n",
+      "\n",
+      "2025/06/17 20:20:06 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 2 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 20.92 / 35 (59.8%): 100%|██████████| 35/35 [00:38<00:00,  1.11s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:20:45 INFO dspy.evaluate.evaluate: Average Metric: 20.924469148217348 / 35 (59.8%)\n",
+      "2025/06/17 20:20:45 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 59.78 on minibatch of size 35 with parameters ['Predictor 0: Instruction 1', 'Predictor 0: Few-Shot Set 3'].\n",
+      "2025/06/17 20:20:45 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78]\n",
+      "2025/06/17 20:20:45 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24]\n",
+      "2025/06/17 20:20:45 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 52.24\n",
+      "2025/06/17 20:20:45 INFO dspy.teleprompt.mipro_optimizer_v2: =========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:20:45 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 3 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 20.07 / 35 (57.4%): 100%|██████████| 35/35 [00:40<00:00,  1.17s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:21:26 INFO dspy.evaluate.evaluate: Average Metric: 20.074049254214792 / 35 (57.4%)\n",
+      "2025/06/17 20:21:26 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 57.35 on minibatch of size 35 with parameters ['Predictor 0: Instruction 2', 'Predictor 0: Few-Shot Set 0'].\n",
+      "2025/06/17 20:21:26 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35]\n",
+      "2025/06/17 20:21:26 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24]\n",
+      "2025/06/17 20:21:26 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 52.24\n",
+      "2025/06/17 20:21:26 INFO dspy.teleprompt.mipro_optimizer_v2: =========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:21:26 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 4 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 20.45 / 35 (58.4%): 100%|██████████| 35/35 [00:37<00:00,  1.08s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:22:04 INFO dspy.evaluate.evaluate: Average Metric: 20.452614424867754 / 35 (58.4%)\n",
+      "2025/06/17 20:22:04 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 58.44 on minibatch of size 35 with parameters ['Predictor 0: Instruction 1', 'Predictor 0: Few-Shot Set 5'].\n",
+      "2025/06/17 20:22:04 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44]\n",
+      "2025/06/17 20:22:04 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24]\n",
+      "2025/06/17 20:22:04 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 52.24\n",
+      "2025/06/17 20:22:04 INFO dspy.teleprompt.mipro_optimizer_v2: =========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:22:04 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 5 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 20.86 / 35 (59.6%): 100%|██████████| 35/35 [00:39<00:00,  1.13s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:22:43 INFO dspy.evaluate.evaluate: Average Metric: 20.863533031592333 / 35 (59.6%)\n",
+      "2025/06/17 20:22:43 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 59.61 on minibatch of size 35 with parameters ['Predictor 0: Instruction 2', 'Predictor 0: Few-Shot Set 2'].\n",
+      "2025/06/17 20:22:43 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44, 59.61]\n",
+      "2025/06/17 20:22:43 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24]\n",
+      "2025/06/17 20:22:43 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 52.24\n",
+      "2025/06/17 20:22:43 INFO dspy.teleprompt.mipro_optimizer_v2: =========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:22:43 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 6 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 22.50 / 35 (64.3%): 100%|██████████| 35/35 [00:42<00:00,  1.22s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:23:26 INFO dspy.evaluate.evaluate: Average Metric: 22.504307654109333 / 35 (64.3%)\n",
+      "2025/06/17 20:23:26 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 64.3 on minibatch of size 35 with parameters ['Predictor 0: Instruction 0', 'Predictor 0: Few-Shot Set 5'].\n",
+      "2025/06/17 20:23:26 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44, 59.61, 64.3]\n",
+      "2025/06/17 20:23:26 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24]\n",
+      "2025/06/17 20:23:26 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 52.24\n",
+      "2025/06/17 20:23:26 INFO dspy.teleprompt.mipro_optimizer_v2: =========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:23:26 INFO dspy.teleprompt.mipro_optimizer_v2: ===== Trial 7 / 13 - Full Evaluation =====\n",
+      "2025/06/17 20:23:26 INFO dspy.teleprompt.mipro_optimizer_v2: Doing full eval on next top averaging program (Avg Score: 64.3) from minibatch trials...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 58.65 / 100 (58.7%): 100%|██████████| 100/100 [01:02<00:00,  1.61it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:24:28 INFO dspy.evaluate.evaluate: Average Metric: 58.65054658356367 / 100 (58.7%)\n",
+      "2025/06/17 20:24:28 INFO dspy.teleprompt.mipro_optimizer_v2: \u001b[92mNew best full eval score!\u001b[0m Score: 58.65\n",
+      "2025/06/17 20:24:28 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24, 58.65]\n",
+      "2025/06/17 20:24:28 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 58.65\n",
+      "2025/06/17 20:24:28 INFO dspy.teleprompt.mipro_optimizer_v2: =======================\n",
+      "2025/06/17 20:24:28 INFO dspy.teleprompt.mipro_optimizer_v2: \n",
+      "\n",
+      "2025/06/17 20:24:28 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 8 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 19.34 / 35 (55.3%): 100%|██████████| 35/35 [00:24<00:00,  1.44it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:24:53 INFO dspy.evaluate.evaluate: Average Metric: 19.338979262327037 / 35 (55.3%)\n",
+      "2025/06/17 20:24:53 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 55.25 on minibatch of size 35 with parameters ['Predictor 0: Instruction 2', 'Predictor 0: Few-Shot Set 0'].\n",
+      "2025/06/17 20:24:53 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44, 59.61, 64.3, 55.25]\n",
+      "2025/06/17 20:24:53 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24, 58.65]\n",
+      "2025/06/17 20:24:53 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 58.65\n",
+      "2025/06/17 20:24:53 INFO dspy.teleprompt.mipro_optimizer_v2: =========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:24:53 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 9 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 17.95 / 35 (51.3%): 100%|██████████| 35/35 [00:47<00:00,  1.37s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:25:41 INFO dspy.evaluate.evaluate: Average Metric: 17.95395292302051 / 35 (51.3%)\n",
+      "2025/06/17 20:25:41 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 51.3 on minibatch of size 35 with parameters ['Predictor 0: Instruction 2', 'Predictor 0: Few-Shot Set 5'].\n",
+      "2025/06/17 20:25:41 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44, 59.61, 64.3, 55.25, 51.3]\n",
+      "2025/06/17 20:25:41 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24, 58.65]\n",
+      "2025/06/17 20:25:41 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 58.65\n",
+      "2025/06/17 20:25:41 INFO dspy.teleprompt.mipro_optimizer_v2: =========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:25:41 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 10 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 20.54 / 35 (58.7%): 100%|██████████| 35/35 [00:31<00:00,  1.12it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:26:12 INFO dspy.evaluate.evaluate: Average Metric: 20.543559645193525 / 35 (58.7%)\n",
+      "2025/06/17 20:26:12 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 58.7 on minibatch of size 35 with parameters ['Predictor 0: Instruction 1', 'Predictor 0: Few-Shot Set 4'].\n",
+      "2025/06/17 20:26:12 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44, 59.61, 64.3, 55.25, 51.3, 58.7]\n",
+      "2025/06/17 20:26:12 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24, 58.65]\n",
+      "2025/06/17 20:26:12 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 58.65\n",
+      "2025/06/17 20:26:12 INFO dspy.teleprompt.mipro_optimizer_v2: ==========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:26:12 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 11 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 20.26 / 35 (57.9%): 100%|██████████| 35/35 [00:01<00:00, 24.41it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:26:14 INFO dspy.evaluate.evaluate: Average Metric: 20.255674014148813 / 35 (57.9%)\n",
+      "2025/06/17 20:26:14 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 57.87 on minibatch of size 35 with parameters ['Predictor 0: Instruction 0', 'Predictor 0: Few-Shot Set 5'].\n",
+      "2025/06/17 20:26:14 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44, 59.61, 64.3, 55.25, 51.3, 58.7, 57.87]\n",
+      "2025/06/17 20:26:14 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24, 58.65]\n",
+      "2025/06/17 20:26:14 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 58.65\n",
+      "2025/06/17 20:26:14 INFO dspy.teleprompt.mipro_optimizer_v2: ==========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:26:14 INFO dspy.teleprompt.mipro_optimizer_v2: == Trial 12 / 13 - Minibatch ==\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 18.27 / 35 (52.2%): 100%|██████████| 35/35 [00:42<00:00,  1.20s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:26:56 INFO dspy.evaluate.evaluate: Average Metric: 18.266113519144685 / 35 (52.2%)\n",
+      "2025/06/17 20:26:56 INFO dspy.teleprompt.mipro_optimizer_v2: Score: 52.19 on minibatch of size 35 with parameters ['Predictor 0: Instruction 1', 'Predictor 0: Few-Shot Set 3'].\n",
+      "2025/06/17 20:26:56 INFO dspy.teleprompt.mipro_optimizer_v2: Minibatch scores so far: [59.78, 57.35, 58.44, 59.61, 64.3, 55.25, 51.3, 58.7, 57.87, 52.19]\n",
+      "2025/06/17 20:26:56 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24, 58.65]\n",
+      "2025/06/17 20:26:56 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 58.65\n",
+      "2025/06/17 20:26:56 INFO dspy.teleprompt.mipro_optimizer_v2: ==========================================\n",
+      "\n",
+      "\n",
+      "2025/06/17 20:26:56 INFO dspy.teleprompt.mipro_optimizer_v2: ===== Trial 13 / 13 - Full Evaluation =====\n",
+      "2025/06/17 20:26:56 INFO dspy.teleprompt.mipro_optimizer_v2: Doing full eval on next top averaging program (Avg Score: 59.61) from minibatch trials...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 57.01 / 100 (57.0%): 100%|██████████| 100/100 [01:02<00:00,  1.61it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:27:58 INFO dspy.evaluate.evaluate: Average Metric: 57.006762023295245 / 100 (57.0%)\n",
+      "2025/06/17 20:27:58 INFO dspy.teleprompt.mipro_optimizer_v2: Full eval scores so far: [52.24, 58.65, 57.01]\n",
+      "2025/06/17 20:27:58 INFO dspy.teleprompt.mipro_optimizer_v2: Best full score so far: 58.65\n",
+      "2025/06/17 20:27:58 INFO dspy.teleprompt.mipro_optimizer_v2: =======================\n",
+      "2025/06/17 20:27:58 INFO dspy.teleprompt.mipro_optimizer_v2: \n",
+      "\n",
+      "2025/06/17 20:27:58 INFO dspy.teleprompt.mipro_optimizer_v2: Returning best identified program with score 58.65!\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Average Metric: 180.78 / 300 (60.3%): 100%|██████████| 300/300 [03:13<00:00,  1.55it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025/06/17 20:31:12 INFO dspy.evaluate.evaluate: Average Metric: 180.78224801513014 / 300 (60.3%)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>question</th>\n",
+       "      <th>example_response</th>\n",
+       "      <th>gold_doc_ids</th>\n",
+       "      <th>reasoning</th>\n",
+       "      <th>pred_response</th>\n",
+       "      <th>SemanticF1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>when to use c over c++, and c++ over c?</td>\n",
+       "      <td>If you are equally familiar with both C++ and C, it's advisable to...</td>\n",
+       "      <td>[733]</td>\n",
+       "      <td>The context outlines several scenarios where one might choose C ov...</td>\n",
+       "      <td>You should consider using C over C++ in the following scenarios: 1...</td>\n",
+       "      <td>✔️ [0.400]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>should images be stored in a git repository?</td>\n",
+       "      <td>One viewpoint expresses that there is no significant downside, esp...</td>\n",
+       "      <td>[6253, 6254, 6275, 6278, 8215]</td>\n",
+       "      <td>Storing images in a Git repository can be problematic due to Git's...</td>\n",
+       "      <td>Storing images in a Git repository is generally not recommended du...</td>\n",
+       "      <td>✔️ [0.444]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>how to chmod without /usr/bin/chmod?</td>\n",
+       "      <td>Run the loader directly, and pass it the command you want to run: ...</td>\n",
+       "      <td>[3252, 3254, 3270, 1964, 4222, 8050]</td>\n",
+       "      <td>The context provides several alternative methods to change file pe...</td>\n",
+       "      <td>To change file permissions without using `/usr/bin/chmod`, you can...</td>\n",
+       "      <td>✔️ [0.500]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>how to show the filesystem type via the terminal?</td>\n",
+       "      <td>To determine the type of file system used, you can employ the moun...</td>\n",
+       "      <td>[8248]</td>\n",
+       "      <td>To show the filesystem type via the terminal, there are several co...</td>\n",
+       "      <td>To show the filesystem type via the terminal, you can use the foll...</td>\n",
+       "      <td>✔️ [0.400]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>can i get the cpu temperature and fan speed from the command line ...</td>\n",
+       "      <td>The iStats ruby gem allows you to monitor the CPU temperature with...</td>\n",
+       "      <td>[4354, 4784]</td>\n",
+       "      <td>Yes, you can get the CPU temperature and fan speed from the comman...</td>\n",
+       "      <td>Yes, you can get the CPU temperature and fan speed from the comman...</td>\n",
+       "      <td>✔️ [0.769]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>how can i see my home folder in the finder?</td>\n",
+       "      <td>To navigate to your home folder on a Mac, you can use the keyboard...</td>\n",
+       "      <td>[6416, 6423, 6424, 2591]</td>\n",
+       "      <td>To see your home folder in Finder, there are several methods you c...</td>\n",
+       "      <td>To see your home folder in Finder, you can use one of the followin...</td>\n",
+       "      <td>✔️ [0.600]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>can you see when someone is looking at your location?</td>\n",
+       "      <td>When using Find My Friends, your friends will not be aware if you ...</td>\n",
+       "      <td>[1951, 1954]</td>\n",
+       "      <td>Based on the context provided, when someone is using location-shar...</td>\n",
+       "      <td>No, you cannot see when someone is looking at your location throug...</td>\n",
+       "      <td>✔️ [0.774]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>is a zip code considered pii?</td>\n",
+       "      <td>On one hand, some argue that by itself, a zip code cannot be class...</td>\n",
+       "      <td>[4775, 4777, 4779, 5541]</td>\n",
+       "      <td>The classification of a zip code as Personally Identifiable Inform...</td>\n",
+       "      <td>A zip code is not considered PII by itself, as it does not uniquel...</td>\n",
+       "      <td>✔️ [0.750]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>why is my message not delivered imessage?</td>\n",
+       "      <td>\"Not Delivered\" implies an error of some kind, perhaps because the...</td>\n",
+       "      <td>[7645, 4712]</td>\n",
+       "      <td>The context explains several reasons why an iMessage may not be ma...</td>\n",
+       "      <td>Your iMessage may not be delivered for several reasons. The recipi...</td>\n",
+       "      <td>✔️ [0.708]</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>how to buy an app for a friend?</td>\n",
+       "      <td>Google Play Gift Cards have become widely accessible in numerous c...</td>\n",
+       "      <td>[383]</td>\n",
+       "      <td>To buy an app for a friend, the most straightforward method is to ...</td>\n",
+       "      <td>To buy an app for a friend, you can use the following methods: 1. ...</td>\n",
+       "      <td>✔️ [0.284]</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                question  \\\n",
+       "0                                when to use c over c++, and c++ over c?   \n",
+       "1                           should images be stored in a git repository?   \n",
+       "2                                   how to chmod without /usr/bin/chmod?   \n",
+       "3                      how to show the filesystem type via the terminal?   \n",
+       "4  can i get the cpu temperature and fan speed from the command line ...   \n",
+       "5                            how can i see my home folder in the finder?   \n",
+       "6                  can you see when someone is looking at your location?   \n",
+       "7                                          is a zip code considered pii?   \n",
+       "8                              why is my message not delivered imessage?   \n",
+       "9                                        how to buy an app for a friend?   \n",
+       "\n",
+       "                                                        example_response  \\\n",
+       "0  If you are equally familiar with both C++ and C, it's advisable to...   \n",
+       "1  One viewpoint expresses that there is no significant downside, esp...   \n",
+       "2  Run the loader directly, and pass it the command you want to run: ...   \n",
+       "3  To determine the type of file system used, you can employ the moun...   \n",
+       "4  The iStats ruby gem allows you to monitor the CPU temperature with...   \n",
+       "5  To navigate to your home folder on a Mac, you can use the keyboard...   \n",
+       "6  When using Find My Friends, your friends will not be aware if you ...   \n",
+       "7  On one hand, some argue that by itself, a zip code cannot be class...   \n",
+       "8  \"Not Delivered\" implies an error of some kind, perhaps because the...   \n",
+       "9  Google Play Gift Cards have become widely accessible in numerous c...   \n",
+       "\n",
+       "                           gold_doc_ids  \\\n",
+       "0                                 [733]   \n",
+       "1        [6253, 6254, 6275, 6278, 8215]   \n",
+       "2  [3252, 3254, 3270, 1964, 4222, 8050]   \n",
+       "3                                [8248]   \n",
+       "4                          [4354, 4784]   \n",
+       "5              [6416, 6423, 6424, 2591]   \n",
+       "6                          [1951, 1954]   \n",
+       "7              [4775, 4777, 4779, 5541]   \n",
+       "8                          [7645, 4712]   \n",
+       "9                                 [383]   \n",
+       "\n",
+       "                                                               reasoning  \\\n",
+       "0  The context outlines several scenarios where one might choose C ov...   \n",
+       "1  Storing images in a Git repository can be problematic due to Git's...   \n",
+       "2  The context provides several alternative methods to change file pe...   \n",
+       "3  To show the filesystem type via the terminal, there are several co...   \n",
+       "4  Yes, you can get the CPU temperature and fan speed from the comman...   \n",
+       "5  To see your home folder in Finder, there are several methods you c...   \n",
+       "6  Based on the context provided, when someone is using location-shar...   \n",
+       "7  The classification of a zip code as Personally Identifiable Inform...   \n",
+       "8  The context explains several reasons why an iMessage may not be ma...   \n",
+       "9  To buy an app for a friend, the most straightforward method is to ...   \n",
+       "\n",
+       "                                                           pred_response  \\\n",
+       "0  You should consider using C over C++ in the following scenarios: 1...   \n",
+       "1  Storing images in a Git repository is generally not recommended du...   \n",
+       "2  To change file permissions without using `/usr/bin/chmod`, you can...   \n",
+       "3  To show the filesystem type via the terminal, you can use the foll...   \n",
+       "4  Yes, you can get the CPU temperature and fan speed from the comman...   \n",
+       "5  To see your home folder in Finder, you can use one of the followin...   \n",
+       "6  No, you cannot see when someone is looking at your location throug...   \n",
+       "7  A zip code is not considered PII by itself, as it does not uniquel...   \n",
+       "8  Your iMessage may not be delivered for several reasons. The recipi...   \n",
+       "9  To buy an app for a friend, you can use the following methods: 1. ...   \n",
+       "\n",
+       "   SemanticF1  \n",
+       "0  ✔️ [0.400]  \n",
+       "1  ✔️ [0.444]  \n",
+       "2  ✔️ [0.500]  \n",
+       "3  ✔️ [0.400]  \n",
+       "4  ✔️ [0.769]  \n",
+       "5  ✔️ [0.600]  \n",
+       "6  ✔️ [0.774]  \n",
+       "7  ✔️ [0.750]  \n",
+       "8  ✔️ [0.708]  \n",
+       "9  ✔️ [0.284]  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <div style='\n",
+       "                text-align: center;\n",
+       "                font-size: 16px;\n",
+       "                font-weight: bold;\n",
+       "                color: #555;\n",
+       "                margin: 10px 0;'>\n",
+       "                ... 290 more rows not displayed ...\n",
+       "            </div>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "60.26"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "tp = dspy.MIPROv2(metric=metric, auto=\"medium\", num_threads=24)  # use fewer threads if your rate limit is small\n",
+    "tp = dspy.MIPROv2(metric=metric, auto=\"light\", num_threads=24)  # use fewer threads if your rate limit is small\n",
     "\n",
-    "optimized_rag = tp.compile(RAG(), trainset=trainset,\n",
-    "                           max_bootstrapped_demos=2, max_labeled_demos=2,\n",
-    "                           requires_permission_to_run=False)"
+    "optimized_rag = tp.compile(\n",
+    "    rag,\n",
+    "    trainset=trainset,\n",
+    "    max_bootstrapped_demos=2,\n",
+    "    max_labeled_demos=2,\n",
+    "    requires_permission_to_run=False,\n",
+    ")\n",
+    "\n",
+    "# Evaluate the optimized RAG.\n",
+    "evaluate(optimized_rag)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The prompt optimization process here is pretty systematic, you can learn about it for example in this paper. Importantly, it's not a magic button. It's very possible that it can overfit your training set for instance and not generalize well to a held-out set, making it essential that we iteratively validate our programs.\n",
+    "We can see that the performance got boosted to `60.26` with very few data under `light` mode. With more data and more iterations we can achieve a better result, please explore on your own!\n",
     "\n",
     "Let's check on an example here, asking the same question to the baseline `rag = RAG()` program, which was not optimized, and to the `optimized_rag = MIPROv2(..)(..)` program, after prompt optimization."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "You are correct that cmd+tab does not work on hidden or minimized windows. To switch back to a minimized app, you must first switch to another application and let it take focus before returning to the minimized one.\n"
+      "You are correct that cmd+tab does not work on hidden or minimized windows. The Command + Tab shortcut is designed to switch between active applications, and minimized windows do not count as active. To access a minimized window, you would need to restore it first, either by clicking on its icon in the Dock or using other methods to unminimize it.\n"
      ]
     }
    ],
@@ -1179,14 +1401,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The Command + Tab shortcut on macOS is designed to switch between currently open applications, but it does not directly restore minimized or hidden windows. When you use Command + Tab, it cycles through the applications that are actively running, and minimized windows do not count as active. To manage minimized windows, you can use other shortcuts or methods. For example, you can use Command + Option + H + M to hide all other applications and minimize the most recently used one. Alternatively, you can navigate to the application you want to restore using Command + Tab and then manually click on the minimized window in the Dock to bring it back to focus.\n"
+      "The Command + Tab shortcut does not allow you to switch directly to hidden or minimized windows. To regain focus on a minimized application, you first need to switch to another application using Command + Tab and let it take focus. If you want to manage minimized windows more effectively, you can adjust settings in System Preferences under Mission Control or use other keyboard shortcuts like Command + Option + H + M to hide all other windows while minimizing the most recent one.\n"
      ]
     }
    ],
@@ -1199,7 +1421,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can use `dspy.inspect_history(n=2)` to view the RAG prompt [before optimization](https://gist.github.com/okhat/5d04648f2226e72e66e26a8cb1456ee4) and [after optimization](https://gist.github.com/okhat/79405b8889b4b07da577ee19f1a3479a).\n",
+    "You can use `dspy.inspect_history(n=2)` to view the RAG prompt before and after the optimization. \n",
+    "\n",
+    "A sample comparison from our run can be found here:\n",
+    "\n",
+    "- [before optimization](https://gist.github.com/okhat/5d04648f2226e72e66e26a8cb1456ee4)\n",
+    "- [after optimization](https://gist.github.com/okhat/79405b8889b4b07da577ee19f1a3479a).\n",
     "\n",
     "Concretely, in one of the runs of this notebook, the optimized prompt does the following (note that it may be different on a later rerun).\n",
     "\n",
@@ -1208,245 +1435,25 @@
     "Using the provided `context` and `question`, analyze the information step by step to generate a comprehensive and informative `response`. Ensure that the response clearly explains the concepts involved, highlights key distinctions, and addresses any complexities noted in the context.\n",
     "```\n",
     "\n",
-    "2. And includes two fully worked out RAG examples with synthetic reasoning and answers, e.g. `how to transfer whatsapp voice message to computer?`.\n",
-    "\n",
-    "Let's now evaluate on the overall devset."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Average Metric: 183.32 / 300 (61.1%): 100%|██████████| 300/300 [00:02<00:00, 104.48it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024/11/23 23:17:21 INFO dspy.evaluate.evaluate: Average Metric: 183.3194433591069 / 300 (61.1%)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>question</th>\n",
-       "      <th>example_response</th>\n",
-       "      <th>gold_doc_ids</th>\n",
-       "      <th>reasoning</th>\n",
-       "      <th>pred_response</th>\n",
-       "      <th>SemanticF1</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>when to use c over c++, and c++ over c?</td>\n",
-       "      <td>If you are equally familiar with both C++ and C, it's advisable to...</td>\n",
-       "      <td>[733]</td>\n",
-       "      <td>The context provides insights into the strengths and weaknesses of...</td>\n",
-       "      <td>You should consider using C over C++ in scenarios where simplicity...</td>\n",
-       "      <td>✔️ [0.333]</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>should images be stored in a git repository?</td>\n",
-       "      <td>One viewpoint expresses that there is no significant downside, esp...</td>\n",
-       "      <td>[6253, 6254, 6275, 6278, 8215]</td>\n",
-       "      <td>The context discusses the challenges and considerations of storing...</td>\n",
-       "      <td>Storing images in a Git repository is generally considered bad pra...</td>\n",
-       "      <td>✔️ [0.500]</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                       question  \\\n",
-       "0       when to use c over c++, and c++ over c?   \n",
-       "1  should images be stored in a git repository?   \n",
-       "\n",
-       "                                                        example_response  \\\n",
-       "0  If you are equally familiar with both C++ and C, it's advisable to...   \n",
-       "1  One viewpoint expresses that there is no significant downside, esp...   \n",
-       "\n",
-       "                     gold_doc_ids  \\\n",
-       "0                           [733]   \n",
-       "1  [6253, 6254, 6275, 6278, 8215]   \n",
-       "\n",
-       "                                                               reasoning  \\\n",
-       "0  The context provides insights into the strengths and weaknesses of...   \n",
-       "1  The context discusses the challenges and considerations of storing...   \n",
-       "\n",
-       "                                                           pred_response  \\\n",
-       "0  You should consider using C over C++ in scenarios where simplicity...   \n",
-       "1  Storing images in a Git repository is generally considered bad pra...   \n",
-       "\n",
-       "   SemanticF1  \n",
-       "0  ✔️ [0.333]  \n",
-       "1  ✔️ [0.500]  "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "                <div style='\n",
-       "                    text-align: center;\n",
-       "                    font-size: 16px;\n",
-       "                    font-weight: bold;\n",
-       "                    color: #555;\n",
-       "                    margin: 10px 0;'>\n",
-       "                    ... 298 more rows not displayed ...\n",
-       "                </div>\n",
-       "                "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "61.11"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "evaluate(optimized_rag)"
+    "2. And includes two fully worked out RAG examples with synthetic reasoning and answers, e.g. `how to transfer whatsapp voice message to computer?`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Keeping an eye on cost.\n",
+    "## Keeping an eye on cost\n",
     "\n",
     "DSPy allows you to track the cost of your programs, which can be used to monitor the cost of your calls. Here, we'll show you how to track the cost of your programs with DSPy."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cost = sum([x['cost'] for x in lm.history if x['cost'] is not None])  # in USD, as calculated by LiteLLM for certain providers"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Saving and loading.\n",
-    "\n",
-    "The optimized program has a pretty simple structure on the inside. Feel free to explore it.\n",
-    "\n",
-    "Here, we'll save `optimized_rag` so we can load it again later without having to optimize from scratch."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Prediction(\n",
-       "    reasoning='The context explains how the Command + Tab shortcut functions on macOS, particularly in relation to switching between applications. It notes that this shortcut does not bring back minimized or hidden windows directly. Instead, it cycles through applications that are currently open and visible. The information also suggests alternative methods for managing minimized windows and provides insights into how to navigate between applications effectively.',\n",
-       "    response='The Command + Tab shortcut on macOS is designed to switch between currently open applications, but it does not directly restore minimized or hidden windows. When you use Command + Tab, it cycles through the applications that are actively running, and minimized windows do not count as active. To manage minimized windows, you can use other shortcuts or methods. For example, you can use Command + Option + H + M to hide all other applications and minimize the most recently used one. Alternatively, you can navigate to the application you want to restore using Command + Tab and then manually click on the minimized window in the Dock to bring it back to focus.'\n",
-       ")"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "optimized_rag.save(\"optimized_rag.json\")\n",
-    "\n",
-    "loaded_rag = RAG()\n",
-    "loaded_rag.load(\"optimized_rag.json\")\n",
-    "\n",
-    "loaded_rag(question=\"cmd+tab does not work on hidden or minimized windows\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<details>\n",
-    "<summary>Saving programs in MLflow Experiment</summary>\n",
-    "\n",
-    "<br/>\n",
-    "\n",
-    "Instead of saving the program to a local file, you can track it in MLflow for better reproducibility and collaboration.\n",
-    "\n",
-    "1. **Dependency Management**: MLflow automatically save the frozen environment metadata along with the program to ensure reproducibility.\n",
-    "2. **Experiment Tracking**: With MLflow, you can track the program's performance and cost along with the program itself.\n",
-    "3. **Collaboration**: You can share the program and results with your team members by sharing the MLflow experiment.\n",
-    "\n",
-    "To save the program in MLflow, run the following code:\n",
-    "\n",
-    "```python\n",
-    "import mlflow\n",
-    "\n",
-    "# Start an MLflow Run and save the program\n",
-    "with mlflow.start_run(run_name=\"optimized_rag\"):\n",
-    "    model_info = mlflow.dspy.log_model(\n",
-    "        optimized_rag,\n",
-    "        artifact_path=\"model\", # Any name to save the program in MLflow\n",
-    "    )\n",
-    "\n",
-    "# Load the program back from MLflow\n",
-    "loaded = mlflow.dspy.load_model(model_info.model_uri)\n",
-    "```\n",
-    "\n",
-    "To learn more about the integration, visit [MLflow DSPy Documentation](https://mlflow.org/docs/latest/llms/dspy/index.html) as well.\n",
-    "\n",
-    "</details>"
+    "cost = sum([x[\"cost\"] for x in lm.history if x[\"cost\"] is not None])  # in USD, as calculated by LiteLLM for certain providers"
    ]
   },
   {
@@ -1456,7 +1463,7 @@
     "\n",
     "## What's next?\n",
     "\n",
-    "Improving from around 42% to approximately 61% on this task, in terms of `SemanticF1`, was pretty easy.\n",
+    "Improving from around 54% to approximately 61% on this task, in terms of `SemanticF1`, was pretty easy through DSPy optimzier.\n",
     "\n",
     "But DSPy gives you paths to continue iterating on the quality of your system and we have barely scratched the surface.\n",
     "\n",
@@ -1475,7 +1482,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py310_sept24_user",
+   "display_name": "dspy",
    "language": "python",
    "name": "python3"
   },
@@ -1489,7 +1496,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The current RAG tutorial https://dspy.ai/tutorials/rag/ is too long, which was written at the time we lacked all the developer guides and tutorials, so the old RAG tutorial was essentially a DSPy overview through RAG. With our current documentation, we can focus on explaining RAG functionalities.

The screenshot shows the current RAG tutorial:
<img width="1601" alt="image" src="https://github.com/user-attachments/assets/e4107971-1d83-4ba2-b334-651cf7a31c41" />

which includes many DSPy fundamentals like how to build programs, and how to use `dspy.Evaluate`, which all have their dedicated sections now. 