### PR TITLE
Add a method to extract system message based on adapter and signature

### DIFF
--- a/docs/docs/learn/programming/adapters.md
+++ b/docs/docs/learn/programming/adapters.md
@@ -74,6 +74,34 @@ The output should resemble:
 {'role': 'user', 'content': '[[ ## question ## ]]\nWhat is 2+2?\n\nRespond with the corresponding output fields, starting with the field `[[ ## answer ## ]]`, and then ending with the marker for `[[ ## completed ## ]]`.'}
 ```
 
+You can also only fetch the system message by calling `adapter.format_system_message(signature)`.
+
+```python
+import dspy
+
+signature = dspy.Signature("question -> answer")
+system_message = dspy.ChatAdapter().format_system_message(signature)
+print(system_message)
+```
+
+The output should resemble:
+
+```
+Your input fields are:
+1. `question` (str):
+Your output fields are:
+1. `answer` (str):
+All interactions will be structured in the following way, with the appropriate values filled in.
+
+[[ ## question ## ]]
+{question}
+[[ ## answer ## ]]
+{answer}
+[[ ## completed ## ]]
+In adhering to this structure, your objective is: 
+        Given the fields `question`, produce the fields `answer`.
+```
+
 ## Types of Adapters
 
 DSPy offers several adapter types, each tailored for specific use cases:

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -272,11 +272,7 @@ class Adapter:
             )
 
         messages = []
-        system_message = (
-            f"{self.format_field_description(signature)}\n"
-            f"{self.format_field_structure(signature)}\n"
-            f"{self.format_task_description(signature)}"
-        )
+        system_message = self.format_system_message(signature)
         messages.append({"role": "system", "content": system_message})
         messages.extend(self.format_demos(signature, demos))
         if history_field_name:
@@ -291,6 +287,19 @@ class Adapter:
 
         messages = split_message_content_for_custom_types(messages)
         return messages
+
+    def format_system_message(self, signature: type[Signature]) -> str:
+        """Format the system message for the LM call.
+
+
+        Args:
+            signature: The DSPy signature for which to format the system message.
+        """
+        return (
+            f"{self.format_field_description(signature)}\n"
+            f"{self.format_field_structure(signature)}\n"
+            f"{self.format_task_description(signature)}"
+        )
 
     def format_field_description(self, signature: type[Signature]) -> str:
         """Format the field description for the system message.

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -442,6 +442,7 @@ def test_chat_adapter_fallback_to_json_adapter_on_exception():
         result = adapter(lm, {}, signature, [], {"question": "What is the capital of France?"})
         assert result == [{"answer": "Paris"}]
 
+
 def test_chat_adapter_respects_use_json_adapter_fallback_flag():
     signature = dspy.make_signature("question->answer")
     adapter = dspy.ChatAdapter(use_json_adapter_fallback=False)
@@ -608,3 +609,35 @@ def test_chat_adapter_toolcalls_vague_match():
         assert result[0]["tool_calls"] == dspy.ToolCalls(
             tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"})]
         )
+
+
+def test_format_system_message():
+    class MySignature(dspy.Signature):
+        """Answer the question with multiple answers and scores"""
+
+        question: str = dspy.InputField()
+        answers: list[str] = dspy.OutputField()
+        scores: list[float] = dspy.OutputField()
+
+    adapter = dspy.ChatAdapter()
+    system_message = adapter.format_system_message(MySignature)
+    expected_system_message = """Your input fields are:
+1. `question` (str):
+Your output fields are:
+1. `answers` (list[str]): 
+2. `scores` (list[float]):
+All interactions will be structured in the following way, with the appropriate values filled in.
+
+[[ ## question ## ]]
+{question}
+
+[[ ## answers ## ]]
+{answers}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "string"}}
+
+[[ ## scores ## ]]
+{scores}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "number"}}
+
+[[ ## completed ## ]]
+In adhering to this structure, your objective is: 
+        Answer the question with multiple answers and scores"""
+    assert system_message == expected_system_message

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -297,3 +297,37 @@ def test_xml_adapter_full_prompt():
 
     assert messages[0]["content"] == expected_system
     assert messages[1]["content"] == expected_user
+
+
+def test_format_system_message():
+    class MySignature(dspy.Signature):
+        """Answer the question with multiple answers and scores"""
+
+        question: str = dspy.InputField()
+        answers: list[str] = dspy.OutputField()
+        scores: list[float] = dspy.OutputField()
+
+    adapter = dspy.XMLAdapter()
+    system_message = adapter.format_system_message(MySignature)
+
+    expected_system_message = """Your input fields are:
+1. `question` (str):
+Your output fields are:
+1. `answers` (list[str]): 
+2. `scores` (list[float]):
+All interactions will be structured in the following way, with the appropriate values filled in.
+
+<question>
+{question}
+</question>
+
+<answers>
+{answers}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "string"}}
+</answers>
+
+<scores>
+{scores}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "number"}}
+</scores>
+In adhering to this structure, your objective is: 
+        Answer the question with multiple answers and scores"""
+    assert system_message == expected_system_message


### PR DESCRIPTION
In some scenarios users want to extract the actual prompt sent to LM programmatically. Right now we allow users to use `Adapter.format()` to get the multi-turn message, but sometimes users only want to extract the system message. This PR introduces a new method `Adapter.format_system_message()` which only extracts system message based on adapter and signature. 

Example usage:

```python
import dspy

signature = dspy.Signature("question -> answer")
system_message = dspy.ChatAdapter().format_system_message(signature)
print(system_message)
```

The output should resemble:

```
Your input fields are:
1. `question` (str):
Your output fields are:
1. `answer` (str):
All interactions will be structured in the following way, with the appropriate values filled in.

[[ ## question ## ]]
{question}
[[ ## answer ## ]]
{answer}
[[ ## completed ## ]]
In adhering to this structure, your objective is: 
        Given the fields `question`, produce the fields `answer`.
```