### PR TITLE
Add type hints for Module.__call__ and Module.acall to return Prediction

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -7,6 +7,7 @@ from dspy.dsp.utils.settings import settings, thread_local_overrides
 from dspy.predict.parallel import Parallel
 from dspy.primitives.base_module import BaseModule
 from dspy.primitives.example import Example
+from dspy.primitives.prediction import Prediction
 from dspy.utils.callback import with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
 from dspy.utils.usage_tracker import track_usage
@@ -62,7 +63,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
             self.callbacks = []
 
     @with_callbacks
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args, **kwargs) -> Prediction:
         caller_modules = settings.caller_modules or []
         caller_modules = list(caller_modules)
         caller_modules.append(self)
@@ -77,7 +78,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
             return self.forward(*args, **kwargs)
 
     @with_callbacks
-    async def acall(self, *args, **kwargs):
+    async def acall(self, *args, **kwargs) -> Prediction:
         caller_modules = settings.caller_modules or []
         caller_modules = list(caller_modules)
         caller_modules.append(self)

--- a/tests/primitives/test_base_module.py
+++ b/tests/primitives/test_base_module.py
@@ -9,6 +9,7 @@ from litellm import Choices, Message, ModelResponse
 from litellm.types.utils import Usage
 
 import dspy
+from dspy.primitives.prediction import Prediction
 from dspy.utils.dummies import DummyLM
 
 
@@ -260,7 +261,7 @@ def test_multi_module_call_with_usage_tracker(lm_for_test):
             self.predict1 = dspy.ChainOfThought("question -> answer")
             self.predict2 = dspy.ChainOfThought("question, answer -> score")
 
-        def __call__(self, question: str) -> str:
+        def __call__(self, question: str) -> Prediction:
             answer = self.predict1(question=question)
             score = self.predict2(question=question, answer=answer)
             return score
@@ -285,7 +286,7 @@ def test_usage_tracker_in_parallel():
             self.predict1 = dspy.ChainOfThought("question -> answer")
             self.predict2 = dspy.ChainOfThought("question, answer -> score")
 
-        def __call__(self, question: str) -> str:
+        def __call__(self, question: str) -> Prediction:
             with dspy.settings.context(lm=self.lm):
                 answer = self.predict1(question=question)
                 score = self.predict2(question=question, answer=answer)
@@ -365,7 +366,7 @@ def test_module_history():
             super().__init__(**kwargs)
             self.cot = dspy.ChainOfThought("question -> answer")
 
-        def forward(self, question: str, **kwargs) -> str:
+        def forward(self, question: str, **kwargs) -> Prediction:
             return self.cot(question=question)
 
     with patch("litellm.completion") as mock_completion:
@@ -415,7 +416,7 @@ def test_module_history_with_concurrency():
             super().__init__()
             self.cot = dspy.ChainOfThought("question -> answer")
 
-        def forward(self, question: str, **kwargs) -> str:
+        def forward(self, question: str, **kwargs) -> Prediction:
             return self.cot(question=question)
 
     with patch("litellm.completion") as mock_completion:
@@ -446,7 +447,7 @@ async def test_module_history_async():
             super().__init__(**kwargs)
             self.cot = dspy.ChainOfThought("question -> answer")
 
-        async def aforward(self, question: str, **kwargs) -> str:
+        async def aforward(self, question: str, **kwargs) -> Prediction:
             return await self.cot.acall(question=question)
 
     with patch("litellm.acompletion") as mock_completion:


### PR DESCRIPTION
  This PR improves type inference in DSPy by adding explicit return type annotations to the `Module` class's `__call__` and `acall` methods. This enables IDEs and type checkers like pyright to correctly infer that DSPy modules return `Prediction` objects.

 **Problem**

  Previously, when using DSPy modules like `dspy.Predict` or `dspy.ChainOfThought`, type checkers would infer the return type as `object | Any`, making it difficult  for users to:
  - Get proper IDE autocomplete for Prediction attributes
  - Catch type-related errors at development time
  - Understand the API without reading documentation

**Solution**

  Added minimal, non-breaking type hints:
  - Added Prediction import to `dspy/primitives/module.py`
  - Annotated `Module.__call__` to return -> `Prediction`
  - Annotated `Module.acall` to return -> `Prediction`
  - Updated test files to reflect the correct return types

**Testing**

  - All existing tests pass
  - Type checkers now correctly infer `Prediction` as the return type
  - No runtime behavior changes - this is purely for static type checking

Before:

<img width="1606" height="870" alt="CleanShot 2025-08-19 at 11 35 53@2x" src="https://github.com/user-attachments/assets/0d0d2b86-3689-4d5f-85c6-8bf3beed7a7e" />

After:

<img width="1614" height="872" alt="CleanShot 2025-08-19 at 11 36 24@2x" src="https://github.com/user-attachments/assets/2378c504-8efb-4133-94cd-fa3a0aac0383" />
