### PR TITLE
Cache Ollama to speed up CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -132,6 +132,9 @@ jobs:
         run: echo "LM_FOR_TEST=ollama/llama3.2:3b" >> $GITHUB_ENV
       - name: Run tests
         run: uv run -p .venv pytest -m llm_call --llm_call -vv --durations=5 tests/
+      - name: Fix permissions for cache
+        if: always()
+        run: sudo chown -R $USER:$USER ollama-data || true
       - name: Stop Ollama service
         if: always()
         run: docker stop ollama && docker rm ollama


### PR DESCRIPTION
As tested in https://github.com/stanfordnlp/dspy/actions/runs/18826667003/job/53711301001?pr=8972, the ollama model weights are cached, and we can greatly improve the CI's latency.