### PR TITLE
chore(docs): gate publish on release

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -2,10 +2,12 @@ name: Update DSPy Docs
 
 on:
   push:
-    branches:
-      - main
-    paths:
-      - "docs/**"
+    tags:
+      - "*"
+  release:
+    types:
+      - published
+  workflow_dispatch:
   pull_request:
     paths:
       - "docs/**"
@@ -28,7 +30,7 @@ jobs:
           mkdocs build
 
   update-docs-subtree:
-    if: github.event_name == 'push' && github.repository == 'stanfordnlp/dspy'
+    if: github.event_name != 'pull_request' && github.repository == 'stanfordnlp/dspy'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Change the doc update condition and update the docs only when a new release is cut or triggered manually