### PR TITLE
Add brief explanation for each tutorial in overview pages

### DIFF
--- a/docs/docs/tutorials/build_ai_program/index.md
+++ b/docs/docs/tutorials/build_ai_program/index.md
@@ -1,11 +1,46 @@
-- [Building AI Agents with DSPy](../customer_service_agent/index.ipynb)
-- [Building AI Applications by Customizing DSPy Modules](../custom_module/index.ipynb)
-- [Retrieval-Augmented Generation (RAG)](../rag/index.ipynb)
-- [Building RAG as Agent](../agents/index.ipynb)
-- [Entity Extraction](../entity_extraction/index.ipynb)
-- [Classification](../classification/index.md)
-- [Multi-Hop RAG](../multihop_search/index.ipynb)
-- [Privacy-Conscious Delegation](../papillon/index.md)
-- [Program Of Thought](../program_of_thought/index.ipynb)
-- [Image Generation Prompt iteration](../image_generation_prompting/index.ipynb)
-- [Audio](../audio/index.ipynb)
+# Build AI Programs with DSPy
+
+This section contains hands-on tutorials that guide you through building production-ready AI applications using DSPy. Each tutorial demonstrates practical use cases and shows you how to leverage DSPy's modular programming approach to create robust, maintainable AI systems.
+
+## Core Applications
+
+### [Building AI Agents with DSPy](../customer_service_agent/index.ipynb)
+Learn to create intelligent agents that can handle complex customer service scenarios. This tutorial shows how to build agents that can understand context, maintain conversation state, and provide helpful responses.
+
+### [Building AI Applications by Customizing DSPy Modules](../custom_module/index.ipynb)
+Discover how to create custom DSPy modules tailored to your specific needs. Learn the patterns for building reusable, composable components that can be shared across different applications.
+
+## Retrieval-Augmented Generation (RAG)
+
+### [Retrieval-Augmented Generation (RAG)](../rag/index.ipynb)
+Master the fundamentals of RAG systems with DSPy. Learn how to combine retrieval mechanisms with language models to build systems that can answer questions using external knowledge sources.
+
+### [Building RAG as Agent](../agents/index.ipynb)
+Take RAG to the next level by building `ReAct` agent-based systems that can reason about when and how to retrieve information, making your RAG systems more intelligent and adaptive.
+
+### [Multi-Hop RAG](../multihop_search/index.ipynb)
+Build sophisticated RAG systems that can perform multi-step reasoning across multiple information sources, perfect for complex research and analysis tasks.
+
+## Specialized Use Cases
+
+### [Entity Extraction](../entity_extraction/index.ipynb)
+Learn to build systems that can identify and extract specific entities from text, essential for information processing and data analysis applications.
+
+### [Classification](../classification/index.md)
+Build robust text classification systems using DSPy's modular approach with a topic classification example.
+
+### [Privacy-Conscious Delegation](../papillon/index.md)
+Explore advanced techniques for building AI systems that respect privacy constraints while maintaining high performance by combining a small local model and an advanced external model.
+
+## Advanced Reasoning
+
+### [Program Of Thought](../program_of_thought/index.ipynb)
+Learn to build systems that can generate and execute code to solve complex problems, combining the power of language models with programmatic reasoning.
+
+## Multimodal Applications
+
+### [Image Generation Prompt iteration](../image_generation_prompting/index.ipynb)
+Discover how to use DSPy to iteratively improve image generation prompts, creating better visual content through systematic optimization.
+
+### [Audio](../audio/index.ipynb)
+Explore audio processing applications with DSPy, learning to build systems that can understand, process, and generate audio content.

--- a/docs/docs/tutorials/core_development/index.md
+++ b/docs/docs/tutorials/core_development/index.md
@@ -1,9 +1,38 @@
-- [Use MCP in DSPy](../mcp/index.md)
-- [Output Refinement](../output_refinement/best-of-n-and-refine.md)
-- [Saving and Loading](../saving/index.md)
-- [Cache](../cache/index.md)
-- [Deployment](../deployment/index.md)
-- [Debugging & Observability](../observability/index.md)
-- [Tracking DSPy Optimizers](../optimizer_tracking/index.md)
-- [Streaming](../streaming/index.md)
-- [Async](../async/index.md)
+# Tools, Development, and Deployment
+
+This section covers essential DSPy features and best practices for professional AI development. Learn how to implement key functionalities like streaming, caching, deployment, and monitoring in your DSPy applications. These tutorials focus on the practical aspects of building production-ready systems.
+
+## Integration and Tooling
+
+### [Use MCP in DSPy](../mcp/index.md)
+Learn to integrate Model Context Protocol (MCP) with DSPy applications. This tutorial shows how to leverage MCP for enhanced context management and more sophisticated AI interactions.
+
+### [Output Refinement](../output_refinement/best-of-n-and-refine.md)
+Master techniques for improving output quality through refinement strategies. Learn how to implement best-of-N sampling and iterative refinement to get higher-quality results from your DSPy programs.
+
+## Data Management and Persistence
+
+### [Saving and Loading](../saving/index.md)
+Understand how to persist and restore DSPy programs and their optimized states. Learn best practices for model versioning, checkpoint management, and program serialization.
+
+### [Cache](../cache/index.md)
+Implement efficient caching strategies to improve performance and reduce API costs. Learn how to configure and use DSPy's caching mechanisms effectively in different scenarios.
+
+## Production Deployment
+
+### [Deployment](../deployment/index.md)
+Learn to deploy DSPy applications in production environments. This tutorial covers multiple deployment strategies such as FastAPI and MLflow.
+
+### [Streaming](../streaming/index.md)
+Implement real-time streaming capabilities in your DSPy applications. Learn how to handle streaming responses for better user experience in interactive applications.
+
+### [Async](../async/index.md)
+Build asynchronous DSPy applications for improved performance and scalability. Learn async/await patterns and concurrent execution strategies for high-throughput systems.
+
+## Monitoring and Optimization
+
+### [Debugging & Observability](../observability/index.md)
+Master debugging and monitoring techniques for DSPy applications. Learn to use comprehensive logging, tracing, and error handling for production systems.
+
+### [Tracking DSPy Optimizers](../optimizer_tracking/index.md)
+Learn to track and analyze optimizer performance and behavior. Understand how to monitor optimization processes and enhance the reproducibility of the optimization.

--- a/docs/docs/tutorials/optimize_ai_program/index.md
+++ b/docs/docs/tutorials/optimize_ai_program/index.md
@@ -1,4 +1,21 @@
-- [Math Reasoning](../math/index.ipynb)
-- [Classification Finetuning](../classification_finetuning/index.ipynb)
-- [Advanced Tool Use](../tool_use/index.ipynb)
-- [Finetuning Agents](../games/index.ipynb)
+# Optimize AI Programs with DSPy
+
+This section focuses on DSPy's powerful optimization capabilities, demonstrating how to systematically improve your AI programs using various optimizers. These tutorials are lighter on programming concepts and instead showcase how DSPy optimizers can automatically enhance the quality and performance of your applications.
+
+## Mathematical and Reasoning Tasks
+
+### [Math Reasoning](../math/index.ipynb)
+Learn how to optimize DSPy programs for mathematical reasoning tasks. This tutorial demonstrates how optimizers can dramatically improve performance on complex math problems by finding better prompting strategies and few-shot examples.
+
+## Model Optimization
+
+### [Classification Finetuning](../classification_finetuning/index.ipynb)
+Discover how to use DSPy's finetuning optimizers to distill knowledge from large language models into smaller, more efficient models. Learn the complete workflow from prompt optimization to model finetuning for classification tasks.
+
+## Advanced Tool Integration
+
+### [Advanced Tool Use](../tool_use/index.ipynb)
+Explore how to optimize AI programs that use external tools and APIs. This tutorial shows how DSPy optimizers can learn to use tools more effectively, improving both accuracy and efficiency in tool-calling scenarios.
+
+### [Finetuning Agents](../games/index.ipynb)
+Learn to optimize complex agent-based systems through finetuning. This tutorial demonstrates how to improve agent performance in interactive environments like games, where strategic thinking and adaptation are crucial.

--- a/docs/docs/tutorials/rl_ai_program/index.md
+++ b/docs/docs/tutorials/rl_ai_program/index.md
@@ -1,1 +1,11 @@
-See the links on the side bar.
+# Experimental RL Optimization for DSPy
+
+This section explores cutting-edge reinforcement learning (RL) approaches for optimizing DSPy programs. These experimental techniques represent the frontier of AI program optimization, combining the power of RL with DSPy's modular programming paradigm to achieve even better performance on complex tasks.
+
+## Advanced RL Optimization Techniques
+
+### [RL for Privacy-Conscious Delegation](../rl_papillon/index.ipynb)
+Explore how reinforcement learning can optimize privacy-conscious AI systems. This tutorial demonstrates how RL agents can learn to balance task performance with privacy constraints, making intelligent decisions about when and how to delegate sensitive operations.
+
+### [RL for Multi-Hop Research](../rl_multihop/index.ipynb)
+Learn to apply reinforcement learning to multi-hop reasoning tasks. This advanced tutorial shows how RL can optimize the search strategy in complex information retrieval scenarios, learning to navigate through multiple information sources more effectively.


### PR DESCRIPTION
Currently, the overview page of each tutorial category only has links. This PR introduces a brief explanation for each tutorial so that users can choose relevant tutorials easily.