### PR TITLE
fix: XML adapter's markers

### DIFF
--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -261,3 +261,18 @@ def test_xml_adapter_with_code():
             {"question": "Write a python program to print 'Hello, world!'"},
         )
         assert result[0]["code"].code == 'print("Hello, world!")'
+
+
+def test_xml_adapter_user_message_contains_xml_input_tags():
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    adapter = dspy.XMLAdapter()
+    messages = adapter.format(MySignature, [], {"question": "When was Marie Curie born?"})
+
+    assert len(messages) == 2
+    assert messages[1]["role"] == "user"
+    assert "<question>" in messages[1]["content"]
+    assert "</question>" in messages[1]["content"]
+    assert "When was Marie Curie born?" in messages[1]["content"]


### PR DESCRIPTION
# Summary

## Issue with the XMLAdapter
- XMLAdapter inherited ChatAdapter’s bracketed completion marker (`[[ ## completed ## ]]`) behavior, leading to prompts that mixed XML tags with ChatAdapter markers. This confused models and produced `[[ ## completed ## ]]` instead of the expected XML-only output (Closes https://github.com/stanfordnlp/dspy/issues/8875)

## Cause of the issue
- XMLAdapter was designed to emit XML tags (e.g., `<answer>...</answer>`), but it only overrode parts of the inherited ChatAdapter class:
  - Overrode: `format_field_with_value` (to XML), `user_message_output_requirements` (wrongly instructing to add a `<completed>` tag), and `parse`.
  - Did not  override all ChatAdapter-provided formatting paths that inject the bracketed style:
    - `format_field_structure` (system structure example) added `[[ ## completed ## ]]` in ChatAdapter.
    - `format_assistant_message_content` appended `[[ ## completed ## ]]` in ChatAdapter
    - `format_user_message_content` for inputs used ChatAdapter’s `[[ ## field ## ]]` headers.

As a result, the final prompt contained the ChatAdapter marker `[[ ## completed ## ]]` and bracketed sections instead of XML fields.

## How I fixed it
- Ensure XMLAdapter formats the entire prompt surface (system, user, assistant) with XML tags only.
- Changes:
  - Override XMLAdapter input message formatting to emit XML tags:
    - `dspy/adapters/xml_adapter.py:44` (`format_user_message_content`) now wraps inputs with `<field>...</field>`.
  - Keep structure and assistant outputs XML-only, (no `[[ ## completed ## ]]`, no `<completed>` tag):

- Tests added:
  - `test_xml_adapter_user_message_contains_xml_input_tags` asserts that `XMLAdapter.format(...)` produces `<question>...</question>` in the user message for an input named `question`, rather than using ChatAdapter's formatting.

## Further discussion

This issue could have been avoided with a better architectural design of the adapters; notably by avoiding inheriting from a base class ChatAdapter that has opinionated formatting of the prompt. Perhaps in a future PR we could take another approach, but this is out of scope for now and would require more discussions.