### PR TITLE
Fix GEPA usage tracking with tuple outputs

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -78,14 +78,15 @@ class Module(BaseModule, metaclass=ProgramMeta):
                 # module.forward to return a tuple: (prediction, trace).
                 # When usage tracking is enabled, ensure we attach usage to the
                 # prediction object if present.
-                target = None
-                if hasattr(output, "set_lm_usage"):
-                    target = output
-                elif isinstance(output, tuple) and len(output) > 0 and hasattr(output[0], "set_lm_usage"):
-                    target = output[0]
+                prediction_in_output = None
+                if isinstance(output, Prediction):
+                    prediction_in_output = output
+                elif isinstance(output, tuple) and len(output) > 0 and isinstance(output[0], Prediction):
+                    prediction_in_output = output[0]
+                if not prediction_in_output:
+                    raise ValueError("No prediction object found in output to call set_lm_usage on.")
 
-                if target:
-                    target.set_lm_usage(tokens)
+                prediction_in_output.set_lm_usage(tokens)
                 return output
 
             return self.forward(*args, **kwargs)

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -1,4 +1,6 @@
 import json
+import threading
+from typing import Any
 
 import pytest
 
@@ -16,6 +18,7 @@ class SimpleModule(dspy.Module):
     def forward(self, **kwargs):
         return self.predictor(**kwargs)
 
+
 class DictDummyLM(dspy.clients.lm.LM):
     def __init__(self, history):
         super().__init__("dummy", "chat", 0.0, 1000, True)
@@ -28,6 +31,7 @@ class DictDummyLM(dspy.clients.lm.LM):
         m = self.history[hash(repr(messages))]
         return m["outputs"]
 
+
 def simple_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
     return dspy.Prediction(score=example.output == prediction.output, feedback="Wrong answer.")
 
@@ -35,10 +39,10 @@ def simple_metric(example, prediction, trace=None, pred_name=None, pred_trace=No
 def bad_metric(example, prediction):
     return 0.0
 
+
 def test_basic_workflow():
     """Test to ensure the basic compile flow runs without errors."""
     student = SimpleModule("input -> output")
-    teacher = SimpleModule("input -> output")
 
     with open("tests/teleprompt/gepa_dummy_lm.json") as f:
         data = json.load(f)
@@ -48,21 +52,76 @@ def test_basic_workflow():
     lm_main = DictDummyLM(lm_history)
     dspy.settings.configure(lm=lm_main)
     reflection_lm = DictDummyLM(reflection_lm_history)
-    optimizer = dspy.GEPA(
-        metric=simple_metric,
-        reflection_lm=reflection_lm,
-        max_metric_calls=5
-    )
+    optimizer = dspy.GEPA(metric=simple_metric, reflection_lm=reflection_lm, max_metric_calls=5)
     trainset = [
         Example(input="What is the color of the sky?", output="blue").with_inputs("input"),
         Example(input="What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!").with_inputs("input"),
     ]
     o = optimizer.compile(student, trainset=trainset, valset=trainset)
-    assert o.predictor.signature.instructions == 'Given the field `input` containing a question or phrase, produce the field `output` containing the exact, direct, and contextually appropriate answer or response that the user expects, without additional explanations, commentary, or general knowledge unless explicitly requested.\n\nKey details and guidelines:\n\n1. The `input` field contains a question or phrase that may be literal, factual, or culturally specific (e.g., references to popular culture or memes).\n\n2. The `output` must be the precise answer or response that directly addresses the `input` as intended by the user, not a general or encyclopedic explanation.\n\n3. If the `input` is a well-known phrase or question from popular culture (e.g., "What does the fox say?"), the `output` should reflect the expected or canonical answer associated with that phrase, rather than a factual or scientific explanation.\n\n4. Avoid providing additional background information, scientific explanations, or alternative interpretations unless explicitly requested.\n\n5. The goal is to produce the answer that the user expects or the "correct" answer in the context of the question, including culturally recognized or meme-based answers.\n\n6. If the `input` is a straightforward factual question (e.g., "What is the color of the sky?"), provide the commonly accepted direct answer (e.g., "Blue") rather than a detailed scientific explanation.\n\n7. The output should be concise, clear, and focused solely on answering the question or phrase in the `input`.\n\nExample:\n\n- Input: "What is the color of the sky?"\n- Output: "Blue."\n\n- Input: "What does the fox say?"\n- Output: "Ring-ding-ding-ding-dingeringeding!"\n\nThis approach ensures that the assistant provides the expected, contextually appropriate answers rather than general or overly detailed responses that may be considered incorrect by the user.'
-
+    assert (
+        o.predictor.signature.instructions
+        == 'Given the field `input` containing a question or phrase, produce the field `output` containing the exact, direct, and contextually appropriate answer or response that the user expects, without additional explanations, commentary, or general knowledge unless explicitly requested.\n\nKey details and guidelines:\n\n1. The `input` field contains a question or phrase that may be literal, factual, or culturally specific (e.g., references to popular culture or memes).\n\n2. The `output` must be the precise answer or response that directly addresses the `input` as intended by the user, not a general or encyclopedic explanation.\n\n3. If the `input` is a well-known phrase or question from popular culture (e.g., "What does the fox say?"), the `output` should reflect the expected or canonical answer associated with that phrase, rather than a factual or scientific explanation.\n\n4. Avoid providing additional background information, scientific explanations, or alternative interpretations unless explicitly requested.\n\n5. The goal is to produce the answer that the user expects or the "correct" answer in the context of the question, including culturally recognized or meme-based answers.\n\n6. If the `input` is a straightforward factual question (e.g., "What is the color of the sky?"), provide the commonly accepted direct answer (e.g., "Blue") rather than a detailed scientific explanation.\n\n7. The output should be concise, clear, and focused solely on answering the question or phrase in the `input`.\n\nExample:\n\n- Input: "What is the color of the sky?"\n- Output: "Blue."\n\n- Input: "What does the fox say?"\n- Output: "Ring-ding-ding-ding-dingeringeding!"\n\nThis approach ensures that the assistant provides the expected, contextually appropriate answers rather than general or overly detailed responses that may be considered incorrect by the user.'
+    )
 
 
 def test_metric_requires_feedback_signature():
     reflection_lm = DictDummyLM([])
     with pytest.raises(TypeError):
         dspy.GEPA(metric=bad_metric, reflection_lm=reflection_lm, max_metric_calls=1)
+
+
+def test_gepa_compile_with_track_usage_no_tuple_error(caplog):
+    """Regression: GEPA.compile should complete quickly and not log tuple-usage error
+    when track_usage=True. Prior to the fix, compile would hang and/or log
+    "'tuple' object has no attribute 'set_lm_usage'" repeatedly.
+    """
+    with open("tests/teleprompt/gepa_dummy_lm.json") as f:
+        data = json.load(f)
+    lm_history = data["lm"]
+    reflection_lm_history = data["reflection_lm"]
+
+    lm_main = DictDummyLM(lm_history)
+    reflection_lm = DictDummyLM(reflection_lm_history)
+
+    dspy.settings.configure(lm=lm_main, track_usage=True)
+
+    student = SimpleModule("input -> output")
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=reflection_lm,
+        max_metric_calls=3,
+    )
+
+    trainset = [
+        Example(input="What is the color of the sky?", output="blue").with_inputs("input"),
+        Example(input="What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!").with_inputs("input"),
+    ]
+
+    compiled_container: dict[str, Any] = {}
+    exc_container: dict[str, BaseException] = {}
+
+    def run_compile():
+        try:
+            compiled_container["prog"] = optimizer.compile(student, trainset=trainset, valset=trainset)
+        except BaseException as e:
+            exc_container["e"] = e
+
+    t = threading.Thread(target=run_compile, daemon=True)
+    t.start()
+    t.join(timeout=5.0)
+
+    # Assert compile did not hang (pre-fix behavior would time out here)
+    assert not t.is_alive(), "GEPA.compile did not complete within timeout (likely pre-fix behavior)."
+
+    # Assert no tuple-usage error is logged anymore
+    assert "'tuple' object has no attribute 'set_lm_usage'" not in caplog.text
+
+    # If any exception occurred, fail explicitly
+    if "e" in exc_container:
+        pytest.fail(f"GEPA.compile raised unexpectedly: {exc_container['e']}")
+
+    # Basic sanity: compiled program should be callable if present
+    if "prog" in compiled_container:
+        _ = compiled_container["prog"].predictor(input="What is the color of the sky?")
+    else:
+        pytest.fail("GEPA.compile did not complete within timeout (likely pre-fix behavior).")

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -19,7 +19,6 @@ class SimpleModule(dspy.Module):
     def forward(self, **kwargs):
         return self.predictor(**kwargs)
 
-
 class DictDummyLM(dspy.clients.lm.LM):
     def __init__(self, history):
         super().__init__("dummy", "chat", 0.0, 1000, True)
@@ -32,7 +31,6 @@ class DictDummyLM(dspy.clients.lm.LM):
         m = self.history[hash(repr(messages))]
         return m["outputs"]
 
-
 def simple_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
     return dspy.Prediction(score=example.output == prediction.output, feedback="Wrong answer.")
 
@@ -40,10 +38,10 @@ def simple_metric(example, prediction, trace=None, pred_name=None, pred_trace=No
 def bad_metric(example, prediction):
     return 0.0
 
-
 def test_basic_workflow():
     """Test to ensure the basic compile flow runs without errors."""
     student = SimpleModule("input -> output")
+    teacher = SimpleModule("input -> output")
 
     with open("tests/teleprompt/gepa_dummy_lm.json") as f:
         data = json.load(f)
@@ -53,16 +51,18 @@ def test_basic_workflow():
     lm_main = DictDummyLM(lm_history)
     dspy.settings.configure(lm=lm_main)
     reflection_lm = DictDummyLM(reflection_lm_history)
-    optimizer = dspy.GEPA(metric=simple_metric, reflection_lm=reflection_lm, max_metric_calls=5)
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=reflection_lm,
+        max_metric_calls=5
+    )
     trainset = [
         Example(input="What is the color of the sky?", output="blue").with_inputs("input"),
         Example(input="What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!").with_inputs("input"),
     ]
     o = optimizer.compile(student, trainset=trainset, valset=trainset)
-    assert (
-        o.predictor.signature.instructions
-        == 'Given the field `input` containing a question or phrase, produce the field `output` containing the exact, direct, and contextually appropriate answer or response that the user expects, without additional explanations, commentary, or general knowledge unless explicitly requested.\n\nKey details and guidelines:\n\n1. The `input` field contains a question or phrase that may be literal, factual, or culturally specific (e.g., references to popular culture or memes).\n\n2. The `output` must be the precise answer or response that directly addresses the `input` as intended by the user, not a general or encyclopedic explanation.\n\n3. If the `input` is a well-known phrase or question from popular culture (e.g., "What does the fox say?"), the `output` should reflect the expected or canonical answer associated with that phrase, rather than a factual or scientific explanation.\n\n4. Avoid providing additional background information, scientific explanations, or alternative interpretations unless explicitly requested.\n\n5. The goal is to produce the answer that the user expects or the "correct" answer in the context of the question, including culturally recognized or meme-based answers.\n\n6. If the `input` is a straightforward factual question (e.g., "What is the color of the sky?"), provide the commonly accepted direct answer (e.g., "Blue") rather than a detailed scientific explanation.\n\n7. The output should be concise, clear, and focused solely on answering the question or phrase in the `input`.\n\nExample:\n\n- Input: "What is the color of the sky?"\n- Output: "Blue."\n\n- Input: "What does the fox say?"\n- Output: "Ring-ding-ding-ding-dingeringeding!"\n\nThis approach ensures that the assistant provides the expected, contextually appropriate answers rather than general or overly detailed responses that may be considered incorrect by the user.'
-    )
+    assert o.predictor.signature.instructions == 'Given the field `input` containing a question or phrase, produce the field `output` containing the exact, direct, and contextually appropriate answer or response that the user expects, without additional explanations, commentary, or general knowledge unless explicitly requested.\n\nKey details and guidelines:\n\n1. The `input` field contains a question or phrase that may be literal, factual, or culturally specific (e.g., references to popular culture or memes).\n\n2. The `output` must be the precise answer or response that directly addresses the `input` as intended by the user, not a general or encyclopedic explanation.\n\n3. If the `input` is a well-known phrase or question from popular culture (e.g., "What does the fox say?"), the `output` should reflect the expected or canonical answer associated with that phrase, rather than a factual or scientific explanation.\n\n4. Avoid providing additional background information, scientific explanations, or alternative interpretations unless explicitly requested.\n\n5. The goal is to produce the answer that the user expects or the "correct" answer in the context of the question, including culturally recognized or meme-based answers.\n\n6. If the `input` is a straightforward factual question (e.g., "What is the color of the sky?"), provide the commonly accepted direct answer (e.g., "Blue") rather than a detailed scientific explanation.\n\n7. The output should be concise, clear, and focused solely on answering the question or phrase in the `input`.\n\nExample:\n\n- Input: "What is the color of the sky?"\n- Output: "Blue."\n\n- Input: "What does the fox say?"\n- Output: "Ring-ding-ding-ding-dingeringeding!"\n\nThis approach ensures that the assistant provides the expected, contextually appropriate answers rather than general or overly detailed responses that may be considered incorrect by the user.'
+
 
 
 def test_metric_requires_feedback_signature():


### PR DESCRIPTION
## Summary

Fixes #8738 - Resolves AttributeError when using GEPA optimizer with `track_usage=True`.

## Problem

GEPA's bootstrap tracing patches `module.forward` to return tuples `(prediction, trace)`, but the usage tracking code in `Module.__call__` expected only prediction objects, causing:

```
AttributeError: 'tuple' object has no attribute 'set_lm_usage'
```

## Solution (well at least a change that works)

Enhanced `Module` to safely handle both prediction objects and tuples:

- **Before**: `output.set_lm_usage(tokens)` (fails with tuples)
- **After**: Detects which part of the output is of type `Prediction` and extracts the object safely

**Key changes:**
1. **`dspy/primitives/module.py`**: Added tuple-safe usage tracking logic
2. **`tests/teleprompt/test_gepa.py`**: Added regression test with timeout protection

**Regarding test and timeout:**
1. The timeout issue is base on the fact that in the case of the error the optimizer stays in an endless loop
2. I did not manage to set up properties like`max_metric_calls` or `reflection_minibatch_size` for this to not loop endlessly 🤷 

## Testing

- ✅ **Regression test**: `test_gepa_compile_with_track_usage_no_tuple_error` 
- ✅ **All GEPA tests pass**: 3/3 tests in `test_gepa.py`
- ✅ **All tests pass**: 440 passed
- ✅ **Code quality**: Ruff formatting applied (to new code)

## Verification

The fix ensures GEPA works correctly with usage tracking enabled while maintaining compatibility.