### PR TITLE
skip unhashable module histories for mipro program proposer

### DIFF
--- a/dspy/propose/utils.py
+++ b/dspy/propose/utils.py
@@ -166,7 +166,10 @@ def get_dspy_source_code(module):
             iterable = [getattr(module, attribute)]
 
         for item in iterable:
-            if item in completed_set:
+            # Skip items that are unhashable (like module history)
+            try:
+                hash(item)
+            except TypeError:
                 continue
             if isinstance(item, Parameter):
                 if hasattr(item, "signature") and item.signature is not None and item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig" not in completed_set:


### PR DESCRIPTION
been noticing this recently - MIPRO's program-aware proposer was erroring out with `Error getting source code: unhashable type: 'dict'.`. The optimization handles this by just skipping over and running without it, but this impacts the proposed instructions without information on the program being optimized. 

Adding module history from [this PR](https://github.com/stanfordnlp/dspy/pull/8199) was breaking this, as the elements are full dictionaries of the callable histories. We can just skip over these when iterating over module attributes (only considering the relevant predictor object information) 

cc @okhat 