### PR TITLE
fix(XMLAdapter): Implement user message formatting

### DIFF
--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -41,6 +41,31 @@ class XMLAdapter(ChatAdapter):
         parts.append(format_signature_fields_for_instructions(signature.output_fields))
         return "\n\n".join(parts).strip()
 
+    def format_user_message_content(
+        self,
+        signature: type[Signature],
+        inputs: dict[str, Any],
+        prefix: str = "",
+        suffix: str = "",
+        main_request: bool = False,
+    ) -> str:
+        messages = [prefix]
+
+        messages.append(self.format_field_with_value(
+            {
+                FieldInfoWithName(name=k, info=v): inputs.get(k)
+                for k, v in signature.input_fields.items() if k in inputs
+            },
+        ))
+
+        if main_request:
+            output_requirements = self.user_message_output_requirements(signature)
+            if output_requirements is not None:
+                messages.append(output_requirements)
+
+        messages.append(suffix)
+        return "\n\n".join(messages).strip()
+
     def format_assistant_message_content(
         self,
         signature: type[Signature],

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -291,7 +291,7 @@ def test_xml_adapter_full_prompt():
     )
 
     expected_user = (
-        "[[ ## query ## ]]\nwhen was Marie Curie born\n\n"
+        "<query>\nwhen was Marie Curie born\n</query>\n\n"
         "Respond with the corresponding output fields wrapped in XML tags `<answer>`."
     )
 


### PR DESCRIPTION
Closes #9002 

As you can see with the screenshot here, the user message is now properly formatted and LMs are no longer repeating inputs in their output. We also no longer need the completed tag used in the chat adapter as a result.

<img width="1354" height="709" alt="image" src="https://github.com/user-attachments/assets/567e6338-1865-4e09-bd74-0d12b07056fd" />

