### PR TITLE
Fix the crash when usage tracker is enabled with non-prediction output

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from typing import Any
 
 import magicattr
 
@@ -177,7 +178,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
             results = parallel_executor.forward(exec_pairs)
             return results
 
-    def _set_lm_usage(self, tokens, output):
+    def _set_lm_usage(self, tokens: dict[str, Any], output: Any):
         # Some optimizers (e.g., GEPA bootstrap tracing) temporarily patch
         # module.forward to return a tuple: (prediction, trace).
         # When usage tracking is enabled, ensure we attach usage to the

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -86,7 +86,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
                 if prediction_in_output:
                     prediction_in_output.set_lm_usage(tokens)
                 else:
-                    logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object to enable usage tracking.")
+                    logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking.")
                 return output
 
             return self.forward(*args, **kwargs)
@@ -110,7 +110,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
                     if prediction_in_output:
                         prediction_in_output.set_lm_usage(tokens)
                     else:
-                        logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object to enable usage tracking.")
+                        logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking.")
                     return output
 
             return await self.aforward(*args, **kwargs)

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -83,10 +83,8 @@ class Module(BaseModule, metaclass=ProgramMeta):
                     prediction_in_output = output
                 elif isinstance(output, tuple) and len(output) > 0 and isinstance(output[0], Prediction):
                     prediction_in_output = output[0]
-                if not prediction_in_output:
-                    raise ValueError("No prediction object found in output to call set_lm_usage on.")
-
-                prediction_in_output.set_lm_usage(tokens)
+                if prediction_in_output:
+                    prediction_in_output.set_lm_usage(tokens)
                 return output
 
             return self.forward(*args, **kwargs)

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -86,7 +86,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
                 if prediction_in_output:
                     prediction_in_output.set_lm_usage(tokens)
                 else:
-                    logger.warning("Failed to set LM usage. Return `dspy.Prediction` object to enable usage tracking.")
+                    logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object to enable usage tracking.")
                 return output
 
             return self.forward(*args, **kwargs)
@@ -110,7 +110,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
                     if prediction_in_output:
                         prediction_in_output.set_lm_usage(tokens)
                     else:
-                        logger.warning("Failed to set LM usage. Return `dspy.Prediction` object to enable usage tracking.")
+                        logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object to enable usage tracking.")
                     return output
 
             return await self.aforward(*args, **kwargs)

--- a/tests/primitives/test_base_module.py
+++ b/tests/primitives/test_base_module.py
@@ -370,6 +370,20 @@ async def test_usage_tracker_async_parallel():
         assert lm_usage1["total_tokens"] == 1163
 
 
+def test_usage_tracker_no_side_effect():
+    class MyProgram(dspy.Module):
+        def __init__(self):
+            self.predict = dspy.Predict("question -> answer")
+
+        def forward(self, question: str, **kwargs) -> str:
+            return self.predict(question=question).answer
+
+    program = MyProgram()
+    with dspy.context(lm=DummyLM([{"answer": "Paris"}]), track_usage=True):
+        result = program(question="What is the capital of France?")
+    assert result == "Paris"
+
+
 def test_module_history():
     class MyProgram(dspy.Module):
         def __init__(self, **kwargs):


### PR DESCRIPTION
Currently, dspy modules whose output is not `dspy.Prediction` fail to execute when the usage tracker is enabled. This PR fixes the crash by skipping the usage tracking for this type of modules. While returning objects other than dspy.Prediciton is not expected, this pattern has been found in several places.

Example:
```python
class MyProgram(dspy.Module):
        def __init__(self):
            self.predict = dspy.Predict("question -> answer")

        def forward(self, question: str, **kwargs) -> str:
            return self.predict(question=question).answer

program = MyProgram()
with dspy.context(track_usage=True):
    program(question="What is the capital of France?")
```