### PR TITLE
Fixed a serialization bug in `dspy.Example`

### DIFF
--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -195,6 +195,8 @@ class Example:
                 return value.toDict()
             elif isinstance(value, list):
                 return [convert_to_serializable(item) for item in value]
+            elif isinstance(value, tuple):
+                return tuple(convert_to_serializable(item) for item in value)
             elif isinstance(value, dict):
                 return {k: convert_to_serializable(v) for k, v in value.items()}
             else:


### PR DESCRIPTION
`Example.toDict()` did not account for the case in which the value is a tuple. This happens in `Evaluate.__call__()`, where the `results` is a list of tuples, where each tuple includes `Prediction` objects internally. Right now, the failure to parse tuples means the internal `Prediction` objects do not get serialized to dicts, which means that the resultant dict is not, for example, json-serializable. 

I opted for a minimal fix, but there could be other approaches, e.g. adding a dependency to handle the serialization, etc.