### PR TITLE
unwrap pyodide object correctly

### DIFF
--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -147,7 +147,11 @@ sys.stderr = old_stderr
       // output += capturedStderr;
     } else {
       // If the code returned a real value, just return that
-      output = result;
+      try {
+        output = result.toJs();
+      } catch (e) {
+        output = result;
+      }
     }
 
     console.log(JSON.stringify({ output }));


### PR DESCRIPTION
Fix for #8448 


pyodide wraps generated python code in a Pyproxy object that cant be JSON-encoded so .toJS properly converts python to js object which can. resolves a failing case mentioned in #8448 as well

```
echo '{"code": "{\\"answer\\": 14}"}' \
  | deno run --allow-read dspy/primitives/runner.js

# Previously incorrect - {"output":{}}
# Now correctly outputs - {"output":{"answer":14}}
```