### PR TITLE
Replace datasets hasher with python hashlib

### DIFF
--- a/dspy/clients/utils_finetune.py
+++ b/dspy/clients/utils_finetune.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 from enum import Enum
 from typing import Any, Literal, TypedDict
@@ -66,10 +67,8 @@ def write_lines(file_path, data):
 def save_data(
     data: list[dict[str, Any]],
 ) -> str:
-    from datasets.fingerprint import Hasher
-
     # Assign a unique name to the file based on the data hash
-    hash = Hasher.hash(data)
+    hash = hashlib.sha256(ujson.dumps(data).encode()).hexdigest()
     file_name = f"{hash}.jsonl"
 
     finetune_dir = get_finetune_directory()

--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -1,8 +1,10 @@
+import hashlib
 import logging
 import random
 import threading
 
 import tqdm
+import ujson
 
 import dspy
 from dspy.teleprompt.teleprompt import Teleprompter
@@ -248,9 +250,7 @@ class BootstrapFewShot(Teleprompter):
                 # If there are multiple traces for the same predictor in the sample example,
                 # sample 50/50 from the first N-1 traces or the last trace.
                 if len(demos) > 1:
-                    from datasets.fingerprint import Hasher
-
-                    rng = random.Random(Hasher.hash(tuple(demos)))
+                    rng = random.Random(hashlib.sha256(ujson.dumps(tuple(demos)).encode()).hexdigest())
                     demos = [rng.choice(demos[:-1]) if rng.random() < 0.5 else demos[-1]]
                 self.name2traces[name].extend(demos)
 


### PR DESCRIPTION
`datasets` is no longer a required dep for DSPy, so we should remove its usage from the critical path.