### PR TITLE
Update uv.lock dspy version to match the latest release

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -729,7 +729,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "3.0.4"
+version = "3.1.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Update uv.lock to match 3.1.0b1 release