### PR TITLE
Add rollout_id to bypass cache in MIPRO

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -61,6 +61,9 @@ class LM(BaseLM):
             provider: The provider to use. If not specified, the provider will be inferred from the model.
             finetuning_model: The model to finetune. In some providers, the models available for finetuning is different
                 from the models available for inference.
+            rollout_id: Optional integer that, when changed, forces a cache miss without
+                affecting the underlying LLM request. This value is excluded from the
+                payload sent to the provider.
         """
         # Remember to update LM.copy() if you modify the constructor!
         self.model = model
@@ -313,6 +316,10 @@ def _get_stream_completion_fn(
 
 def litellm_completion(request: dict[str, Any], num_retries: int, cache: dict[str, Any] | None = None):
     cache = cache or {"no-cache": True, "no-store": True}
+    # Copy to avoid mutating the caller's request
+    request = dict(request)
+    # rollout_id is only used for caching and should not be forwarded to the provider
+    request.pop("rollout_id", None)
     stream_completion = _get_stream_completion_fn(request, cache, sync=True)
     if stream_completion is None:
         return litellm.completion(
@@ -327,6 +334,10 @@ def litellm_completion(request: dict[str, Any], num_retries: int, cache: dict[st
 
 def litellm_text_completion(request: dict[str, Any], num_retries: int, cache: dict[str, Any] | None = None):
     cache = cache or {"no-cache": True, "no-store": True}
+    # Copy to avoid mutating the caller's request
+    request = dict(request)
+    # rollout_id is only used for caching and should not be forwarded to the provider
+    request.pop("rollout_id", None)
     # Extract the provider and model from the model string.
     # TODO: Not all the models are in the format of "provider/model"
     model = request.pop("model").split("/", 1)
@@ -353,6 +364,10 @@ def litellm_text_completion(request: dict[str, Any], num_retries: int, cache: di
 
 async def alitellm_completion(request: dict[str, Any], num_retries: int, cache: dict[str, Any] | None = None):
     cache = cache or {"no-cache": True, "no-store": True}
+    # Copy to avoid mutating the caller's request
+    request = dict(request)
+    # rollout_id is only used for caching and should not be forwarded to the provider
+    request.pop("rollout_id", None)
     stream_completion = _get_stream_completion_fn(request, cache, sync=False)
     if stream_completion is None:
         return await litellm.acompletion(
@@ -367,6 +382,10 @@ async def alitellm_completion(request: dict[str, Any], num_retries: int, cache: 
 
 async def alitellm_text_completion(request: dict[str, Any], num_retries: int, cache: dict[str, Any] | None = None):
     cache = cache or {"no-cache": True, "no-store": True}
+    # Copy to avoid mutating the caller's request
+    request = dict(request)
+    # rollout_id is only used for caching and should not be forwarded to the provider
+    request.pop("rollout_id", None)
     model = request.pop("model").split("/", 1)
     provider, model = model[0] if len(model) > 1 else "openai", model[-1]
 
@@ -390,6 +409,10 @@ async def alitellm_text_completion(request: dict[str, Any], num_retries: int, ca
 
 def litellm_responses_completion(request: dict[str, Any], num_retries: int, cache: dict[str, Any] | None = None):
     cache = cache or {"no-cache": True, "no-store": True}
+    # Copy to avoid mutating the caller's request
+    request = dict(request)
+    # rollout_id is only used for caching and should not be forwarded to the provider
+    request.pop("rollout_id", None)
     request = _convert_chat_request_to_responses_request(request)
 
     return litellm.responses(
@@ -402,6 +425,10 @@ def litellm_responses_completion(request: dict[str, Any], num_retries: int, cach
 
 async def alitellm_responses_completion(request: dict[str, Any], num_retries: int, cache: dict[str, Any] | None = None):
     cache = cache or {"no-cache": True, "no-store": True}
+    # Copy to avoid mutating the caller's request
+    request = dict(request)
+    # rollout_id is only used for caching and should not be forwarded to the provider
+    request.pop("rollout_id", None)
     request = _convert_chat_request_to_responses_request(request)
 
     return await litellm.aresponses(

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -61,9 +61,10 @@ class LM(BaseLM):
             provider: The provider to use. If not specified, the provider will be inferred from the model.
             finetuning_model: The model to finetune. In some providers, the models available for finetuning is different
                 from the models available for inference.
-            rollout_id: Optional integer that, when changed, forces a cache miss without
-                affecting the underlying LLM request. This value is excluded from the
-                payload sent to the provider.
+            rollout_id: Optional integer incorporated into the cache key so that calls
+                with different values are cached separately without changing the
+                request sent to the provider. This value is excluded from the payload
+                sent to the provider.
         """
         # Remember to update LM.copy() if you modify the constructor!
         self.model = model

--- a/tests/clients/test_litellm_cache.py
+++ b/tests/clients/test_litellm_cache.py
@@ -58,6 +58,21 @@ def test_lm_calls_are_cached_across_lm_instances(litellm_test_server, temporary_
     assert len(request_logs) == 3
 
 
+def test_rollout_id_affects_cache_key(litellm_test_server, temporary_blank_cache_dir):
+    api_base, server_log_file_path = litellm_test_server
+
+    lm = dspy.LM(
+        model="openai/dspy-test-model",
+        api_base=api_base,
+        api_key="fakekey",
+    )
+    lm("Example query", rollout_id=1)
+    lm("Example query", rollout_id=2)
+
+    request_logs = read_litellm_test_server_request_logs(server_log_file_path)
+    assert len(request_logs) == 2
+
+
 def test_lm_calls_are_cached_in_memory_when_expected(litellm_test_server, temporary_blank_cache_dir):
     api_base, server_log_file_path = litellm_test_server
 

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -200,6 +200,14 @@ def test_retry_number_set_correctly():
     assert mock_completion.call_args.kwargs["num_retries"] == 3
 
 
+def test_rollout_id_not_forwarded():
+    lm = dspy.LM("fakemodel/fake")
+    with mock.patch("litellm.completion") as mock_completion:
+        lm("Example query", rollout_id=123)
+
+    assert "rollout_id" not in mock_completion.call_args.kwargs
+
+
 def test_retry_made_on_system_errors():
     retry_tracking = [0]  # Using a list to track retries
 


### PR DESCRIPTION
## Summary
- allow passing rollout_id to dspy.LM to force cache misses without altering provider request
- update MIPRO's GroundedProposer to supply rollout_id via `config` instead of mutating LM parameters
- clarify request-copying logic so rollout_id never reaches the provider

## Testing
- `pytest tests/clients/test_lm.py::test_rollout_id_not_forwarded -q`
- `pytest tests/clients/test_litellm_cache.py::test_rollout_id_affects_cache_key -q` *(fails: Missing dependency No module named 'fastapi')*
- `pre-commit run --files dspy/clients/lm.py dspy/propose/grounded_proposer.py tests/clients/test_litellm_cache.py tests/clients/test_lm.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f668356c8329ad78d7f370abb560