### PR TITLE
Remove roadmap page from the sidenav

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -72,7 +72,6 @@ nav:
     - Community:
         - Community Resources: community/community-resources.md
         - Use Cases: community/use-cases.md
-        - Roadmap: roadmap.md
         - Contributing: community/how-to-contribute.md
     - FAQ:
         - FAQ: faqs.md


### PR DESCRIPTION
The content on the Roadmap page is highly outdated. Removed the page from the sidenav temporarily until we update the content.