### PR TITLE
fix bedrock streaming token tracking

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -269,6 +269,9 @@ def _get_stream_completion_fn(
     stream = cast(MemoryObjectSendStream, stream)
     caller_predict_id = id(caller_predict) if caller_predict else None
 
+    if dspy.settings.track_usage:
+        request["stream_options"] = {"include_usage": True}
+
     async def stream_completion(request: Dict[str, Any], cache_kwargs: Dict[str, Any]):
         response = await litellm.acompletion(
             cache=cache_kwargs,


### PR DESCRIPTION
Fixes token tracking when using streamified module when using AWS Bedrock as a provider.

closes #8416 