### PR TITLE
fix: Allow DummyLM answers dict values to be of any type to work with a wider range of signatures

### DIFF
--- a/dspy/utils/dummies.py
+++ b/dspy/utils/dummies.py
@@ -67,7 +67,7 @@ class DummyLM(LM):
 
     """
 
-    def __init__(self, answers: list[dict[str, str]] | dict[str, dict[str, str]], follow_examples: bool = False, adapter=None):
+    def __init__(self, answers: list[dict[str, Any]] | dict[str, dict[str, Any]], follow_examples: bool = False, adapter=None):
         super().__init__("dummy", "chat", 0.0, 1000, True)
         self.answers = answers
         if isinstance(answers, list):


### PR DESCRIPTION
Currently, our unit tests have to ignore types because we are returning pydantic base models rather than strings for every field. This more accurately represents signature return types. There may be something slightly less generic than Any, however this at least allows any return type and falls back to parsing of responses to catch mistakes.