### PR TITLE
Increment python version for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.9
+  python: python3.10
 
 default_stages: [pre-commit]
 default_install_hook_types: [pre-commit]


### PR DESCRIPTION
Since we dropped 3.9 support, we should use 3.10 in the pre-commit config