### PR TITLE
feat(optimizers): let users set the seed in LabeledFewShot

### DIFF
--- a/dspy/teleprompt/vanilla.py
+++ b/dspy/teleprompt/vanilla.py
@@ -4,8 +4,9 @@ from dspy.teleprompt.teleprompt import Teleprompter
 
 
 class LabeledFewShot(Teleprompter):
-    def __init__(self, k=16):
+    def __init__(self, k: int = 16, seed: int = 0):
         self.k = k
+        self.seed = seed
 
     def compile(self, student, *, trainset, sample=True):
         self.student = student.reset_copy()
@@ -14,7 +15,7 @@ class LabeledFewShot(Teleprompter):
         if len(self.trainset) == 0:
             return self.student
 
-        rng = random.Random(0)
+        rng = random.Random(self.seed)
 
         for predictor in self.student.predictors():
             if sample:


### PR DESCRIPTION
Setting the seed in LabeledFewShot means the caller can try this optimizer for a few seeds and pick the best one. This is useful for systems where LabeledFewShot is a pretty strong baseline (e.g. single Predict module with a small number of classes, where it does not make sense to do bootstrapping.

(A workaround to this is to just shuffle the trainset separately)