### PR TITLE
docs: add note on Python version for pre-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,10 +91,6 @@ Once the pull request is approved, a team member will take care of merging.
 
 Python 3.10 or later is required.
 
-> **Note on Python Versions:** While the setup instructions below recommend Python 3.11 for development, our `pre-commit` hooks (in `.pre-commit-config.yaml`) are configured to use **Python 3.10**.
->
-> To ensure `pre-commit install` works correctly, please make sure you also have a `python3.10` executable installed and available on your system's PATH. Alternatively, you can create your `conda` or `uv` environment using `python=3.10` to satisfy both requirements.
-
 Setting up your DSPy development environment requires you to fork the DSPy repository and clone it locally.
 If you are not familiar with the GitHub fork process, please refer to [Fork a repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo). After creating the fork, clone
 it to your local development device:
@@ -113,7 +109,12 @@ dev environment.
 way to set up the development environment. First, install uv by following the
 [installation guide](https://docs.astral.sh/uv/getting-started/installation/).
 
-After uv is installed, in your working directory (`dspy/`), run:
+After uv is installed, in your working directory (`dspy/`), create a virtual environment using Python 3.10:
+
+```shell
+uv venv --python 3.10
+```
+This creates a `.venv` directory. Now, sync the environment with the development dependencies:
 
 ```shell
 uv sync --extra dev
@@ -140,7 +141,7 @@ make sure you have conda installed. If not, please follow the instructions
 To set up the environment, run:
 
 ```shell
-conda create -n dspy-dev python=3.11
+conda create -n dspy-dev python=3.10
 conda activate dspy-dev
 pip install -e ".[dev]"
 ```


### PR DESCRIPTION
This PR adds a warning note to the `CONTRIBUTING.md` file.

**The Problem:**
The "Environment Setup" guide recommends using `Python 3.11`, but the `.pre-commit-config.yaml` file requires `Python 3.10` . This causes `pre-commit install` to fail for new contributors who follow the instructions and only have `Python 3.11` .

**The Fix:**
This note clarifies the discrepancy *before* the setup instructions. It advises contributors to either ensure `python3.10` is also available on their PATH or simply use `python=3.10` for their virtual environment to satisfy both requirements.

Hi @TomeHirata , I've pushed the requested changes. Thanks!