### PR TITLE
feat: add test for nested stream and check value has predict_id

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -182,7 +182,7 @@ def streamify(
                     if len(predict_id_to_listener) == 0:
                         # No listeners are configured, yield the chunk directly for backwards compatibility.
                         yield value
-                    else:
+                    elif hasattr(value, "predict_id"):
                         # We are receiving a chunk from the LM's response stream, delegate it to the listeners to
                         # determine if we should yield a value to the user.
                         output = None


### PR DESCRIPTION
This PR is to add test for nested streaming where we have an agent streaming its response and its tools to run some dspy programs.

- I added the test to validate the use case
- I add check the predict_id before attempt to response to client

Related issue: https://github.com/stanfordnlp/dspy/issues/8454

cc @chenmoneygithub, @okhat 