### PR TITLE
fix(evaluate): Raise TypeError on return_outputs in evaluate kwargs

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -101,6 +101,9 @@ class Evaluate:
         self.provide_traceback = provide_traceback
         self.failure_score = failure_score
 
+        if "return_outputs" in kwargs:
+            raise ValueError("`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object.")
+
     @with_callbacks
     def __call__(
         self,


### PR DESCRIPTION
Raises a TypeError when the now deprecated "return_output" is present in kwargs. If the user is using "return_output", the it will currently not crash, and instead return the string "outputs".

"return_outputs" is now on by default with the EvaluationResult object