### PR TITLE
Add DSPy User agent header

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -307,6 +307,7 @@ def _get_stream_completion_fn(
         response = await litellm.acompletion(
             cache=cache_kwargs,
             stream=True,
+            headers=_get_headers(),
             **request,
         )
         chunks = []
@@ -341,6 +342,7 @@ def litellm_completion(request: dict[str, Any], num_retries: int, cache: dict[st
             cache=cache,
             num_retries=num_retries,
             retry_strategy="exponential_backoff_retry",
+            headers=_get_headers(),
             **request,
         )
 
@@ -371,6 +373,7 @@ def litellm_text_completion(request: dict[str, Any], num_retries: int, cache: di
         prompt=prompt,
         num_retries=num_retries,
         retry_strategy="exponential_backoff_retry",
+        headers=_get_headers(),
         **request,
     )
 
@@ -385,6 +388,7 @@ async def alitellm_completion(request: dict[str, Any], num_retries: int, cache: 
             cache=cache,
             num_retries=num_retries,
             retry_strategy="exponential_backoff_retry",
+            headers=_get_headers(),
             **request,
         )
 
@@ -413,6 +417,7 @@ async def alitellm_text_completion(request: dict[str, Any], num_retries: int, ca
         prompt=prompt,
         num_retries=num_retries,
         retry_strategy="exponential_backoff_retry",
+        headers=_get_headers(),
         **request,
     )
 
@@ -427,6 +432,7 @@ def litellm_responses_completion(request: dict[str, Any], num_retries: int, cach
         cache=cache,
         num_retries=num_retries,
         retry_strategy="exponential_backoff_retry",
+        headers=_get_headers(),
         **request,
     )
 
@@ -441,6 +447,7 @@ async def alitellm_responses_completion(request: dict[str, Any], num_retries: in
         cache=cache,
         num_retries=num_retries,
         retry_strategy="exponential_backoff_retry",
+        headers=_get_headers(),
         **request,
     )
 
@@ -457,3 +464,8 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
                 content_blocks.extend(c)
         request["input"] = [{"role": msg.get("role", "user"), "content": content_blocks}]
     return request
+
+def _get_headers():
+    return {
+        "User-Agent": f"DSPy/{dspy.__version__}"
+    }


### PR DESCRIPTION
Include "User-Agent: DSPy/{version}" in the HTTP header to specify traffic made by DSPy.