### PR TITLE
Adds support for using batch APIs

### DIFF
--- a/batch_test.py
+++ b/batch_test.py
@@ -1,0 +1,50 @@
+import dspy
+
+class TranslateSignature(dspy.Signature):
+    """Translate an English question to French."""
+    english_question = dspy.InputField()
+    french_question = dspy.OutputField()
+
+class FrenchQASignature(dspy.Signature):
+    """Answer a question in French."""
+    french_question = dspy.InputField()
+    french_answer = dspy.OutputField()
+
+class TranslateAndAnswer(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.translator = dspy.Predict(TranslateSignature)
+        self.qa = dspy.Predict(FrenchQASignature)
+
+    def forward(self, english_question):
+        french_question = self.translator(english_question=english_question).french_question
+        french_answer = self.qa(french_question=french_question).french_answer
+        return dspy.Prediction(answer=french_answer)
+
+def main():
+    # Configure the language model
+    # Make sure to set your OPENAI_API_KEY environment variable
+    lm = dspy.LM("openai/gpt-3.5-turbo-0125", num_retries=3)
+    dspy.settings.configure(lm=lm)
+
+    questions = [
+        "What is the capital of France?",
+        "Who wrote '1984'?",
+        "What is the square root of 16?",
+        "What is the boiling point of water in Celsius?",
+        "Who discovered penicillin?",
+    ]
+    examples = [dspy.Example(english_question=q).with_inputs("english_question") for q in questions]
+    translate_and_answer = TranslateAndAnswer()
+
+    print("Running multi-step module in batch mode...")
+    results = translate_and_answer.batch(examples, batch_mode=True)
+
+    print("\n--- Results ---")
+    for i, result in enumerate(results):
+        print(f"English Q: {questions[i]}")
+        print(f"French A: {result.answer}")
+        print("-" * 15)
+
+if __name__ == "__main__":
+    main() # uv run batch_test.py

--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -1,4 +1,5 @@
 from dspy.adapters.base import Adapter
+from dspy.adapters.batch_adapter import BatchAdapter, StandardLMResponse
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.two_step_adapter import TwoStepAdapter
@@ -7,6 +8,8 @@ from dspy.adapters.xml_adapter import XMLAdapter
 
 __all__ = [
     "Adapter",
+    "BatchAdapter",
+    "StandardLMResponse",
     "ChatAdapter",
     "Type",
     "History",

--- a/dspy/adapters/batch_adapter.py
+++ b/dspy/adapters/batch_adapter.py
@@ -1,0 +1,90 @@
+import json
+import logging
+
+from dspy.utils.exceptions import AdapterParseError
+
+logger = logging.getLogger(__name__)
+
+
+class StandardLMResponse:
+    """Normalizes provider batch formats to DSPy-compatible structure.
+    
+    NOTE: Currently uses OpenAI's response format as standard. Other providers 
+    must convert their responses to match this structure (not optimal).
+    """
+    def __init__(self, response_dict: dict, custom_id: str):
+        # Convert dict to object attributes for DSPy compatibility  
+        for key, value in response_dict.items():
+            setattr(self, key, value)
+        # Keep custom_id for result routing to correct worker thread
+        self.custom_id = custom_id
+
+
+class BatchAdapter:
+    """Simple adapter for OpenAI batch API format conversion."""
+    
+    def format(self, call_data_list: list[dict], lm) -> tuple[list[dict], str]:
+        """Convert call data to batch request format."""
+        if 'openai' in lm.model.lower() or '/' not in lm.model:
+            return self.format_batch_openai(call_data_list, lm)
+        else:
+            raise NotImplementedError(f"Batch adapter for {lm.model} not implemented")
+    
+    def parse(self, completion: str, lm) -> list:
+        """Parse provider batch results to standard format."""  
+        if 'openai' in lm.model.lower() or '/' not in lm.model:
+            return self.parse_batch_openai(completion)
+        else:
+            raise NotImplementedError(f"Batch adapter for {lm.model} not implemented")
+    
+    def format_batch_openai(self, call_data_list: list[dict], lm) -> tuple[list[dict], str]:
+        """Format to OpenAI batch API structure."""
+        batch_requests = []
+        for call_data in call_data_list:
+            messages = call_data.get('messages', [])
+            # Extract model name from provider/model format if present
+            model_name = lm.model.split("/")[-1] if "/" in lm.model else lm.model
+            
+            request = {
+                'custom_id': call_data['id'],
+                'method': 'POST',
+                'url': '/v1/chat/completions',
+                'body': {
+                    'model': model_name,
+                    'messages': messages,
+                    **lm.kwargs
+                }
+            }
+            batch_requests.append(request)
+        
+        # Extract provider from model string for litellm routing
+        provider = lm.model.split('/')[0] if '/' in lm.model else 'openai'
+        return batch_requests, provider
+    
+    def parse_batch_openai(self, completion: str) -> list:
+        """Parse OpenAI JSONL results to standard LM response format."""
+        results = []
+        
+        for line in completion.strip().split("\n"):
+            if line.strip():
+                try:
+                    result = json.loads(line)
+                    response_body = result["response"]["body"]
+                    
+                    # Add "text" key for DSPy compatibility
+                    if "choices" in response_body:
+                        for choice in response_body["choices"]:
+                            if "message" in choice and "content" in choice["message"]:
+                                choice["text"] = choice["message"]["content"]
+                    
+                    results.append(StandardLMResponse(response_body, result.get('custom_id')))
+                    
+                except Exception as e:
+                    raise AdapterParseError(
+                        adapter_name="BatchAdapter",
+                        signature=None,
+                        lm_response=str(result) if 'result' in locals() else line,
+                        message=f"Failed to parse OpenAI batch result: {e}"
+                    )
+        
+        return results

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -100,8 +100,37 @@ def disable_litellm_logging():
     configure_litellm_logging("ERROR")
 
 
+def _patch_litellm_batch_errors():
+    """Patch litellm's batch utils to handle the 'Output file id is None' error silently."""
+    try:
+        import litellm.batches.batch_utils as batch_utils
+        
+        # Store the original function
+        original_get_batch_output = batch_utils._get_batch_output_file_content_as_dictionary
+        
+        # Create a wrapper that catches the specific error
+        async def patched_get_batch_output(*args, **kwargs):
+            try:
+                return await original_get_batch_output(*args, **kwargs)
+            except ValueError as e:
+                if "Output file id is None cannot retrieve file content" in str(e):
+                    # Silently ignore this specific error - it's a litellm internal issue
+                    return {}
+                raise
+        
+        # Replace the function
+        batch_utils._get_batch_output_file_content_as_dictionary = patched_get_batch_output
+        
+    except ImportError:
+        # If we can't import the module, just continue
+        pass
+
+
 # By default, we disable LiteLLM logging for clean logging
 disable_litellm_logging()
+
+# Apply batch error patches
+_patch_litellm_batch_errors()
 
 __all__ = [
     "BaseLM",

--- a/dspy/predict/parallel.py
+++ b/dspy/predict/parallel.py
@@ -3,13 +3,18 @@ from typing import Any
 
 from dspy.dsp.utils.settings import settings
 from dspy.primitives.example import Example
-from dspy.utils.parallelizer import ParallelExecutor
+from dspy.utils.parallelizer import ParallelExecutor, BatchExecutor
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class Parallel:
     def __init__(
         self,
         num_threads: int | None = None,
+        batch_mode: bool = False,
         max_errors: int | None = None,
         access_examples: bool = True,
         return_failed_examples: bool = False,
@@ -18,6 +23,7 @@ class Parallel:
     ):
         super().__init__()
         self.num_threads = num_threads or settings.num_threads
+        self.batch_mode = batch_mode
         self.max_errors = settings.max_errors if max_errors is None else max_errors
         self.access_examples = access_examples
         self.return_failed_examples = return_failed_examples
@@ -30,39 +36,49 @@ class Parallel:
         self.failed_examples = []
         self.exceptions = []
 
-    def forward(self, exec_pairs: list[tuple[Any, Example]], num_threads: int | None = None) -> list[Any]:
-        num_threads = num_threads if num_threads is not None else self.num_threads
+    def _process_pair(self, pair):
+        result = None
+        module, example = pair
 
-        executor = ParallelExecutor(
-            num_threads=num_threads,
-            max_errors=self.max_errors,
-            provide_traceback=self.provide_traceback,
-            disable_progress_bar=self.disable_progress_bar,
-        )
-
-        def process_pair(pair):
-            result = None
-            module, example = pair
-
-            if isinstance(example, Example):
-                if self.access_examples:
-                    result = module(**example.inputs())
-                else:
-                    result = module(example)
-            elif isinstance(example, dict):
-                result = module(**example)
-            elif isinstance(example, list) and module.__class__.__name__ == "Parallel":
-                result = module(example)
-            elif isinstance(example, tuple):
-                result = module(*example)
+        if isinstance(example, Example):
+            if self.access_examples:
+                result = module(**example.inputs())
             else:
-                raise ValueError(
-                    f"Invalid example type: {type(example)}, only supported types are Example, dict, list and tuple"
-                )
-            return result
+                result = module(example)
+        elif isinstance(example, dict):
+            result = module(**example)
+        elif isinstance(example, list) and module.__class__.__name__ == "Parallel":
+            result = module(example)
+        elif isinstance(example, tuple):
+            result = module(*example)
+        else:
+            raise ValueError(
+                f"Invalid example type: {type(example)}, only supported types are Example, dict, list and tuple"
+            )
+        return result
 
-        # Execute the processing function over the execution pairs
-        results = executor.execute(process_pair, exec_pairs)
+    def forward(self, exec_pairs: list[tuple[Any, Example]], num_threads: int | None = None) -> list[Any]:
+        if self.batch_mode:
+            if not exec_pairs:
+                return []
+            
+            # Extract the module from the first exec_pair
+            # ASSUMPTION: All exec_pairs have the same module type for stage-by-stage batching
+            # TODO: Could be enhanced to group by unique module types and batch each group separately
+            module = exec_pairs[0][0]
+            
+            # Use staged batch execution
+            executor = BatchExecutor()
+            results = executor.execute(module, exec_pairs)
+        else:
+            num_threads = num_threads if num_threads is not None else self.num_threads
+            executor = ParallelExecutor(
+                num_threads=num_threads,
+                max_errors=self.max_errors,
+                provide_traceback=self.provide_traceback,
+                disable_progress_bar=self.disable_progress_bar,
+            )
+            results = executor.execute(self._process_pair, exec_pairs)
 
         if self.return_failed_examples:
             return results, self.failed_examples, self.exceptions

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -146,6 +146,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def batch(
         self,
         examples: list[Example],
+        batch_mode: bool = False,
         num_threads: int | None = None,
         max_errors: int | None = None,
         return_failed_examples: bool = False,
@@ -173,6 +174,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
         # Create an instance of Parallel
         parallel_executor = Parallel(
             num_threads=num_threads,
+            batch_mode=batch_mode,
             max_errors=max_errors,
             return_failed_examples=return_failed_examples,
             provide_traceback=provide_traceback,


### PR DESCRIPTION
Adds support for Batch API calls by intercepting LLM calls during DSPy program execution.
A BatchExecutor spins up a thread for each execution pair and uses a mock 
LLM object that collects inputs from all threads at each Predict step, 
bundles them into JSONL format, and sends them through LiteLLM's batch API.

The system polls for batch completion, then distributes results back to each 
waiting thread, allowing them to continue through their forward() method to 
subsequent Predict steps. This enables batching for multi-step DSPy programs 
while preserving the existing API - users simply add batch_mode=True.