### PR TITLE
Add missing SIMBA optimizer description

### DIFF
--- a/docs/docs/learn/optimization/optimizers.md
+++ b/docs/docs/learn/optimization/optimizers.md
@@ -58,7 +58,7 @@ These optimizers produce optimal instructions for the prompt and, in the case of
 
 6. [**`MIPROv2`**](../../api/optimizers/MIPROv2.md): Generates instructions *and* few-shot examples in each step. The instruction generation is data-aware and demonstration-aware. Uses Bayesian Optimization to effectively search over the space of generation instructions/demonstrations across your modules.
 
-7. [**`SIMBA`**](../../api/optimizers/SIMBA.md): Uses the LLM to analyze its own performance, identifies challenging examples with high output variability, and generates improvement rules by either creating self-reflective rules or adding successful examples as demonstrations.
+7. [**`SIMBA`**](../../api/optimizers/SIMBA.md): Samples mini-batches, identifies challenging examples with high output variability, and improves the program by either adding successful examples as demonstrations or using the LLM to compare good vs. bad trajectories and generate improvement instructions.
 
 8. [**`GEPA`**](../../api/optimizers/GEPA/overview.md): Uses LM's to reflect on the DSPy program's trajectory, to identify what worked, what didn't and propose prompts addressing the gaps. Additionally, GEPA can leverage domain-specific textual feedback to rapidly improve the DSPy program. Detailed tutorials on using GEPA are available at [dspy.GEPA Tutorials](../../tutorials/gepa_ai_program/index.md).
 


### PR DESCRIPTION
Noticed that SIMBA was the only optimizer in the "Automatic Instruction Optimization" section without an explanation. Added a description based on the implementation that matches the style and detail level of the other optimizers (COPRO, MIPROv2, GEPA).