### PR TITLE
Add Anthropic Citation API support

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -6,7 +6,7 @@ from dspy.teleprompt import *
 
 from dspy.evaluate import Evaluate  # isort: skip
 from dspy.clients import *  # isort: skip
-from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, History, Type, Tool, ToolCalls, Code  # isort: skip
+from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, History, Type, Tool, ToolCalls, Code, Citations, Document  # isort: skip
 from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, enable_logging
 from dspy.utils.asyncify import asyncify
 from dspy.utils.syncify import syncify

--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -2,7 +2,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.two_step_adapter import TwoStepAdapter
-from dspy.adapters.types import Audio, Code, History, Image, Tool, ToolCalls, Type
+from dspy.adapters.types import Audio, Citations, Code, Document, History, Image, Tool, ToolCalls, Type
 from dspy.adapters.xml_adapter import XMLAdapter
 
 __all__ = [
@@ -13,6 +13,8 @@ __all__ = [
     "Image",
     "Audio",
     "Code",
+    "Citations",
+    "Document",
     "JSONAdapter",
     "XMLAdapter",
     "TwoStepAdapter",

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -74,7 +74,7 @@ class Adapter:
         values = []
 
         tool_call_output_field_name = self._get_tool_call_output_field_name(original_signature)
-        citation_output_field_names = self._get_citation_output_field_names(original_signature)
+        citation_output_field_name = self._get_citation_output_field_name(original_signature)
 
         for output in outputs:
             output_logprobs = None
@@ -109,11 +109,9 @@ class Adapter:
                 ]
                 value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
 
-            if citations and citation_output_field_names:
+            if citations and citation_output_field_name:
                 citations_obj = Citations.from_dict_list(citations)
-
-                for field_name in citation_output_field_names:
-                    value[field_name] = citations_obj
+                value[citation_output_field_name] = citations_obj
 
             if output_logprobs:
                 value["logprobs"] = output_logprobs
@@ -399,13 +397,12 @@ class Adapter:
                 return name
         return None
 
-    def _get_citation_output_field_names(self, signature: type[Signature]) -> list[str]:
-        """Find all Citations output fields in the signature."""
-        citation_fields = []
+    def _get_citation_output_field_name(self, signature: type[Signature]) -> str | None:
+        """Find the Citations output field in the signature."""
         for name, field in signature.output_fields.items():
             if field.annotation == Citations:
-                citation_fields.append(name)
-        return citation_fields
+                return name
+        return None
 
     def format_conversation_history(
         self,

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -110,10 +110,8 @@ class Adapter:
                 value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
 
             if citations and citation_output_field_names:
-                # Convert citation dictionaries to Citations object using from_dict_list
                 citations_obj = Citations.from_dict_list(citations)
 
-                # Assign to all citation fields found
                 for field_name in citation_output_field_names:
                     value[field_name] = citations_obj
 

--- a/dspy/adapters/types/__init__.py
+++ b/dspy/adapters/types/__init__.py
@@ -1,8 +1,10 @@
 from dspy.adapters.types.audio import Audio
 from dspy.adapters.types.base_type import Type
+from dspy.adapters.types.citation import Citations
 from dspy.adapters.types.code import Code
+from dspy.adapters.types.document import Document
 from dspy.adapters.types.history import History
 from dspy.adapters.types.image import Image
 from dspy.adapters.types.tool import Tool, ToolCalls
 
-__all__ = ["History", "Image", "Audio", "Type", "Tool", "ToolCalls", "Code"]
+__all__ = ["History", "Image", "Audio", "Type", "Tool", "ToolCalls", "Code", "Citations", "Document"]

--- a/dspy/adapters/types/citation.py
+++ b/dspy/adapters/types/citation.py
@@ -1,0 +1,164 @@
+from typing import Any
+
+import pydantic
+
+from dspy.adapters.types.base_type import Type
+
+
+class Citations(Type):
+    """Citations extracted from an LM response with source references.
+
+    This type represents citations returned by language models that support
+    citation extraction, particularly Anthropic's Citations API through LiteLLM.
+    Citations include the quoted text and source information.
+
+    Example:
+        ```python
+        import dspy
+        from dspy.signatures import Signature
+
+        class AnswerWithSources(Signature):
+            '''Answer questions using provided documents with citations.'''
+            documents: list[dspy.Document] = dspy.InputField()
+            question: str = dspy.InputField()
+            answer: str = dspy.OutputField()
+            citations: dspy.Citations = dspy.OutputField()
+
+        # Create documents to provide as sources
+        docs = [
+            dspy.Document(
+                content="The Earth orbits the Sun in an elliptical path.",
+                title="Basic Astronomy Facts"
+            ),
+            dspy.Document(
+                content="Water boils at 100°C at standard atmospheric pressure.",
+                title="Physics Fundamentals",
+                metadata={"author": "Dr. Smith", "year": 2023}
+            )
+        ]
+
+        # Use with a model that supports citations like Claude
+        lm = dspy.LM("anthropic/claude-3-5-sonnet-20241022")
+        predictor = dspy.Predict(AnswerWithSources, lm=lm)
+        result = predictor(documents=docs, question="What temperature does water boil?")
+
+        for citation in result.citations.citations:
+            print(citation.format())
+        ```
+    """
+
+    class Citation(Type):
+        """Individual citation with text and source information."""
+        text: str
+        source: str | dict[str, Any] | None = None
+        start: int | None = None
+        end: int | None = None
+
+        def format(self) -> str:
+            """Format citation as a readable string.
+
+            Returns:
+                A formatted citation string showing the quoted text and source.
+            """
+            source_info = ""
+            if self.source:
+                if isinstance(self.source, str):
+                    source_info = f" ({self.source})"
+                elif isinstance(self.source, dict):
+                    title = self.source.get("title", "")
+                    url = self.source.get("url", "")
+                    if title and url:
+                        source_info = f" ({title}: {url})"
+                    elif title:
+                        source_info = f" ({title})"
+                    elif url:
+                        source_info = f" ({url})"
+
+            return f'"{self.text}"{source_info}'
+
+    citations: list[Citation]
+
+    @classmethod
+    def from_dict_list(cls, citations_dicts: list[dict[str, Any]]) -> "Citations":
+        """Convert a list of dictionaries to a Citations instance.
+
+        Args:
+            citations_dicts: A list of dictionaries, where each dictionary should have 'text' key
+                and optionally 'source', 'start', and 'end' keys.
+
+        Returns:
+            A Citations instance.
+
+        Example:
+            ```python
+            citations_dict = [
+                {"text": "The sky is blue", "source": "Weather Guide"},
+                {"text": "Water boils at 100°C", "source": {"title": "Physics Book", "url": "http://example.com"}}
+            ]
+            citations = Citations.from_dict_list(citations_dict)
+            ```
+        """
+        citations = [cls.Citation(**item) for item in citations_dicts]
+        return cls(citations=citations)
+
+    @classmethod
+    def description(cls) -> str:
+        """Description of the citations type for use in prompts."""
+        return (
+            "Citations with quoted text and source references. "
+            "Include the exact text being cited and information about its source."
+        )
+
+    def format(self) -> list[dict[str, Any]]:
+        """Format citations as a list of dictionaries."""
+        return [
+            {
+                "text": citation.text,
+                "source": citation.source,
+                "start": citation.start,
+                "end": citation.end,
+            }
+            for citation in self.citations
+        ]
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def validate_input(cls, data: Any):
+        if isinstance(data, cls):
+            return data
+
+        # Handle case where data is a list of dicts with citation info
+        if isinstance(data, list) and all(
+            isinstance(item, dict) and "text" in item for item in data
+        ):
+            return {"citations": [cls.Citation(**item) for item in data]}
+
+        # Handle case where data is a dict
+        elif isinstance(data, dict):
+            if "citations" in data:
+                # Handle case where data is a dict with "citations" key
+                citations_data = data["citations"]
+                if isinstance(citations_data, list):
+                    return {
+                        "citations": [
+                            cls.Citation(**item) if isinstance(item, dict) else item
+                            for item in citations_data
+                        ]
+                    }
+            elif "text" in data:
+                # Handle case where data is a single citation dict
+                return {"citations": [cls.Citation(**data)]}
+
+        raise ValueError(f"Received invalid value for `dspy.Citations`: {data}")
+
+    def __iter__(self):
+        """Allow iteration over citations."""
+        return iter(self.citations)
+
+    def __len__(self):
+        """Return the number of citations."""
+        return len(self.citations)
+
+    def __getitem__(self, index):
+        """Allow indexing into citations."""
+        return self.citations[index]

--- a/dspy/adapters/types/document.py
+++ b/dspy/adapters/types/document.py
@@ -1,0 +1,107 @@
+from typing import Any, Literal
+
+import pydantic
+
+from dspy.adapters.types.base_type import Type
+
+
+class Document(Type):
+    """A document type for providing content that can be cited by language models.
+
+    This type represents documents that can be passed to language models for citation-enabled
+    responses, particularly useful with Anthropic's Citations API. Documents include the content
+    and metadata that helps the LM understand and reference the source material.
+
+    Attributes:
+        data: The text content of the document
+        title: Optional title for the document (used in citations)
+        media_type: MIME type of the document content (defaults to "text/plain")
+        metadata: Optional additional metadata about the document
+        context: Optional context information about the document
+
+    Example:
+        ```python
+        import dspy
+        from dspy.signatures import Signature
+
+        class AnswerWithSources(Signature):
+            '''Answer questions using provided documents with citations.'''
+            documents: list[dspy.Document] = dspy.InputField()
+            question: str = dspy.InputField()
+            answer: str = dspy.OutputField()
+            citations: dspy.Citations = dspy.OutputField()
+
+        # Create documents
+        docs = [
+            dspy.Document(
+                data="The Earth orbits the Sun in an elliptical path.",
+                title="Basic Astronomy Facts"
+            ),
+            dspy.Document(
+                data="Water boils at 100°C at standard atmospheric pressure.",
+                title="Physics Fundamentals",
+                metadata={"author": "Dr. Smith", "year": 2023}
+            )
+        ]
+
+        # Use with a citation-supporting model
+        lm = dspy.LM("anthropic/claude-opus-4-1-20250805")
+        predictor = dspy.Predict(AnswerWithSources)
+        result = predictor(documents=docs, question="What temperature does water boil?", lm=lm)
+        print(result.citations)
+        ```
+    """
+
+    data: str
+    title: str | None = None
+    media_type: Literal["text/plain", "application/pdf"] = "text/plain"
+    metadata: dict[str, Any] | None = None
+    context: str | None = None
+
+    def format(self) -> list[dict[str, Any]]:
+        """Format document for LM consumption.
+
+        Returns:
+            A list containing the document block in the format expected by citation-enabled language models.
+        """
+        return {
+            "type": "document",
+            "source": {
+                "type": "text",
+                "media_type": self.media_type,
+                "data": self.data
+            },
+            "citations": {"enabled": True},
+            "title": self.title
+        }
+
+
+
+    @classmethod
+    def description(cls) -> str:
+        """Description of the document type for use in prompts."""
+        return (
+            "A document containing text content that can be referenced and cited. "
+            "Include the full text content and optionally a title for proper referencing."
+        )
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def validate_input(cls, data: Any):
+        if isinstance(data, cls):
+            return data
+
+        # Handle case where data is just a string (data only)
+        if isinstance(data, str):
+            return {"data": data}
+
+        # Handle case where data is a dict
+        elif isinstance(data, dict):
+            return data
+
+        raise ValueError(f"Received invalid value for `dspy.Document`: {data}")
+
+    def __str__(self) -> str:
+        """String representation showing title and content length."""
+        title_part = f"'{self.title}': " if self.title else ""
+        return f"Document({title_part}{len(self.data)} chars)"

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -173,6 +173,12 @@ class BaseLM:
                 output["logprobs"] = c.logprobs if hasattr(c, "logprobs") else c["logprobs"]
             if hasattr(c, "message") and getattr(c.message, "tool_calls", None):
                 output["tool_calls"] = c.message.tool_calls
+
+            # Extract citations from LiteLLM response if available
+            citations = self._extract_citations_from_response(response, c)
+            if citations:
+                output["citations"] = citations
+
             outputs.append(output)
 
         if all(len(output) == 1 for output in outputs):
@@ -180,6 +186,68 @@ class BaseLM:
             outputs = [output["text"] for output in outputs]
 
         return outputs
+
+    def _extract_citations_from_response(self, response, choice):
+        """Extract citations from LiteLLM response if available.
+        
+        Args:
+            response: The LiteLLM response object
+            choice: The choice object from response.choices
+            
+        Returns:
+            List of citation dictionaries or None if no citations found
+        """
+        try:
+            # Check for citations in LiteLLM provider_specific_fields
+            if hasattr(response, "choices") and hasattr(choice, "message"):
+                message = choice.message
+                # Check for citations in provider_specific_fields (Anthropic format)
+                if hasattr(message, "provider_specific_fields") and message.provider_specific_fields:
+                    provider_fields = message.provider_specific_fields
+                    if isinstance(provider_fields, dict) and "citations" in provider_fields:
+                        citations_data = provider_fields["citations"]
+                        if isinstance(citations_data, list):
+                            citations = []
+                            for citation_data in citations_data:
+                                citation_dict = {
+                                    "text": citation_data.get("quote", ""),
+                                    "source": citation_data.get("source"),
+                                    "start": citation_data.get("start"),
+                                    "end": citation_data.get("end"),
+                                }
+                                citations.append(citation_dict)
+                            return citations
+
+                # Check for citations directly in the message (fallback)
+                if hasattr(message, "citations") and message.citations:
+                    citations_data = message.citations
+                    if isinstance(citations_data, list):
+                        citations = []
+                        for citation_data in citations_data:
+                            if hasattr(citation_data, "quote"):
+                                citation_dict = {
+                                    "text": citation_data.quote,
+                                    "source": getattr(citation_data, "source", None),
+                                    "start": getattr(citation_data, "start", None),
+                                    "end": getattr(citation_data, "end", None),
+                                }
+                            elif isinstance(citation_data, dict):
+                                citation_dict = {
+                                    "text": citation_data.get("quote", citation_data.get("text", "")),
+                                    "source": citation_data.get("source"),
+                                    "start": citation_data.get("start"),
+                                    "end": citation_data.get("end"),
+                                }
+                            else:
+                                continue
+                            citations.append(citation_dict)
+                        return citations
+
+        except Exception:
+            # If citation extraction fails, just continue without citations
+            pass
+
+        return None
 
     def _process_response(self, response):
         """Process the response of OpenAI Response API and extract outputs.

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -211,10 +211,12 @@ class BaseLM:
                             citations = []
                             for citation_data in citations_data:
                                 citation_dict = {
-                                    "text": citation_data.get("quote", ""),
-                                    "source": citation_data.get("source"),
-                                    "start": citation_data.get("start"),
-                                    "end": citation_data.get("end"),
+                                    "type": citation_data.get("type", ""),
+                                    "cited_text": citation_data.get("cited_text", ""),
+                                    "document_index": citation_data.get("document_index", 0),
+                                    "document_title": citation_data.get("document_title"),
+                                    "start_char_index": citation_data.get("start_char_index", 0),
+                                    "end_char_index": citation_data.get("end_char_index", 0),
                                 }
                                 citations.append(citation_dict)
                             return citations

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -189,6 +189,7 @@ class BaseLM:
 
     def _extract_citations_from_response(self, response, choice):
         """Extract citations from LiteLLM response if available.
+        Reference: https://docs.litellm.ai/docs/providers/anthropic#beta-citations-api
         
         Args:
             response: The LiteLLM response object
@@ -217,32 +218,6 @@ class BaseLM:
                                 }
                                 citations.append(citation_dict)
                             return citations
-
-                # Check for citations directly in the message (fallback)
-                if hasattr(message, "citations") and message.citations:
-                    citations_data = message.citations
-                    if isinstance(citations_data, list):
-                        citations = []
-                        for citation_data in citations_data:
-                            if hasattr(citation_data, "quote"):
-                                citation_dict = {
-                                    "text": citation_data.quote,
-                                    "source": getattr(citation_data, "source", None),
-                                    "start": getattr(citation_data, "start", None),
-                                    "end": getattr(citation_data, "end", None),
-                                }
-                            elif isinstance(citation_data, dict):
-                                citation_dict = {
-                                    "text": citation_data.get("quote", citation_data.get("text", "")),
-                                    "source": citation_data.get("source"),
-                                    "start": citation_data.get("start"),
-                                    "end": citation_data.get("end"),
-                                }
-                            else:
-                                continue
-                            citations.append(citation_dict)
-                        return citations
-
         except Exception:
             # If citation extraction fails, just continue without citations
             pass

--- a/tests/adapters/test_citation.py
+++ b/tests/adapters/test_citation.py
@@ -1,0 +1,225 @@
+from unittest.mock import MagicMock
+
+import dspy
+from dspy.adapters.types import Citations
+from dspy.signatures.signature import Signature
+
+
+class CitationSignature(Signature):
+    """Test signature with citations."""
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField()
+    citations: Citations = dspy.OutputField()
+
+
+def test_citation_type():
+    """Test the individual Citation type."""
+    citation = Citations.Citation(
+        text="The sky is blue",
+        source="Weather Guide",
+        start=10,
+        end=25
+    )
+
+    assert citation.text == "The sky is blue"
+    assert citation.source == "Weather Guide"
+    assert citation.start == 10
+    assert citation.end == 25
+
+    # Test formatting
+    formatted = citation.format()
+    assert '"The sky is blue"' in formatted
+    assert "Weather Guide" in formatted
+
+
+def test_citation_type_with_dict_source():
+    """Test Citation with dict source."""
+    citation = Citations.Citation(
+        text="The sky is blue",
+        source={"title": "Weather Guide", "url": "http://example.com"}
+    )
+
+    formatted = citation.format()
+    assert '"The sky is blue"' in formatted
+    assert "Weather Guide" in formatted
+    assert "http://example.com" in formatted
+
+
+def test_citations_container_type():
+    """Test the Citations container type."""
+    citations_data = [
+        {"text": "The sky is blue", "source": "Weather Guide"},
+        {"text": "Water boils at 100°C", "source": "Physics Book"}
+    ]
+
+    citations = Citations.from_dict_list(citations_data)
+
+    assert len(citations) == 2
+    assert citations[0].text == "The sky is blue"
+    assert citations[1].text == "Water boils at 100°C"
+
+    # Test iteration
+    citation_texts = [c.text for c in citations]
+    assert "The sky is blue" in citation_texts
+    assert "Water boils at 100°C" in citation_texts
+
+
+def test_citations_description():
+    """Test Citations description method."""
+    desc = Citations.description()
+    assert "citation" in desc.lower()
+    assert "source" in desc.lower()
+
+
+def test_citations_format():
+    """Test Citations format method."""
+    citations_data = [
+        {"text": "The sky is blue", "source": "Weather Guide", "start": 10, "end": 25}
+    ]
+    citations = Citations.from_dict_list(citations_data)
+
+    formatted = citations.format()
+    assert isinstance(formatted, list)
+    assert len(formatted) == 1
+    assert formatted[0]["text"] == "The sky is blue"
+    assert formatted[0]["source"] == "Weather Guide"
+
+
+def test_citations_validation():
+    """Test Citations validation with different input formats."""
+    # Test with from_dict_list
+    citations1 = Citations.from_dict_list([{"text": "Hello", "source": "World"}])
+    assert len(citations1) == 1
+
+    # Test direct construction with citations list
+    citations2 = Citations(citations=[Citations.Citation(text="Hello", source="World")])
+    assert len(citations2) == 1
+
+
+def test_citation_field_detection():
+    """Test that Citations fields are properly detected by adapter."""
+    from dspy.adapters.chat_adapter import ChatAdapter
+
+    adapter = ChatAdapter()
+
+    # Test citation field detection
+    citation_fields = adapter._get_citation_output_field_names(CitationSignature)
+    assert "citations" in citation_fields
+
+
+def test_citation_extraction_from_lm_response():
+    """Test citation extraction from mock LM response."""
+    from dspy.clients.base_lm import BaseLM
+
+    # Create a mock response with citations
+    mock_response = MagicMock()
+    mock_choice = MagicMock()
+    mock_message = MagicMock()
+
+    # Mock provider_specific_fields with citations (Anthropic format)
+    mock_message.provider_specific_fields = {
+        "citations": [
+            {
+                "quote": "The sky is blue",
+                "source": "Weather Guide",
+                "start": 10,
+                "end": 25
+            }
+        ]
+    }
+
+    mock_choice.message = mock_message
+    mock_response.choices = [mock_choice]
+
+    # Create BaseLM instance and test citation extraction
+    lm = BaseLM(model="test")
+    citations = lm._extract_citations_from_response(mock_response, mock_choice)
+
+    assert citations is not None
+    assert len(citations) == 1
+    assert citations[0]["text"] == "The sky is blue"
+    assert citations[0]["source"] == "Weather Guide"
+    assert citations[0]["start"] == 10
+    assert citations[0]["end"] == 25
+
+
+def test_citations_postprocessing():
+    """Test that citations are properly processed in adapter postprocessing."""
+    from dspy.adapters.chat_adapter import ChatAdapter
+
+    adapter = ChatAdapter()
+
+    # Mock outputs with citations - need valid parsed text in ChatAdapter format
+    outputs = [{
+        "text": "[[ ## answer ## ]]\nThe answer is blue.\n\n[[ ## citations ## ]]\n[]",
+        "citations": [
+            {
+                "text": "The sky is blue",
+                "source": "Weather Guide",
+                "start": 10,
+                "end": 25
+            }
+        ]
+    }]
+
+    # Process with citation signature
+    result = adapter._call_postprocess(
+        CitationSignature,
+        CitationSignature,
+        outputs
+    )
+
+    # Should have Citations object in the result
+    assert len(result) == 1
+    assert "citations" in result[0]
+    assert isinstance(result[0]["citations"], Citations)
+    assert len(result[0]["citations"]) == 1
+    assert result[0]["citations"][0].text == "The sky is blue"
+
+
+def test_citations_without_citations():
+    """Test that processing works when no citations are present."""
+    from dspy.adapters.chat_adapter import ChatAdapter
+
+    adapter = ChatAdapter()
+
+    # Mock outputs without citations
+    outputs = [{
+        "text": "[[ ## answer ## ]]\nThe answer is blue.\n\n[[ ## citations ## ]]\n[]"
+    }]
+
+    # Process with citation signature
+    result = adapter._call_postprocess(
+        CitationSignature,
+        CitationSignature,
+        outputs
+    )
+
+    # Should still work, with None for citations (since no citations in LM response)
+    assert len(result) == 1
+    # Note: When no citations are in LM response, citations field should be None
+    # but the field gets set to empty list from parsing. Let's verify it's empty.
+    assert result[0]["citations"] is None or (
+        isinstance(result[0]["citations"], Citations) and len(result[0]["citations"]) == 0
+    )
+
+
+def test_citation_imports():
+    """Test that Citations can be imported from main dspy module."""
+    assert hasattr(dspy, "Citations")
+    assert dspy.Citations is Citations
+
+    # Individual Citation should only be accessible via Citations.Citation
+    assert not hasattr(dspy, "Citation")
+
+
+def test_citation_access_pattern():
+    """Test that Citation class is accessible as Citations.Citation (like ToolCalls pattern)."""
+    # Test that we can create Citation objects via Citations.Citation
+    citation = Citations.Citation(text="Hello", source="World")
+    assert citation.text == "Hello"
+    assert citation.source == "World"
+
+    # Test that Citations.Citation is the correct class
+    assert hasattr(Citations, "Citation")
+    assert isinstance(citation, Citations.Citation)

--- a/tests/adapters/test_document.py
+++ b/tests/adapters/test_document.py
@@ -1,0 +1,55 @@
+import pydantic
+import pytest
+
+import dspy
+
+
+def test_document_validate_input():
+    # Create a `dspy.Document` instance with valid data.
+    doc = dspy.Document(data="The Earth orbits the Sun.")
+    assert doc.data == "The Earth orbits the Sun."
+
+    with pytest.raises(pydantic.ValidationError):
+        # Try to create a `dspy.Document` instance with invalid type.
+        dspy.Document(data=123)
+
+
+def test_document_in_nested_type():
+    class Wrapper(pydantic.BaseModel):
+        document: dspy.Document
+
+    doc = dspy.Document(data="Hello, world!")
+    wrapper = Wrapper(document=doc)
+    assert wrapper.document.data == "Hello, world!"
+
+
+def test_document_with_all_fields():
+    doc = dspy.Document(
+        data="Water boils at 100°C at standard pressure.",
+        title="Physics Facts",
+        media_type="application/pdf",
+        metadata={"author": "Dr. Smith", "year": 2023},
+        context="Laboratory conditions"
+    )
+    assert doc.data == "Water boils at 100°C at standard pressure."
+    assert doc.title == "Physics Facts"
+    assert doc.media_type == "application/pdf"
+    assert doc.metadata == {"author": "Dr. Smith", "year": 2023}
+    assert doc.context == "Laboratory conditions"
+
+
+def test_document_format():
+    doc = dspy.Document(
+        data="The sky is blue.",
+        title="Color Facts",
+        media_type="text/plain"
+    )
+    
+    formatted = doc.format()
+    
+    assert formatted["type"] == "document"
+    assert formatted["source"]["type"] == "text"
+    assert formatted["source"]["media_type"] == "text/plain"
+    assert formatted["source"]["data"] == "The sky is blue."
+    assert formatted["title"] == "Color Facts"
+    assert formatted["citations"]["enabled"] is True

--- a/tests/adapters/test_document.py
+++ b/tests/adapters/test_document.py
@@ -44,9 +44,9 @@ def test_document_format():
         title="Color Facts",
         media_type="text/plain"
     )
-    
+
     formatted = doc.format()
-    
+
     assert formatted["type"] == "document"
     assert formatted["source"]["type"] == "text"
     assert formatted["source"]["media_type"] == "text/plain"


### PR DESCRIPTION
Add support for Anthropic Citation API through new types (dspy.Document, dspy.Citation)

Example
```python
import dspy
from dspy.signatures import Signature

class AnswerWithSources(Signature):
    '''Answer questions using provided documents with citations.'''
    documents: list[dspy.Document] = dspy.InputField()
    question: str = dspy.InputField()
    answer: str = dspy.OutputField()
    citations: dspy.Citations = dspy.OutputField()

# Create documents to provide as sources
docs = [
    dspy.Document(
        content="The Earth orbits the Sun in an elliptical path.",
        title="Basic Astronomy Facts"
    ),
    dspy.Document(
        content="Water boils at 100°C at standard atmospheric pressure.",
        title="Physics Fundamentals",
        metadata={"author": "Dr. Smith", "year": 2023}
    )
]

# Use with a model that supports citations like Claude
lm = dspy.LM("anthropic/claude-3-5-sonnet-20241022")
predictor = dspy.Predict(AnswerWithSources, lm=lm)
result = predictor(documents=docs, question="What temperature does water boil?")

for citation in result.citations.citations:
    print(citation.format())
```

References
- https://docs.anthropic.com/en/docs/build-with-claude/citations
- https://docs.litellm.ai/docs/providers/anthropic#beta-citations-api