### PR TITLE
change the default model to llama-4 for databricks provider

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -28,7 +28,7 @@ jobs:
           mkdocs build
 
   update-docs-subtree:
-    if: github.event_name == 'push' && github.repository == 'stanfordnlp/dspy'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -28,7 +28,7 @@ jobs:
           mkdocs build
 
   update-docs-subtree:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'stanfordnlp/dspy'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -49,7 +49,7 @@ Instead of wrangling prompts or training jobs, DSPy (Declarative Self-improving 
 
         ```python linenums="1"
         import dspy
-        lm = dspy.LM('databricks/databricks-meta-llama-3-1-70b-instruct')
+        lm = dspy.LM('databricks/databricks-llama-4-maverick')
         dspy.configure(lm=lm)
         ```
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -49,7 +49,11 @@ Instead of wrangling prompts or training jobs, DSPy (Declarative Self-improving 
 
         ```python linenums="1"
         import dspy
-        lm = dspy.LM('databricks/databricks-llama-4-maverick')
+        lm = dspy.LM(
+            'databricks/databricks-llama-4-maverick',
+            api_key="YOUR_DATABRICKS_ACCESS_TOKEN",
+            api_base="YOUR_DATABRICKS_WORKSPACE_URL",  # e.g.: https://dbc-64bf4923-e39e.cloud.databricks.com/serving-endpoints
+        )
         dspy.configure(lm=lm)
         ```
 


### PR DESCRIPTION
llama 3.1 is an old model, we should ping users to a newer one for robust experience. Things move too fast in GenAI, cheers!