### PR TITLE
Revert bootstrap patch safely

### DIFF
--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -107,7 +107,10 @@ def bootstrap_trace_data(
 
     program.forward = MethodType(patched_forward, program)
 
-    results = evaluator(program, metric=wrapped_metric).results
+    try:
+        results = evaluator(program, metric=wrapped_metric).results
+    finally:
+        program.forward = original_forward
 
     data = []
     for example_ind, (example, prediction, score) in enumerate(results):


### PR DESCRIPTION
Use a finally block to revert the patch inside `bootstrap_trace_data`.