### PR TITLE
Allow custom chunk type in stream

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -203,6 +203,8 @@ def streamify(
                     ):
                         yield value
                     return
+                else:
+                    yield value
 
     if async_streaming:
         return async_streamer

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -845,3 +845,34 @@ async def test_stream_listener_returns_correct_chunk_xml_adapter():
     assert all_chunks[1].predict_name == "predict2"
     assert all_chunks[1].signature_field_name == "judgement"
     assert all_chunks[1].chunk == "The answer is humorous."
+
+
+@pytest.mark.anyio
+async def test_streaming_allows_custom_chunk_types():
+    from dataclasses import dataclass
+
+    from asyncer import syncify
+
+    @dataclass
+    class CustomChunk:
+        text: str
+
+    class MyProgram(dspy.Module):
+        def forward(self, question, **kwargs):
+            async def send_to_stream():
+                chunk = CustomChunk(text="hello")
+                await dspy.settings.send_stream.send(chunk)
+
+            syncified_send_to_stream = syncify(send_to_stream)
+            syncified_send_to_stream()
+            return dspy.Prediction(answer="dummy output")
+
+    program = dspy.streamify(MyProgram())
+
+    output = program(question="why did a chicken cross the kitchen?")
+    all_chunks = []
+    async for value in output:
+        all_chunks.append(value)
+
+    assert isinstance(all_chunks[0], CustomChunk)
+    assert isinstance(all_chunks[1], dspy.Prediction)


### PR DESCRIPTION
Responses API is not yet alive in DSPy, but sometimes people may want to leverage it for the interesting structured output streaming. To bridge the gap, we are allowing the custom-type chunk in the streaming. Then users can do something like:

```
import asyncio

import litellm
import pydantic
from asyncer import syncify

import dspy

dspy.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False), adapter=dspy.JSONAdapter())


class ScienceNews(pydantic.BaseModel):
    text: str
    scientists_involved: list[str]


class NewsQA(dspy.Signature):
    """Get news about the given science field"""

    science_field: str = dspy.InputField()
    year: int = dspy.InputField()
    num_of_outputs: int = dspy.InputField()
    news: list[ScienceNews] = dspy.OutputField(desc="science news")


class MyModule(dspy.Module):
    def forward(self, science_field: str, year: int, num_of_outputs: int):
        async def stream_completion():
            response = await litellm.aresponses(
                model="openai/gpt-4o-mini",
                input="Tell me a 3 scient news about computer theory in 2022.",
                max_output_tokens=1000,
                stream=True,
                response_format=NewsQA,
            )
            stream = dspy.settings.send_stream
            async for event in response:
                await stream.send(event)

        syncified_stream_completion = syncify(stream_completion)
        syncified_stream_completion()
        return dspy.Prediction(news=[])


predict = MyModule()
streamed_predict = dspy.streamify(predict)


async def read_output_stream():
    output_stream = streamed_predict(science_field="Computer Theory", year=2022, num_of_outputs=1)

    chunks = []
    async for chunk in output_stream:
        chunks.append(chunk)
        print(chunk)

    return chunks


chunks = asyncio.run(read_output_stream())


print(chunks[0])
```