### PR TITLE
fix(JSONAdapter): Braces inside output not properly escaped by parser

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -10,6 +10,7 @@ from pydantic.fields import FieldInfo
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
 from dspy.adapters.types.tool import ToolCalls
 from dspy.adapters.utils import (
+    _extract_braces_raw,
     _extract_first_json_object,
     format_field_value,
     get_annotation_name,
@@ -157,10 +158,9 @@ class JSONAdapter(ChatAdapter):
         fields = json_repair.loads(completion)
 
         if not isinstance(fields, dict):
-            pattern = r"\{(?:[^{}]|(?R))*\}"
-            match = regex.search(pattern, completion, regex.DOTALL)
-            if match:
-                completion = match.group(0)
+            extracted = _extract_braces_raw(completion)
+            if extracted:
+                completion = extracted
                 fields = json_repair.loads(completion)
 
         if not isinstance(fields, dict):

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -319,14 +319,14 @@ def _extract_first_json_object(text: str) -> str | None:
             in_string = True
             continue
 
-        if char == '{':
+        if char == "{":
             if depth == 0:
                 start_idx = idx
                 seen_lbrace = True
             depth += 1
             continue
 
-        if char == '}':
+        if char == "}":
             if depth == 0 or start_idx is None:
                 continue
             depth -= 1

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -313,3 +313,26 @@ def _extract_first_json_object(text: str) -> str | None:
                     return text[start : i + 1]
 
     return None
+
+
+def _extract_braces_raw(text: str) -> str | None:
+    """Fallback: balance braces ignoring string contents.
+
+    This is intentionally simpler than _extract_first_json_object - it doesn't
+    track strings, so it can extract JSON even when string delimiters are malformed.
+    The result can then be passed to json_repair to fix string issues.
+    """
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+
+    return None

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -285,3 +285,42 @@ def _quoted_string_for_literal_type_annotation(s: str) -> str:
     else:
         # Neither => enclose in single quotes
         return f"'{s}'"
+
+def _extract_first_json_object(text: str) -> str | None:
+    """Return the first balanced JSON object found in text or None if absent."""
+
+    in_string = False
+    escape = False
+    depth = 0
+    start_idx: int | None = None
+    seen_lbrace = False
+
+    for idx, char in enumerate(text):
+        if seen_lbrace and in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if seen_lbrace and char == '"':
+            in_string = True
+            continue
+
+        if char == "{":
+            if depth == 0:
+                start_idx = idx
+                seen_lbrace = True
+            depth += 1
+            continue
+
+        if char == "}":
+            if depth == 0 or start_idx is None:
+                continue
+            depth -= 1
+            if depth == 0:
+                return text[start_idx : idx + 1]
+
+    return None

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -288,39 +288,28 @@ def _quoted_string_for_literal_type_annotation(s: str) -> str:
 
 def _extract_first_json_object(text: str) -> str | None:
     """Return the first balanced JSON object found in text or None if absent."""
+    start = text.find("{")
+    if start == -1:
+        return None
 
+    depth = 0
     in_string = False
     escape = False
-    depth = 0
-    start_idx: int | None = None
-    seen_lbrace = False
 
-    for idx, char in enumerate(text):
-        if seen_lbrace and in_string:
-            if escape:
-                escape = False
-            elif char == "\\":
-                escape = True
-            elif char == '"':
-                in_string = False
-            continue
-
-        if seen_lbrace and char == '"':
-            in_string = True
-            continue
-
-        if char == "{":
-            if depth == 0:
-                start_idx = idx
-                seen_lbrace = True
-            depth += 1
-            continue
-
-        if char == "}":
-            if depth == 0 or start_idx is None:
-                continue
-            depth -= 1
-            if depth == 0:
-                return text[start_idx : idx + 1]
+    for i in range(start, len(text)):
+        char = text[i]
+        if escape:
+            escape = False
+        elif char == "\\" and in_string:
+            escape = True
+        elif char == '"':
+            in_string = not in_string
+        elif not in_string:
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
 
     return None

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -122,6 +122,10 @@ def test_parse_value_json_repair():
         ('{"message": "Use {placeholders} like {this}", "valid": true}', '{"message": "Use {placeholders} like {this}", "valid": true}'),
         # JSON with escaped quotes in strings
         ('{"quote": "She said \\"hello\\" to me"}', '{"quote": "She said \\"hello\\" to me"}'),
+        # String ending with escaped backslash (backslash before closing quote)
+        ('{"path": "C:\\\\"}', '{"path": "C:\\\\"}'),
+        # Escaped backslash followed by escaped quote (tests escape state reset)
+        ('{"a": "\\\\\\"\\""}', '{"a": "\\\\\\"\\""}'),
         # No JSON present
         ("This is just plain text without any JSON", None),
         # Empty JSON object

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -239,6 +239,35 @@ def test_json_adapter_parse_raise_error_on_mismatch_fields():
     )
 
 
+# Issue (#8759)
+def test_json_adapter_parse_handles_braces_inside_string_values():
+    class CodeIssue(pydantic.BaseModel):
+        issue_type: str
+        severity_level: str
+        problem_code_snippet: str
+
+    class CodeReview(dspy.Signature):
+        reasoning: str = dspy.OutputField(desc="Short chain-of-thought analysis")
+        issue_list: list[CodeIssue] = dspy.OutputField(desc="Detected issues")
+
+    adapter = dspy.JSONAdapter()
+    completion = (
+        "Here is the review output you asked for:\n\n"
+        "{\n"
+        "  \"reasoning\": \"Inspecting the conditional reveals an unmatched brace.\",\n"
+        "  \"issue_list\": [\n"
+        "    {\n"
+        "      \"issue_type\": \"style\",\n"
+        "      \"severity_level\": \"fatal\",\n"
+        "      \"problem_code_snippet\": \"if (user) {\"\n"
+        "    }\n"
+        "  ]\n"
+        "}\n"
+    )
+
+    adapter.parse(CodeReview, completion)
+
+
 def test_json_adapter_formats_image():
     # Test basic image formatting
     image = dspy.Image(url="https://example.com/image.jpg")

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -265,7 +265,14 @@ def test_json_adapter_parse_handles_braces_inside_string_values():
         "}\n"
     )
 
-    adapter.parse(CodeReview, completion)
+    result = adapter.parse(CodeReview, completion)
+
+    assert result["reasoning"] == "Inspecting the conditional reveals an unmatched brace."
+    assert len(result["issue_list"]) == 1
+    issue = result["issue_list"][0]
+    assert issue.issue_type == "style"
+    assert issue.severity_level == "fatal"
+    assert issue.problem_code_snippet == "if (user) {"
 
 
 def test_json_adapter_formats_image():

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -239,7 +239,6 @@ def test_json_adapter_parse_raise_error_on_mismatch_fields():
     )
 
 
-# Issue (#8759)
 def test_json_adapter_parse_handles_braces_inside_string_values():
     class CodeIssue(pydantic.BaseModel):
         issue_type: str

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -254,12 +254,12 @@ def test_json_adapter_parse_handles_braces_inside_string_values():
     completion = (
         "Here is the review output you asked for:\n\n"
         "{\n"
-        "  \"reasoning\": \"Inspecting the conditional reveals an unmatched brace.\",\n"
-        "  \"issue_list\": [\n"
+        '  "reasoning": "Inspecting the conditional reveals an unmatched brace.",\n'
+        '  "issue_list": [\n'
         "    {\n"
-        "      \"issue_type\": \"style\",\n"
-        "      \"severity_level\": \"fatal\",\n"
-        "      \"problem_code_snippet\": \"if (user) {\"\n"
+        '      "issue_type": "style",\n'
+        '      "severity_level": "fatal",\n'
+        '      "problem_code_snippet": "if (user) {"\n'
         "    }\n"
         "  ]\n"
         "}\n"


### PR DESCRIPTION
Adds a json extraction function, which will allow us to properly parse brackets that jsonAdapter outputs:

Before, we would use a regex string that naively matches curly braces, but now we have a smarter extractor that takes the first full object.

We always pass this object to json_repair after.

```json
{
  "reasoning": "think step by step",
  "issue_list": [
    {
      "issue_type": "some type",
      "severity_level": "fatal",
      "problem_code_snippet": "if (user) {"
    }
  ]
}
```

We recently added behavior to retry json_repair (#9182), but this used the regex module. We can replace it with a simple bracket based search (unescaped) to mimic this behavior.

This will also allow us to remove the regex dependency in a follow on PR.

Fixes #8759 