### PR TITLE
move datasets into offline optional dependency group

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -330,7 +330,7 @@ Given a few tens or hundreds of representative _inputs_ of your task and a _metr
     Examples below rely on HuggingFace/datasets, you can install it by the command below.
 
     ```bash
-    > pip install -U datasets
+    > pip install -U dspy[offline]
     ```
 
     === "Optimizing prompts for a ReAct agent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,7 @@ dependencies = [
     "backoff>=2.2",
     "joblib~=1.3",
     "openai>=0.28.1",
-    "datasets>=2.14.6", # needed for Bootstrap's Hasher
     "regex>=2023.10.3",
-    "datasets>=2.14.6", # needed for Bootstrap's Hasher
     "ujson>=5.8.0",
     "tqdm>=4.66.1",
     "requests>=2.31.0",
@@ -51,6 +49,7 @@ anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client~=4.5.4"]
 mcp = ["mcp; python_version >= '3.10'"]
 langchain = ["langchain_core"]
+offline = ["datasets>=2.14.6"]
 dev = [
     "pytest>=6.2.5",
     "pytest-mock>=3.12.0",


### PR DESCRIPTION
More rationale for this change in the Issue: https://github.com/stanfordnlp/dspy/issues/8616

I updated getting started instructions in docs which already seemed to assume that datasets was *not* in the core dependencies (it instructed user to install `datasets` before optimizing). 

I think the optional dependency group will help clarify how datasets is used, and provide space for easier addition of "offline" dependencies (eg: pytorch, diffusers, etc?)