### PR TITLE
Propagate callback metadata during GEPA minibatch eval

### DIFF
--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -37,6 +37,7 @@ def bootstrap_trace_data(
     failure_score: float = 0,
     format_failure_score: float = -1,
     log_format_failures: bool = False,
+    callback_metadata: dict[str, Any] | None = None,
 ) -> list[TraceData]:
     # Return a list of dicts with the following keys: example_ind, example, prediction, trace, and score
     # (if metric != None)
@@ -110,7 +111,11 @@ def bootstrap_trace_data(
     program.forward = MethodType(patched_forward, program)
 
     try:
-        results = evaluator(program, metric=wrapped_metric).results
+        results = evaluator(
+            program,
+            metric=wrapped_metric,
+            callback_metadata=callback_metadata,
+        ).results
     finally:
         program.forward = original_forward
 

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -119,8 +119,10 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
 
         if capture_traces:
             # bootstrap_trace_data-like flow with trace capture
-            from dspy.teleprompt.bootstrap_trace import bootstrap_trace_data
-            trajs = bootstrap_trace_data(
+            from dspy.teleprompt import bootstrap_trace as bootstrap_trace_module
+
+            eval_callback_metadata = {"disable_logging": True}
+            trajs = bootstrap_trace_module.bootstrap_trace_data(
                 program=program,
                 dataset=batch,
                 metric=self.metric_fn,
@@ -129,6 +131,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 capture_failed_parses=True,
                 failure_score=self.failure_score,
                 format_failure_score=self.failure_score,
+                callback_metadata=eval_callback_metadata,
             )
             scores = []
             outputs = []


### PR DESCRIPTION
## Summary
Pass the disable-logging callback metadata when the GEPA adapter is running minibatch eval.

## Testing
- pytest tests/teleprompt/test_gepa.py::test_gepa_adapter_disables_logging_on_minibatch_eval -q
- pytest tests/teleprompt/test_bootstrap_trace.py::test_bootstrap_trace_data_passes_callback_metadata -q