### PR TITLE
add dspy.Code

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -6,7 +6,7 @@ from dspy.teleprompt import *
 
 from dspy.evaluate import Evaluate  # isort: skip
 from dspy.clients import *  # isort: skip
-from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, History, Type, Tool, ToolCalls  # isort: skip
+from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, History, Type, Tool, ToolCalls, Code  # isort: skip
 from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, enable_logging
 from dspy.utils.asyncify import asyncify
 from dspy.utils.syncify import syncify

--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -2,7 +2,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.two_step_adapter import TwoStepAdapter
-from dspy.adapters.types import Audio, History, Image, Tool, ToolCalls, Type
+from dspy.adapters.types import Audio, Code, History, Image, Tool, ToolCalls, Type
 from dspy.adapters.xml_adapter import XMLAdapter
 
 __all__ = [
@@ -12,6 +12,7 @@ __all__ = [
     "History",
     "Image",
     "Audio",
+    "Code",
     "JSONAdapter",
     "XMLAdapter",
     "TwoStepAdapter",

--- a/dspy/adapters/types/__init__.py
+++ b/dspy/adapters/types/__init__.py
@@ -1,7 +1,8 @@
 from dspy.adapters.types.audio import Audio
 from dspy.adapters.types.base_type import Type
+from dspy.adapters.types.code import Code
 from dspy.adapters.types.history import History
 from dspy.adapters.types.image import Image
 from dspy.adapters.types.tool import Tool, ToolCalls
 
-__all__ = ["History", "Image", "Audio", "Type", "Tool", "ToolCalls"]
+__all__ = ["History", "Image", "Audio", "Type", "Tool", "ToolCalls", "Code"]

--- a/dspy/adapters/types/code.py
+++ b/dspy/adapters/types/code.py
@@ -1,0 +1,115 @@
+import re
+from typing import Any
+
+import pydantic
+
+from dspy.adapters.types.base_type import Type
+
+
+class Code(Type):
+    """Code type in DSPy.
+
+    This type is useful for code generation and code analysis.
+
+    Example 1: dspy.Code as output type in code generation:
+
+    ```python
+    import dspy
+
+    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+
+
+    class CodeGeneration(dspy.Signature):
+        '''Generate python code to answer the question.'''
+
+        question: str = dspy.InputField(description="The question to answer")
+        code: dspy.Code = dspy.OutputField(description="The code to execute")
+
+
+    predict = dspy.Predict(CodeGeneration)
+
+    result = predict(question="Given an array, find if any of the two numbers sum up to 10")
+    print(result.code)
+    ```
+
+    Example 2: dspy.Code as input type in code analysis:
+
+    ```python
+    class CodeAnalysis(dspy.Signature):
+        '''Analyze the time complexity of the function.'''
+
+        code: dspy.Code = dspy.InputField(description="The function to analyze")
+        result: str = dspy.OutputField(description="The time complexity of the function")
+
+
+    predict = dspy.Predict(CodeAnalysis)
+
+
+    def sleepsort(x):
+        import time
+
+        for i in x:
+            time.sleep(i)
+            print(i)
+
+
+    import inspect
+
+    result = predict(code=inspect.getsource(sleepsort))
+    print(result.result)
+    ```
+    """
+
+    code: str
+
+    def format(self):
+        return f"{self.code}"
+
+    @pydantic.model_serializer()
+    def serialize_model(self):
+        """Override to bypass the <<CUSTOM-TYPE-START-IDENTIFIER>> and <<CUSTOM-TYPE-END-IDENTIFIER>> tags."""
+        return self.format()
+
+    @classmethod
+    def description(cls) -> str:
+        return (
+            "Code represented in a string, specified in the `code` field. If this is an output field, the code "
+            "should follow the markdown code block format, e.g. \n```python\n{code}\n``` or \n```cpp\n{code}\n```."
+        )
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def validate_input(cls, data: Any):
+        if isinstance(data, cls):
+            return data
+
+        if isinstance(data, str):
+            return {"code": _filter_code(data)}
+
+        if isinstance(data, dict):
+            if "code" not in data:
+                raise ValueError("`code` field is required for `dspy.Code`")
+            if not isinstance(data["code"], str):
+                raise ValueError(f"`code` field must be a string, but received type: {type(data['code'])}")
+            return {"code": _filter_code(data["code"])}
+
+        raise ValueError(f"Received invalid value for `dspy.Code`: {data}")
+
+
+def _filter_code(code: str) -> str:
+    """Extract code from markdown code blocks, stripping any language identifier."""
+    # Case 1: format like:
+    # ```python
+    # {code_block}
+    # ```
+    regex_pattern = r"```(?:[^\n]*)\n(.*?)```"
+    match = re.search(regex_pattern, code, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    # Case 2: ```<code>``` (no language, single-line)
+    regex_pattern_simple = r"```(.*?)```"
+    match = re.search(regex_pattern_simple, code, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    # Fallback case
+    return code

--- a/dspy/adapters/types/code.py
+++ b/dspy/adapters/types/code.py
@@ -35,6 +35,11 @@ class Code(Type):
     Example 2: dspy.Code as input type in code analysis:
 
     ```python
+    import dspy
+    import inspect
+
+    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+
     class CodeAnalysis(dspy.Signature):
         '''Analyze the time complexity of the function.'''
 
@@ -51,9 +56,6 @@ class Code(Type):
         for i in x:
             time.sleep(i)
             print(i)
-
-
-    import inspect
 
     result = predict(code=inspect.getsource(sleepsort))
     print(result.result)

--- a/tests/adapters/test_code.py
+++ b/tests/adapters/test_code.py
@@ -1,0 +1,51 @@
+import inspect
+
+import pydantic
+import pytest
+
+import dspy
+
+
+def test_code_validate_input():
+    # Create a `dspy.Code` instance with valid code.
+    code = dspy.Code(code="print('Hello, world!')")
+    assert code.code == "print('Hello, world!')"
+
+    with pytest.raises(ValueError):
+        # Try to create a `dspy.Code` instance with invalid type.
+        dspy.Code(code=123)
+
+    def foo(x):
+        return x + 1
+
+    code_source = inspect.getsource(foo)
+    code = dspy.Code(code=code_source)
+
+    assert code.code == code_source
+
+
+def test_code_in_nested_type():
+    class Wrapper(pydantic.BaseModel):
+        code: dspy.Code
+
+    code = dspy.Code(code="print('Hello, world!')")
+    wrapper = Wrapper(code=code)
+    assert wrapper.code.code == "print('Hello, world!')"
+
+
+def test_code_parses_from_dirty_code():
+    dirty_code = "```python\nprint('Hello, world!')```"
+    code = dspy.Code(code=dirty_code)
+    assert code.code == "print('Hello, world!')"
+
+    dirty_code_with_reasoning = """
+The generated code is:
+```python
+print('Hello, world!')
+```
+
+The reasoning is:
+The code is a simple print statement.
+"""
+    code = dspy.Code(code=dirty_code_with_reasoning)
+    assert code.code == "print('Hello, world!')"

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -435,6 +435,48 @@ def test_json_adapter_with_tool():
     }
 
 
+def test_json_adapter_with_code():
+    # Test with code as input field
+    class CodeAnalysis(dspy.Signature):
+        """Analyze the time complexity of the code"""
+
+        code: dspy.Code = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter()
+    messages = adapter.format(CodeAnalysis, [], {"code": "print('Hello, world!')"})
+
+    assert len(messages) == 2
+
+    # The output field type description should be included in the system message even if the output field is nested
+    assert dspy.Code.description() in messages[0]["content"]
+
+    # The user message should include the question and the tools
+    assert "print('Hello, world!')" in messages[1]["content"]
+
+    # Test with code as output field
+    class CodeGeneration(dspy.Signature):
+        """Generate code to answer the question"""
+
+        question: str = dspy.InputField()
+        code: dspy.Code = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter()
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="{'code': 'print(\"Hello, world!\")'}"))],
+            model="openai/gpt-4o-mini",
+        )
+        result = adapter(
+            dspy.LM(model="openai/gpt-4o-mini", cache=False),
+            {},
+            CodeGeneration,
+            [],
+            {"question": "Write a python program to print 'Hello, world!'"},
+        )
+        assert result[0]["code"].code == 'print("Hello, world!")'
+
+
 def test_json_adapter_formats_conversation_history():
     class MySignature(dspy.Signature):
         question: str = dspy.InputField()


### PR DESCRIPTION
New type `dspy.Code`. Right now it's just a value holder with parser to get rid of the boilerplate like "```python".

We will incorporate this in dspy.CodeAct and dspy.ProgramOfThought after some benchmarking work. 

Sample usage (also available in the docstring):

Example 1: dspy.Code as output type in code generation:

```python
import dspy
dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
class CodeGeneration(dspy.Signature):
    '''Generate python code to answer the question.'''
    question: str = dspy.InputField(description="The question to answer")
    code: dspy.Code = dspy.OutputField(description="The code to execute")
predict = dspy.Predict(CodeGeneration)
result = predict(question="Given an array, find if any of the two numbers sum up to 10")
print(result.code)
```

Example 2: dspy.Code as input type in code analysis:

```python
import dspy
import inspect
dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
class CodeAnalysis(dspy.Signature):
    '''Analyze the time complexity of the function.'''
    code: dspy.Code = dspy.InputField(description="The function to analyze")
    result: str = dspy.OutputField(description="The time complexity of the function")
predict = dspy.Predict(CodeAnalysis)
def sleepsort(x):
    import time
    for i in x:
        time.sleep(i)
        print(i)
result = predict(code=inspect.getsource(sleepsort))
print(result.result)
```

