### PR TITLE
[docs] Add Google-style docstring for Signature.with_instructions #8942

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -258,11 +258,17 @@ class Signature(BaseModel, metaclass=SignatureMeta):
             and whose instructions equal ``instructions``.
 
         Example:
-            >>> NewSig = MySig.with_instructions("Translate to French.")
-            >>> NewSig is MySig
-            False
-            >>> NewSig.instructions
-            'Translate to French.'
+            ```
+            from dspy.signatures import Signature, InputField, OutputField
+
+            class MySig(Signature):
+                input_text: str = InputField(desc="Input text")
+                output_text: str = OutputField(desc="Output text")
+
+            NewSig = MySig.with_instructions("Translate to French.")
+            assert NewSig is not MySig
+            assert NewSig.instructions == "Translate to French."
+            ```
         """
         return Signature(cls.fields, instructions)
 


### PR DESCRIPTION
This PR adds a Google-style docstring for `Signature.with_instructions`
in `dspy/signatures/signature.py`.

- Behavior verified in IPython (returns a NEW Signature class with same fields and new instructions).
- No logic changes; minimal diff.

Marking as draft; I’ll extend to additional Signature methods per #8926.
