### PR TITLE
Standardize dspy.Retrieve on Document class

### DIFF
--- a/dspy/retrievers/weaviate_rm.py
+++ b/dspy/retrievers/weaviate_rm.py
@@ -1,7 +1,4 @@
-
-import dspy
-from dspy.dsp.utils import dotdict
-from dspy.primitives.prediction import Prediction
+from dspy.retrievers.retrieve import Document, Retrieve
 
 try:
     from uuid import uuid4
@@ -14,7 +11,7 @@ except ImportError as err:
     ) from err
 
 
-class WeaviateRM(dspy.Retrieve):
+class WeaviateRM(Retrieve):
     """A retrieval module that uses Weaviate to return the top passages for a given query.
 
     Assumes that a Weaviate collection has been created and populated with the following payload:
@@ -56,7 +53,9 @@ class WeaviateRM(dspy.Retrieve):
     ):
         self._weaviate_collection_name = weaviate_collection_name
         self._weaviate_client = weaviate_client
-        self._weaviate_collection = self._weaviate_client.collections.get(self._weaviate_collection_name)
+        self._weaviate_collection = self._weaviate_client.collections.get(
+            self._weaviate_collection_name
+        )
         self._weaviate_collection_text_key = weaviate_collection_text_key
         self._tenant_id = tenant_id
 
@@ -70,7 +69,9 @@ class WeaviateRM(dspy.Retrieve):
 
         super().__init__(k=k)
 
-    def forward(self, query_or_queries: str | list[str], k: int | None = None, **kwargs) -> Prediction:
+    def forward(
+        self, query_or_queries: str | list[str], k: int | None = None, *args, **kwargs
+    ) -> list[Document]:
         """Search with Weaviate for self.k top passages for query or queries.
 
         Args:
@@ -82,57 +83,78 @@ class WeaviateRM(dspy.Retrieve):
             dspy.Prediction: An object containing the retrieved passages.
         """
         k = k if k is not None else self.k
-        queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
+        queries = (
+            [query_or_queries]
+            if isinstance(query_or_queries, str)
+            else query_or_queries
+        )
         queries = [q for q in queries if q]
         passages, parsed_results = [], []
         tenant = kwargs.pop("tenant_id", self._tenant_id)
         for query in queries:
             if self._client_type == "WeaviateClient":
                 if tenant:
-                    results = self._weaviate_collection.query.with_tenant(tenant).hybrid(query=query, limit=k, **kwargs)
+                    results = self._weaviate_collection.query.with_tenant(
+                        tenant
+                    ).hybrid(query=query, limit=k, **kwargs)
                 else:
-                    results = self._weaviate_collection.query.hybrid(query=query, limit=k, **kwargs)
+                    results = self._weaviate_collection.query.hybrid(
+                        query=query, limit=k, **kwargs
+                    )
 
-                parsed_results = [result.properties[self._weaviate_collection_text_key] for result in results.objects]
+                parsed_results = [
+                    result.properties[self._weaviate_collection_text_key]
+                    for result in results.objects
+                ]
 
             elif self._client_type == "Client":
                 q = self._weaviate_client.query.get(
-                        self._weaviate_collection_name, [self._weaviate_collection_text_key]
-                    )
+                    self._weaviate_collection_name, [self._weaviate_collection_text_key]
+                )
                 if tenant:
                     q = q.with_tenant(tenant)
                 results = q.with_hybrid(query=query).with_limit(k).do()
 
                 results = results["data"]["Get"][self._weaviate_collection_name]
-                parsed_results = [result[self._weaviate_collection_text_key] for result in results]
+                parsed_results = [
+                    result[self._weaviate_collection_text_key] for result in results
+                ]
 
-            passages.extend(dotdict({"long_text": d}) for d in parsed_results)
+            passages.extend(parsed_results)
 
-        return passages
+        return [
+            Document(page_content=text, metadata={}, type="Document")
+            for text in passages
+        ]
 
     def get_objects(self, num_samples: int, fields: list[str]) -> list[dict]:
         """Get objects from Weaviate using the cursor API."""
         if self._client_type == "WeaviateClient":
             objects = []
             counter = 0
-            for item in self._weaviate_collection.iterator(): # TODO: add tenancy scoping
+            for (
+                item
+            ) in self._weaviate_collection.iterator():  # TODO: add tenancy scoping
                 if counter >= num_samples:
                     break
                 new_object = {}
                 for key in item.properties.keys():
                     if key in fields:
-                      new_object[key] = item.properties[key]
+                        new_object[key] = item.properties[key]
                 objects.append(new_object)
                 counter += 1
             return objects
         else:
-            raise ValueError("`get_objects` is not supported for the v3 Weaviate Python client, please upgrade to v4.")
+            raise ValueError(
+                "`get_objects` is not supported for the v3 Weaviate Python client, please upgrade to v4."
+            )
 
     def insert(self, new_object_properties: dict):
         if self._client_type == "WeaviateClient":
             self._weaviate_collection.data.insert(
-                properties=new_object_properties,
-                uuid=get_valid_uuid(uuid4())
-            ) # TODO: add tenancy scoping
+                properties=new_object_properties, uuid=get_valid_uuid(uuid4())
+            )  # TODO: add tenancy scoping
         else:
-            raise AttributeError("`insert` is not supported for the v3 Weaviate Python client, please upgrade to v4.")
+            raise AttributeError(
+                "`insert` is not supported for the v3 Weaviate Python client, please upgrade to v4."
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -664,7 +664,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "3.0.0"
+version = "3.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -740,7 +740,7 @@ requires-dist = [
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
     { name = "diskcache", specifier = ">=5.6.0" },
-    { name = "gepa", specifier = "==0.0.2" },
+    { name = "gepa", extras = ["dspy"], specifier = "==0.0.4" },
     { name = "joblib", specifier = "~=1.3" },
     { name = "json-repair", specifier = ">=0.30.0" },
     { name = "langchain-core", marker = "extra == 'langchain'" },
@@ -956,11 +956,11 @@ wheels = [
 
 [[package]]
 name = "gepa"
-version = "0.0.2"
+version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/8b/2aba83c1a85d1260151c7b0ec57c4b34901ae7a74f27eba4e7532c2f80c8/gepa-0.0.2.tar.gz", hash = "sha256:0fa8ca333e4a69eec68087a68cdd651c9e4b8df0c147009f42a5563f1b9702dc", size = 32253, upload-time = "2025-08-12T02:26:49.112Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/0d/aa6065d7d59b3f10ff6818d527dada5a7179ac5643b666b6b6b71d11dab4/gepa-0.0.4.tar.gz", hash = "sha256:b3e020124c7d8a80c07595aca3b73647ec9151203d7166915ad62492b8459bd6", size = 32957, upload-time = "2025-08-14T05:08:36.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/9c/a1111dfc06e1f4b3adac51670b76b45b8385ed510f35bca6c002ca25eef8/gepa-0.0.2-py3-none-any.whl", hash = "sha256:9894ceefd53d46a6811cf8737b698c99f626777a773307dafc5f8e0038007e53", size = 34191, upload-time = "2025-08-12T02:26:47.625Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/c0/836c79f05113c96155e8de1bb8bf3631a9e7b3b75238c592d39460141ea8/gepa-0.0.4-py3-none-any.whl", hash = "sha256:53d275490d644855e90adf4eba1e3ace5c414c76ba0c0f22760b99a0e43984f9", size = 35191, upload-time = "2025-08-14T05:08:35.558Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #8678

Currently, `dspy.Retrieve` coerces every `rm` module to a simple list of passages, which is not ideal for every enterprise use-case. This PR formalizes the databricks Document dataclass as the standard for output from a retriever.

I did my best with this PR to remain backwards compatible, making this return type opt-in by default (See dspy/retrievers/retrieve.py). I updated each of the built-in retriever classes to return a list of these documents without any additional metadata, as this is unused in the current day.

My goal here is to be able to add things like document score, source url, etc to the document metadata such that it can empower rich UIs through more information about the source data that was fetched and used during inference. This feels like a potentially heavy-handed approach, so I am happy to discuss alternatives.

Right now, the pain that I am feeling is that the current retrieve base class only returns the text with no additional information available about the documents themselves.