### PR TITLE
doc: Move Conversation History tutorial

### DIFF
--- a/docs/docs/tutorials/build_ai_program/index.md
+++ b/docs/docs/tutorials/build_ai_program/index.md
@@ -4,6 +4,9 @@ This section contains hands-on tutorials that guide you through building product
 
 ## Core Applications
 
+### [Managing Conversation History](../conversation_history/index.md)
+Learn how to manage conversation history in DSPy applications.
+
 ### [Building AI Agents with DSPy](../customer_service_agent/index.ipynb)
 Learn to create intelligent agents that can handle complex customer service scenarios. This tutorial shows how to build agents that can understand context, maintain conversation state, and provide helpful responses.
 

--- a/docs/docs/tutorials/core_development/index.md
+++ b/docs/docs/tutorials/core_development/index.md
@@ -4,9 +4,6 @@ This section covers essential DSPy features and best practices for professional 
 
 ## Integration and Tooling
 
-### [Managing Conversation History](../conversation_history/index.md)
-Learn how to manage conversation history in DSPy applications.
-
 ### [Use MCP in DSPy](../mcp/index.md)
 Learn to integrate Model Context Protocol (MCP) with DSPy applications. This tutorial shows how to leverage MCP for enhanced context management and more sophisticated AI interactions.
 

--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -13,6 +13,7 @@ Welcome to DSPy tutorials! We've organized our tutorials into three main categor
 
 
 - Build AI Programs with DSPy
+    - [Managing Conversation History](conversation_history/index.md)
     - [Building AI Agents with DSPy](customer_service_agent/index.ipynb)
     - [Building AI Applications by Customizing DSPy Modules](custom_module/index.ipynb)
     - [Retrieval-Augmented Generation (RAG)](rag/index.ipynb)
@@ -33,7 +34,6 @@ Welcome to DSPy tutorials! We've organized our tutorials into three main categor
     - [Finetuning Agents](games/index.ipynb)
 
 - Tools, Development, and Deployment
-    - [Managing Conversation History](conversation_history/index.md)
     - [Use MCP in DSPy](mcp/index.md)
     - [Output Refinement](output_refinement/best-of-n-and-refine.md)
     - [Saving and Loading](saving/index.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
         - Tutorials Overview: tutorials/index.md
         - Build AI Programs with DSPy:
             - Overview: tutorials/build_ai_program/index.md
+            - Managing Conversation History: tutorials/conversation_history/index.md
             - Building AI Agents with DSPy: tutorials/customer_service_agent/index.ipynb
             - Building AI Applications by Customizing DSPy Modules: tutorials/custom_module/index.ipynb
             - Retrieval-Augmented Generation (RAG): tutorials/rag/index.ipynb
@@ -51,7 +52,6 @@ nav:
             - RL for Multi-Hop Research: tutorials/rl_multihop/index.ipynb
         - Tools, Development, and Deployment:
             - Overview: tutorials/core_development/index.md
-            - Managing Conversation History: tutorials/conversation_history/index.md
             - Use MCP in DSPy: tutorials/mcp/index.md
             - Output Refinement: tutorials/output_refinement/best-of-n-and-refine.md
             - Saving and Loading: tutorials/saving/index.md


### PR DESCRIPTION
This moves [Managing Conversation History](https://dspy.ai/tutorials/conversation_history/) from `Tools, Development, and Deployment` to `Build AI Programs with DSPy`, so it is easier for beginners to see it, since it is a basic tutorial.
ref issue https://github.com/stanfordnlp/dspy/issues/8531