### PR TITLE
docs: Add XMLAdapter documentation

### DIFF
--- a/docs/docs/api/adapters/XMLAdapter.md
+++ b/docs/docs/api/adapters/XMLAdapter.md
@@ -1,0 +1,31 @@
+# dspy.XMLAdapter
+
+<!-- START_API_REF -->
+::: dspy.XMLAdapter
+    handler: python
+    options:
+        members:
+            - __call__
+            - acall
+            - format
+            - format_assistant_message_content
+            - format_conversation_history
+            - format_demos
+            - format_field_description
+            - format_field_structure
+            - format_field_with_value
+            - format_finetune_data
+            - format_task_description
+            - format_user_message_content
+            - parse
+            - user_message_output_requirements
+        show_source: true
+        show_root_heading: true
+        heading_level: 2
+        docstring_style: google
+        show_root_full_path: true
+        show_object_full_path: false
+        separate_signature: false
+        inherited_members: true
+:::
+<!-- END_API_REF -->


### PR DESCRIPTION
Noticed that XMLAdapter doesn't have it's own documentation, even though it was referenced in some of the talks. Asked Claude Code to update it. Please feel free to review!

---

Add comprehensive documentation for XMLAdapter to both the main adapters guide and API reference.

Changes:
- Add XMLAdapter section to docs/docs/learn/programming/adapters.md
  - Format structure with example usage
  - When to use and when not to use guidance
  - Complete example with expected output
- Create docs/docs/api/adapters/XMLAdapter.md for API reference
- Update adapter types overview with XMLAdapter mention

XMLAdapter has been in the codebase since August 2025 but was missing from documentation. This fills that gap.