### PR TITLE
fix(docs): add python language id to code block

### DIFF
--- a/docs/docs/tutorials/conversation_history/index.md
+++ b/docs/docs/tutorials/conversation_history/index.md
@@ -118,7 +118,7 @@ You may notice that `history` does not appear in the input fields section of the
 
 For example:
 
-```
+```python
 import dspy
 
 dspy.settings.configure(lm=dspy.LM("openai/gpt-4o-mini"))


### PR DESCRIPTION
This pull request updates the code block formatting in the documentation for the conversation history tutorial.

* Updated the code block in `docs/docs/tutorials/conversation_history/index.md` to use `python` syntax highlighting for better readability.