### PR TITLE
Warn once per LM instance for zero-temperature rollout

### DIFF
--- a/docs/docs/cheatsheet.md
+++ b/docs/docs/cheatsheet.md
@@ -10,12 +10,13 @@ This page will contain snippets for frequent usage patterns.
 
 ### Forcing fresh LM outputs
 
-DSPy caches LM calls. Provide a unique ``rollout_id`` to bypass an existing
-cache entry while still caching the new result:
+DSPy caches LM calls. Provide a unique ``rollout_id`` and set a non-zero
+``temperature`` (e.g., 1.0) to bypass an existing cache entry while still caching
+the new result:
 
 ```python
 predict = dspy.Predict("question -> answer")
-predict(question="1+1", config={"rollout_id": 1})
+predict(question="1+1", config={"rollout_id": 1, "temperature": 1.0})
 ```
 
 ### dspy.Signature

--- a/docs/docs/learn/programming/language_models.md
+++ b/docs/docs/learn/programming/language_models.md
@@ -167,20 +167,21 @@ gpt_4o_mini = dspy.LM('openai/gpt-4o-mini', temperature=0.9, max_tokens=3000, st
 By default LMs in DSPy are cached. If you repeat the same call, you will get the same outputs. But you can turn off caching by setting `cache=False`.
 
 If you want to keep caching enabled but force a new request (for example, to obtain diverse outputs),
-pass a unique `rollout_id` in your call. DSPy hashes both the inputs and the `rollout_id` when
-looking up a cache entry, so different values force a new LM request while
+pass a unique `rollout_id` and set a non-zero `temperature` in your call. DSPy hashes both the inputs
+and the `rollout_id` when looking up a cache entry, so different values force a new LM request while
 still caching future calls with the same inputs and `rollout_id`. The ID is also recorded in
-`lm.history`, which makes it easy to track or compare different rollouts during experiments.
+`lm.history`, which makes it easy to track or compare different rollouts during experiments. Changing
+only the `rollout_id` while keeping `temperature=0` will not affect the LM's output.
 
 ```python linenums="1"
-lm("Say this is a test!", rollout_id=1)
+lm("Say this is a test!", rollout_id=1, temperature=1.0)
 ```
 
 You can pass these LM kwargs directly to DSPy modules as well. Supplying them at
 initialization sets the defaults for every call:
 
 ```python linenums="1"
-predict = dspy.Predict("question -> answer", rollout_id=1)
+predict = dspy.Predict("question -> answer", rollout_id=1, temperature=1.0)
 ```
 
 To override them for a single invocation, provide a ``config`` dictionary when
@@ -188,7 +189,7 @@ calling the module:
 
 ```python linenums="1"
 predict = dspy.Predict("question -> answer")
-predict(question="What is 1 + 52?", config={"rollout_id": 5})
+predict(question="What is 1 + 52?", config={"rollout_id": 5, "temperature": 1.0})
 ```
 
 In both cases, ``rollout_id`` is forwarded to the underlying LM, affects

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -113,8 +113,8 @@ class BaseLM:
         """Returns a copy of the language model with possibly updated parameters.
 
         Any provided keyword arguments update the corresponding attributes or LM kwargs of
-        the copy. For example, ``lm.copy(rollout_id=1)`` returns an LM whose requests use a
-        different rollout ID to bypass cache collisions.
+        the copy. For example, ``lm.copy(rollout_id=1, temperature=1.0)`` returns an LM whose
+        requests use a different rollout ID at non-zero temperature to bypass cache collisions.
         """
 
         import copy
@@ -130,6 +130,8 @@ class BaseLM:
                     new_instance.kwargs.pop(key, None)
                 else:
                     new_instance.kwargs[key] = value
+        if hasattr(new_instance, "_warned_zero_temp_rollout"):
+            new_instance._warned_zero_temp_rollout = False
 
         return new_instance
 

--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -14,8 +14,9 @@ class BestOfN(Module):
         fail_count: int | None = None,
     ):
         """
-        Runs a module up to `N` times with different rollout IDs and returns the best prediction
-        out of `N` attempts or the first prediction that passes the `threshold`.
+        Runs a module up to `N` times with different rollout IDs at `temperature=1.0` and
+        returns the best prediction out of `N` attempts or the first prediction that passes the
+        `threshold`.
 
         Args:
             module (Module): The module to run.
@@ -53,14 +54,12 @@ class BestOfN(Module):
 
     def forward(self, **kwargs):
         lm = self.module.get_lm() or dspy.settings.lm
-        base_rollout = lm.kwargs.get("rollout_id")
-        start = 0 if base_rollout is None else base_rollout
+        start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]
-        rollout_ids = list(dict.fromkeys(rollout_ids))[: self.N]
         best_pred, best_trace, best_reward = None, None, -float("inf")
 
         for idx, rid in enumerate(rollout_ids):
-            lm_ = lm.copy(rollout_id=rid)
+            lm_ = lm.copy(rollout_id=rid, temperature=1.0)
             mod = self.module.deepcopy()
             mod.set_lm(lm_)
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -27,8 +27,8 @@ class Predict(Module, Parameter):
             invocation by passing a ``config`` dictionary when calling the
             module. For example::
 
-                predict = dspy.Predict("q -> a", rollout_id=1)
-                predict(q="What is 1 + 52?", config={"rollout_id": 2})
+                predict = dspy.Predict("q -> a", rollout_id=1, temperature=1.0)
+                predict(q="What is 1 + 52?", config={"rollout_id": 2, "temperature": 1.0})
     """
 
     def __init__(self, signature: str | type[Signature], callbacks: list[BaseCallback] | None = None, **config):

--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -284,7 +284,8 @@ class GroundedProposer(Proposer):
         set_tip_randomly=True,
         set_history_randomly=True,
         verbose=False,
-        rng=None
+        rng=None,
+        init_temperature: float = 1.0,
     ):
         super().__init__()
         self.program_aware = program_aware
@@ -299,6 +300,7 @@ class GroundedProposer(Proposer):
         self.rng = rng or random
 
         self.prompt_model = get_prompt_model(prompt_model)
+        self.init_temperature = init_temperature
 
         self.program_code_string = None
         if self.program_aware:
@@ -412,7 +414,10 @@ class GroundedProposer(Proposer):
         )
 
         # Generate a new instruction for our predictor using a unique rollout id to bypass cache
-        rollout_lm = self.prompt_model.copy(rollout_id=self.rng.randint(0, 10**9))
+        rollout_lm = self.prompt_model.copy(
+            rollout_id=self.rng.randint(0, 10**9),
+            temperature=self.init_temperature,
+        )
 
         with dspy.settings.context(lm=rollout_lm):
             proposed_instruction = instruction_generator(

--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -47,6 +47,9 @@ class BootstrapFewShot(Teleprompter):
         """A Teleprompter class that composes a set of demos/examples to go into a predictor's prompt.
         These demos come from a combination of labeled examples in the training set, and bootstrapped demos.
 
+        Each bootstrap round copies the LM with a new ``rollout_id`` at ``temperature=1.0`` to
+        bypass caches and gather diverse traces.
+
         Args:
             metric (Callable): A function that compares an expected value and predicted value,
                 outputting the result of that comparison.
@@ -181,7 +184,8 @@ class BootstrapFewShot(Teleprompter):
         try:
             with dspy.settings.context(trace=[], **self.teacher_settings):
                 lm = dspy.settings.lm
-                lm = lm.copy(rollout_id=round_idx) if round_idx > 0 else lm
+                # Use a fresh rollout with temperature=1.0 to bypass caches.
+                lm = lm.copy(rollout_id=round_idx, temperature=1.0) if round_idx > 0 else lm
                 new_settings = {"lm": lm} if round_idx > 0 else {}
 
                 with dspy.settings.context(**new_settings):

--- a/dspy/teleprompt/infer_rules.py
+++ b/dspy/teleprompt/infer_rules.py
@@ -143,7 +143,10 @@ class RulesInductionProgram(dspy.Module):
 
     def forward(self, examples_text):
         with dspy.settings.context(**self.teacher_settings):
-            lm = dspy.settings.lm.copy(rollout_id=self.rng.randint(0, 10**9))
+            # Generate rules with a fresh rollout and non-zero temperature.
+            lm = dspy.settings.lm.copy(
+                rollout_id=self.rng.randint(0, 10**9), temperature=1.0
+            )
             with dspy.settings.context(lm=lm):
                 rules = self.rules_induction(examples_text=examples_text).natural_language_rules
 

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -58,7 +58,7 @@ class MIPROv2(Teleprompter):
         num_threads: int | None = None,
         max_errors: int | None = None,
         seed: int = 9,
-        init_temperature: float = 0.5,
+        init_temperature: float = 1.0,
         verbose: bool = False,
         track_stats: bool = True,
         log_dir: str | None = None,
@@ -400,6 +400,7 @@ class MIPROv2(Teleprompter):
             set_history_randomly=False,
             verbose=self.verbose,
             rng=self.rng,
+            init_temperature=self.init_temperature,
         )
 
         logger.info(f"\nProposing N={self.num_instruct_candidates} instructions...\n")

--- a/dspy/teleprompt/simba_utils.py
+++ b/dspy/teleprompt/simba_utils.py
@@ -14,11 +14,9 @@ logger = logging.getLogger(__name__)
 
 def prepare_models_for_resampling(program: dspy.Module, n: int):
     lm = program.get_lm() or dspy.settings.lm
-    base_rollout = lm.kwargs.get("rollout_id")
-    start = 0 if base_rollout is None else base_rollout
+    start = lm.kwargs.get("rollout_id", 0)
     rollout_ids = [start + i for i in range(n)]
-    rollout_ids = list(dict.fromkeys(rollout_ids))[:n]
-    return [lm.copy(rollout_id=r) for r in rollout_ids]
+    return [lm.copy(rollout_id=r, temperature=1.0) for r in rollout_ids]
 
 
 def wrap_program(program: dspy.Module, metric: Callable):


### PR DESCRIPTION
## Summary
- Warn once per `dspy.LM` instance when `rollout_id` is used with `temperature=0`, and reset the warning on `LM.copy`.
- Default `init_temperature` to `1.0` in MIPROv2 and propagate it through `GroundedProposer` and related proposers.
- Hardcode rollout copies to `temperature=1.0` and sequential IDs in `BestOfN`, `Refine`, `BootstrapFewShot`, `InferRules`, and SIMBA resampling, clarifying when cache bypass occurs.

## Testing
- `pre-commit run --files dspy/clients/lm.py dspy/clients/base_lm.py` *(fails: pre-commit not installed, installation blocked)*
- `pytest tests/clients/test_lm.py::test_rollout_id_bypasses_cache tests/clients/test_lm.py::test_zero_temperature_rollout_warns_once -q`


------
https://chatgpt.com/codex/tasks/task_e_68b486c77b78832984300abc4a28e89f