### PR TITLE
Allow reusing the stream listener

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -183,10 +183,9 @@ def streamify(
                         # No listeners are configured, yield the chunk directly for backwards compatibility.
                         yield value
                     else:
-                        # We are receiving a chunk from the LM's response stream, delegate it to the listeners to
+                        # We are receiving a chunk from the LM's response stream, delgate it to the listeners to
                         # determine if we should yield a value to the user.
                         output = None
-
                         for listener in predict_id_to_listener[value.predict_id]:
                             # There should be at most one listener provides a return value.
                             output = listener.receive(value) or output

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -183,9 +183,10 @@ def streamify(
                         # No listeners are configured, yield the chunk directly for backwards compatibility.
                         yield value
                     else:
-                        # We are receiving a chunk from the LM's response stream, delgate it to the listeners to
+                        # We are receiving a chunk from the LM's response stream, delegate it to the listeners to
                         # determine if we should yield a value to the user.
                         output = None
+
                         for listener in predict_id_to_listener[value.predict_id]:
                             # There should be at most one listener provides a return value.
                             output = listener.receive(value) or output


### PR DESCRIPTION
Add `allow_reuse` to stream listeners so that the same listener can be used multiple times. This feature is useful when streaming out the ReAct agent (or any programs that have a loop)

We turn it off by default because we don't want the stream chunk go to all listeners, which is not efficient. This downside is negligible with <5 listeners, but can be pretty bad if there are like 20 listeners configured in a complex system.