### PR TITLE
Add gemini to LM provider

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -53,6 +53,15 @@ Instead of wrangling prompts or training jobs, DSPy (Declarative Self-improving 
         dspy.configure(lm=lm)
         ```
 
+    === "Gemini"
+        You can authenticate by setting the GEMINI_API_KEY env variable or passing `api_key` below.
+
+        ```python linenums="1"
+        import dspy
+        lm = dspy.LM('gemini/gemini-2.5-flash', api_key='YOUR_GEMINI_API_KEY')
+        dspy.configure(lm=lm)
+        ```
+
     === "Local LMs on your laptop"
           First, install [Ollama](https://github.com/ollama/ollama) and launch its server with your LM.
 


### PR DESCRIPTION
Gemini has been irrelevant until the recent gemini-2.5 launch. I have been seeing lots of Gemini users now, so we should include it in the LM setup. 

To be fair, gemini-2.5 is pretty good, definitely not a marketing thing. 

change preview:

<img width="971" alt="image" src="https://github.com/user-attachments/assets/537d6e04-0494-4c18-8191-ee46a191fd8e" />
