### PR TITLE
fix(MIPROv2): select between task_model and prompt_model

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -90,6 +90,9 @@ class MIPROv2(Teleprompter):
         self.seed = seed
         self.rng = None
 
+        if not self.prompt_model or not self.task_model:
+            raise ValueError("Either provide both prompt_model and task_model or set a default LM through dspy.configure(lm=...)")
+
     def compile(
         self,
         student: Any,

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -178,38 +178,41 @@ class MIPROv2(Teleprompter):
             provide_traceback=provide_traceback,
         )
 
-        # Step 1: Bootstrap few-shot examples
-        demo_candidates = self._bootstrap_fewshot_examples(program, trainset, seed, teacher)
+        with dspy.context(lm=self.task_model):
+            # Step 1: Bootstrap few-shot examples
+            demo_candidates = self._bootstrap_fewshot_examples(program, trainset, seed, teacher)
 
-        # Step 2: Propose instruction candidates
-        instruction_candidates = self._propose_instructions(
-            program,
-            trainset,
-            demo_candidates,
-            view_data_batch_size,
-            program_aware_proposer,
-            data_aware_proposer,
-            tip_aware_proposer,
-            fewshot_aware_proposer,
-        )
+        with dspy.context(lm=self.prompt_model):
+            # Step 2: Propose instruction candidates
+            instruction_candidates = self._propose_instructions(
+                program,
+                trainset,
+                demo_candidates,
+                view_data_batch_size,
+                program_aware_proposer,
+                data_aware_proposer,
+                tip_aware_proposer,
+                fewshot_aware_proposer,
+            )
 
         # If zero-shot, discard demos
         if zeroshot_opt:
             demo_candidates = None
 
-        # Step 3: Find optimal prompt parameters
-        best_program = self._optimize_prompt_parameters(
-            program,
-            instruction_candidates,
-            demo_candidates,
-            evaluate,
-            valset,
-            num_trials,
-            minibatch,
-            minibatch_size,
-            minibatch_full_eval_steps,
-            seed,
-        )
+        with dspy.context(lm=self.task_model):
+            # Step 3: Find optimal prompt parameters
+            best_program = self._optimize_prompt_parameters(
+                program,
+                instruction_candidates,
+                demo_candidates,
+                evaluate,
+                valset,
+                num_trials,
+                minibatch,
+                minibatch_size,
+                minibatch_full_eval_steps,
+                seed,
+            )
 
         return best_program
 

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -185,18 +185,17 @@ class MIPROv2(Teleprompter):
             # Step 1: Bootstrap few-shot examples
             demo_candidates = self._bootstrap_fewshot_examples(program, trainset, seed, teacher)
 
-        with dspy.context(lm=self.prompt_model):
-            # Step 2: Propose instruction candidates
-            instruction_candidates = self._propose_instructions(
-                program,
-                trainset,
-                demo_candidates,
-                view_data_batch_size,
-                program_aware_proposer,
-                data_aware_proposer,
-                tip_aware_proposer,
-                fewshot_aware_proposer,
-            )
+        # Step 2: Propose instruction candidates
+        instruction_candidates = self._propose_instructions(
+            program,
+            trainset,
+            demo_candidates,
+            view_data_batch_size,
+            program_aware_proposer,
+            data_aware_proposer,
+            tip_aware_proposer,
+            fewshot_aware_proposer,
+        )
 
         # If zero-shot, discard demos
         if zeroshot_opt:


### PR DESCRIPTION
MIPROv2 doesn't actually use `task_model` anywhere in the code. It does pass `prompt_model` to `GroundedProposer`.

Manually validated that MIPRO runs e2e with no dspy.configure via the following script:

```python
import dspy

lm = dspy.LM("openai/gpt-5-nano", temperature=1.0, max_tokens=16000)

program = dspy.Predict("number_as_string: str -> number: int")
trainset = [
    dspy.Example(number_as_string="123", number=123).with_inputs("number_as_string"),
    dspy.Example(number_as_string="456", number=456).with_inputs("number_as_string"),
    dspy.Example(number_as_string="789", number=789).with_inputs("number_as_string"),
]


def metric_dspy(e, p, t=None):
    return 1 if p.number == e.number else 0

optimizer = dspy.MIPROv2(
    metric_dspy, 
    max_bootstrapped_demos = 3, 
    max_labeled_demos = 3, 
    prompt_model=lm, 
    task_model=lm,
    auto = "medium",
    num_threads=6)
dprogram_optimized_v2 = optimizer.compile(program, trainset=trainset, requires_permission_to_run = False, teacher = program)
```


Fixes #8672 