### PR TITLE
Manage duplicate multiple LMs in the same module

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -93,10 +93,19 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def get_lm(self):
         all_used_lms = [param.lm for _, param in self.named_predictors()]
 
-        if len(set(all_used_lms)) == 1:
-            return all_used_lms[0]
+        if len(all_used_lms) == 0:
+            raise ValueError("No LMs are being used in the module. There's no LM to return.")
 
-        raise ValueError("Multiple LMs are being used in the module. There's no unique LM to return.")
+        elif len(all_used_lms) == 1:
+            return all_used_lms.pop()
+
+        else:
+            first_lm = all_used_lms.pop()
+            for lm in all_used_lms:
+                if first_lm.dump_state() != lm.dump_state():
+                    raise ValueError("Multiple LMs are being used in the module. There's no unique LM to return.")
+
+            return first_lm
 
     def __repr__(self):
         s = []


### PR DESCRIPTION
PR addresses  https://github.com/stanfordnlp/dspy/issues/8469

When checking for all used LMs from within `get_lm()` (in *dspy/primitives/module.py*), now the various LMs are compared with each other using `dump_state()` that returns a dictionary of the respective states containing values for the following attributes
```
model
model_type
cache
cache_in_memory
num_retries
finetuning_model
launch_kwargs
train_kwargs
```
Reminder: Only the LMs of instance type `Predict` are considered

