### PR TITLE
Feature/add retry and raw hooks

### DIFF
--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -1,3 +1,5 @@
 # API Reference
 
+See also: Utils → Callback for the callback interface and event hooks.
+
 Welcome to the DSPy API reference documentation. This section provides detailed information about DSPy's classes, modules, and functions.

--- a/docs/docs/api/utils/callback.md
+++ b/docs/docs/api/utils/callback.md
@@ -1,0 +1,46 @@
+# Callback (BaseCallback)
+
+DSPy exposes a callback interface to observe execution across modules, LMs, adapters, tools, and evaluation.
+
+## Interface
+
+- on_module_start(call_id, instance, inputs)
+- on_module_end(call_id, outputs, exception)
+- on_lm_start(call_id, instance, inputs)
+- on_lm_end(call_id, outputs, exception)
+- on_lm_raw_response(call_id, instance, response)
+  - Fired immediately after the provider returns, before parsing/processing.
+- on_adapter_format_start(call_id, instance, inputs)
+- on_adapter_format_end(call_id, outputs, exception)
+- on_adapter_parse_start(call_id, instance, inputs)
+  - inputs["completion"] contains the raw completion string before parsing.
+- on_adapter_parse_end(call_id, outputs, exception)
+- on_tool_start(call_id, instance, inputs)
+- on_tool_end(call_id, outputs, exception)
+- on_evaluate_start(call_id, instance, inputs)
+- on_evaluate_end(call_id, outputs, exception)
+- on_retry_start(call_id, instance, attempt, reason=None, parent_call_id=None)
+  - Emitted by modules that retry (BestOfN, Refine, ProgramOfThought).
+- on_retry_end(call_id, outputs, exception)
+
+All handlers include a call_id to correlate events.
+
+## Usage
+
+```python
+import dspy
+from dspy.utils.callback import BaseCallback
+
+class MyCallback(BaseCallback):
+    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):
+        ...
+
+    def on_lm_raw_response(self, call_id, instance, response):
+        ...
+
+    def on_adapter_parse_start(self, call_id, instance, inputs):
+        raw = inputs.get("completion", "")
+        ...
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"), callbacks=[MyCallback()])
+```

--- a/docs/docs/tutorials/observability/hooks_demo.ipynb
+++ b/docs/docs/tutorials/observability/hooks_demo.ipynb
@@ -1,0 +1,198 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d3621c0a",
+   "metadata": {},
+   "source": [
+    "This notebook-like script demonstrates how to use DSPy callback hooks for\n",
+    "raw provider responses, raw completion text before parsing, and retry events\n",
+    "in multi-try modules. It runs offline with a dummy LM for reliability."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35aa5b4b",
+   "metadata": {
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "import types\n",
+    "import dspy\n",
+    "from dspy.utils.callback import BaseCallback"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59ace464",
+   "metadata": {},
+   "source": [
+    "We define a callback that records events from three key hook families. It\n",
+    "captures the raw provider response object, the raw completion text right\n",
+    "before adapter parsing, and retry start/end signals with attempt metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73a156d2",
+   "metadata": {
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "class DemoCallback(BaseCallback):\n",
+    "    def __init__(self):\n",
+    "        self.events = []\n",
+    "\n",
+    "    def on_lm_raw_response(self, call_id, instance, response):\n",
+    "        content = getattr(response.choices[0].message, \"content\", \"\")\n",
+    "        self.events.append((\"lm.raw\", getattr(instance, \"model\", None), len(content)))\n",
+    "        print({\"event\": \"lm.raw\", \"model\": getattr(instance, \"model\", None)})\n",
+    "\n",
+    "    def on_adapter_parse_start(self, call_id, instance, inputs):\n",
+    "        c = inputs.get(\"completion\", \"\") if isinstance(inputs, dict) else \"\"\n",
+    "        self.events.append((\"adapter.parse.start\", len(c)))\n",
+    "        print({\"event\": \"adapter.parse.start\", \"chars\": len(c)})\n",
+    "\n",
+    "    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):\n",
+    "        self.events.append((\"retry.start\", attempt, reason))\n",
+    "        print({\"event\": \"retry.start\", \"attempt\": attempt, \"reason\": reason})\n",
+    "\n",
+    "    def on_retry_end(self, call_id, outputs, exception):\n",
+    "        self.events.append((\"retry.end\", exception is None))\n",
+    "        print({\"event\": \"retry.end\", \"success\": exception is None})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d5d5d60",
+   "metadata": {},
+   "source": [
+    "Next, we define a tiny provider-compatible response and a dummy LM. The LM\n",
+    "returns a single chat message containing a JSON string so the JSON adapter\n",
+    "can parse to the expected output field format reliably in offline runs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ef34b4b",
+   "metadata": {
+    "lines_to_next_cell": 1
+   },
+   "outputs": [],
+   "source": [
+    "class DummyResponse:\n",
+    "    def __init__(self, text):\n",
+    "        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=text))]\n",
+    "        self.usage = {\"prompt_tokens\": 1, \"completion_tokens\": 1}\n",
+    "        self.model = \"dummy-model\"\n",
+    "\n",
+    "class DummyLM(dspy.BaseLM):\n",
+    "    def forward(self, prompt=None, messages=None, **kwargs):\n",
+    "        return DummyResponse(text='{\"a\": \"hello\"}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5e4f2be",
+   "metadata": {},
+   "source": [
+    "We configure DSPy to use the dummy LM and the JSON adapter to ensure that the\n",
+    "raw completion string is valid JSON and maps to the signature output fields.\n",
+    "We also register our callback to observe the hook events during execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49ecb4e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dspy.configure(\n",
+    "    lm=DummyLM(model=\"dummy-model\"),\n",
+    "    adapter=dspy.JSONAdapter(),\n",
+    "    callbacks=[DemoCallback()],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9da1e2a",
+   "metadata": {},
+   "source": [
+    "The raw provider response hook fires as soon as the LM returns, before any\n",
+    "processing or parsing is performed. Calling the LM directly triggers it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d809115",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lm = dspy.settings.lm\n",
+    "_ = lm(prompt=\"hi\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0819d256",
+   "metadata": {},
+   "source": [
+    "The raw completion hook is emitted right before adapters parse the LM output.\n",
+    "Running a simple predictor produces a valid JSON output that can be parsed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d69fa771",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pred = dspy.Predict(\"q->a\")\n",
+    "res = pred(q=\"hello\")\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2692d4e",
+   "metadata": {},
+   "source": [
+    "Retry hooks are emitted by multi-try modules such as BestOfN and Refine. We\n",
+    "force retries by using a reward function that always returns a low score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66f90b3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mod = dspy.Predict(\"q->a\")\n",
+    "bon = dspy.BestOfN(module=mod, N=2, reward_fn=lambda args, pr: 0.0, threshold=1.0)\n",
+    "try:\n",
+    "    _ = bon(q=\"force\")\n",
+    "except Exception:\n",
+    "    pass"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/docs/tutorials/observability/hooks_demo.py
+++ b/docs/docs/tutorials/observability/hooks_demo.py
@@ -1,0 +1,94 @@
+# %% [markdown]
+# This notebook-like script demonstrates how to use DSPy callback hooks for
+# raw provider responses, raw completion text before parsing, and retry events
+# in multi-try modules. It runs offline with a dummy LM for reliability.
+
+# %%
+import types
+import dspy
+from dspy.utils.callback import BaseCallback
+
+# %% [markdown]
+# We define a callback that records events from three key hook families. It
+# captures the raw provider response object, the raw completion text right
+# before adapter parsing, and retry start/end signals with attempt metadata.
+
+# %%
+class DemoCallback(BaseCallback):
+    def __init__(self):
+        self.events = []
+
+    def on_lm_raw_response(self, call_id, instance, response):
+        content = getattr(response.choices[0].message, "content", "")
+        self.events.append(("lm.raw", getattr(instance, "model", None), len(content)))
+        print({"event": "lm.raw", "model": getattr(instance, "model", None)})
+
+    def on_adapter_parse_start(self, call_id, instance, inputs):
+        c = inputs.get("completion", "") if isinstance(inputs, dict) else ""
+        self.events.append(("adapter.parse.start", len(c)))
+        print({"event": "adapter.parse.start", "chars": len(c)})
+
+    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):
+        self.events.append(("retry.start", attempt, reason))
+        print({"event": "retry.start", "attempt": attempt, "reason": reason})
+
+    def on_retry_end(self, call_id, outputs, exception):
+        self.events.append(("retry.end", exception is None))
+        print({"event": "retry.end", "success": exception is None})
+
+# %% [markdown]
+# Next, we define a tiny provider-compatible response and a dummy LM. The LM
+# returns a single chat message containing a JSON string so the JSON adapter
+# can parse to the expected output field format reliably in offline runs.
+
+# %%
+class DummyResponse:
+    def __init__(self, text):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=text))]
+        self.usage = {"prompt_tokens": 1, "completion_tokens": 1}
+        self.model = "dummy-model"
+
+class DummyLM(dspy.BaseLM):
+    def forward(self, prompt=None, messages=None, **kwargs):
+        return DummyResponse(text='{"a": "hello"}')
+
+# %% [markdown]
+# We configure DSPy to use the dummy LM and the JSON adapter to ensure that the
+# raw completion string is valid JSON and maps to the signature output fields.
+# We also register our callback to observe the hook events during execution.
+
+# %%
+dspy.configure(
+    lm=DummyLM(model="dummy-model"),
+    adapter=dspy.JSONAdapter(),
+    callbacks=[DemoCallback()],
+)
+
+# %% [markdown]
+# The raw provider response hook fires as soon as the LM returns, before any
+# processing or parsing is performed. Calling the LM directly triggers it.
+
+# %%
+lm = dspy.settings.lm
+_ = lm(prompt="hi")
+
+# %% [markdown]
+# The raw completion hook is emitted right before adapters parse the LM output.
+# Running a simple predictor produces a valid JSON output that can be parsed.
+
+# %%
+pred = dspy.Predict("q->a")
+res = pred(q="hello")
+print(res)
+
+# %% [markdown]
+# Retry hooks are emitted by multi-try modules such as BestOfN and Refine. We
+# force retries by using a reward function that always returns a low score.
+
+# %%
+mod = dspy.Predict("q->a")
+bon = dspy.BestOfN(module=mod, N=2, reward_fn=lambda args, pr: 0.0, threshold=1.0)
+try:
+    _ = bon(q="force")
+except Exception:
+    pass

--- a/docs/docs/tutorials/observability/index.md
+++ b/docs/docs/tutorials/observability/index.md
@@ -201,6 +201,7 @@ Sometimes, you may want to implement a custom logging solution. For instance, yo
 |:--|:--|
 |`on_module_start` / `on_module_end` | Triggered when a `dspy.Module` subclass is invoked. |
 |`on_lm_start` / `on_lm_end` | Triggered when a `dspy.LM` subclass is invoked. |
+|`on_lm_raw_response`| Triggered immediately after the provider returns, before DSPy processes/parses it. Useful for telemetry (OpenTelemetry/Langfuse) or detailed logging.|
 |`on_adapter_format_start` / `on_adapter_format_end`| Triggered when a `dspy.Adapter` subclass formats the input prompt. |
 |`on_adapter_parse_start` / `on_adapter_parse_end`| Triggered when a `dspy.Adapter` subclass postprocess the output text from an LM. Useful to access the raw completion string before parsing. |
 |`on_retry_start` / `on_retry_end`| Triggered when a module performs a retry attempt (e.g., `BestOfN`, `Refine`, `ProgramOfThought`). Includes attempt index and optional reason. |

--- a/docs/docs/tutorials/observability/index.md
+++ b/docs/docs/tutorials/observability/index.md
@@ -202,7 +202,8 @@ Sometimes, you may want to implement a custom logging solution. For instance, yo
 |`on_module_start` / `on_module_end` | Triggered when a `dspy.Module` subclass is invoked. |
 |`on_lm_start` / `on_lm_end` | Triggered when a `dspy.LM` subclass is invoked. |
 |`on_adapter_format_start` / `on_adapter_format_end`| Triggered when a `dspy.Adapter` subclass formats the input prompt. |
-|`on_adapter_parse_start` / `on_adapter_parse_end`| Triggered when a `dspy.Adapter` subclass postprocess the output text from an LM. |
+|`on_adapter_parse_start` / `on_adapter_parse_end`| Triggered when a `dspy.Adapter` subclass postprocess the output text from an LM. Useful to access the raw completion string before parsing. |
+|`on_retry_start` / `on_retry_end`| Triggered when a module performs a retry attempt (e.g., `BestOfN`, `Refine`, `ProgramOfThought`). Includes attempt index and optional reason. |
 |`on_tool_start` / `on_tool_end` | Triggered when a `dspy.Tool` subclass is invoked. |
 |`on_evaluate_start` / `on_evaluate_end` | Triggered when a `dspy.Evaluate` instance is invoked. |
 

--- a/docs/docs/tutorials/observability/index.md
+++ b/docs/docs/tutorials/observability/index.md
@@ -232,6 +232,25 @@ class AgentLoggingCallback(BaseCallback):
 dspy.configure(callbacks=[AgentLoggingCallback()])
 ```
 
+## Example: Custom minimal logging callback
+
+```python
+import dspy
+from dspy.utils.callback import BaseCallback
+
+class MinimalLogger(BaseCallback):
+    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):
+        print({"event": "retry.start", "attempt": attempt, "reason": reason})
+
+    def on_lm_raw_response(self, call_id, instance, response):
+        print({"event": "lm.raw_response", "model": instance.model})
+
+    def on_adapter_parse_start(self, call_id, instance, inputs):
+        print({"event": "adapter.parse.start", "len": len(inputs.get("completion", ""))})
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"), callbacks=[MinimalLogger()])
+```
+
 
 ```
 == Reasoning Step ===

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -2,7 +2,7 @@ import datetime
 import uuid
 
 from dspy.dsp.utils import settings
-from dspy.utils.callback import with_callbacks
+from dspy.utils.callback import with_callbacks, get_active_callbacks, get_active_call_id
 from dspy.utils.inspect_history import pretty_print_history
 
 MAX_HISTORY_SIZE = 10_000
@@ -92,6 +92,15 @@ class BaseLM:
     @with_callbacks
     def __call__(self, prompt=None, messages=None, **kwargs):
         response = self.forward(prompt=prompt, messages=messages, **kwargs)
+        # Emit raw response hook before processing/parsing
+        callbacks = get_active_callbacks(self)
+        if callbacks:
+            call_id = get_active_call_id()
+            for cb in callbacks:
+                try:
+                    cb.on_lm_raw_response(call_id=call_id, instance=self, response=response)
+                except Exception:
+                    pass
         outputs = self._process_lm_response(response, prompt, messages, **kwargs)
 
         return outputs
@@ -99,6 +108,14 @@ class BaseLM:
     @with_callbacks
     async def acall(self, prompt=None, messages=None, **kwargs):
         response = await self.aforward(prompt=prompt, messages=messages, **kwargs)
+        callbacks = get_active_callbacks(self)
+        if callbacks:
+            call_id = get_active_call_id()
+            for cb in callbacks:
+                try:
+                    cb.on_lm_raw_response(call_id=call_id, instance=self, response=response)
+                except Exception:
+                    pass
         outputs = self._process_lm_response(response, prompt, messages, **kwargs)
         return outputs
 

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -6,6 +6,7 @@ import dspy
 from dspy.primitives.module import Module
 from dspy.primitives.python_interpreter import PythonInterpreter
 from dspy.signatures.signature import Signature, ensure_signature
+from dspy.utils.callback import get_active_callbacks, get_active_call_id
 
 logger = logging.getLogger(__name__)
 
@@ -185,11 +186,29 @@ class ProgramOfThought(Module):
             if hop == self.max_iters:
                 self.interpreter.shutdown()
                 raise RuntimeError(f"Max hops reached. Failed to run ProgramOfThought: {error}")
+            # Fire retry start before regeneration attempt
+            callbacks = get_active_callbacks(self)
+            if callbacks:
+                call_id = get_active_call_id()
+                for cb in callbacks:
+                    try:
+                        cb.on_retry_start(call_id=call_id, instance=self, attempt=hop + 1, reason="code_error", parent_call_id=None)
+                    except Exception:
+                        pass
             input_kwargs.update({"previous_code": code, "error": error})
             code_data = self.code_regenerate(**input_kwargs)
             code, error = self._parse_code(code_data)
             if not error:
                 output, error = self._execute_code(code)
+            # End retry for this attempt
+            callbacks = get_active_callbacks(self)
+            if callbacks:
+                call_id = get_active_call_id()
+                for cb in callbacks:
+                    try:
+                        cb.on_retry_end(call_id=call_id, outputs=output if error is None else None, exception=None if error is None else Exception(str(error)))
+                    except Exception:
+                        pass
             hop += 1
         input_kwargs.update({"final_generated_code": code, "code_output": output})
         answer_gen_result = self.generate_answer(**input_kwargs)

--- a/dspy/tests/callback/test_pot_retry_hooks.py
+++ b/dspy/tests/callback/test_pot_retry_hooks.py
@@ -19,10 +19,8 @@ def test_program_of_thought_retry_hooks(monkeypatch):
 
     # Use a tiny signature; interpreter may raise, so we focus on hook wiring
     pot = dspy.ProgramOfThought("question -> answer", max_iters=2)
-    try:
-        pot(question="what is 1+1?")
-    except Exception:
-        pass
+    
+    pot(question="what is 1+1?")
 
     starts = [e for e in cb.events if e[0] == "start"]
     assert len(starts) >= 1

--- a/dspy/tests/callback/test_pot_retry_hooks.py
+++ b/dspy/tests/callback/test_pot_retry_hooks.py
@@ -1,0 +1,28 @@
+import dspy
+from dspy.utils.callback import BaseCallback
+
+
+class RecordingCallback(BaseCallback):
+    def __init__(self):
+        self.events = []
+
+    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):
+        self.events.append(("start", attempt, reason, type(instance).__name__))
+
+    def on_retry_end(self, call_id, outputs, exception):
+        self.events.append(("end", outputs is not None, exception is not None))
+
+
+def test_program_of_thought_retry_hooks(monkeypatch):
+    cb = RecordingCallback()
+    dspy.settings.configure(callbacks=[cb], lm=dspy.LM("openai/gpt-4o-mini"))
+
+    # Use a tiny signature; interpreter may raise, so we focus on hook wiring
+    pot = dspy.ProgramOfThought("question -> answer", max_iters=2)
+    try:
+        pot(question="what is 1+1?")
+    except Exception:
+        pass
+
+    starts = [e for e in cb.events if e[0] == "start"]
+    assert len(starts) >= 1

--- a/dspy/tests/callback/test_refine_retry_hooks.py
+++ b/dspy/tests/callback/test_refine_retry_hooks.py
@@ -33,12 +33,13 @@ def test_refine_retry_hooks(monkeypatch):
             return []
 
     def reward_fn(args, pred):
-        return 0.0 if mod.calls == 1 else 1.0
+        return 0.0
 
     mod = SimpleModule()
     ref = dspy.Refine(module=mod, N=2, reward_fn=reward_fn, threshold=1.0)
-    ref()
 
+    ref()
+    
     starts = [e for e in cb.events if e[0] == "start"]
     ends = [e for e in cb.events if e[0] == "end"]
     assert len(starts) >= 1

--- a/dspy/tests/callback/test_refine_retry_hooks.py
+++ b/dspy/tests/callback/test_refine_retry_hooks.py
@@ -1,0 +1,45 @@
+import dspy
+from dspy.utils.callback import BaseCallback
+
+
+class RecordingCallback(BaseCallback):
+    def __init__(self):
+        self.events = []
+
+    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):
+        self.events.append(("start", attempt, reason, type(instance).__name__))
+
+    def on_retry_end(self, call_id, outputs, exception):
+        self.events.append(("end", outputs is not None, exception is not None))
+
+
+def test_refine_retry_hooks(monkeypatch):
+    cb = RecordingCallback()
+    dspy.settings.configure(callbacks=[cb], lm=dspy.LM("openai/gpt-4o-mini"))
+
+    class SimpleModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, **kwargs):
+            self.calls += 1
+            return dspy.Prediction(answer="x")
+
+        def get_lm(self):
+            return dspy.settings.lm
+
+        def named_predictors(self):
+            return []
+
+    def reward_fn(args, pred):
+        return 0.0 if mod.calls == 1 else 1.0
+
+    mod = SimpleModule()
+    ref = dspy.Refine(module=mod, N=2, reward_fn=reward_fn, threshold=1.0)
+    ref()
+
+    starts = [e for e in cb.events if e[0] == "start"]
+    ends = [e for e in cb.events if e[0] == "end"]
+    assert len(starts) >= 1
+    assert len(ends) >= 1

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -160,6 +160,21 @@ class BaseCallback:
         """
         pass
 
+    def on_lm_raw_response(
+        self,
+        call_id: str,
+        instance: Any,
+        response: Any,
+    ):
+        """A handler triggered immediately after the LM provider returns, before DSPy processes/parses it.
+
+        Args:
+            call_id: A unique identifier for the LM call.
+            instance: The LM instance.
+            response: The raw provider response object (e.g., OpenAI response-like object).
+        """
+        pass
+
     def on_adapter_format_start(
         self,
         call_id: str,

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -78,6 +78,40 @@ class BaseCallback:
         """
         pass
 
+    def on_retry_start(
+        self,
+        call_id: str,
+        instance: Any,
+        attempt: int,
+        reason: str | None = None,
+        parent_call_id: str | None = None,
+    ):
+        """A handler triggered when a module is about to perform a retry attempt.
+
+        Args:
+            call_id: The active call identifier associated with the parent module call.
+            instance: The Module instance performing the retry.
+            attempt: 1-based attempt index for the retry attempt that is about to start.
+            reason: Optional machine-readable reason for retry (e.g., "below_threshold", "exception", "code_error").
+            parent_call_id: Optional parent call id if a nested call hierarchy is tracked.
+        """
+        pass
+
+    def on_retry_end(
+        self,
+        call_id: str,
+        outputs: Any | None,
+        exception: Exception | None = None,
+    ):
+        """A handler triggered after a retry attempt completes.
+
+        Args:
+            call_id: The active call identifier associated with the parent module call.
+            outputs: Outputs produced by the retry attempt, if any.
+            exception: If an exception occurred during the retry, the exception instance.
+        """
+        pass
+
     def on_module_end(
         self,
         call_id: str,
@@ -390,3 +424,16 @@ def _get_on_end_handler(callback: BaseCallback, instance: Any, fn: Callable) -> 
 
     # We treat everything else as a module.
     return callback.on_module_end
+
+
+def get_active_call_id() -> str | None:
+    """Return the current active call id for the decorated call context, if any."""
+    return ACTIVE_CALL_ID.get()
+
+
+def get_active_callbacks(instance: Any) -> list[BaseCallback]:
+    """Return the list of active callbacks for the given instance.
+
+    Combines globally configured callbacks with instance-level callbacks.
+    """
+    return dspy.settings.get("callbacks", []) + getattr(instance, "callbacks", [])

--- a/tests/callback/test_lm_raw_response.py
+++ b/tests/callback/test_lm_raw_response.py
@@ -28,8 +28,8 @@ def test_on_lm_raw_response_hook(monkeypatch):
     cb = RecordingCallback()
     lm = DummyLM(model="dummy-model")
     dspy.settings.configure(callbacks=[cb], lm=lm)
-    pred = dspy.Predict("q->a")
-    pred(q="hi")
+    # Call LM directly to avoid adapter parsing requirements
+    lm(prompt="hi")
 
     assert len(cb.raw) == 1
     call_id, model, response = cb.raw[0]

--- a/tests/callback/test_lm_raw_response.py
+++ b/tests/callback/test_lm_raw_response.py
@@ -1,0 +1,37 @@
+import types
+
+import dspy
+from dspy.utils.callback import BaseCallback
+
+
+class RecordingCallback(BaseCallback):
+    def __init__(self):
+        self.raw = []
+
+    def on_lm_raw_response(self, call_id, instance, response):
+        self.raw.append((call_id, instance.model, response))
+
+
+class DummyResponse:
+    def __init__(self, text="ok"):
+        self.choices = [types.SimpleNamespace(message=types.SimpleNamespace(content=text))]
+        self.usage = {"prompt_tokens": 1, "completion_tokens": 1}
+        self.model = "dummy-model"
+
+
+class DummyLM(dspy.BaseLM):
+    def forward(self, prompt=None, messages=None, **kwargs):
+        return DummyResponse()
+
+
+def test_on_lm_raw_response_hook(monkeypatch):
+    cb = RecordingCallback()
+    lm = DummyLM(model="dummy-model")
+    dspy.settings.configure(callbacks=[cb], lm=lm)
+    pred = dspy.Predict("q->a")
+    pred(q="hi")
+
+    assert len(cb.raw) == 1
+    call_id, model, response = cb.raw[0]
+    assert model == "dummy-model"
+    assert hasattr(response, "choices")

--- a/tests/callback/test_retry_hooks.py
+++ b/tests/callback/test_retry_hooks.py
@@ -1,0 +1,49 @@
+import dspy
+from dspy.utils.callback import BaseCallback
+
+
+class RecordingCallback(BaseCallback):
+    def __init__(self):
+        self.events = []
+
+    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):
+        self.events.append(("start", attempt, reason, type(instance).__name__))
+
+    def on_retry_end(self, call_id, outputs, exception):
+        self.events.append(("end", outputs is not None, exception is not None))
+
+
+def test_best_of_n_retry_hooks(monkeypatch):
+    cb = RecordingCallback()
+    dspy.settings.configure(callbacks=[cb], lm=dspy.LM("openai/gpt-4o-mini"))
+
+    # Create a simple module that always returns low reward on first attempt, higher later
+    class SimpleModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def forward(self, **kwargs):
+            self.calls += 1
+            return dspy.Prediction(answer="x")
+
+        def get_lm(self):
+            return dspy.settings.lm
+
+        def named_predictors(self):
+            return []
+
+    def reward_fn(args, pred):
+        # First attempt low, second attempt high
+        return 0.0 if mod.calls == 1 else 1.0
+
+    mod = SimpleModule()
+    bon = dspy.BestOfN(module=mod, N=2, reward_fn=reward_fn, threshold=1.0)
+    bon()
+
+    # Expect one retry start (attempt 2) and one retry end
+    starts = [e for e in cb.events if e[0] == "start"]
+    ends = [e for e in cb.events if e[0] == "end"]
+    assert len(starts) == 1
+    assert len(ends) == 1
+


### PR DESCRIPTION
### PR: Observability Hooks for Raw Provider Responses and Retries

This PR enhances DSPy’s callback system for better observability and debugging.

### What’s New
- `on_lm_raw_response(call_id, instance, response)`
  - Fired immediately after LM provider returns, before any parsing/processing.
  - Use for telemetry/auditing/provider-level debugging.

- `on_retry_start(call_id, instance, attempt, reason=None, parent_call_id=None)`
  - Fired when a module begins a retry attempt.
  - `reason` includes: `"below_threshold"`, `"exception"`, `"feedback_refine"`, `"code_error"`.

- `on_retry_end(call_id, outputs, exception)`
  - Fired after a retry attempt completes (success or failure).

Note: `on_adapter_parse_start` already exposes raw completion text via `inputs["completion"]` prior to parsing.

### Integrations
- Retry hooks: `BestOfN`, `Refine`, `ProgramOfThought`
- Raw provider response hook: `BaseLM.__call__` / `BaseLM.acall`

### Usage
```python
import dspy
from dspy.utils.callback import BaseCallback

class MyCallback(BaseCallback):
    def on_lm_raw_response(self, call_id, instance, response):
        print("LM raw:", instance.model, getattr(response, "model", None))

    def on_adapter_parse_start(self, call_id, instance, inputs):
        raw = inputs.get("completion", "")
        print("Raw completion (pre-parse):", raw[:160])

    def on_retry_start(self, call_id, instance, attempt, reason=None, parent_call_id=None):
        print("Retry start:", attempt, reason)

    def on_retry_end(self, call_id, outputs, exception):
        print("Retry end:", "success" if exception is None else f"error={exception}")

dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"), callbacks=[MyCallback()])
```

### Tests & Docs
- Added callback tests (retry/raw response). Updated observability tutorial and API docs at `docs/docs/api/utils/callback.md`.