### PR TITLE
Fix incorrect `build-system` requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel"]
+requires = ["setuptools>=77.0.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,12 +12,11 @@ version="3.0.0b3"
 description = "DSPy"
 readme = "README.md"
 authors = [{ name = "Omar Khattab", email = "okhattab@stanford.edu" }]
-license = { text = "MIT License" }
+license = "MIT"
 requires-python = ">=3.10, <3.14"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3"
 ]


### PR DESCRIPTION
This change fixes incorrect `build-system` requirements and resolves deprecation warnings thrown in CI when building using the latest setuptools versions. [[recent example](https://github.com/stanfordnlp/dspy/actions/runs/16390769890/job/46316448067#step:8:13)]

> ```
> /tmp/build-env-gfscc8yk/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
> !!
> 
>         ********************************************************************************
>         Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
> 
>         By 2026-Feb-18, you need to update your project and remove deprecated calls
>         or your builds will no longer be supported.
> 
>         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
>         ********************************************************************************
> 
> !!
>   corresp(dist, value, root_dir)
> /tmp/build-env-gfscc8yk/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
> !!
> 
>         ********************************************************************************
>         Please consider removing the following classifiers in favor of a SPDX license expression:
> 
>         License :: OSI Approved :: MIT License
> 
>         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
>         ********************************************************************************
> 
> !!
>   dist._finalize_license_expression()
> /tmp/build-env-gfscc8yk/lib/python3.11/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
> !!
> 
>         ********************************************************************************
>         Please consider removing the following classifiers in favor of a SPDX license expression:
> 
>         License :: OSI Approved :: MIT License
> 
>         See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
>         ********************************************************************************
> 
> !!
> ```

----

# Reproducing locally

## Verifying the current minimum setuptools version

The current `build-system` requirements were confirmed to be unusable by running the following commands:

```
python3.10 -m venv .venv-build
echo '*' > .venv-build/.gitignore
source .venv-build/bin/activate

python -m pip install --upgrade pip
python -m pip install build setuptools==40.8.0

python -m build --no-isolation
```

This results in a crash from within setuptools.

## Testing setuptools v77.0.0

The `build-system` was updated and retested. (Note that "wheel" is no longer a recommended requirement, and that setuptools v77.0.0 was never actually published.)

```
python -m pip install setuptools==77.0.1
python -m build --no-isolation
```

The build succeeded.

## Resolving build warnings

Finally, the latest version of setuptools was installed and all warnings were resolved.

```
python -m pip install --upgrade setuptools
python -m build --no-isolation
```

The following warnings were displayed:

* `project.license` as a TOML table is deprecated!!

  Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

* License classifiers are deprecated.

  Please consider removing the following classifiers in favor of a SPDX license expression:

  `License :: OSI Approved :: MIT License`


Therefore, the `license` and `classifiers` in `pyproject.toml` were also updated.