### PR TITLE
Refactor: update type hints for adapter and LM methods

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -114,7 +114,7 @@ class Adapter:
         self,
         processed_signature: type[Signature],
         original_signature: type[Signature],
-        outputs: list[dict[str, Any]],
+        outputs: list[dict[str, Any] | str],
         lm: "LM",
     ) -> list[dict[str, Any]]:
         values = []

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from typing import Any
 
 from dspy.dsp.utils import settings
 from dspy.utils.callback import with_callbacks
@@ -81,31 +82,55 @@ class BaseLM:
         return outputs
 
     @with_callbacks
-    def __call__(self, prompt=None, messages=None, **kwargs):
+    def __call__(
+        self,
+        prompt: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        **kwargs
+    ) -> list[dict[str, Any] | str]:
         response = self.forward(prompt=prompt, messages=messages, **kwargs)
         outputs = self._process_lm_response(response, prompt, messages, **kwargs)
 
         return outputs
 
     @with_callbacks
-    async def acall(self, prompt=None, messages=None, **kwargs):
+    async def acall(
+        self,
+        prompt: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        **kwargs
+    ) -> list[dict[str, Any] | str]:
         response = await self.aforward(prompt=prompt, messages=messages, **kwargs)
         outputs = self._process_lm_response(response, prompt, messages, **kwargs)
         return outputs
 
-    def forward(self, prompt=None, messages=None, **kwargs):
+    def forward(
+        self,
+        prompt: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        **kwargs
+    ):
         """Forward pass for the language model.
 
-        Subclasses must implement this method, and the response should be identical to
-        [OpenAI response format](https://platform.openai.com/docs/api-reference/responses/object).
+        Subclasses must implement this method, and the response should be identical to either of the following formats:
+        - [OpenAI response format](https://platform.openai.com/docs/api-reference/responses/object)
+        - [OpenAI chat completion format](https://platform.openai.com/docs/api-reference/chat/object)
+        - [OpenAI text completion format](https://platform.openai.com/docs/api-reference/completions/object)
         """
         raise NotImplementedError("Subclasses must implement this method.")
 
-    async def aforward(self, prompt=None, messages=None, **kwargs):
+    async def aforward(
+        self,
+        prompt: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        **kwargs
+    ):
         """Async forward pass for the language model.
 
-        Subclasses that support async should implement this method, and the response should be identical to
-        [OpenAI response format](https://platform.openai.com/docs/api-reference/responses/object).
+        Subclasses must implement this method, and the response should be identical to either of the following formats:
+        - [OpenAI response format](https://platform.openai.com/docs/api-reference/responses/object)
+        - [OpenAI chat completion format](https://platform.openai.com/docs/api-reference/chat/object)
+        - [OpenAI text completion format](https://platform.openai.com/docs/api-reference/completions/object)
         """
         raise NotImplementedError("Subclasses must implement this method.")
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -123,7 +123,12 @@ class LM(BaseLM):
 
         return completion_fn, litellm_cache_args
 
-    def forward(self, prompt=None, messages=None, **kwargs):
+    def forward(
+        self,
+        prompt: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        **kwargs
+    ):
         # Build the request.
         kwargs = dict(kwargs)
         cache = kwargs.pop("cache", self.cache)
@@ -156,7 +161,12 @@ class LM(BaseLM):
             settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 
-    async def aforward(self, prompt=None, messages=None, **kwargs):
+    async def aforward(
+        self,
+        prompt: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        **kwargs,
+    ):
         # Build the request.
         kwargs = dict(kwargs)
         cache = kwargs.pop("cache", self.cache)


### PR DESCRIPTION
- Changed output type in Adapter class to support both dict and str.
- Updated __call__, acall, forward, and aforward methods in BaseLM and LM classes to use more explicit type hints for prompt and messages parameters.
- Enhanced documentation to clarify expected response formats for forward and aforward methods.