### PR TITLE
[MIPRO v2] Fix parameter update order in `MIPROv2.compile`

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -124,6 +124,13 @@ class MIPROv2(Teleprompter):
             if self.max_errors is not None
             else dspy.settings.max_errors
         )
+
+        # Update max demos if specified
+        if max_bootstrapped_demos is not None:
+            self.max_bootstrapped_demos = max_bootstrapped_demos
+        if max_labeled_demos is not None:
+            self.max_labeled_demos = max_labeled_demos
+        
         zeroshot_opt = (self.max_bootstrapped_demos == 0) and (self.max_labeled_demos == 0)
 
         # If auto is None, and num_trials is not provided (but num_candidates is), raise an error that suggests a good num_trials value
@@ -145,12 +152,6 @@ class MIPROv2(Teleprompter):
         # Set random seeds
         seed = seed or self.seed
         self._set_random_seeds(seed)
-
-        # Update max demos if specified
-        if max_bootstrapped_demos is not None:
-            self.max_bootstrapped_demos = max_bootstrapped_demos
-        if max_labeled_demos is not None:
-            self.max_labeled_demos = max_labeled_demos
 
         # Set training & validation sets
         trainset, valset = self._set_and_validate_datasets(trainset, valset)


### PR DESCRIPTION
In the `compile` function of `MIPROv2`, the parameters `max_bootstrapped_demos` and `max_labeled_demos` are intended to override the defaults and update the `zeroshot_opt` value.

However, in the main branch, `zeroshot_opt` is assigned **before** `self.max_bootstrapped_demos` and `self.max_labeled_demos` are updated. This makes the passed-in parameters ineffective.

This PR fixes the issue by moving the update of `self.max_bootstrapped_demos` and `self.max_labeled_demos` **before** assigning `zeroshot_opt`.
