### PR TITLE
Disable doc-push on forked repo

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -28,7 +28,7 @@ jobs:
           mkdocs build
 
   update-docs-subtree:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository == 'stanfordnlp/dspy'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
It's quite annoying that every time I sync from the main repo, it displays a red cross mark because the doc-push fails because it is supposed to fail.

I don't know why it took me this long to fix this either 🤨