### PR TITLE
fix: removed duplicate cell from GEPA information extraction tutorial

### DIFF
--- a/docs/docs/tutorials/gepa_facilitysupportanalyzer/index.ipynb
+++ b/docs/docs/tutorials/gepa_facilitysupportanalyzer/index.ipynb
@@ -10,16 +10,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4319980",
-   "metadata": {},
-   "source": [
-    "In this tutorial, we'll explore a three-part task for structured information extraction and classification using the [Facility Support Analyzer](https://github.com/meta-llama/llama-prompt-ops/tree/main/use-cases/facility-support-analyzer) dataset released by Meta. Given an email or message sent in an enterprise setting related to facility maintenance or support requests, the goal is to extract its urgency, assess the sentiment, and identify all relevant service request categories.\n",
-    "\n",
-    "We will build a simple DSPy program, and then use the `dspy.GEPA` optimizer to optimize it for the task."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "1114c356",
    "metadata": {},
    "source": [


### PR DESCRIPTION
There was a duplicate cell in the beginning of the GEPA information extraction tutorial. I removed it. 
