### PR TITLE
Check for batch_fn before calling close

### DIFF
--- a/dspy/utils/unbatchify.py
+++ b/dspy/utils/unbatchify.py
@@ -109,4 +109,5 @@ class Unbatchify:
         """
         Ensures the worker thread is terminated when the object is garbage collected.
         """
-        self.close()
+        if hasattr(self, "batch_fn"):
+            self.close()


### PR DESCRIPTION
When performing GEPA optimization using a pipeline that involves an embedder, the following error tends to occur: 

```
Exception ignored in: <function Unbatchify.__del__ at 0x1263e0180>
Traceback (most recent call last):
  File "/Users/zachbam/.local/share/mise/installs/python/3.12.11/lib/python3.12/site-packages/dspy/utils/unbatchify.py", line 112, in __del__
    self.close()
  File "/Users/zachbam/.local/share/mise/installs/python/3.12.11/lib/python3.12/site-packages/dspy/utils/unbatchify.py", line 92, in close
    if not self.stop_event.is_set():
           ^^^^^^^^^^^^^^^
AttributeError: 'Unbatchify' object has no attribute 'stop_event'
```

The issue seems to stem from instances where deletion is called, but the object is already gone. My suggested fix resolves this issue.