### PR TITLE
feat(docs): Change text alignment from justify to left for better redability

### DIFF
--- a/docs/docs/stylesheets/extra.css
+++ b/docs/docs/stylesheets/extra.css
@@ -46,9 +46,9 @@
 }
 
 
-/* Justified text for main content */
+/* Left-aligned text for main content */
 .md-content__inner p {
-    text-align: justify;
+    text-align: left;
 }
 
 /* Left-aligned text for grid cards */


### PR DESCRIPTION
This PR changes the text alignment in the documentation from `justify` to `left` for improved readability. The current rendering has spacing issues
<img width="723" height="248" alt="image" src="https://github.com/user-attachments/assets/de0e33db-90a3-43a2-8b7c-6f52dc8c4bb4" />

This is a small CSS fix that improves documentation readability. Creating a separate issue seems unnecessary for this straightforward change."