### PR TITLE
Deflake the real LM test

### DIFF
--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -157,7 +157,7 @@ async def test_stream_listener_chat_adapter(lm_for_test):
         include_final_prediction_in_output_stream=False,
     )
     # Turn off the cache to ensure the stream is produced.
-    with dspy.context(lm=dspy.LM(lm_for_test, cache=False)):
+    with dspy.context(lm=dspy.LM(lm_for_test, cache=False, temperature=0.0)):
         output = program(x="why did a chicken cross the kitchen?")
         all_chunks = []
         async for value in output:
@@ -221,7 +221,7 @@ async def test_stream_listener_json_adapter(lm_for_test):
         include_final_prediction_in_output_stream=False,
     )
     # Turn off the cache to ensure the stream is produced.
-    with dspy.context(lm=dspy.LM(lm_for_test, cache=False), adapter=dspy.JSONAdapter()):
+    with dspy.context(lm=dspy.LM(lm_for_test, cache=False, temperature=0.0), adapter=dspy.JSONAdapter()):
         output = program(x="why did a chicken cross the kitchen?")
         all_chunks = []
         async for value in output:
@@ -289,7 +289,7 @@ def test_sync_streaming(lm_for_test):
         async_streaming=False,
     )
     # Turn off the cache to ensure the stream is produced.
-    with dspy.context(lm=dspy.LM(lm_for_test, cache=False)):
+    with dspy.context(lm=dspy.LM(lm_for_test, cache=False, temperature=0.0)):
         output = program(x="why did a chicken cross the kitchen?")
         all_chunks = []
         for value in output:
@@ -436,6 +436,7 @@ async def test_stream_listener_returns_correct_chunk_chat_adapter():
         assert all_chunks[21].chunk == " format"
         assert all_chunks[22].chunk == "."
         assert all_chunks[22].is_last_chunk is True
+
 
 @pytest.mark.anyio
 async def test_stream_listener_returns_correct_chunk_json_adapter():


### PR DESCRIPTION
There is some flakiness due to the randomness in small LMs used for real LM testing. This test change will deflake it by explicitly setting `temperature=0.0`

resolve #8919 