### PR TITLE
Use pydantic's `ConfigDict` for config; filter litellm warnings

### DIFF
--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -21,10 +21,10 @@ class Audio(Type):
     data: str
     audio_format: str
 
-    model_config = {
-        "frozen": True,
-        "extra": "forbid",
-    }
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        extra="forbid",
+    )
 
     def format(self) -> list[dict[str, Any]]:
         try:

--- a/dspy/adapters/types/history.py
+++ b/dspy/adapters/types/history.py
@@ -60,9 +60,9 @@ class History(pydantic.BaseModel):
 
     messages: list[dict[str, Any]]
 
-    model_config = {
-        "frozen": True,
-        "str_strip_whitespace": True,
-        "validate_assignment": True,
-        "extra": "forbid",
-    }
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="forbid",
+    )

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -21,12 +21,12 @@ except ImportError:
 class Image(Type):
     url: str
 
-    model_config = {
-        "frozen": True,
-        "str_strip_whitespace": True,
-        "validate_assignment": True,
-        "extra": "forbid",
-    }
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
 
     def format(self) -> list[dict[str, Any]] | str:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,14 @@ exclude_lines = [
     "continue",
 ]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    # litellm uses deprecated pydantic config classes sometimes.
+    # The issue has been fixed repeatedly, but still keeps showing up.
+    # For examples, see litellm PRs #6903, #7300, #8096, #9372, and #12528.
+    "ignore:.+class-based `config` is deprecated, use ConfigDict:DeprecationWarning",
+]
+
 [tool.ruff]
 include = ["dspy/**/*.py", "tests/**/*.py"]
 exclude = [


### PR DESCRIPTION
litellm has repeatedly introduced and fixed pydantic deprecation warnings. These appear in dspy's CI with this text [[recent example](https://github.com/stanfordnlp/dspy/actions/runs/16959566922/job/48068816280#step:10:707)]:

```
PydanticDeprecatedSince20:
Support for class-based `config` is deprecated, use ConfigDict instead.
Deprecated in Pydantic V2.0 to be removed in V3.0.
```

To resolve the specific deprecation warnings that show up in the test suite, a pytest configuration is introduced that filters the pydantic warnings caused by litellm.

In addition, the unadorned Python dict syntax in dspy is replaced with `pydantic.ConfigDict` usage, which helps with IDE auto-completion as well as type checking.

----

Ideally, the `filterwarnings` pytest configuration will eventually be configured with `"error"` as its first string so that warnings result in test suite failures. However, there are many other test suite warnings to diagnose and address first. This PR is a first step to systematically addressing these issues.