### PR TITLE
fix: Allow reuse of Pydantic models in BAML schema generation

### DIFF
--- a/dspy/adapters/baml_adapter.py
+++ b/dspy/adapters/baml_adapter.py
@@ -102,32 +102,35 @@ def _build_simplified_schema(
     if pydantic_model in seen_models:
         raise ValueError("BAMLAdapter cannot handle recursive pydantic models, please use a different adapter.")
 
-    # Add `pydantic_model` to `seen_models` with a placeholder value to avoid infinite recursion.
+    # Track models currently being traversed so we only flag true recursion.
     seen_models.add(pydantic_model)
+    try:
+        lines = []
+        current_indent = "  " * indent
+        next_indent = "  " * (indent + 1)
 
-    lines = []
-    current_indent = "  " * indent
-    next_indent = "  " * (indent + 1)
+        lines.append(f"{current_indent}{{")
 
-    lines.append(f"{current_indent}{{")
+        fields = pydantic_model.model_fields
+        if not fields:
+            lines.append(f"{next_indent}{COMMENT_SYMBOL} No fields defined")
+        for name, field in fields.items():
+            if field.description:
+                lines.append(f"{next_indent}{COMMENT_SYMBOL} {field.description}")
+            elif field.alias and field.alias != name:
+                # If there's an alias but no description, show the alias as a comment
+                lines.append(f"{next_indent}{COMMENT_SYMBOL} alias: {field.alias}")
 
-    fields = pydantic_model.model_fields
-    if not fields:
-        lines.append(f"{next_indent}{COMMENT_SYMBOL} No fields defined")
-    for name, field in fields.items():
-        if field.description:
-            lines.append(f"{next_indent}{COMMENT_SYMBOL} {field.description}")
-        elif field.alias and field.alias != name:
-            # If there's an alias but no description, show the alias as a comment
-            lines.append(f"{next_indent}{COMMENT_SYMBOL} alias: {field.alias}")
+            rendered_type = _render_type_str(field.annotation, indent=indent + 1, seen_models=seen_models)
+            line = f"{next_indent}{name}: {rendered_type},"
 
-        rendered_type = _render_type_str(field.annotation, indent=indent + 1, seen_models=seen_models)
-        line = f"{next_indent}{name}: {rendered_type},"
+            lines.append(line)
 
-        lines.append(line)
-
-    lines.append(f"{current_indent}}}")
-    return "\n".join(lines)
+        lines.append(f"{current_indent}}}")
+        return "\n".join(lines)
+    finally:
+        # Remove the model so other branches can reuse it without triggering a false recursion.
+        seen_models.remove(pydantic_model)
 
 
 class BAMLAdapter(JSONAdapter):


### PR DESCRIPTION
### Description

Addresses issue https://github.com/stanfordnlp/dspy/issues/8715

The BAML adapter previously disallowed re-use of a BaseModel in a schema, incorrectly classifying all such cases as recursion.

### Changes

- Modified `_build_simplified_schema` to only track models during active traversal using try/finally to ensure cleanup after traversal

- Added test for this situation
