### PR TITLE
Add Pillow dependency and adjust ReAct test import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "cachetools>=5.5.0",
     "cloudpickle>=3.0.0",
     "rich>=13.7.1",
+    "pillow>=10.1.0",
     "numpy>=1.26.0",
     "xxhash>=3.5.0",
     "gepa[dspy]==0.0.17",

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -2,14 +2,17 @@ import re
 
 import litellm
 import pytest
-from PIL import Image
 from pydantic import BaseModel
 
 import dspy
 from dspy.utils.dummies import DummyLM
 
 
+@pytest.mark.extra
 def test_tool_observation_preserves_custom_type():
+    pytest.importorskip("PIL.Image")
+    from PIL import Image
+
     captured_calls = []
 
     class SpyChatAdapter(dspy.ChatAdapter):

--- a/uv.lock
+++ b/uv.lock
@@ -683,6 +683,7 @@ dependencies = [
     { name = "openai" },
     { name = "optuna" },
     { name = "orjson" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "regex" },
     { name = "requests" },


### PR DESCRIPTION
## Summary
- add Pillow as a core dependency so PIL utilities are available for runtime features
- mark the ReAct test that depends on PIL as an extra test to match optional execution expectations
- import PIL lazily inside the ReAct test using `pytest.importorskip`