### PR TITLE
Use `language` in system instructions for `dspy.Code` fields

### DIFF
--- a/dspy/adapters/types/code.py
+++ b/dspy/adapters/types/code.py
@@ -79,7 +79,7 @@ class Code(Type):
     def description(cls) -> str:
         return (
             "Code represented in a string, specified in the `code` field. If this is an output field, the code "
-            f"field should follow the markdown code block format, e.g. \n```{cls.language}\n{{code}}\n```"
+            f"field should follow the markdown code block format, e.g. \n```{cls.language.lower()}\n{{code}}\n```"
             f"\nProgramming language: {cls.language}"
         )
 


### PR DESCRIPTION
Right now the instructions mention `python` and `cpp` instead of the exact specified language, which can be confusing for arbitrary languages (e.g., Rust).

This PR uses the `language.lower()` to instruct the model directly on what the backtick annotation should be.