### PR TITLE
fix(retrieve): call with_tenant on collection before query

### DIFF
--- a/dspy/retrievers/weaviate_rm.py
+++ b/dspy/retrievers/weaviate_rm.py
@@ -90,7 +90,7 @@ class WeaviateRM(dspy.Retrieve):
         for query in queries:
             if self._client_type == "WeaviateClient":
                 if tenant:
-                    results = self._weaviate_collection.query.with_tenant(tenant).hybrid(query=query, limit=k, **kwargs)
+                    results = self._weaviate_collection.with_tenant(tenant).query.hybrid(query=query, limit=k, **kwargs)
                 else:
                     results = self._weaviate_collection.query.hybrid(query=query, limit=k, **kwargs)
 


### PR DESCRIPTION
### Summary
Calling multi-tenant hybrid search in **WeaviateRM** raised  
`AttributeError: '_QueryCollection' object has no attribute 'with_tenant'`.  
This PR fixes the bug by scoping the collection first (`collection.with_tenant(...)`) before executing `.query.hybrid(...)`.

### Root cause
The v4 Python client exposes **`with_tenant()` on `Collection`**, not on the
`_QueryCollection` helper returned by `collection.query`.  
Current code path:

```python
# buggy – AttributeError
collection.query.with_tenant(tenant).hybrid(...)
````

### Fix

```python
# fixed – tenant scoping first, then query
collection.with_tenant(tenant).query.hybrid(...)
```

### How to reproduce the original bug

```python
client = weaviate.connect_to_weaviate_cloud(
    cluster_url=os.environ["WEAVIATE_URL"],
    auth_credentials=Auth.api_key(os.environ["WEAVIATE_API_KEY"]),
)

rm = WeaviateRM(
    weaviate_client=client,
    weaviate_collection_name="test-collection",
    tenant_id="dev",
)

# raises AttributeError on current main
rm("What is the capital of France?")
```

### What’s in this PR

* **Single-line change** in `dspy/retrieve/weaviate_rm.py` (no other files touched).

### Test & lint status

| Step                                 | Result                             |
| ------------------------------------ | ---------------------------------- |
| `pre-commit run --all-files`         | ✅ passed                           |
| `uv run pytest` (macOS, Python 3.10) | ✅ 402 passed, 222 skipped, 2 xfail |

<details>
<summary>pytest summary</summary>

```
402 passed, 222 skipped, 2 xfailed, 12 warnings in 76.9 s
```

</details>

### Checklist

* [x] Follows Contribution Guide.
* [x] Only necessary source change; **no lockfile or version bumps**.
* [x] Pre-commit hooks clean.
* [x] Full test suite passes locally.
* [ ] Unit tests added/updated if needed (N/A – existing retrieval tests exercised path).
* [ ] Docs updated (N/A).

### Related issues

<!-- e.g. Fixes #1234 if an issue exists -->

### Notes for reviewers

This unblocks multi-tenant RAG flows with the v4 Weaviate Python client.