### PR TITLE
Add missing API reference documentation for dspy.majority

### DIFF
--- a/docs/docs/api/modules/majority.md
+++ b/docs/docs/api/modules/majority.md
@@ -1,0 +1,15 @@
+# dspy.majority
+
+<!-- START_API_REF -->
+::: dspy.majority
+    handler: python
+    options:
+        show_source: true
+        show_root_heading: true
+        heading_level: 2
+        docstring_style: google
+        show_root_full_path: true
+        show_object_full_path: false
+        separate_signature: false
+:::
+<!-- END_API_REF -->


### PR DESCRIPTION
The dspy.majority function exists in the codebase (dspy/predict/aggregation.py) and is referenced in the [learn documentation](https://dspy.ai/learn/programming/modules/), but was missing from the [API reference](https://dspy.ai/api/). This adds the corresponding API documentation page.