### PR TITLE
Lower max_tokens requirement for reasoning LMs

### DIFF
--- a/dspy/adapters/two_step_adapter.py
+++ b/dspy/adapters/two_step_adapter.py
@@ -30,7 +30,7 @@ class TwoStepAdapter(Adapter):
     Example:
     ```
     import dspy
-    lm = dspy.LM(model="openai/o3-mini", max_tokens=10000, temperature = 1.0)
+    lm = dspy.LM(model="openai/o3-mini", max_tokens=16000, temperature = 1.0)
     adapter = dspy.TwoStepAdapter(dspy.LM("openai/gpt-4o-mini"))
     dspy.configure(lm=lm, adapter=adapter)
     program = dspy.ChainOfThought("question->answer")

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -86,10 +86,10 @@ class LM(BaseLM):
         model_pattern = re.match(r"^(?:o[1345]|gpt-5)(?:-(?:mini|nano))?", model_family)
 
         if model_pattern:
-            if max_tokens < 20000 or temperature != 1.0:
+            if max_tokens < 16000 or temperature != 1.0:
                 raise ValueError(
-                    "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 20000 to "
-                    "`dspy.LM(...)`, e.g., dspy.LM('openai/gpt-5', temperature=1.0, max_tokens=20000)"
+                    "OpenAI's reasoning models require passing temperature=1.0 and max_tokens >= 16000 to "
+                    "`dspy.LM(...)`, e.g., dspy.LM('openai/gpt-5', temperature=1.0, max_tokens=16000)"
                 )
             self.kwargs = dict(temperature=temperature, max_completion_tokens=max_tokens, **kwargs)
             if self.kwargs.get("rollout_id") is None:

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -269,12 +269,12 @@ def test_reasoning_model_token_parameter():
         lm = dspy.LM(
             model=model_name,
             temperature=1.0 if is_reasoning_model else 0.7,
-            max_tokens=20_000 if is_reasoning_model else 1000,
+            max_tokens=16_000 if is_reasoning_model else 1000,
         )
         if is_reasoning_model:
             assert "max_completion_tokens" in lm.kwargs
             assert "max_tokens" not in lm.kwargs
-            assert lm.kwargs["max_completion_tokens"] == 20_000
+            assert lm.kwargs["max_completion_tokens"] == 16_000
         else:
             assert "max_completion_tokens" not in lm.kwargs
             assert "max_tokens" in lm.kwargs
@@ -285,21 +285,21 @@ def test_reasoning_model_requirements(model_name):
     # Should raise assertion error if temperature or max_tokens requirements not met
     with pytest.raises(
         ValueError,
-        match="reasoning models require passing temperature=1.0 and max_tokens >= 20000",
+        match="reasoning models require passing temperature=1.0 and max_tokens >= 16000",
     ):
         dspy.LM(
             model=model_name,
             temperature=0.7,  # Should be 1.0
-            max_tokens=1000,  # Should be >= 20_000
+            max_tokens=1000,  # Should be >= 16_000
         )
 
     # Should pass with correct parameters
     lm = dspy.LM(
         model=model_name,
         temperature=1.0,
-        max_tokens=20_000,
+        max_tokens=16_000,
     )
-    assert lm.kwargs["max_completion_tokens"] == 20_000
+    assert lm.kwargs["max_completion_tokens"] == 16_000
 
 
 def test_dump_state():


### PR DESCRIPTION
## Summary
- allow OpenAI reasoning models to run with as few as 16k `max_tokens`
- update tests for new 16k requirement
- correct TwoStepAdapter example to use 16k tokens

## Testing
- `pytest tests/clients/test_lm.py::test_reasoning_model_token_parameter tests/clients/test_lm.py::test_reasoning_model_requirements -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4965c29f08329858bd6cbbd013e9d