### PR TITLE
docs: Change class name as to not conflict 

### DIFF
--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -187,13 +187,13 @@ class QueryResult(pydantic.BaseModel):
 
 signature = dspy.Signature("query: str -> result: QueryResult")
 
-class Container:
+class MyContainer:
     class Query(pydantic.BaseModel):
         text: str
     class Score(pydantic.BaseModel):
         score: float
 
-signature = dspy.Signature("query: Container.Query -> score: Container.Score")
+signature = dspy.Signature("query: MyContainer.Query -> score: MyContainer.Score")
 ```
 
 ## Using signatures to build modules & compiling them


### PR DESCRIPTION
This PR fixes a breaking issue with the example used in the Programming Signatures page.  It changes the class name as to not conflict with the typing objects.

I give the details in this issue: https://github.com/stanfordnlp/dspy/issues/8543