### PR TITLE
Suppress expected test warning

### DIFF
--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -366,6 +366,7 @@ async def test_async_concurrent_calls():
     assert end_time - start_time < 0.3
 
 
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_async_tool_call_in_sync_mode():
     tool = Tool(async_dummy_function)
     with dspy.context(allow_tool_async_sync_conversion=False):


### PR DESCRIPTION
The warning in `test_async_tool_call_in_sync_mode` is expected, so suppress the runtime warning