### PR TITLE
Fix issues in BAMLAdapter

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -37,7 +37,6 @@ class ChatAdapter(Adapter):
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
-            raise e
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -76,10 +76,7 @@ class JSONAdapter(ChatAdapter):
             )
             lm_kwargs["response_format"] = structured_output_model
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
-        except Exception as e:
-            import pdb
-
-            pdb.set_trace()
+        except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -83,9 +83,9 @@ class LM(BaseLM):
 
         if model_pattern:
             # Handle OpenAI reasoning models (o1, o3)
-            assert max_tokens >= 20_000 and temperature == 1.0, (
-                "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 20_000 to `dspy.LM(...)`"
-            )
+            assert (
+                max_tokens >= 20_000 and temperature == 1.0
+            ), "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 20_000 to `dspy.LM(...)`"
             self.kwargs = dict(temperature=temperature, max_completion_tokens=max_tokens, **kwargs)
         else:
             self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)


### PR DESCRIPTION
There are a few issues in the newly-added BAMLAdapter. While we are still discussing where we should land this BAMLAdapter: https://github.com/stanfordnlp/dspy/pull/8614#issuecomment-3182313121, this PR fixes issues so that users are unblocked. 

Here is a list of existing issues:

- BAMLAdapter doesn't handle recursive pydantic models well. For case like:
  ```
  class RecursiveListField(BaseModel):
      value: int
      items: list["RecursiveListField"]
  
  
  print(_build_simplified_schema(RecursiveListField))
  ```
  it's hitting infinite loop
- There are many mixed calls to `_render_type_str` and `_build_simplified_schema`, making the code hard to follow. We can consolidate them into calling `_render_type_str`.
- The format building is wrapped in try-except block, which is unnecessary and can potential hide actual issues and make meaningless LM calls. If the format serlialization is failed, a safer way is to raise an exception instead of making an LM call, because by following the latter approach users won't be able to investigate the error.
- No need to test JSONAdapter behavior in BAMLAdapter, so I am deleting a few test cases.
- Avoid parameter names starting with underscore, like `_depth`.
- `format_task_description` is the same as JSONAdapter, no need to duplicate.


A sample LM calling entity after disabling structured output mode is like below:

```
[2025-08-14T00:01:41.468330]

System message:

Your input fields are:
1. `clinical_note` (str):
Your output fields are:
1. `patient_info` (PatientDetails):
All interactions will be structured in the following way, with the appropriate values filled in.

[[ ## clinical_note ## ]]
{clinical_note}

[[ ## patient_info ## ]]
Output field `patient_info` should be of type: {
  # Full name of the patient.
  name: string,
  age: int,
  address:   {
    street: string,
    city: string,
    country: "US" or "CA",
  } or null,
}

[[ ## completed ## ]]
In adhering to this structure, your objective is: 
        Extract patient information from the clinical note.


User message:

[[ ## clinical_note ## ]]
John Doe, 45 years old, lives at 123 Main St, Anytown. Resident of the US.

Respond with a JSON object in the following order of fields: `patient_info` (must be formatted as a valid Python PatientDetails).


Response:

{
  "patient_info": {
    "name": "John Doe",
    "age": 45,
    "address": {
      "street": "123 Main St",
      "city": "Anytown",
      "country": "US"
    }
  }
}
```
