### PR TITLE
Add support for PEP 604 union types in inline signatures

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -580,6 +580,18 @@ def _parse_type_node(node, names=None) -> Any:
 
         return base_type[arg_types]
 
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        # Handle PEP 604: int | None, str | float, etc.
+        left = _parse_type_node(node.left, names)
+        right = _parse_type_node(node.right, names)
+
+        # Optional[X] is Union[X, NoneType]
+        if right is type(None):
+            return typing.Optional[left]
+        if left is type(None):
+            return typing.Optional[right]
+        return typing.Union[left, right]
+
     if isinstance(node, ast.Tuple):
         return tuple(_parse_type_node(elt, names) for elt in node.elts)
 


### PR DESCRIPTION
## Description

This pull request adds support for [PEP 604](https://peps.python.org/pep-0604/)-style union types in inline signatures (ex: `int | None`, `str | float`). 

In `_parse_type_node`, it gets the left and right parts of the operator, and runs `_parse_type_node` on both. It represents it as a `typing.Union` if both the left and right are not None, and as a `typing.Optional` if one of the sides is None.

## Example

```python
input = "Say Hello World"
output = dspy.Predict(dspy.Signature("input: str -> output: str | int"))(input=input).output
print(f"Output: {output} with type {type(output)}")
## Output: Hello World with type <class 'str'>

input = "Say the number 42"
output = dspy.Predict(dspy.Signature("input: str -> output: str | int"))(input=input).output
print(f"Output: {output} with type {type(output)}")
## Output: 42 with type <class 'int'>
```