### PR TITLE
Fix infinite growing trace and add tests

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -5,6 +5,7 @@ from dspy.dsp.utils import settings
 from dspy.utils.callback import with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
 
+MAX_HISTORY_SIZE = 10_000
 GLOBAL_HISTORY = []
 
 
@@ -147,7 +148,7 @@ class BaseLM:
         self.history.append(entry)
 
         # Global LM history
-        if len(GLOBAL_HISTORY) >= settings.max_history_size:
+        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
             GLOBAL_HISTORY.pop(0)
 
         GLOBAL_HISTORY.append(entry)

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -137,7 +137,7 @@ class BaseLM:
         return pretty_print_history(self.history, n)
 
     def update_history(self, entry):
-        if settings.disable_history:
+        if settings.disable_history or settings.max_history_size == 0:
             return
 
         # dspy.LM.history

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -138,7 +138,16 @@ class BaseLM:
         return pretty_print_history(self.history, n)
 
     def update_history(self, entry):
-        if settings.disable_history or settings.max_history_size == 0:
+        if settings.disable_history:
+            return
+
+        # Global LM history
+        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
+            GLOBAL_HISTORY.pop(0)
+
+        GLOBAL_HISTORY.append(entry)
+
+        if settings.max_history_size == 0:
             return
 
         # dspy.LM.history
@@ -146,12 +155,6 @@ class BaseLM:
             self.history.pop(0)
 
         self.history.append(entry)
-
-        # Global LM history
-        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
-            GLOBAL_HISTORY.pop(0)
-
-        GLOBAL_HISTORY.append(entry)
 
         # Per-module history
         caller_modules = settings.caller_modules or []

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -4,6 +4,8 @@ import copy
 import threading
 from contextlib import contextmanager
 
+from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
+
 from dspy.dsp.utils.utils import dotdict
 
 DEFAULT_CONFIG = dotdict(
@@ -26,6 +28,8 @@ DEFAULT_CONFIG = dotdict(
     max_errors=10,  # Maximum errors before halting operations.
     # If true, async tools can be called in sync mode by getting converted to sync.
     allow_tool_async_sync_conversion=False,
+    max_history_size=10000,
+    max_trace_size=10000,
 )
 
 # Global base configuration and owner tracking

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -4,8 +4,6 @@ import copy
 import threading
 from contextlib import contextmanager
 
-from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
-
 from dspy.dsp.utils.utils import dotdict
 
 DEFAULT_CONFIG = dotdict(

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -147,8 +147,10 @@ class Predict(Module, Parameter):
 
     def _forward_postprocess(self, completions, signature, **kwargs):
         pred = Prediction.from_completions(completions, signature=signature)
-        if kwargs.pop("_trace", True) and settings.trace is not None:
+        if kwargs.pop("_trace", True) and settings.trace is not None and settings.max_trace_size > 0:
             trace = settings.trace
+            if len(trace) >= settings.max_trace_size:
+                trace.pop(0)
             trace.append((self, {**kwargs}, pred))
         return pred
 

--- a/dspy/utils/dummies.py
+++ b/dspy/utils/dummies.py
@@ -124,8 +124,7 @@ class DummyLM(LM):
             entry = {"prompt": prompt, "messages": messages, "kwargs": kwargs}
             entry = {**entry, "outputs": outputs, "usage": 0}
             entry = {**entry, "cost": 0}
-            self.history.append(entry)
-            self.update_global_history(entry)
+            self.update_history(entry)
 
         return outputs
 

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -374,3 +374,39 @@ async def test_async_lm_call_with_cache(tmp_path):
         assert mock_alitellm_completion.call_count == 2
 
     dspy.cache = original_cache
+
+
+def test_lm_history_size_limit():
+    lm = dspy.LM(model="openai/gpt-4o-mini")
+    with dspy.context(max_history_size=5):
+        with mock.patch("litellm.completion") as mock_completion:
+            mock_completion.return_value = ModelResponse(
+                choices=[Choices(message=Message(content="test answer"))],
+                model="openai/gpt-4o-mini",
+            )
+
+            for _ in range(10):
+                lm("query")
+
+    assert len(lm.history) == 5
+
+
+def test_disable_history():
+    lm = dspy.LM(model="openai/gpt-4o-mini")
+    with dspy.context(disable_history=True):
+        with mock.patch("litellm.completion") as mock_completion:
+            mock_completion.return_value = ModelResponse(
+                choices=[Choices(message=Message(content="test answer"))],
+                model="openai/gpt-4o-mini",
+            )
+            for _ in range(10):
+                lm("query")
+
+    assert len(lm.history) == 0
+
+    with dspy.context(disable_history=False):
+        with mock.patch("litellm.completion") as mock_completion:
+            mock_completion.return_value = ModelResponse(
+                choices=[Choices(message=Message(content="test answer"))],
+                model="openai/gpt-4o-mini",
+            )

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -716,10 +716,7 @@ def test_dump_state_pydantic_non_primitive_types():
     assert reloaded == serialized
 
     predictor = Predict(TestSignature)
-    demo = {
-        "website_info": website_info,
-        "summary": "This is a test website."
-    }
+    demo = {"website_info": website_info, "summary": "This is a test website."}
     predictor.demos = [demo]
 
     state = predictor.dump_state()
@@ -729,3 +726,41 @@ def test_dump_state_pydantic_non_primitive_types():
     demo_data = reloaded_state["demos"][0]
     assert demo_data["website_info"]["url"] == "https://www.example.com/"
     assert demo_data["website_info"]["created_at"] == "2021-01-01T12:00:00"
+
+
+def test_trace_size_limit():
+    program = Predict("question -> answer")
+    dspy.settings.configure(lm=DummyLM([{"answer": "Paris"}]), max_trace_size=3)
+
+    for _ in range(10):
+        program(question="What is the capital of France?")
+
+    assert len(dspy.settings.trace) == 3
+
+
+def test_disable_trace():
+    program = Predict("question -> answer")
+    dspy.settings.configure(lm=DummyLM([{"answer": "Paris"}]), trace=None)
+
+    for _ in range(10):
+        program(question="What is the capital of France?")
+
+    assert dspy.settings.trace is None
+
+
+def test_per_module_history_size_limit():
+    program = Predict("question -> answer")
+    dspy.settings.configure(lm=DummyLM([{"answer": "Paris"}]), max_history_size=5)
+
+    for _ in range(10):
+        program(question="What is the capital of France?")
+    assert len(program.history) == 5
+
+
+def test_per_module_history_disabled():
+    program = Predict("question -> answer")
+    dspy.settings.configure(lm=DummyLM([{"answer": "Paris"}]), disable_history=True)
+
+    for _ in range(10):
+        program(question="What is the capital of France?")
+    assert len(program.history) == 0


### PR DESCRIPTION
We introduced `disable_history` in the past, but `dspy.settings.trace` can still grow infinitely. Technically it's able to be disabled by `dspy.configure(trace=None)`, but we still need  a safeguard for the default path. 

fix #8604 

After this PR, even if users don't explicitly disable history and trace, the memory cost won't grow infinitely.

For e2e test, see the script below (this is mostly the same as reported in #8604, but I made a few edits):

```
#!/usr/bin/env python3
"""
Minimal reproduction of DSPy memory leak issue.
Each iteration creates a fresh ChainOfThought instance and deletes it,
but memory continuously grows and is never released.
"""

import gc
import asyncio
import os
from datetime import datetime
import dspy
import psutil


def get_memory():
    """Get memory info (cross-platform, works on macOS and Linux)."""
    process = psutil.Process(os.getpid())
    mem_info = process.memory_info()
    # rss: Resident Set Size (physical memory)
    # vms: Virtual Memory Size
    return {
        "rss_mb": mem_info.rss / 1024 / 1024,
        "vms_mb": mem_info.vms / 1024 / 1024,
        # data_mb is not directly available, but you can add more fields if needed
    }


# Define signature outside of function to avoid recreation
class SimpleSignature(dspy.Signature):
    """Simple test signature."""

    context: str = dspy.InputField(desc="Context information")
    query: str = dspy.InputField(desc="Query to process")
    result: str = dspy.OutputField(desc="Processed result")


def test_iteration_sync(num_parallel_calls=10):
    # Use context manager to create localized LM instance
    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=True)):
        # Get module type from environment variable
        module_type = os.environ.get("DSPY_MODULE", "chainofthought")

        # Create fresh module instancerate
        if module_type == "predict":
            module = dspy.Predict(SimpleSignature)
        else:  # default to chainofthought
            module = dspy.ChainOfThought(SimpleSignature)

        module(context="Context for request", query="Why did the chicken cross the kitchen?")


async def test_iteration(num_parallel_calls=10):
    """Test DSPy ChainOfThought with parallel calls."""

    # Get API key for this iteration
    api_key = os.environ.get("OPENAI_API_KEY")

    # Use context manager to create localized LM instance
    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", api_key=api_key, cache=True)):
        # Get module type from environment variable
        module_type = os.environ.get("DSPY_MODULE", "chainofthought")

        # Create fresh module instancerate
        if module_type == "predict":
            module = dspy.Predict(SimpleSignature)
        else:  # default to chainofthought
            module = dspy.ChainOfThought(SimpleSignature)

        # Create test inputs
        test_inputs = []
        for i in range(num_parallel_calls):
            test_inputs.append((f"Request number {i}", "Why did the chicken cross the kitchen?"))

        # Execute parallel calls
        coroutines = []
        for context, query in test_inputs:
            coro = module.acall(context=context, query=query)
            coroutines.append(coro)

        # Wait for all calls to complete
        results = await asyncio.gather(*coroutines, return_exceptions=True)

    # Small delay to allow async cleanup
    await asyncio.sleep(0.01)


async def main():
    """Main test loop demonstrating memory leak."""

    # Get module type from environment variable
    module_type = os.environ.get("DSPY_MODULE", "chainofthought")
    module_name = "ChainOfThought" if module_type == "chainofthought" else "Predict"

    print("=" * 60)
    print("DSPy Memory Leak Reproduction")
    print("=" * 60)
    print(f"\nThis test demonstrates DSPy {module_name} memory usage")
    print("with module history clearing enabled.\n")

    # Configure DSPy with OpenAI (requires OPENAI_API_KEY env var)
    api_key = os.environ.get("OPENAI_API_KEY")
    if not api_key:
        print("❌ ERROR: OPENAI_API_KEY environment variable is required")
        print("Set your OpenAI API key and run again:")
        print("docker run --rm -e OPENAI_API_KEY='your-key-here' dspy-memory-leak")
        return

    print("✓ Using OpenAI LM with context manager")

    # Number of parallel calls per iteration
    NUM_PARALLEL_CALLS = 10

    # Get initial memory baseline
    initial_memory = get_memory()
    print(f"Initial memory: RSS={initial_memory['rss_mb']:.1f}MB")
    print(f"\nRunning test with {NUM_PARALLEL_CALLS} parallel calls per iteration...")
    print("Press Ctrl+C to stop")
    print("Memory growth will be logged to /app/memory_growth.log\n")

    # Initialize log file
    with open("memory_growth_tmp.log", "w") as log_file:
        log_file.write("DSPy Memory Leak Test - Memory Growth Log\n")
        log_file.write("=" * 50 + "\n")
        log_file.flush()

    # Run test iterations indefinitely
    iteration = 0
    total_iterations = 1000
    dspy.configure(trace=None, disable_history=True)
    while iteration < total_iterations:
        iteration += 1

        # Run test iteration async
        await test_iteration(NUM_PARALLEL_CALLS)

        # Check and log memory every iteration
        current_memory = get_memory()
        growth = current_memory["rss_mb"] - initial_memory["rss_mb"]

        # Create log message
        log_msg = f"Iteration {iteration:3d}: RSS={current_memory['rss_mb']:.1f}MB (growth={growth:+.1f}MB, rate={growth / iteration:.3f}MB/iter)"

        # Print to console with immediate flush
        print(log_msg, flush=True)

        # Also write to log file with immediate flush
        with open("memory_growth_tmp.log", "a") as log_file:
            log_file.write(f"[{datetime.now().isoformat()}] {log_msg}\n")
            log_file.flush()

        # Small delay between iterations
        await asyncio.sleep(0.1)


if __name__ == "__main__":
    asyncio.run(main())

```