### PR TITLE
Handle gpt-5-nano as reasoning model

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -78,8 +78,8 @@ class LM(BaseLM):
         # Handle model-specific configuration for different model families
         model_family = model.split("/")[-1].lower() if "/" in model else model.lower()
 
-        # Match pattern: o[1,3,4] at the start, optionally followed by -mini and anything else
-        model_pattern = re.match(r"^(?:o([1345])|gpt-(5))(?:-mini)?", model_family)
+        # Recognize OpenAI reasoning models (o1, o3, o4, gpt-5 family)
+        model_pattern = re.match(r"^(?:o[1345]|gpt-5)(?:-(?:mini|nano))?", model_family)
 
         if model_pattern:
             if max_tokens < 20000 or temperature != 1.0:

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -226,6 +226,9 @@ def test_reasoning_model_token_parameter():
         ("openai/o1-2023-01-01", True),
         ("openai/o3", True),
         ("openai/o3-mini-2023-01-01", True),
+        ("openai/gpt-5", True),
+        ("openai/gpt-5-mini", True),
+        ("openai/gpt-5-nano", True),
         ("openai/gpt-4", False),
         ("anthropic/claude-2", False),
     ]
@@ -245,19 +248,22 @@ def test_reasoning_model_token_parameter():
             assert "max_tokens" in lm.kwargs
             assert lm.kwargs["max_tokens"] == 1000
 
-
-def test_reasoning_model_requirements():
+@pytest.mark.parametrize("model_name", ["openai/o1", "openai/gpt-5-nano"])
+def test_reasoning_model_requirements(model_name):
     # Should raise assertion error if temperature or max_tokens requirements not met
-    with pytest.raises(ValueError, match="reasoning models require passing temperature=1.0 and max_tokens >= 20000"):
+    with pytest.raises(
+        ValueError,
+        match="reasoning models require passing temperature=1.0 and max_tokens >= 20000",
+    ):
         dspy.LM(
-            model="openai/o1",
+            model=model_name,
             temperature=0.7,  # Should be 1.0
             max_tokens=1000,  # Should be >= 20_000
         )
 
     # Should pass with correct parameters
     lm = dspy.LM(
-        model="openai/o1",
+        model=model_name,
         temperature=1.0,
         max_tokens=20_000,
     )


### PR DESCRIPTION
## Summary
- handle OpenAI's `gpt-5-nano` as a reasoning model
- test `gpt-5` family models to ensure reasoning-specific token settings

## Testing
- ⚠️ `pre-commit run --files dspy/clients/lm.py tests/clients/test_lm.py` (pre-commit not installed)
- ⚠️ `pytest tests/clients/test_lm.py -q` (timeout waiting for test server)
- ✅ `pytest tests/clients/test_lm.py::test_reasoning_model_token_parameter tests/clients/test_lm.py::test_reasoning_model_requirements -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72cc87bb8832996bc8db71cf6db2e