### PR TITLE
Fix value parsing and add tests

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -2,6 +2,7 @@ import ast
 import enum
 import inspect
 import json
+import types
 from collections.abc import Mapping
 from typing import Any, Literal, Union, get_args, get_origin
 
@@ -10,7 +11,7 @@ import pydantic
 from pydantic import TypeAdapter
 from pydantic.fields import FieldInfo
 
-from dspy.adapters.types.base_type import Type
+from dspy.adapters.types.base_type import Type as DspyType
 from dspy.signatures.utils import get_dspy_field_type
 
 
@@ -172,14 +173,14 @@ def parse_value(value, annotation):
     try:
         return TypeAdapter(annotation).validate_python(candidate)
     except pydantic.ValidationError as e:
-        if issubclass(annotation, Type):
+        if inspect.isclass(annotation) and issubclass(annotation, DspyType):
             try:
                 # For dspy.Type, try parsing from the original value in case it has a custom parser
                 return TypeAdapter(annotation).validate_python(value)
             except Exception:
                 raise e
 
-        if origin is Union and type(None) in get_args(annotation) and str in get_args(annotation):
+        if origin in (Union, types.UnionType) and type(None) in get_args(annotation) and str in get_args(annotation):
             return str(candidate)
         raise
 
@@ -211,7 +212,7 @@ def get_field_description_string(fields: dict) -> str:
         field_message += f" ({get_annotation_name(v.annotation)})"
         desc = v.json_schema_extra["desc"] if v.json_schema_extra["desc"] != f"${{{k}}}" else ""
 
-        custom_types = Type.extract_custom_type_from_annotation(v.annotation)
+        custom_types = DspyType.extract_custom_type_from_annotation(v.annotation)
         for custom_type in custom_types:
             if len(custom_type.description()) > 0:
                 desc += f"\n    Type description of {get_annotation_name(custom_type)}: {custom_type.description()}"

--- a/tests/adapters/test_utils.py
+++ b/tests/adapters/test_utils.py
@@ -1,0 +1,101 @@
+# ruff: noqa: UP007
+
+from typing import Literal, Optional, Union
+
+import pytest
+from pydantic import BaseModel
+
+from dspy.adapters.utils import parse_value
+
+
+class TestModel(BaseModel):
+    name: str
+    age: int
+
+
+def test_parse_value_str_annotation():
+    # Test basic string conversion
+    assert parse_value(123, str) == "123"
+    assert parse_value(True, str) == "True"
+    assert parse_value("hello", str) == "hello"
+    assert parse_value(None, str) == "None"
+    assert parse_value([1, 2, 3], str) == "[1, 2, 3]"
+
+
+def test_parse_value_pydantic_types():
+    # Test with pydantic BaseModel - JSON string input
+    json_str = '{"name": "John", "age": 30}'
+    result = parse_value(json_str, TestModel)
+    assert isinstance(result, TestModel)
+    assert result.name == "John"
+    assert result.age == 30
+
+    # Test with pydantic BaseModel - dict input
+    dict_input = {"name": "Jane", "age": 25}
+    result = parse_value(dict_input, TestModel)
+    assert isinstance(result, TestModel)
+    assert result.name == "Jane"
+    assert result.age == 25
+
+    # Test with invalid pydantic data
+    with pytest.raises(Exception):
+        parse_value('{"name": "John"}', TestModel)  # missing required age field
+
+
+def test_parse_value_basic_types():
+    # Test int
+    assert parse_value("42", int) == 42
+    assert parse_value(42, int) == 42
+
+    # Test float
+    assert parse_value("3.14", float) == 3.14
+    assert parse_value(3.14, float) == 3.14
+
+    # Test bool
+    assert parse_value("true", bool) is True
+    assert parse_value(True, bool) is True
+    assert parse_value("false", bool) is False
+
+    # Test list
+    assert parse_value("[1, 2, 3]", list[int]) == [1, 2, 3]
+    assert parse_value([1, 2, 3], list[int]) == [1, 2, 3]
+
+
+def test_parse_value_literal():
+    # Test Literal type
+    assert parse_value("option1", Literal["option1", "option2"]) == "option1"
+    assert parse_value("option2", Literal["option1", "option2"]) == "option2"
+
+    # Test Literal with quotes and prefixes
+    assert parse_value("'option1'", Literal["option1", "option2"]) == "option1"
+    assert parse_value('"option1"', Literal["option1", "option2"]) == "option1"
+    assert parse_value("Literal[option1]", Literal["option1", "option2"]) == "option1"
+    assert parse_value("str[option1]", Literal["option1", "option2"]) == "option1"
+
+    # Test invalid literal
+    with pytest.raises(ValueError):
+        parse_value("invalid", Literal["option1", "option2"])
+
+
+def test_parse_value_union():
+    # Test Union with None (Optional)
+    assert parse_value("test", Optional[str]) == "test"
+    assert parse_value("test", str | None) == "test"
+    assert parse_value(None, Optional[str]) is None
+
+    # Test Union fallback to str
+    assert parse_value("fallback", Union[int, str, None]) == "fallback"
+    assert parse_value("fallback", int | str | None) == "fallback"
+
+
+def test_parse_value_json_repair():
+    # Test cases where json_repair is needed
+    assert parse_value('{"key": "value"}', dict) == {"key": "value"}
+
+    # Test ast.literal_eval fallback
+    assert parse_value("{'key': 'value'}", dict) == {"key": "value"}
+
+    # Test fallback to original value when parsing fails
+    malformed = "not json or literal"
+    with pytest.raises(Exception):
+        parse_value(malformed, dict)


### PR DESCRIPTION
the current `parse_value` implementation doesn't work well with `Optional[str]` and `str | None`, and this PR fixes it. Also adding unit test for safe guarding.