### PR TITLE
Remove unsupported options of Plugin 'material/search'

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -184,15 +184,6 @@ plugins:
     - search:
         lang: en
         separator: '[\s\-\.]+'
-        min_search_length: 2
-        prebuild_index: true
-        indexing: 'full'
-        properties:
-            - title
-            - tags
-            - content
-            - sections
-        search_index_only: false
     - mkdocstrings:
         handlers:
             python:


### PR DESCRIPTION
Fix the following warnings caused by the unsupported options
```
WARNING -  Config value 'plugins': Plugin 'material/search' option 'indexing': Unsupported option
WARNING -  Config value 'plugins': Plugin 'material/search' option 'prebuild_index': Unsupported option
WARNING -  Config value 'plugins': Plugin 'material/search' option 'min_search_length': Unsupported option
WARNING -  Config value 'plugins': Plugin 'material/search' option 'properties': Unrecognised configuration name: properties
WARNING -  Config value 'plugins': Plugin 'material/search' option 'search_index_only': Unrecognised configuration name: search_index_only
```