### PR TITLE
Adding support for mutliple mcp server connections

### DIFF
--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -1,10 +1,13 @@
 from typing import TYPE_CHECKING, Any
 
 from dspy.adapters.types.tool import Tool, convert_input_schema_to_tool_args
+from langchain_mcp_adapters.sessions import create_session
+from langchain_mcp_adapters.tools import _list_all_tools
+from langchain_mcp_adapters.client import MultiServerMCPClient
+import asyncio
 
 if TYPE_CHECKING:
     import mcp
-
 
 def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> str | list[Any]:
     from mcp.types import TextContent
@@ -27,12 +30,17 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     return tool_content or non_text_contents
 
 
-def convert_mcp_tool(session: "mcp.client.session.ClientSession", tool: "mcp.types.Tool") -> Tool:
+def convert_mcp_tool(
+        session: "mcp.client.session.ClientSession | None",
+        tool: "mcp.types.Tool", 
+        connection: "langchain_mcp_adapters.sessions.Connection | None" = None
+    ) -> Tool:
     """Build a DSPy tool from an MCP tool.
 
     Args:
         session: The MCP session to use.
         tool: The MCP tool to convert.
+        connection: The connection config to use for the MCP session.
 
     Returns:
         A dspy Tool object.
@@ -41,7 +49,92 @@ def convert_mcp_tool(session: "mcp.client.session.ClientSession", tool: "mcp.typ
 
     # Convert the MCP tool and Session to a single async method
     async def func(*args, **kwargs):
-        result = await session.call_tool(tool.name, arguments=kwargs)
-        return _convert_mcp_tool_result(result)
+        if session is None:
+            async with create_session(connection) as tool_session:
+                await tool_session.initialize()
+                call_tool_result = await tool_session.call_tool(tool.name, arguments=kwargs)
+        else:
+            call_tool_result = await session.call_tool(tool.name, arguments=kwargs)
+            
+        return _convert_mcp_tool_result(call_tool_result)
 
     return Tool(func=func, name=tool.name, desc=tool.description, args=args, arg_types=arg_types, arg_desc=arg_desc)
+
+
+async def load_mcp_tools(
+    session: "mcp.client.session.ClientSession | None",
+    *,
+    connection: "langchain_mcp_adapters.sessions.Connection | None" = None
+) -> list[Tool]:
+    """Load all available MCP tools and convert them to DSPy tools.
+
+    Args:
+        session: The MCP client session. If None, connection must be provided.
+        connection: Connection config to create a new session if session is None.
+
+    Returns:
+        List of DSPy tools. Tool annotations are returned as part
+        of the tool metadata object.
+
+    Raises:
+        ValueError: If neither session nor connection is provided.
+    """
+    
+    if session is None and connection is None:
+        msg = "Either a session or a connection config must be provided"
+        raise ValueError(msg)
+
+    if session is None:
+        # If a session is not provided, we will create one on the fly
+        async with create_session(connection) as tool_session:
+            await tool_session.initialize()
+            tools = await _list_all_tools(tool_session)
+    else:
+        tools = await _list_all_tools(session)
+
+    return [
+        convert_mcp_tool(session, tool, connection=connection)
+        for tool in tools
+    ]
+
+
+# thanks langchain
+class DspyMultiServerMCPClient(MultiServerMCPClient):
+    """Client for connecting to multiple MCP servers.
+
+    Loads DSPy-compatible tools, prompts and resources from MCP servers.
+    """
+
+    async def get_tools(self, *, server_name: str | None = None) -> list[Tool]:
+        """Get a list of all tools from all connected servers.
+
+        Args:
+            server_name: Optional name of the server to get tools from.
+                If None, all tools from all servers will be returned (default).
+
+        NOTE: a new session will be created for each tool call
+
+        Returns:
+            A list of DSPy tools
+
+        """
+        if server_name is not None:
+            if server_name not in self.connections:
+                msg = (
+                    f"Couldn't find a server with name '{server_name}', "
+                    f"expected one of '{list(self.connections.keys())}'"
+                )
+                raise ValueError(msg)
+            return await load_mcp_tools(None, connection=self.connections[server_name])
+
+        all_tools: list[Tool] = []
+        load_mcp_tool_tasks = []
+        for connection in self.connections.values():
+            load_mcp_tool_task = asyncio.create_task(
+                load_mcp_tools(None, connection=connection)
+            )
+            load_mcp_tool_tasks.append(load_mcp_tool_task)
+        tools_list = await asyncio.gather(*load_mcp_tool_tasks)
+        for tools in tools_list:
+            all_tools.extend(tools)
+        return all_tools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "cloudpickle>=3.0.0",
     "rich>=13.7.1",
     "numpy>=1.26.0",
+    "langchain-mcp-adapters>=0.1.9",
 ]
 
 [project.optional-dependencies]

--- a/tests/utils/resources/mcp_time_server.py
+++ b/tests/utils/resources/mcp_time_server.py
@@ -1,0 +1,13 @@
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("time")
+
+
+@mcp.tool()
+def get_time() -> str:
+    """Get current time"""
+    return "5:20:00 PM EST"
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/utils/resources/mcp_weather_server.py
+++ b/tests/utils/resources/mcp_weather_server.py
@@ -1,0 +1,13 @@
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("Weather")
+
+
+@mcp.tool()
+async def get_weather(location: str) -> str:
+    """Get weather for location."""
+    return f"It's always sunny in {location}"
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -4,6 +4,7 @@ import importlib
 import pytest
 
 from dspy.utils.mcp import convert_mcp_tool
+from dspy.utils.mcp import DspyMultiServerMCPClient
 
 if importlib.util.find_spec("mcp") is None:
     pytest.skip(reason="mcp is not installed", allow_module_level=True)
@@ -87,3 +88,153 @@ async def test_convert_mcp_tool():
             }
             result = await nested_pydantic_tool.acall(account=account_in_json)
             assert result == "Bob"
+
+
+@pytest.mark.asyncio
+@pytest.mark.extra
+async def test_mcp_tool_multiserver_single():
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    client = DspyMultiServerMCPClient({
+        'math': {
+            "command": "python",
+            # Make sure to update to the full absolute path to your math_server.py file
+            "args": ["tests/utils/resources/mcp_server.py"],
+            "transport": "stdio"
+        }
+    })
+
+    response = await client.get_tools()
+
+    # Check add
+    add_tool = response[0]
+    assert add_tool.name == "add"
+    assert add_tool.desc == "Add two numbers"
+    assert add_tool.args == {"a": {"title": "A", "type": "integer"}, "b": {"title": "B", "type": "integer"}}
+    assert add_tool.arg_types == {"a": int, "b": int}
+    assert add_tool.arg_desc == {
+        "a": "No description provided. (Required)",
+        "b": "No description provided. (Required)",
+    }
+    assert await add_tool.acall(a=1, b=2) == "3"
+
+    # Check hello
+    hello_tool = response[1]
+    assert hello_tool.name == "hello"
+    assert hello_tool.desc == "Greet people"
+    assert hello_tool.args == {"names": {"title": "Names", "type": "array", "items": {"type": "string"}}}
+    assert hello_tool.arg_types == {"names": list}
+    assert hello_tool.arg_desc == {"names": "No description provided. (Required)"}
+    assert await hello_tool.acall(names=["Bob", "Tom"]) == ["Hello, Bob!", "Hello, Tom!"]
+
+    # # Check error handling
+    error_tool = response[2]
+    assert error_tool.name == "wrong_tool"
+    assert error_tool.desc == "This tool raises an error"
+    with pytest.raises(
+        RuntimeError, match="Failed to call a MCP tool: Error executing tool wrong_tool: error!"
+    ):
+        await error_tool.acall()
+
+    # # Check nested Pydantic arg
+    nested_pydantic_tool = response[3]
+
+    assert nested_pydantic_tool.name == "get_account_name"
+    assert nested_pydantic_tool.desc == "This extracts the name from account"
+    assert nested_pydantic_tool.args == {
+        "account": {
+            "title": "Account",
+            "type": "object",
+            "required": ["profile", "account_id"],
+            "properties": {
+                "profile": {
+                    "title": "Profile",
+                    "type": "object",
+                    "properties": {
+                        "name": {"title": "Name", "type": "string"},
+                        "age": {"title": "Age", "type": "integer"},
+                    },
+                    "required": ["name", "age"],
+                },
+                "account_id": {"title": "Account Id", "type": "string"},
+            },
+        }
+    }
+    account_in_json = {
+        "profile": {
+            "name": "Bob",
+            "age": 20,
+        },
+        "account_id": "123",
+    }
+    result = await nested_pydantic_tool.acall(account=account_in_json)
+    assert result == "Bob"
+
+@pytest.mark.asyncio
+@pytest.mark.extra
+async def test_mcp_tool_multiserver_multiple():
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from dspy.adapters.types.tool import Tool
+
+    client = DspyMultiServerMCPClient({
+        'math': {
+            "command": "python",
+            # Make sure to update to the full absolute path to your math_server.py file
+            "args": ["tests/utils/resources/mcp_server.py"],
+            "transport": "stdio"
+        },
+        'weather': {
+            "command": "python",
+            # Make sure to update to the full absolute path to your math_server.py file
+            "args": ["tests/utils/resources/mcp_weather_server.py"],
+            "transport": "stdio"
+        },
+        'time': {
+            "command": "python",
+            # Make sure to update to the full absolute path to your math_server.py file
+            "args": ["tests/utils/resources/mcp_time_server.py"],
+            "transport": "stdio"
+        }
+    })
+
+
+    all_tools = await client.get_tools()
+
+    assert set(map(lambda t: t.name, all_tools)) == set(["add", "hello", "wrong_tool", "get_account_name", "get_weather", "get_time"])
+
+    # Check that tools are Tool instances
+    for tool in all_tools:
+        assert isinstance(tool, Tool)
+
+    # Check math server tools
+    math_tools = await client.get_tools(server_name="math")
+    assert len(math_tools) == 4
+    math_tool_names = {tool.name for tool in math_tools}
+    assert math_tool_names == {"add", "hello", "wrong_tool", "get_account_name"}
+
+    # Check weather server tools
+    weather_tools = await client.get_tools(server_name="weather")
+    assert len(weather_tools) == 1
+    assert weather_tools[0].name == "get_weather"
+
+    # Check time server tools
+    time_tools = await client.get_tools(server_name="time")
+    assert len(time_tools) == 1
+    assert time_tools[0].name == "get_time"
+
+    # Test that we can call a math tool
+    add_tool = next(tool for tool in all_tools if tool.name == "add")
+    result = await add_tool.acall(a=2, b=3)
+    assert result == "5"
+
+    # Test that we can call a weather tool
+    weather_tool = next(tool for tool in all_tools if tool.name == "get_weather")
+    result = await weather_tool.acall(location="London")
+    assert result == "It's always sunny in London"
+
+    # Test that we can call a time tool
+    time_tool = next(tool for tool in all_tools if tool.name == "get_time")
+    result = await time_tool.acall(args="")
+    assert result == "5:20:00 PM EST"

--- a/uv.lock
+++ b/uv.lock
@@ -664,7 +664,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "3.0.0b1"
+version = "3.0.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -672,9 +672,11 @@ dependencies = [
     { name = "backoff" },
     { name = "cachetools" },
     { name = "cloudpickle" },
+    { name = "datasets" },
     { name = "diskcache" },
     { name = "joblib" },
     { name = "json-repair" },
+    { name = "langchain-mcp-adapters" },
     { name = "litellm" },
     { name = "magicattr" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -736,12 +738,14 @@ requires-dist = [
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "cloudpickle", specifier = ">=3.0.0" },
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
+    { name = "datasets", specifier = ">=2.14.6" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
     { name = "diskcache", specifier = ">=5.6.0" },
     { name = "joblib", specifier = "~=1.3" },
     { name = "json-repair", specifier = ">=0.30.0" },
     { name = "langchain-core", marker = "extra == 'langchain'" },
     { name = "langchain-core", marker = "extra == 'test-extras'" },
+    { name = "langchain-mcp-adapters", specifier = ">=0.1.9" },
     { name = "litellm", specifier = ">=1.64.0" },
     { name = "litellm", marker = "sys_platform == 'win32' and extra == 'dev'", specifier = ">=1.64.0" },
     { name = "litellm", extras = ["proxy"], marker = "sys_platform != 'win32' and extra == 'dev'", specifier = ">=1.64.0" },
@@ -788,7 +792,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1424,6 +1428,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/8a/d08c83195d1ef26c42728412ab92ab08211893906b283abce65775e21327/langchain_core-0.3.65.tar.gz", hash = "sha256:54b5e0c8d9bb405415c3211da508ef9cfe0acbe5b490d1b4a15664408ee82d9b", size = 558557, upload-time = "2025-06-10T20:08:28.94Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/f0/31db18b7b8213266aed926ce89b5bdd84ccde7ee2edf4cab14e3dd2bfcf1/langchain_core-0.3.65-py3-none-any.whl", hash = "sha256:80e8faf6e9f331f8ef728f3fe793549f1d3fb244fcf9e1bdcecab6a6f4669394", size = 438052, upload-time = "2025-06-10T20:08:27.393Z" },
+]
+
+[[package]]
+name = "langchain-mcp-adapters"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "mcp", version = "1.9.3", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
+    { name = "mcp", version = "1.9.4", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'win32'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/74/e36003a43136f9095a5f968c730fbfe894f94284ebe6d2b50bb17d41b8b5/langchain_mcp_adapters-0.1.9.tar.gz", hash = "sha256:0018cf7b5f7bc4c044e05ec20fcb9ebe345311c8d1060c61d411188001ab3aab", size = 22101, upload-time = "2025-07-09T15:56:14.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/eb/9e98822d3db22beff44449a8f61fca208d4f59d592a7ce67ce4c400b8f8f/langchain_mcp_adapters-0.1.9-py3-none-any.whl", hash = "sha256:fd131009c60c9e5a864f96576bbe757fc1809abd604891cb2e5d6e8aebd6975c", size = 15300, upload-time = "2025-07-09T15:56:13.316Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Langchain supports session management and connection to multiple mcp servers (see [here](https://github.com/langchain-ai/langchain-mcp-adapters?tab=readme-ov-file#client-1)), which is a nice feature to have. This PR is heavily inspired/is based on langchain's implementation of their MultiServerMCPClient