### PR TITLE
support usage tracking with response api to _merge_usage_entries

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -29,7 +29,9 @@ class UsageTracker:
             result["prompt_tokens_details"] = dict(prompt_tokens_details)
         return result
 
-    def _merge_usage_entries(self, usage_entry1: dict[str, Any] | None, usage_entry2: dict[str, Any] | None) -> dict[str, Any]:
+    def _merge_usage_entries(
+        self, usage_entry1: dict[str, Any] | None, usage_entry2: dict[str, Any] | None
+    ) -> dict[str, Any]:
         if usage_entry1 is None or len(usage_entry1) == 0:
             return dict(usage_entry2)
         if usage_entry2 is None or len(usage_entry2) == 0:
@@ -40,6 +42,8 @@ class UsageTracker:
             current_v = result.get(k)
             if isinstance(v, dict) or isinstance(current_v, dict):
                 result[k] = self._merge_usage_entries(current_v, v)
+            elif hasattr(v, "__dict__") or hasattr(current_v, "__dict__"):
+                result[k] = self._merge_usage_entries(dict(current_v), dict(v))
             else:
                 result[k] = (current_v or 0) + (v or 0)
         return result


### PR DESCRIPTION
With response API you get additional usage token information in the form of litellm's InputTokenDetails and OutputTokenDetails.

Because these are objects the current _merge_usage_entries cannot handle them and thus cause the entire request to fail.
This PR fixes that.

This pull request improves the aggregation logic for usage tracking and adds comprehensive tests to ensure correct merging of token usage details, including handling of custom objects and `None` values.

### Improvements to usage aggregation logic

* Enhanced the `_merge_usage_entries` method in `dspy/utils/usage_tracker.py` to correctly merge usage entries when values are custom objects (with a `__dict__`), ensuring that details from types like `InputTokensDetails` and `OutputTokensDetails` are properly aggregated.
* Updated the method signature for `_merge_usage_entries` for better readability and consistency.

### Expanded test coverage

* Added new tests in `tests/utils/test_usage_tracker.py` to verify that input and output token details are accurately aggregated across multiple usage entries, including cases with missing or `None` values.
* Included imports for `InputTokensDetails` and `OutputTokensDetails` from `litellm.types.llms.openai` to support new test scenarios.