### PR TITLE
Fix missing Real-World Examples and Experimental RL Optimization sections on tutorials page

### DIFF
--- a/docs/docs/tutorials/index.md
+++ b/docs/docs/tutorials/index.md
@@ -42,14 +42,10 @@ Welcome to DSPy tutorials! We've organized our tutorials into three main categor
     - [GEPA for Code Backdoor Classification (AI control)](gepa_trusted_monitor/index.ipynb)
 
 
-- Real-World Examples:
-    - [Overview](real_world_examples/index.md)
-    - [Generating llms.txt](llms_txt_generation/index.md)
-    - [Email Information Extraction](email_extraction/index.md)
-    - [Memory-Enabled ReAct Agents with Mem0](mem0_react_agent/index.md)
-    - [Financial Analysis with Yahoo Finance](yahoo_finance_react/index.md)
-    - [Automated Code Generation from Documentation](sample_code_generation/index.md)
-    - [Building a Creative Text-Based AI Game](ai_text_game/index.md)
+- Experimental RL Optimization:
+    - [Overview](rl_ai_program/index.md)
+    - [RL for Privacy-Conscious Delegation](rl_papillon/index.ipynb)
+    - [RL for Multi-Hop Research](rl_multihop/index.ipynb)
 
 
 - Tools, Development, and Deployment
@@ -62,5 +58,15 @@ Welcome to DSPy tutorials! We've organized our tutorials into three main categor
     - [Tracking DSPy Optimizers](optimizer_tracking/index.md)
     - [Streaming](streaming/index.md)
     - [Async](async/index.md)
+
+
+- Real-World Examples:
+    - [Overview](real_world_examples/index.md)
+    - [Generating llms.txt](llms_txt_generation/index.md)
+    - [Email Information Extraction](email_extraction/index.md)
+    - [Memory-Enabled ReAct Agents with Mem0](mem0_react_agent/index.md)
+    - [Financial Analysis with Yahoo Finance](yahoo_finance_react/index.md)
+    - [Automated Code Generation from Documentation](sample_code_generation/index.md)
+    - [Building a Creative Text-Based AI Game](ai_text_game/index.md)
 
 


### PR DESCRIPTION
The tutorials index page (https://dspy.ai/tutorials/) was missing two entire sections:

Real-World Examples (6 tutorials) - wasn't displayed at all
Experimental RL Optimization (2 tutorials) - also not included