### PR TITLE
Warn on deprecated requires_permission_to_run

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -109,13 +109,16 @@ class MIPROv2(Teleprompter):
         view_data_batch_size: int = 10,
         tip_aware_proposer: bool = True,
         fewshot_aware_proposer: bool = True,
-        requires_permission_to_run: bool = False, # deprecated
+        requires_permission_to_run: bool | None = None, # deprecated
         provide_traceback: bool | None = None,
     ) -> Any:
-        if requires_permission_to_run:
+        if requires_permission_to_run == False:
             logger.warning(
                 "'requires_permission_to_run' is deprecated and will be removed in a future version."
             )
+        elif requires_permission_to_run == True:
+            raise ValueError("User confirmation is removed from MIPROv2. Please remove the 'requires_permission_to_run' argument.")
+
         effective_max_errors = (
             self.max_errors
             if self.max_errors is not None


### PR DESCRIPTION
## Summary
- warn via logger when deprecated `requires_permission_to_run` is supplied to `MIPROv2.compile`