### PR TITLE
Fix unexpected parsing of Optional[str] fields when string has brackets or braces

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -144,10 +144,8 @@ def parse_value(value, annotation):
     origin = get_origin(annotation)
 
     if origin in (Union, types.UnionType) and type(None) in get_args(annotation) and str in get_args(annotation):
-        if value is None:
-            return None
-        if isinstance(value, str):
-            return value
+        # Handle annotation `str | None`, `Optional[str]`, `Union[str, None]`, etc.
+        return str(value) if value else None
 
     if origin is Literal:
         allowed = get_args(annotation)
@@ -185,9 +183,6 @@ def parse_value(value, annotation):
                 return TypeAdapter(annotation).validate_python(value)
             except Exception:
                 raise e
-
-        if origin in (Union, types.UnionType) and type(None) in get_args(annotation) and str in get_args(annotation):
-            return str(candidate)
         raise
 
 

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -143,6 +143,12 @@ def parse_value(value, annotation):
 
     origin = get_origin(annotation)
 
+    if origin in (Union, types.UnionType) and type(None) in get_args(annotation) and str in get_args(annotation):
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return value
+
     if origin is Literal:
         allowed = get_args(annotation)
         if value in allowed:

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -82,10 +82,12 @@ def test_parse_value_union():
     assert parse_value("test", Optional[str]) == "test"
     assert parse_value("test", str | None) == "test"
     assert parse_value(None, Optional[str]) is None
+    assert parse_value("text with [placeholder]", Optional[str]) == "text with [placeholder]"
 
     # Test Union fallback to str
     assert parse_value("fallback", Union[int, str, None]) == "fallback"
     assert parse_value("fallback", int | str | None) == "fallback"
+    assert parse_value("text with [placeholder]", Union[int, str, None]) == "text with [placeholder]"
 
 
 def test_parse_value_json_repair():

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -81,13 +81,16 @@ def test_parse_value_union():
     # Test Union with None (Optional)
     assert parse_value("test", Optional[str]) == "test"
     assert parse_value("test", str | None) == "test"
+    assert parse_value("5", int | None) == 5
     assert parse_value(None, Optional[str]) is None
     assert parse_value("text with [placeholder]", Optional[str]) == "text with [placeholder]"
     assert parse_value("text with [placeholder]", str | None) == "text with [placeholder]"
 
     # Test Union fallback to str
     assert parse_value("fallback", Union[int, str, None]) == "fallback"
+    assert parse_value(5, Union[int, str, None]) == 5
     assert parse_value("fallback", int | str | None) == "fallback"
+    assert parse_value(5, int | str | None) == 5
     assert parse_value("text with [placeholder]", Union[int, str, None]) == "text with [placeholder]"
 
 

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -83,6 +83,7 @@ def test_parse_value_union():
     assert parse_value("test", str | None) == "test"
     assert parse_value(None, Optional[str]) is None
     assert parse_value("text with [placeholder]", Optional[str]) == "text with [placeholder]"
+    assert parse_value("text with [placeholder]", str | None) == "text with [placeholder]"
 
     # Test Union fallback to str
     assert parse_value("fallback", Union[int, str, None]) == "fallback"


### PR DESCRIPTION
This is my proposed fix for #8804 