### PR TITLE
[Docstring Fix] Add docstring for Adapter

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -22,7 +22,7 @@ _DEFAULT_NATIVE_RESPONSE_TYPES = [Citations]
 class Adapter:
     """Base Adapter class.
 
-    The Adapter serves as the interface layer between DSPy module/signature andLanguage Models (LMs). It handles the
+    The Adapter serves as the interface layer between DSPy module/signature and Language Models (LMs). It handles the
     complete transformation pipeline from DSPy inputs to LM calls and back to structured outputs.
 
     Key responsibilities:


### PR DESCRIPTION
Sample PR for the effort of docstring fix, which we will get help from our community members. This one fixes the docstring of `dspy.Adapter`. The basic rule is 1) every public method should have a docstring 2) there must be no errors in the docstring. 

After merging this PR, I will open an issue that contains the guideline of contributing. 