### PR TITLE
Properly yield the last chunk in streaming

### DIFF
--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -274,7 +274,7 @@ class StreamListener:
         except ValueError:
             pass
 
-        if token:
+        if token or self.stream_end:
             return StreamResponse(
                 self.predict_name,
                 self.signature_field_name,


### PR DESCRIPTION
Fix #9085 

Earlier we introduced the logic to immediately yield when the chunk cannot form the last chunk, which is leading to the case where the last chunk only contains the end identifier, whereas we still want to yield it.