### PR TITLE
Fix PEP 604 union types when using Class Signatures for ChainOfThought

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -430,7 +430,7 @@ def make_signature(
         # program of thought and teleprompters, so we just silently default to string.
         if type_ is None:
             type_ = str
-        if not isinstance(type_, (type, typing._GenericAlias, types.GenericAlias, typing._SpecialForm)):
+        if not isinstance(type_, (type, typing._GenericAlias, types.GenericAlias, typing._SpecialForm, types.UnionType)):
             raise ValueError(f"Field types must be types, but received: {type_} of type {type(type_)}.")
         if not isinstance(field, FieldInfo):
             raise ValueError(f"Field values must be Field instances, but received: {field}.")


### PR DESCRIPTION
## Description

This pull request fixes a bug where [PEP 604](https://peps.python.org/pep-0604/)-style union types in Class-based DSPy Signatures work when using `dspy.Predict`, but fail when using `dspy.ChainOfThought`.


This is due to PEP 604 Union Types being defined as a [types.UnionType](https://docs.python.org/3/library/types.html#types.UnionType), which was not included in the list of types to check in `make_signature` in `signature.py`. For reference, the original union type is defined as a [typing.Union](https://docs.python.org/3/library/typing.html#typing.Union)

## Example

```python
class SayTheRightType(dspy.Signature):
    input: str = dspy.InputField()
    output: str | int = dspy.OutputField()


input1 = "Say Hello World"
output = dspy.ChainOfThought(SayTheRightType)(input=input1).output
print(f"Output: {output} with type {type(output)}")
# Output: Hello World with type <class 'str'>

input1 = "Say the number 42"
output = dspy.ChainOfThought(SayTheRightType)(input=input1).output
print(f"Output: {output} with type {type(output)}")
# Output: 42 with type <class 'int'>

```

## Additional Info

This bug fixes one of two issues in issue #8446 related to support of union types.
The other issue was fixed in pull request #8449 where support for PEP 604 union types was added to inline signatures. 

PEP 604 union types seems to be fully supported in signatures now, I will make another pull request over the next few days to add more testing for PEP 604 union types to confirm.