### PR TITLE
refactor(Evaluate): Handle compare_results of ParallelExecutor more generically

### DIFF
--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -168,7 +168,7 @@ class ParallelExecutor:
 
                             # Update progress
                             if self.compare_results:
-                                vals = [r[-1] for r in results if r is not None]
+                                vals = [float(r) for r in results if r is not None]
                                 self._update_progress(pbar, sum(vals), len(vals))
                             else:
                                 self._update_progress(


### PR DESCRIPTION
Currently ParallelExecutor requires the passed in `function` returns a list / tuple with numeric value in index -1 when `compare_results=True`. This PR adjusts the logic to support any function which return a numeric value.