### PR TITLE
Fix stale version instruction in docs

### DIFF
--- a/docs/docs/tutorials/deployment/index.md
+++ b/docs/docs/tutorials/deployment/index.md
@@ -65,7 +65,7 @@ You can configure the async capacity using the new `async_max_workers` setting.
 
 ??? "Streaming, in DSPy 2.6.0+"
 
-    Streaming is also supported in DSPy 2.6.0+, available as a release candidate via `pip install -U --pre dspy`.
+    Streaming is also supported in DSPy 2.6.0+, which can be installed via `pip install -U dspy`.
 
     We can use `dspy.streamify` to convert the dspy program to a streaming mode. This is useful when you want to stream
     the intermediate outputs (i.e. O1-style reasoning) to the client before the final prediction is ready. This uses

--- a/docs/docs/tutorials/games/index.ipynb
+++ b/docs/docs/tutorials/games/index.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "### Install dependencies and download data\n",
     "\n",
-    "Install the latest DSPy via `pip install -U --pre dspy` and follow along. This tutorial uses the AlfWorld dataset, which depends on DSPy 2.6.0 (pre-release).\n",
+    "Install the latest DSPy via `pip install -U dspy` and follow along. This tutorial uses the AlfWorld dataset, which depends on DSPy 2.6.0.\n",
     "\n",
     "You will also need the following dependencies:\n",
     "\n",


### PR DESCRIPTION
Some tutorials mentioned that the latest DSPy version is 2.6.0