### PR TITLE
Fix gpt-5-chat incorrectly classified as reasoning model

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -85,7 +85,7 @@ class LM(BaseLM):
         model_family = model.split("/")[-1].lower() if "/" in model else model.lower()
 
         # Recognize OpenAI reasoning models (o1, o3, o4, gpt-5 family)
-        model_pattern = re.match(r"^(?:o[1345]|gpt-5)(?:-(?:mini|nano))?", model_family)
+        model_pattern = re.match(r"^(?:o[1345](?:-(?:mini|nano))?(?:-\d{4}-\d{2}-\d{2})?|gpt-5(?:-(?:mini|nano|pro))?)$", model_family)
 
         if model_pattern:
             if (temperature and temperature != 1.0) or (max_tokens and max_tokens < 16000):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -298,6 +298,9 @@ def test_reasoning_model_token_parameter():
         ("openai/gpt-5", True),
         ("openai/gpt-5-mini", True),
         ("openai/gpt-5-nano", True),
+        ("openai/gpt-5-pro", True),
+        ("openai/gpt-5-chat", False),
+        ("azure/gpt-5-chat", False),
         ("openai/gpt-4", False),
         ("anthropic/claude-2", False),
     ]


### PR DESCRIPTION
## Summary

Fixes #9032 - Updates the reasoning model regex pattern to prevent `gpt-5-chat` from being incorrectly classified as a reasoning model.

## Problem

The Azure `gpt-5-chat` model was being misclassified as a reasoning model, causing it to fail with inappropriate validation requirements:
- `ValueError: reasoning models require passing temperature=1.0 and max_tokens >= 16000`
- Even when complying, Azure API rejects the `reasoning` parameter with `BadRequestError`

**Root Cause**: The regex pattern lacked an end anchor (`$`), allowing any model starting with `gpt-5-` to match as a reasoning model.

## Changes

### Regex Pattern Update

**Before:**
```python
r"^(?:o[1345]|gpt-5)(?:-(?:mini|nano))?"
```

**After:**
```python
r"^(?:o[1345](?:-(?:mini|nano))?(?:-\d{4}-\d{2}-\d{2})?|gpt-5(?:-(?:mini|nano|pro))?)$"
```

**Improvements:**
- ✅ Added `$` anchor for exact matching (prevents `gpt-5-chat` from matching)
- ✅ Added `pro` variant support (`gpt-5-pro` now recognized as reasoning model)
- ✅ Explicit date suffix support for o-series models (`o1-2023-01-01`)
- ✅ Separate handling for o-series vs gpt-5 models

### Test Coverage

Added test cases to verify:
- ✅ `gpt-5-pro` correctly identified as reasoning model
- ✅ `gpt-5-chat` correctly identified as NON-reasoning model  
- ✅ `azure/gpt-5-chat` correctly identified as NON-reasoning model

## Verification

Tested regex pattern against all model variants:

**Reasoning Models (should match):**
- `o1`, `o1-mini`, `o1-nano`, `o1-2023-01-01`, `o1-mini-2023-01-01`
- `o3`, `o3-mini`, `o3-mini-2023-01-01`  
- `o4`, `o5`
- `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-pro`

**Non-Reasoning Models (should NOT match):**
- `gpt-5-chat` ✓
- `gpt-4`, `gpt-4o`
- `o2`, `o6`
- Other models

All tests pass correctly.

## Impact

Users can now use `gpt-5-chat` with standard conversational parameters (temperature < 1.0, max_tokens < 16000) without triggering incorrect reasoning model validation.