### PR TITLE
fix gepa optimize parameters

### DIFF
--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -422,7 +422,7 @@ class GEPA(Teleprompter):
             reflection_lm=reflection_lm,
             candidate_selection_strategy=self.candidate_selection_strategy,
             skip_perfect_score=self.skip_perfect_score,
-            reflection_minibatch_size=self.reflection_minibatch_size,
+            num_examples_per_gepa_step=self.reflection_minibatch_size,
 
             perfect_score=self.perfect_score,
 
@@ -439,7 +439,7 @@ class GEPA(Teleprompter):
             use_wandb=self.use_wandb,
             wandb_api_key=self.wandb_api_key,
             wandb_init_kwargs=self.wandb_init_kwargs,
-            track_best_outputs=self.track_best_outputs,
+            #track_best_outputs=self.track_best_outputs,
 
             # Reproducibility
             seed=self.seed,


### PR DESCRIPTION
When playing around with new GEPA optimizer, with following program:
```python
import dspy
from dspy.teleprompt import GEPA
import os
from typing import List


class HotpotQASignature(dspy.Signature):
    """Answer questions that require reasoning over multiple sources."""
    context = dspy.InputField(desc="Relevant context from multiple sources")
    question = dspy.InputField()
    answer = dspy.OutputField(desc="A detailed answer based on the context")


class HotpotQA(dspy.Module):
    def __init__(self):
        super().__init__()
        self.generate_answer = dspy.ChainOfThought(HotpotQASignature)
    
    def forward(self, question, context):
        prediction = self.generate_answer(question=question, context=context)
        return dspy.Prediction(answer=prediction.answer)


def create_sample_data():
    """Create sample training data similar to HotpotQA format"""
    return [
        dspy.Example(
            question="What is the capital of the country where the Eiffel Tower is located?",
            context="The Eiffel Tower is located in Paris, France. Paris is the capital city of France.",
            answer="Paris"
        ).with_inputs("question", "context"),
        dspy.Example(
            question="Who wrote the novel that features the character Atticus Finch?",
            context="To Kill a Mockingbird is a novel by Harper Lee. The main character is Scout Finch, whose father is Atticus Finch.",
            answer="Harper Lee"
        ).with_inputs("question", "context"),
        dspy.Example(
            question="What is the largest planet in our solar system?",
            context="Jupiter is the largest planet in our solar system. It is a gas giant with a mass greater than all other planets combined.",
            answer="Jupiter"
        ).with_inputs("question", "context")
    ]


def evaluate_model(example, prediction, trace=None):
    """GEPA-compatible evaluation function"""
    try:
        if hasattr(prediction, 'answer') and hasattr(example, 'answer'):
            if example.answer.lower() in prediction.answer.lower():
                return 1.0
        return 0.0
    except Exception as e:
        print(f"Error evaluating: {e}")
        return 0.0


def run_gepa_optimization():
    """Run GEPA optimization similar to the Go reproduction example"""
    
    # Configure DSPy with a language model
    lm = dspy.LM(model='gemini/gemini-1.5-flash', api_key=os.getenv('GEMINI_API_KEY'))
    dspy.configure(lm=lm)
    
    # Create the model to optimize
    hotpot_qa = HotpotQA()
    
    # Create training data
    train_data = create_sample_data()
    
    print("Starting GEPA optimization...")
    print(f"Training data size: {len(train_data)}")
    
    # Configure GEPA optimizer
    # Note: These parameters are based on the actual GEPA API
    gepa_optimizer = GEPA(
        metric=evaluate_model,
        auto="light",  # Using auto budget for demonstration
        reflection_minibatch_size=3,  # Fixed in your fork
        candidate_selection_strategy="pareto",
        reflection_lm=lm,  # Provide reflection LM explicitly
        use_merge=True,
        max_merge_invocations=5,
        failure_score=0.0,
        perfect_score=1.0,
        seed=42,
        track_stats=False  # Disable tracking to avoid parameter issues
    )
    
    # Run optimization
    try:
        # GEPA might need both trainset and valset
        optimized_model = gepa_optimizer.compile(
            student=hotpot_qa,
            trainset=train_data,
            valset=train_data  # Using same data for demo purposes
        )
        
        print("GEPA optimization completed!")
        
        # Test the optimized model
        print("\nTesting optimized model:")
        test_data = create_sample_data()
        
        for i, item in enumerate(test_data):
            try:
                pred = optimized_model(question=item["question"], context=item["context"])
                print(f"\nTest {i+1}:")
                print(f"Question: {item['question']}")
                print(f"Expected: {item['answer']}")
                print(f"Predicted: {pred.answer}")
            except Exception as e:
                print(f"Error testing item {i+1}: {e}")
                
        # Calculate final performance
        correct = 0
        for item in test_data:
            try:
                pred = optimized_model(question=item.question, context=item.context)
                if item.answer.lower() in pred.answer.lower():
                    correct += 1
            except Exception as e:
                print(f"Error in final evaluation: {e}")
        
        final_score = correct / len(test_data) if test_data else 0
        print(f"\nFinal performance: {final_score:.2%}")
        
    except Exception as e:
        print(f"Error during GEPA optimization: {e}")
        print("This might be due to GEPA not being available in the current DSPy version.")
        print("Please ensure you have the latest DSPy version with GEPA support.")


def run_prompt_evolution_demo():
    """Demonstrate prompt evolution similar to Figure 2 from the paper"""
    print("\n" + "="*50)
    print("PROMPT EVOLUTION DEMONSTRATION")
    print("="*50)
    
    # Simulate the dramatic prompt evolution mentioned in the Go example
    initial_prompt = "Answer the question."
    
    evolved_prompts = [
        "Answer the question based on the given context.",
        "Carefully analyze the context and provide a detailed answer to the question.",
        "Examine the provided context thoroughly. Consider all relevant information and relationships between different pieces of data. Provide a comprehensive and accurate answer that directly addresses the question while citing specific details from the context.",
        "As an expert analyst, systematically examine the provided context to identify key information, relationships, and relevant details. Apply critical thinking to synthesize this information and generate a precise, well-reasoned answer that fully addresses the question while maintaining factual accuracy and providing appropriate context for your reasoning."
    ]
    
    print(f"Initial prompt: '{initial_prompt}' (Length: {len(initial_prompt)} chars)")
    print("\nEvolved prompts:")
    
    for i, prompt in enumerate(evolved_prompts, 1):
        length_increase = len(prompt) / len(initial_prompt)
        print(f"\nGeneration {i}: (Length: {len(prompt)} chars, {length_increase:.1f}x increase)")
        print(f"'{prompt}'")
    
    final_increase = len(evolved_prompts[-1]) / len(initial_prompt)
    print(f"\nFinal prompt is {final_increase:.1f}x longer than initial prompt")


def main():
    print("DSPy GEPA Reproduction Example")
    print("Based on: https://github.com/XiaoConstantine/dspy-go/tree/main/examples/others/gepa/reproduction")
    print()
    
    # Check for API key
    if not os.getenv('GEMINI_API_KEY'):
        print("Warning: GEMINI_API_KEY not found in environment variables.")
        print("Please set your Gemini API key to run the optimization.")
        print()
    
    # Run prompt evolution demonstration
    run_prompt_evolution_demo()
    
    # Attempt to run GEPA optimization
    if os.getenv('GEMINI_API_KEY'):
        try:
            run_gepa_optimization()
        except ImportError:
            print("\n" + "="*50)
            print("GEPA IMPORT ERROR")
            print("="*50)
            print("GEPA is not available in this DSPy version.")
            print("To use GEPA, you need DSPy with PR #8624 merged.")
            print("This example demonstrates the intended structure and usage.")
    else:
        print("\nSkipping GEPA optimization due to missing API key.")
        print("Set GEMINI_API_KEY environment variable to run optimization.")


if __name__ == "__main__":
    main()
 ```

I got a couple of parameters mis-match in current `GEPA` impl:
1. `num_examples_per_gepa_step` in `gepa`'s `optimize` function
2. `track_best_outputs` is missing

