### PR TITLE
Expand sidenav items by default

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -146,6 +146,7 @@ theme:
         - navigation.tabs
         - navigation.path
         - navigation.indexes
+        - navigation.expand
         - toc.follow
         - navigation.top
         - search.suggest


### PR DESCRIPTION
Expand sidenav items by default to improve the discoverability like other frameworks

Before
<img width="1410" alt="image" src="https://github.com/user-attachments/assets/d80d747a-cdec-44de-996b-518ae60a097d" />

After
<img width="1397" alt="image" src="https://github.com/user-attachments/assets/ef96c67e-315c-4f95-a3df-833a672cf9f6" />
