### PR TITLE
Support both dict and object for _process_response

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -191,15 +191,31 @@ class BaseLM:
         Returns:
             List of processed outputs
         """
+        def _to_dict(obj):
+            """Convert object-like values into plain dicts when possible."""
+            if obj is None:
+                return None
+            if isinstance(obj, dict):
+                return obj
+            if hasattr(obj, "model_dump"):
+                return obj.model_dump()
+            if hasattr(obj, "__dict__") and not isinstance(obj, dict):
+                return {k: v for k, v in obj.__dict__.items() if not k.startswith("_")}
+            return obj
+
         outputs = []
         tool_calls = []
         for output_item in response.output:
-            if output_item.type == "message":
-                for content_item in output_item.content:
-                    outputs.append(content_item.text)
-            elif output_item.type == "function_call":
-                tool_calls.append(output_item.model_dump())
-
+            output_dict = _to_dict(output_item)
+            item_type = output_dict.get("type")
+            if item_type == "message":
+                content = output_dict.get("content", [])
+                for content_item in content:
+                    content_dict = _to_dict(content_item)
+                    text = content_dict.get("text")
+                    outputs.append(text)
+            elif item_type == "function_call":
+                tool_calls.append(output_dict)
         if tool_calls:
             outputs.append({"tool_calls": tool_calls})
         return outputs


### PR DESCRIPTION
With @TomeHirata 's #8692 that adds support for ResponseAPI, we can already actually use OpenAI's native tools like web_search or interpreter by initiating dspy.LM as the following:
```
        lm = LM(
            'openai/gpt-5',
            max_tokens=100_000,
            temperature=1.0,
            api_key=os.getenv("OPENAI_API_KEY"),
            model_type="responses",
            cache=False,
            text={
                "verbosity": "low"
            },
            tools=[{"type": "web_search_preview"}, {"type": "code_interpreter", "container": {"type": "auto"}}],
        )

        dspy.configure(lm=lm)
```

However, the current version of dspy would always fail, saying the response doesn't have the property `type`.

Upon debugging further, I found out that this is because base_lm undergoes litellm's wrapper function that [transform each item in output as object](https://github.com/BerriAI/litellm/blob/f01c7d13e7400b267f70ecae69d7ec64c0f9db19/litellm/completion_extras/litellm_responses_transformation/transformation.py#L243). However they haven't added support for web_search_call or interpreter yet, therefore returning a simple dictionary. This causes the dspy to fail despite having the capability to return results.

This pull request refactors the `_process_response` method in `dspy/clients/base_lm.py` to add dict support so that dspy does not have to wait for litellm to add support for those objects.