### PR TITLE
Relax configure allowance in async tasks

### DIFF
--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -109,8 +109,6 @@ class Settings:
         global main_thread_config, config_owner_thread_id, config_owner_async_task
         current_thread_id = threading.get_ident()
 
-        print("GEEZ Thread id in configure: ", current_thread_id)
-
         if config_owner_thread_id is None:
             # First `configure` call assigns the owner thread id.
             config_owner_thread_id = current_thread_id

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -20,6 +20,9 @@ def test_forbid_configure_call_in_child_thread():
     dspy.configure(lm=dspy.LM("openai/gpt-4o"), adapter=dspy.JSONAdapter(), callbacks=[lambda x: x])
 
     def worker():
+        import threading
+
+        print("GEEZ Thread id in worker: ", threading.get_ident())
         with pytest.raises(RuntimeError, match="Cannot call dspy.configure in a child thread"):
             dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"), callbacks=[])
 
@@ -165,3 +168,35 @@ async def test_dspy_context_with_async_task_group():
         # The main thread is not affected by the context
         assert dspy.settings.lm.model == "openai/gpt-4.1"
         assert dspy.settings.trace == []
+
+
+async def test_dspy_configure_allowance_async():
+    def bar1():
+        # `dspy.configure` is disallowed in different async tasks from the initial one.
+        # In this case, foo1 (async) calls bar1 (sync), and bar1 uses the async task from foo1.
+        with pytest.raises(RuntimeError) as e:
+            dspy.configure(lm=dspy.LM("openai/gpt-4o"))
+        assert "dspy.settings.configure(...) can only be called from the same async" in str(e.value)
+
+    async def foo1():
+        bar1()
+        await asyncio.sleep(0.1)
+
+    async def foo2():
+        # `dspy.configure` is disallowed in different async tasks from the initial one.
+        with pytest.raises(RuntimeError) as e:
+            dspy.configure(lm=dspy.LM("openai/gpt-4o"))
+        assert "dspy.settings.configure(...) can only be called from the same async" in str(e.value)
+        await asyncio.sleep(0.1)
+
+    async def foo3():
+        # `dspy.context` is allowed in different async tasks from the initial one.
+        with dspy.context(lm=dspy.LM("openai/gpt-4o")):
+            await asyncio.sleep(0.1)
+
+    # `dspy.configure` is allowed to be called multiple times in the same async task.
+    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+    dspy.configure(lm=dspy.LM("openai/gpt-4o"))
+    dspy.configure(adapter=dspy.JSONAdapter())
+
+    asyncio.run(asyncio.gather(foo1(), foo2(), foo3()))


### PR DESCRIPTION
Earlier we introduced a strict rule on `dspy.configure` in async task, which forces people to use `dspy.context` in the second call. This approach is safe but terrible because that ruins the developer experience. In this PR, we are relaxing the constraint so that configure is allowed to be called in the same task.

The unit test below should clarify things:

```
@pytest.mark.asyncio
async def test_dspy_configure_allowance_async():
    def bar1():
        # `dspy.configure` is disallowed in different async tasks from the initial one.
        # In this case, foo1 (async) calls bar1 (sync), and bar1 uses the async task from foo1.
        with pytest.raises(RuntimeError) as e:
            dspy.configure(lm=dspy.LM("openai/gpt-4o"))
        assert "dspy.settings.configure(...) can only be called from the same async" in str(e.value)

    async def foo1():
        bar1()
        await asyncio.sleep(0.1)

    async def foo2():
        # `dspy.configure` is disallowed in different async tasks from the initial one.
        with pytest.raises(RuntimeError) as e:
            dspy.configure(lm=dspy.LM("openai/gpt-4o"))
        assert "dspy.settings.configure(...) can only be called from the same async" in str(e.value)
        await asyncio.sleep(0.1)

    async def foo3():
        # `dspy.context` is allowed in different async tasks from the initial one.
        with dspy.context(lm=dspy.LM("openai/gpt-4o")):
            await asyncio.sleep(0.1)

    async def foo4():
        # foo4 is directly invoked by the entry task, so it has the same async task as the entry task.
        dspy.configure(lm=dspy.LM("openai/gpt-4o"))
        await asyncio.sleep(0.1)

    # `dspy.configure` is allowed to be called multiple times in the same async task.
    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
    dspy.configure(lm=dspy.LM("openai/gpt-4o"))
    dspy.configure(adapter=dspy.JSONAdapter())

    await asyncio.gather(foo1(), foo2(), foo3())

    foo4()
```

In the entry task, `dspy.configure` is allowed to get called multiple times, so does `foo4`, which is called by the entry task without adding concurrency. foo1 and foo2 are not allowed, because they were called using `asyncio.gather`, which assigns different task ids for them. foo3 is allowed because it's using `dspy.context` instead of `dspy.configure`.