### PR TITLE
Use rollout_id to bypass LM cache

### DIFF
--- a/docs/docs/cheatsheet.md
+++ b/docs/docs/cheatsheet.md
@@ -463,7 +463,7 @@ dspy.configure_cache(
 
 ### BestofN
 
-Runs a module up to `N` times with different temperatures and returns the best prediction, as defined by the `reward_fn`, or the first prediction that passes the `threshold`.
+Runs a module up to `N` times with different rollout IDs (bypassing cache) and returns the best prediction, as defined by the `reward_fn`, or the first prediction that passes the `threshold`.
 
 ```python
 import dspy
@@ -478,7 +478,7 @@ best_of_3(question="What is the capital of Belgium?").answer
 
 ### Refine
 
-Refines a module by running it up to `N` times with different temperatures and returns the best prediction, as defined by the `reward_fn`, or the first prediction that passes the `threshold`. After each attempt (except the final one), `Refine` automatically generates detailed feedback about the module's performance and uses this feedback as hints for subsequent runs, creating an iterative refinement process.
+Refines a module by running it up to `N` times with different rollout IDs (bypassing cache) and returns the best prediction, as defined by the `reward_fn`, or the first prediction that passes the `threshold`. After each attempt (except the final one), `Refine` automatically generates detailed feedback about the module's performance and uses this feedback as hints for subsequent runs, creating an iterative refinement process.
 
 ```python
 import dspy

--- a/docs/docs/learn/programming/language_models.md
+++ b/docs/docs/learn/programming/language_models.md
@@ -166,6 +166,14 @@ gpt_4o_mini = dspy.LM('openai/gpt-4o-mini', temperature=0.9, max_tokens=3000, st
 
 By default LMs in DSPy are cached. If you repeat the same call, you will get the same outputs. But you can turn off caching by setting `cache=False`.
 
+If you want to keep caching enabled but force a new request (for example, to obtain diverse outputs),
+pass a unique `rollout_id` in your call. Different values ensure a different cache entry while
+still caching future calls with the same inputs and `rollout_id`.
+
+```python linenums="1"
+lm("Say this is a test!", rollout_id=1)
+```
+
 
 ## Inspecting output and usage metadata.
 

--- a/docs/docs/tutorials/output_refinement/best-of-n-and-refine.md
+++ b/docs/docs/tutorials/output_refinement/best-of-n-and-refine.md
@@ -1,14 +1,14 @@
 # Output Refinement: BestOfN and Refine
 
-Both `BestOfN` and `Refine` are DSPy modules designed to improve the reliability and quality of predictions by making multiple `LM` calls with different parameter settings. Both modules stop when they have reached `N` attempts or when the `reward_fn` returns an award above the `threshold`.
+Both `BestOfN` and `Refine` are DSPy modules designed to improve the reliability and quality of predictions by making multiple `LM` calls with different rollout IDs to bypass caching. Both modules stop when they have reached `N` attempts or when the `reward_fn` returns an award above the `threshold`.
 
 ## BestOfN
 
-`BestOfN` is a module that runs the provided module multiple times (up to `N`) with different temperature settings. It returns either the first prediction that passes a specified threshold or the one with the highest reward if none meets the threshold.
+`BestOfN` is a module that runs the provided module multiple times (up to `N`) with different rollout IDs. It returns either the first prediction that passes a specified threshold or the one with the highest reward if none meets the threshold.
 
 ### Basic Usage
 
-Lets say we wanted to have the best chance of getting a one word answer from the model. We could use `BestOfN` to try multiple temperature settings and return the best result.
+Lets say we wanted to have the best chance of getting a one word answer from the model. We could use `BestOfN` to try multiple rollout IDs and return the best result.
 
 ```python
 import dspy
@@ -86,7 +86,7 @@ refine = dspy.Refine(
 
 Both modules serve similar purposes but differ in their approach:
 
-- `BestOfN` simply tries different temperature settings and selects the best resulting prediction as defined by the `reward_fn`.
+- `BestOfN` simply tries different rollout IDs and selects the best resulting prediction as defined by the `reward_fn`.
 - `Refine` adds an feedback loop, using the lm to generate a detailed feedback about the module's own performance using the previous prediction and the code in the `reward_fn`. This feedback is then used as hints for subsequent runs.
 
 ## Practical Examples

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -110,7 +110,12 @@ class BaseLM:
         raise NotImplementedError("Subclasses must implement this method.")
 
     def copy(self, **kwargs):
-        """Returns a copy of the language model with possibly updated parameters."""
+        """Returns a copy of the language model with possibly updated parameters.
+
+        Any provided keyword arguments update the corresponding attributes or LM kwargs of
+        the copy. For example, ``lm.copy(rollout_id=1)`` returns an LM whose requests use a
+        different rollout ID to bypass cache collisions.
+        """
 
         import copy
 
@@ -121,7 +126,10 @@ class BaseLM:
             if hasattr(self, key):
                 setattr(new_instance, key, value)
             if (key in self.kwargs) or (not hasattr(self, key)):
-                new_instance.kwargs[key] = value
+                if value is None:
+                    new_instance.kwargs.pop(key, None)
+                else:
+                    new_instance.kwargs[key] = value
 
         return new_instance
 

--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -48,9 +48,9 @@ class Refine(Module):
         fail_count: int | None = None,
     ):
         """
-        Refines a module by running it up to N times with different temperatures and returns the best prediction.
+        Refines a module by running it up to N times with different rollout IDs and returns the best prediction.
 
-        This module runs the provided module multiple times with varying temperature settings and selects
+        This module runs the provided module multiple times with varying rollout identifiers and selects
         either the first prediction that exceeds the specified threshold or the one with the highest reward.
         If no prediction meets the threshold, it automatically generates feedback to improve future predictions.
 
@@ -96,14 +96,16 @@ class Refine(Module):
 
     def forward(self, **kwargs):
         lm = self.module.get_lm() or dspy.settings.lm
-        temps = [lm.kwargs["temperature"]] + [0.5 + i * (0.5 / self.N) for i in range(self.N)]
-        temps = list(dict.fromkeys(temps))[: self.N]
+        base_rollout = lm.kwargs.get("rollout_id")
+        start = 0 if base_rollout is None else base_rollout
+        rollout_ids = [start + i for i in range(self.N)]
+        rollout_ids = list(dict.fromkeys(rollout_ids))[: self.N]
         best_pred, best_trace, best_reward = None, None, -float("inf")
         advice = None
         adapter = dspy.settings.adapter or dspy.ChatAdapter()
 
-        for idx, t in enumerate(temps):
-            lm_ = lm.copy(temperature=t)
+        for idx, rid in enumerate(rollout_ids):
+            lm_ = lm.copy(rollout_id=rid)
             mod = self.module.deepcopy()
             mod.set_lm(lm_)
 
@@ -167,7 +169,7 @@ class Refine(Module):
                 # print(f"Advice for each module: {advice}")
 
             except Exception as e:
-                print(f"Refine: Attempt failed with temperature {t}: {e}")
+                print(f"Refine: Attempt failed with rollout id {rid}: {e}")
                 if idx > self.fail_count:
                     raise e
                 self.fail_count -= 1

--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -330,7 +330,6 @@ class GroundedProposer(Proposer):
         demo_candidates,
         trial_logs,
         N, # noqa: N803
-        T, # noqa: N803
     ) -> list[str]:
         """This method is responsible for returning the full set of new instructions for our program, given the specified criteria."""
 
@@ -375,7 +374,6 @@ class GroundedProposer(Proposer):
                         program=program,
                         predictor=predictor,
                         pred_i=pred_i,
-                        T=T,
                         demo_candidates=demo_candidates,
                         demo_set_i=demo_set_i,
                         trial_logs=trial_logs,
@@ -390,7 +388,6 @@ class GroundedProposer(Proposer):
         program,
         predictor,
         pred_i,
-        T, # noqa: N803
         demo_candidates,
         demo_set_i,
         trial_logs,
@@ -414,14 +411,10 @@ class GroundedProposer(Proposer):
             verbose=self.verbose
         )
 
-        # Generate a new instruction for our predictor, using the temperature specified for this round
-        original_temp = self.prompt_model.kwargs["temperature"]
+        # Generate a new instruction for our predictor using a unique rollout id to bypass cache
+        rollout_lm = self.prompt_model.copy(rollout_id=self.rng.randint(0, 10**9))
 
-        epsilon = self.rng.uniform(0.01, 0.05)
-        modified_temp = T + epsilon
-
-        with dspy.settings.context(lm=self.prompt_model):
-            self.prompt_model.kwargs["temperature"] = modified_temp
+        with dspy.settings.context(lm=rollout_lm):
             proposed_instruction = instruction_generator(
                 demo_candidates=demo_candidates,
                 pred_i=pred_i,
@@ -432,7 +425,6 @@ class GroundedProposer(Proposer):
                 num_demos_in_context = self.num_demos_in_context,
                 tip=tip,
             ).proposed_instruction
-        self.prompt_model.kwargs["temperature"] = original_temp
 
         # Log the trace used to generate the new instruction, along with the new instruction itself
         if self.verbose:

--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -181,7 +181,7 @@ class BootstrapFewShot(Teleprompter):
         try:
             with dspy.settings.context(trace=[], **self.teacher_settings):
                 lm = dspy.settings.lm
-                lm = lm.copy(temperature=0.7 + 0.001 * round_idx) if round_idx > 0 else lm
+                lm = lm.copy(rollout_id=round_idx) if round_idx > 0 else lm
                 new_settings = {"lm": lm} if round_idx > 0 else {}
 
                 with dspy.settings.context(**new_settings):

--- a/dspy/teleprompt/infer_rules.py
+++ b/dspy/teleprompt/infer_rules.py
@@ -143,7 +143,7 @@ class RulesInductionProgram(dspy.Module):
 
     def forward(self, examples_text):
         with dspy.settings.context(**self.teacher_settings):
-            lm = dspy.settings.lm.copy(temperature=self.rng.uniform(0.9, 1.0))
+            lm = dspy.settings.lm.copy(rollout_id=self.rng.randint(0, 10**9))
             with dspy.settings.context(lm=lm):
                 rules = self.rules_induction(examples_text=examples_text).natural_language_rules
 

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -408,7 +408,6 @@ class MIPROv2(Teleprompter):
             program=program,
             demo_candidates=demo_candidates,
             N=self.num_instruct_candidates,
-            T=self.init_temperature,
             trial_logs={},
         )
 

--- a/dspy/teleprompt/simba_utils.py
+++ b/dspy/teleprompt/simba_utils.py
@@ -14,9 +14,11 @@ logger = logging.getLogger(__name__)
 
 def prepare_models_for_resampling(program: dspy.Module, n: int):
     lm = program.get_lm() or dspy.settings.lm
-    temps = [lm.kwargs["temperature"]] + [0.5 + i * (0.5 / n) for i in range(n)]
-    temps = list(dict.fromkeys(temps))[:n]
-    return [lm.copy(temperature=t) for t in temps]
+    base_rollout = lm.kwargs.get("rollout_id")
+    start = 0 if base_rollout is None else base_rollout
+    rollout_ids = [start + i for i in range(n)]
+    rollout_ids = list(dict.fromkeys(rollout_ids))[:n]
+    return [lm.copy(rollout_id=r) for r in rollout_ids]
 
 
 def wrap_program(program: dspy.Module, metric: Callable):

--- a/tests/propose/test_grounded_proposer.py
+++ b/tests/propose/test_grounded_proposer.py
@@ -21,7 +21,7 @@ def test_propose_instructions_for_program(demo_candidates):
 
     proposer = GroundedProposer(prompt_model=prompt_model, program=program, trainset=trainset, verbose=False)
     result = proposer.propose_instructions_for_program(
-        trainset=trainset, program=program, demo_candidates=demo_candidates, trial_logs={}, N=1, T=0.5
+        trainset=trainset, program=program, demo_candidates=demo_candidates, trial_logs={}, N=1
     )
     assert isinstance(result, dict)
     assert len(result) == len(program.predictors())
@@ -45,7 +45,6 @@ def test_propose_instruction_for_predictor(demo_candidates):
         program=program,
         predictor=None,
         pred_i=0,
-        T=0.5,
         demo_candidates=demo_candidates,
         demo_set_i=0,
         trial_logs={},


### PR DESCRIPTION
## Summary
- add rollout_id handling in LM so caches ignore but providers don't see it
- replace temperature jitter with rollout_id across BestOfN, Refine, the MIPRO proposer, SIMBA utils, bootstrap and infer_rules
- document rollout_id usage and avoid LM mutations by copying requests
- treat `rollout_id=None` as unspecified and default base rollout IDs to `None`
- test rollout_id avoids caching collisions

## Testing
- `pytest tests/clients/test_lm.py::test_rollout_id_bypasses_cache tests/propose/test_grounded_proposer.py::test_propose_instructions_for_program tests/propose/test_grounded_proposer.py::test_propose_instruction_for_predictor tests/predict/test_best_of_n.py::test_refine_forward_success_first_attempt tests/predict/test_refine.py::test_refine_forward_success_first_attempt tests/teleprompt/test_bootstrap.py::test_bootstrap_initialization -q`


------
https://chatgpt.com/codex/tasks/task_e_68b46e8f96e4832980b46a4210d35624