### PR TITLE
[Fix] Add parsing for custom type arrays

### DIFF
--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -99,11 +99,54 @@ def split_message_content_for_custom_types(messages: list[dict[str, Any]]) -> li
             # Custom type messages are only in user messages
             continue
 
+        # DSPy adapter always formats user input into a string content before custom type splitting
+        content: str = message["content"]
+
+        print("[split_message_content_for_custom_types] content:", content)
+
+        # Look for JSON array patterns that contain custom types
+        # Pattern: [..."<<CUSTOM-TYPE-START-IDENTIFIER>>...<<CUSTOM-TYPE-END-IDENTIFIER>>"...]
+        json_array_pattern = r"\[([^[\]]*" + re.escape(CUSTOM_TYPE_START_IDENTIFIER) + r".*?" + re.escape(CUSTOM_TYPE_END_IDENTIFIER) + r"[^[\]]*)\]"
+
+        # Find all JSON arrays containing custom types
+        array_matches = list(re.finditer(json_array_pattern, content, re.DOTALL))
+
+        if array_matches:
+            # Process content by replacing JSON arrays with their processed content
+            result = []
+            last_end = 0
+
+            for array_match in array_matches:
+                array_start, array_end = array_match.span()
+
+                # Add text before this array (process any standalone custom types)
+                if array_start > last_end:
+                    text_before = content[last_end:array_start]
+                    text_result = _process_standalone_custom_types(text_before)
+                    result.extend(text_result)
+
+                # Process the JSON array
+                array_content = array_match.group(0)  # Full match including [ ]
+                array_result = _process_json_array_with_custom_types(array_content)
+                result.extend(array_result)
+
+                last_end = array_end
+
+            # Add any remaining content after the last array
+            if last_end < len(content):
+                remaining_text = content[last_end:]
+                text_result = _process_standalone_custom_types(remaining_text)
+                result.extend(text_result)
+
+            if result:
+                message["content"] = result
+                print("[split_message_content_for_custom_types] result:", result)
+                continue
+
+        # Original logic for standalone custom types
         pattern = rf"{CUSTOM_TYPE_START_IDENTIFIER}(.*?){CUSTOM_TYPE_END_IDENTIFIER}"
         result = []
         last_end = 0
-        # DSPy adapter always formats user input into a string content before custom type splitting
-        content: str = message["content"]
 
         for match in re.finditer(pattern, content, re.DOTALL):
             start, end = match.span()
@@ -141,3 +184,77 @@ def split_message_content_for_custom_types(messages: list[dict[str, Any]]) -> li
         message["content"] = result
 
     return messages
+
+
+def _process_json_array_with_custom_types(array_content):
+    """Process a JSON array that contains custom types"""
+    try:
+        # Replace custom type markers with placeholders
+        custom_type_pattern = rf"{CUSTOM_TYPE_START_IDENTIFIER}(.*?){CUSTOM_TYPE_END_IDENTIFIER}"
+        matches = list(re.finditer(custom_type_pattern, array_content, re.DOTALL))
+
+        temp_content = array_content
+        placeholders = {}
+
+        for i, match in enumerate(matches):
+            placeholder = f"__CUSTOM_TYPE_PLACEHOLDER_{i}__"
+            placeholders[placeholder] = match.group(1).strip()
+            temp_content = temp_content.replace(match.group(0), placeholder)
+
+        # Parse the JSON array
+        array_items = json.loads(temp_content)
+
+        # Process each item in the array
+        result = []
+        for item in array_items:
+            if isinstance(item, str) and item in placeholders:
+                custom_type_content = placeholders[item]
+                try:
+                    parsed = json_repair.loads(custom_type_content.replace("'", '"'))
+                    for parsed_item in parsed:
+                        result.append(parsed_item)
+                except json.JSONDecodeError:
+                    result.append({"type": "text", "text": custom_type_content})
+            else:
+                result.append({"type": "text", "text": str(item)})
+
+        return result
+
+    except (json.JSONDecodeError, ValueError):
+        # If JSON parsing fails, fall back to standalone processing
+        return _process_standalone_custom_types(array_content)
+
+
+def _process_standalone_custom_types(content):
+    """Process standalone custom types (original logic)"""
+    pattern = rf"{CUSTOM_TYPE_START_IDENTIFIER}(.*?){CUSTOM_TYPE_END_IDENTIFIER}"
+    result = []
+    last_end = 0
+
+    for match in re.finditer(pattern, content, re.DOTALL):
+        start, end = match.span()
+
+        # Add text before the current block
+        if start > last_end:
+            result.append({"type": "text", "text": content[last_end:start]})
+
+        # Parse the custom type
+        custom_type_content = match.group(1).strip()
+        try:
+            parsed = json_repair.loads(custom_type_content.replace("'", '"'))
+            for parsed_item in parsed:
+                result.append(parsed_item)
+        except json.JSONDecodeError:
+            result.append({"type": "text", "text": custom_type_content})
+
+        last_end = end
+
+    # If no custom types found, return as text
+    if last_end == 0:
+        return [{"type": "text", "text": content}]
+
+    # Add any remaining text
+    if last_end < len(content):
+        result.append({"type": "text", "text": content[last_end:]})
+
+    return result

--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -102,8 +102,6 @@ def split_message_content_for_custom_types(messages: list[dict[str, Any]]) -> li
         # DSPy adapter always formats user input into a string content before custom type splitting
         content: str = message["content"]
 
-        print("[split_message_content_for_custom_types] content:", content)
-
         # Look for JSON array patterns that contain custom types
         # Pattern: [..."<<CUSTOM-TYPE-START-IDENTIFIER>>...<<CUSTOM-TYPE-END-IDENTIFIER>>"...]
         json_array_pattern = r"\[([^[\]]*" + re.escape(CUSTOM_TYPE_START_IDENTIFIER) + r".*?" + re.escape(CUSTOM_TYPE_END_IDENTIFIER) + r"[^[\]]*)\]"
@@ -140,7 +138,6 @@ def split_message_content_for_custom_types(messages: list[dict[str, Any]]) -> li
 
             if result:
                 message["content"] = result
-                print("[split_message_content_for_custom_types] result:", result)
                 continue
 
         # Original logic for standalone custom types

--- a/tests/adapters/test_base_type.py
+++ b/tests/adapters/test_base_type.py
@@ -49,3 +49,22 @@ def test_extract_custom_type_from_annotation_with_nested_type():
         EventIdentifier,
         Event,
     ]
+
+def test_split_message_content_for_custom_types():
+    from dspy.adapters.types.base_type import split_message_content_for_custom_types
+
+    messages = [
+        {
+            "role": "user",
+            "content":
+            """["<<CUSTOM-TYPE-START-IDENTIFIER>>[{'type': 'document', 'source': {'type': 'text', 'media_type': 'text/plain', 'data': \"test\"}, \
+                'citations': {'enabled': True}, 'title': \"Document 0\", 'context': \"Context for Document 0\"}]<<CUSTOM-TYPE-END-IDENTIFIER>>", \
+                "<<CUSTOM-TYPE-START-IDENTIFIER>>[{'type': 'document', 'source': {'type': 'text', 'media_type': 'text/plain', 'data': \"test\"}, \
+                'citations': {'enabled': True}, 'title': \"Document 1\", 'context': \"Context for Document 1\"}]<<CUSTOM-TYPE-END-IDENTIFIER>>"]"""
+        }
+    ]
+    result = split_message_content_for_custom_types(messages.copy())
+    print(result)
+
+    assert result[0]["content"][0] == {"type": "document", "source": {"type": "text", "media_type": "text/plain", "data": "test"}, "citations": {"enabled": True}, "title": "Document 0", "context": "Context for Document 0"}
+    assert result[0]["content"][1] == {"type": "document", "source": {"type": "text", "media_type": "text/plain", "data": "test"}, "citations": {"enabled": True}, "title": "Document 1", "context": "Context for Document 1"}


### PR DESCRIPTION
Arrays containing custom types were not parsed properly before. For example, 
```
messages = [
  "role": "user",
  "content": """["<<CUSTOM_TYPE_START_IDENTIFIER>>custom_type_0<<CUSTOM_TYPE_END_IDENTIFIER>>", "<<CUSTOM_TYPE_START_IDENTIFIER>>custom_type_1<<CUSTOM_TYPE_END_IDENTIFIER>>"]"""
]
split_message_content_for_custom_types(messages)
```
would return an array with `['["', 'custom_type_0', ', ', 'custom_type_1', ']"']`.

This fix changes the function to return `['custom_type_0', 'custom_type_1']` correctly.