### PR TITLE
Enable callback logging only for full eval on GEPA

### DIFF
--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -546,7 +546,7 @@ class GEPA(Teleprompter):
             reflection_lm=self.reflection_lm,
             custom_instruction_proposer=self.custom_instruction_proposer,
             warn_on_score_mismatch=self.warn_on_score_mismatch,
-            full_eval_size=len(valset),
+            reflection_minibatch_size=self.reflection_minibatch_size,
         )
 
         # Instantiate GEPA with the simpler adapter-based API

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -77,7 +77,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         reflection_lm=None,
         custom_instruction_proposer: "ProposalFn | None" = None,
         warn_on_score_mismatch: bool = True,
-        full_eval_size: int | None = None,
+        reflection_minibatch_size: int | None = None,
     ):
         self.student = student_module
         self.metric_fn = metric_fn
@@ -89,7 +89,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         self.reflection_lm = reflection_lm
         self.custom_instruction_proposer = custom_instruction_proposer
         self.warn_on_score_mismatch = warn_on_score_mismatch
-        self.full_eval_size = full_eval_size
+        self.reflection_minibatch_size = reflection_minibatch_size
 
         if self.custom_instruction_proposer is not None:
             # We are only overriding the propose_new_texts method when a custom
@@ -130,7 +130,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
 
     def evaluate(self, batch, candidate, capture_traces=False):
         program = self.build_program(candidate)
-        callback_metadata = {"metric_key": "eval_full"} if self.full_eval_size == len(batch) else {"disable_logging": True}
+        callback_metadata = {"metric_key": "eval_full"} if self.reflection_minibatch_size is None or len(batch) > self.reflection_minibatch_size else {"disable_logging": True}
 
         if capture_traces:
             # bootstrap_trace_data-like flow with trace capture

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -43,11 +43,16 @@ def bad_metric(example, prediction):
     return 0.0
 
 
-@pytest.mark.parametrize("full_eval_size, batch, expected_callback_metadata", [
+@pytest.mark.parametrize("reflection_minibatch_size, batch, expected_callback_metadata", [
+    (None, [], {"metric_key": "eval_full"}),
+    (None, [Example(input="What is the color of the sky?", output="blue")], {"metric_key": "eval_full"}),
     (1, [], {"disable_logging": True}),
-    (1, [Example(input="What is the color of the sky?", output="blue")], {"metric_key": "eval_full"}),
+    (1, [
+        Example(input="What is the color of the sky?", output="blue"),
+        Example(input="What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!"),
+    ], {"metric_key": "eval_full"}),
 ])
-def test_gepa_adapter_disables_logging_on_minibatch_eval(monkeypatch, full_eval_size, batch, expected_callback_metadata):
+def test_gepa_adapter_disables_logging_on_minibatch_eval(monkeypatch, reflection_minibatch_size, batch, expected_callback_metadata):
     from dspy.teleprompt import bootstrap_trace as bootstrap_trace_module
     from dspy.teleprompt.gepa import gepa_utils
 
@@ -61,7 +66,7 @@ def test_gepa_adapter_disables_logging_on_minibatch_eval(monkeypatch, full_eval_
         metric_fn=simple_metric,
         feedback_map={},
         failure_score=0.0,
-        full_eval_size=full_eval_size,
+        reflection_minibatch_size=reflection_minibatch_size,
     )
 
     captured_kwargs: dict[str, Any] = {}


### PR DESCRIPTION
Instead of relying on "capture_trace" option, enable/disable logging based on the sample size since sample size is a more accurate indicator.