### PR TITLE
Fix download function to handle zero remote size case

### DIFF
--- a/dspy/utils/__init__.py
+++ b/dspy/utils/__init__.py
@@ -16,7 +16,7 @@ def download(url):
     remote_size = int(requests.head(url, allow_redirects=True).headers.get("Content-Length", 0))
     local_size = os.path.getsize(filename) if os.path.exists(filename) else 0
 
-    if local_size != remote_size:
+    if local_size != remote_size or remote_size == 0:
         print(f"Downloading '{filename}'...")
         with requests.get(url, stream=True) as r, open(filename, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):


### PR DESCRIPTION
Sometimes, `remote_size` is always 0. I found this error when I tried an offcial tutorial. 

```python
import ujson
from dspy.utils import download

download("https://huggingface.co/dspy/cache/resolve/main/ragqa_arena_tech_examples.jsonl")
```