### PR TITLE
[DNM, WIP] feat(ReAct, History): Refactor (1) dspy.History to be flexible to more input types and (2) ReAct to use dspy.History

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -9,6 +9,7 @@ from dspy.adapters.types.base_type import split_message_content_for_custom_types
 from dspy.adapters.types.reasoning import Reasoning
 from dspy.adapters.types.tool import Tool, ToolCalls
 from dspy.experimental import Citations
+from dspy.signatures.field import InputField, OutputField
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback, with_callbacks
 
@@ -474,6 +475,23 @@ class Adapter:
                 return name
         return None
 
+    def _serialize_kv_value(self, v: Any) -> Any:
+        """Safely serialize values for kv-mode formatting."""
+        if isinstance(v, (str, int, float, bool)) or v is None:
+            return v
+        try:
+            return str(v)
+        except Exception:
+            return f"<unserializable {type(v).__name__}>"
+
+    def _make_dynamic_signature_for_inputs(self, keys: list[str]) -> type[Signature]:
+        """Create a dynamic signature with input fields only (no instructions)."""
+        return Signature({k: InputField() for k in keys}, instructions="")
+
+    def _make_dynamic_signature_for_outputs(self, keys: list[str]) -> type[Signature]:
+        """Create a dynamic signature with output fields only (no instructions)."""
+        return Signature({k: OutputField() for k in keys}, instructions="")
+
     def format_conversation_history(
         self,
         signature: type[Signature],
@@ -483,6 +501,11 @@ class Adapter:
         """Format the conversation history.
 
         This method formats the conversation history and the current input as multiturn messages.
+        Supports four modes:
+        - signature: Dict keys match signature input/output fields → user/assistant pairs
+        - kv: Nested {"input_fields": {...}, "output_fields": {...}} → user/assistant pairs
+        - dict: Arbitrary serializable kv pairs → all in single user message (default)
+        - raw: Direct LM messages with {"role": "user", "content": "..."} → passed through
 
         Args:
             signature: The DSPy signature for which to format the conversation history.
@@ -492,25 +515,50 @@ class Adapter:
         Returns:
             A list of multiturn messages.
         """
-        conversation_history = inputs[history_field_name].messages if history_field_name in inputs else None
-
-        if conversation_history is None:
+        history = inputs.get(history_field_name)
+        if history is None:
             return []
 
         messages = []
-        for message in conversation_history:
-            messages.append(
-                {
+        for msg in history.messages:
+            mode = history._detect_mode(msg)
+
+            if mode == "raw":
+                messages.append(dict(msg))
+
+            elif mode == "kv":
+                if "input_fields" in msg:
+                    input_dict = {k: self._serialize_kv_value(v) for k, v in msg["input_fields"].items()}
+                    sig = self._make_dynamic_signature_for_inputs(list(input_dict.keys()))
+                    messages.append({
+                        "role": "user",
+                        "content": self.format_user_message_content(sig, input_dict),
+                    })
+                if "output_fields" in msg:
+                    output_dict = {k: self._serialize_kv_value(v) for k, v in msg["output_fields"].items()}
+                    sig = self._make_dynamic_signature_for_outputs(list(output_dict.keys()))
+                    messages.append({
+                        "role": "assistant",
+                        "content": self.format_assistant_message_content(sig, output_dict),
+                    })
+
+            elif mode == "signature":
+                messages.append({
                     "role": "user",
-                    "content": self.format_user_message_content(signature, message),
-                }
-            )
-            messages.append(
-                {
+                    "content": self.format_user_message_content(signature, msg),
+                })
+                messages.append({
                     "role": "assistant",
-                    "content": self.format_assistant_message_content(signature, message),
-                }
-            )
+                    "content": self.format_assistant_message_content(signature, msg),
+                })
+
+            else:  # dict mode (default) - all kv pairs go into single user message
+                serialized = {k: self._serialize_kv_value(v) for k, v in msg.items()}
+                sig = self._make_dynamic_signature_for_inputs(list(serialized.keys()))
+                messages.append({
+                    "role": "user",
+                    "content": self.format_user_message_content(sig, serialized),
+                })
 
         # Remove the history field from the inputs
         del inputs[history_field_name]

--- a/dspy/adapters/types/history.py
+++ b/dspy/adapters/types/history.py
@@ -4,33 +4,12 @@ import pydantic
 
 
 class History(pydantic.BaseModel):
-    """Class representing the conversation history.
+    """Class representing conversation history.
 
-    History supports four message formats:
-    
-    1. **Signature mode**: Dict keys match signature input/output fields → user/assistant pairs.
-       Must be explicitly set via mode="signature".
-       ```python
-       history = dspy.History(messages=[
-           {"question": "What is 2+2?", "answer": "4"},
-       ], mode="signature")
-       ```
-    
-    2. **KV mode**: Nested `{"input_fields": {...}, "output_fields": {...}}` → user/assistant pairs.
-       ```python
-       history = dspy.History.from_kv([
-           {"input_fields": {"thought": "...", "tool_name": "search"}, "output_fields": {"observation": "..."}},
-       ])
-       ```
-    
-    3. **Dict mode** (default): Arbitrary serializable key-value pairs → all in single user message.
-       ```python
-       history = dspy.History(messages=[
-           {"thought": "I need to search", "tool_name": "search", "observation": "Results found"},
-       ])
-       ```
-    
-    4. **Raw mode**: Direct LM messages with `{"role": "user", "content": "..."}` → passed through.
+    History supports four message formats, with one mode per History instance:
+
+    1. **Raw mode**: Direct LM messages with `{"role": "...", "content": "..."}`.
+       Used for ReAct trajectories and native tool calling.
        ```python
        history = dspy.History.from_raw([
            {"role": "user", "content": "Hello"},
@@ -38,7 +17,28 @@ class History(pydantic.BaseModel):
        ])
        ```
 
-    The mode is auto-detected from the first message if not explicitly provided.
+    2. **Demo mode**: Nested `{"input_fields": {...}, "output_fields": {...}}` pairs.
+       Used for few-shot demonstrations with explicit input/output separation.
+       ```python
+       history = dspy.History.from_demo([
+           {"input_fields": {"question": "2+2?"}, "output_fields": {"answer": "4"}},
+       ])
+       ```
+
+    3. **Flat mode** (default): Arbitrary key-value pairs in a single user message.
+       ```python
+       history = dspy.History(messages=[
+           {"thought": "I need to search", "tool_name": "search", "observation": "Found it"},
+       ])
+       ```
+
+    4. **Signature mode**: Dict keys match signature fields → user/assistant pairs.
+       Must be explicitly set.
+       ```python
+       history = dspy.History.from_signature([
+           {"question": "What is 2+2?", "answer": "4"},
+       ])
+       ```
 
     Example:
         ```python
@@ -51,12 +51,9 @@ class History(pydantic.BaseModel):
             history: dspy.History = dspy.InputField()
             answer: str = dspy.OutputField()
 
-        history = dspy.History(
-            messages=[
-                {"question": "What is the capital of France?", "answer": "Paris"},
-                {"question": "What is the capital of Germany?", "answer": "Berlin"},
-            ]
-        )
+        history = dspy.History.from_signature([
+            {"question": "What is the capital of France?", "answer": "Paris"},
+        ])
 
         predict = dspy.Predict(MySignature)
         outputs = predict(question="What is the capital of France?", history=history)
@@ -81,7 +78,7 @@ class History(pydantic.BaseModel):
     """
 
     messages: list[dict[str, Any]]
-    mode: Literal["signature", "kv", "dict", "raw"] | None = None
+    mode: Literal["signature", "demo", "flat", "raw"] = "flat"
 
     model_config = pydantic.ConfigDict(
         frozen=True,
@@ -90,85 +87,85 @@ class History(pydantic.BaseModel):
         extra="forbid",
     )
 
-    def _detect_mode(self, msg: dict) -> str:
-        """Detect the mode for a message based on its structure.
-        
-        Detection rules:
-        - Raw: has "role" and "content" keys, but NOT "input_fields"/"output_fields"
-        - KV: keys are ONLY "input_fields" and/or "output_fields"
-        - Signature: must be explicitly set (requires matching against signature fields)
-        - Dict: everything else (default) - arbitrary kv pairs go into user message
+    @staticmethod
+    def _infer_mode_from_msg(msg: dict) -> str:
+        """Infer the mode from a message's structure.
+
+        Detection rules (conservative):
+        - Raw: has "role" key and ONLY LM-like keys (role, content, tool_calls, tool_call_id, name)
+        - Demo: keys are ONLY "input_fields" and/or "output_fields"
+        - Flat: everything else (signature mode must be explicit)
         """
-        if self.mode:
-            return self.mode
-
         keys = set(msg.keys())
+        lm_keys = {"role", "content", "tool_calls", "tool_call_id", "name"}
 
-        if {"role", "content"} <= keys and not ({"input_fields", "output_fields"} & keys):
+        if "role" in keys and keys <= lm_keys:
             return "raw"
 
         if keys <= {"input_fields", "output_fields"} and keys:
-            return "kv"
+            return "demo"
 
-        return "dict"
+        return "flat"
+
+    def _validate_msg_for_mode(self, msg: dict, mode: str) -> None:
+        """Validate a message conforms to the expected mode structure."""
+        if mode == "raw":
+            if not isinstance(msg.get("role"), str):
+                raise ValueError(f"Raw mode: 'role' must be a string: {msg}")
+            content = msg.get("content")
+            if content is not None and not isinstance(content, str):
+                raise ValueError(f"Raw mode: 'content' must be a string or None: {msg}")
+
+        elif mode == "demo":
+            if "input_fields" in msg and not isinstance(msg["input_fields"], dict):
+                raise ValueError(f"Demo mode: 'input_fields' must be a dict: {msg}")
+            if "output_fields" in msg and not isinstance(msg["output_fields"], dict):
+                raise ValueError(f"Demo mode: 'output_fields' must be a dict: {msg}")
+
+        elif mode == "signature":
+            if not isinstance(msg, dict) or not msg:
+                raise ValueError(f"Signature mode: messages must be non-empty dicts: {msg}")
 
     @pydantic.model_validator(mode="after")
     def _validate_messages(self) -> "History":
+        if not self.messages:
+            return self
+
+        # Only infer if mode is the default "flat" and messages clearly match another mode
+        if self.mode == "flat":
+            inferred = self._infer_mode_from_msg(self.messages[0])
+            if inferred in {"raw", "demo"}:
+                object.__setattr__(self, "mode", inferred)
+
         for msg in self.messages:
-            detected = self._detect_mode(msg)
-
-            if detected == "raw":
-                if not isinstance(msg.get("role"), str):
-                    raise ValueError(f"'role' must be a string: {msg}")
-                # content can be None for tool call messages, or string otherwise
-                content = msg.get("content")
-                if content is not None and not isinstance(content, str):
-                    raise ValueError(f"'content' must be a string or None: {msg}")
-
-            elif detected == "kv":
-                if "input_fields" in msg and not isinstance(msg["input_fields"], dict):
-                    raise ValueError(f"'input_fields' must be a dict: {msg}")
-                if "output_fields" in msg and not isinstance(msg["output_fields"], dict):
-                    raise ValueError(f"'output_fields' must be a dict: {msg}")
+            self._validate_msg_for_mode(msg, self.mode)
 
         return self
 
     def with_messages(self, messages: list[dict[str, Any]]) -> "History":
-        """Return a new History with additional messages appended.
-        
-        Args:
-            messages: List of messages to append.
-            
-        Returns:
-            A new History instance with the messages appended.
-        """
+        """Return a new History with additional messages appended."""
         return History(messages=[*self.messages, *messages], mode=self.mode)
 
     @classmethod
-    def from_kv(cls, messages: list[dict[str, Any]]) -> "History":
-        """Create a History instance with KV mode.
-        
-        KV mode expects messages with "input_fields" and/or "output_fields" keys,
-        each containing a dict of field names to values.
-        
-        Args:
-            messages: List of dicts with "input_fields" and/or "output_fields" keys.
-            
-        Returns:
-            A History instance with mode="kv".
+    def from_demo(cls, messages: list[dict[str, Any]]) -> "History":
+        """Create a History with demo mode.
+
+        Demo mode expects messages with "input_fields" and/or "output_fields" keys.
         """
-        return cls(messages=messages, mode="kv")
+        return cls(messages=messages, mode="demo")
 
     @classmethod
     def from_raw(cls, messages: list[dict[str, Any]]) -> "History":
-        """Create a History instance with raw mode.
-        
+        """Create a History with raw mode.
+
         Raw mode expects direct LM messages with "role" and "content" keys.
-        
-        Args:
-            messages: List of dicts with "role" and "content" keys.
-            
-        Returns:
-            A History instance with mode="raw".
         """
         return cls(messages=messages, mode="raw")
+
+    @classmethod
+    def from_signature(cls, messages: list[dict[str, Any]]) -> "History":
+        """Create a History with signature mode.
+
+        Signature mode expects dicts with keys matching the signature's fields.
+        """
+        return cls(messages=messages, mode="signature")

--- a/dspy/adapters/types/history.py
+++ b/dspy/adapters/types/history.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 import pydantic
 
@@ -6,20 +6,42 @@ import pydantic
 class History(pydantic.BaseModel):
     """Class representing the conversation history.
 
-    The conversation history is a list of messages, each message entity should have keys from the associated signature.
-    For example, if you have the following signature:
+    History supports four message formats:
+    
+    1. **Signature mode**: Dict keys match signature input/output fields → user/assistant pairs.
+       Must be explicitly set via mode="signature".
+       ```python
+       history = dspy.History(messages=[
+           {"question": "What is 2+2?", "answer": "4"},
+       ], mode="signature")
+       ```
+    
+    2. **KV mode**: Nested `{"input_fields": {...}, "output_fields": {...}}` → user/assistant pairs.
+       ```python
+       history = dspy.History.from_kv([
+           {"input_fields": {"thought": "...", "tool_name": "search"}, "output_fields": {"observation": "..."}},
+       ])
+       ```
+    
+    3. **Dict mode** (default): Arbitrary serializable key-value pairs → all in single user message.
+       ```python
+       history = dspy.History(messages=[
+           {"thought": "I need to search", "tool_name": "search", "observation": "Results found"},
+       ])
+       ```
+    
+    4. **Raw mode**: Direct LM messages with `{"role": "user", "content": "..."}` → passed through.
+       ```python
+       history = dspy.History.from_raw([
+           {"role": "user", "content": "Hello"},
+           {"role": "assistant", "content": "Hi there!"},
+       ])
+       ```
 
-    ```
-    class MySignature(dspy.Signature):
-        question: str = dspy.InputField()
-        history: dspy.History = dspy.InputField()
-        answer: str = dspy.OutputField()
-    ```
-
-    Then the history should be a list of dictionaries with keys "question" and "answer".
+    The mode is auto-detected from the first message if not explicitly provided.
 
     Example:
-        ```
+        ```python
         import dspy
 
         dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
@@ -41,7 +63,7 @@ class History(pydantic.BaseModel):
         ```
 
     Example of capturing the conversation history:
-        ```
+        ```python
         import dspy
 
         dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
@@ -59,6 +81,7 @@ class History(pydantic.BaseModel):
     """
 
     messages: list[dict[str, Any]]
+    mode: Literal["signature", "kv", "dict", "raw"] | None = None
 
     model_config = pydantic.ConfigDict(
         frozen=True,
@@ -66,3 +89,86 @@ class History(pydantic.BaseModel):
         validate_assignment=True,
         extra="forbid",
     )
+
+    def _detect_mode(self, msg: dict) -> str:
+        """Detect the mode for a message based on its structure.
+        
+        Detection rules:
+        - Raw: has "role" and "content" keys, but NOT "input_fields"/"output_fields"
+        - KV: keys are ONLY "input_fields" and/or "output_fields"
+        - Signature: must be explicitly set (requires matching against signature fields)
+        - Dict: everything else (default) - arbitrary kv pairs go into user message
+        """
+        if self.mode:
+            return self.mode
+
+        keys = set(msg.keys())
+
+        if {"role", "content"} <= keys and not ({"input_fields", "output_fields"} & keys):
+            return "raw"
+
+        if keys <= {"input_fields", "output_fields"} and keys:
+            return "kv"
+
+        return "dict"
+
+    @pydantic.model_validator(mode="after")
+    def _validate_messages(self) -> "History":
+        for msg in self.messages:
+            detected = self._detect_mode(msg)
+
+            if detected == "raw":
+                if not isinstance(msg.get("role"), str):
+                    raise ValueError(f"'role' must be a string: {msg}")
+                # content can be None for tool call messages, or string otherwise
+                content = msg.get("content")
+                if content is not None and not isinstance(content, str):
+                    raise ValueError(f"'content' must be a string or None: {msg}")
+
+            elif detected == "kv":
+                if "input_fields" in msg and not isinstance(msg["input_fields"], dict):
+                    raise ValueError(f"'input_fields' must be a dict: {msg}")
+                if "output_fields" in msg and not isinstance(msg["output_fields"], dict):
+                    raise ValueError(f"'output_fields' must be a dict: {msg}")
+
+        return self
+
+    def with_messages(self, messages: list[dict[str, Any]]) -> "History":
+        """Return a new History with additional messages appended.
+        
+        Args:
+            messages: List of messages to append.
+            
+        Returns:
+            A new History instance with the messages appended.
+        """
+        return History(messages=[*self.messages, *messages], mode=self.mode)
+
+    @classmethod
+    def from_kv(cls, messages: list[dict[str, Any]]) -> "History":
+        """Create a History instance with KV mode.
+        
+        KV mode expects messages with "input_fields" and/or "output_fields" keys,
+        each containing a dict of field names to values.
+        
+        Args:
+            messages: List of dicts with "input_fields" and/or "output_fields" keys.
+            
+        Returns:
+            A History instance with mode="kv".
+        """
+        return cls(messages=messages, mode="kv")
+
+    @classmethod
+    def from_raw(cls, messages: list[dict[str, Any]]) -> "History":
+        """Create a History instance with raw mode.
+        
+        Raw mode expects direct LM messages with "role" and "content" keys.
+        
+        Args:
+            messages: List of dicts with "role" and "content" keys.
+            
+        Returns:
+            A History instance with mode="raw".
+        """
+        return cls(messages=messages, mode="raw")

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -10,6 +10,14 @@ def _blue(text: str, end: str = "\n"):
     return "\x1b[34m" + str(text) + "\x1b[0m" + end
 
 
+def _yellow(text: str, end: str = "\n"):
+    return "\x1b[33m" + str(text) + "\x1b[0m" + end
+
+
+def _cyan(text: str, end: str = "\n"):
+    return "\x1b[36m" + str(text) + "\x1b[0m" + end
+
+
 def pretty_print_history(history, n: int = 1):
     """Prints the last n prompts and their completions."""
 
@@ -22,37 +30,67 @@ def pretty_print_history(history, n: int = 1):
         print("\x1b[34m" + f"[{timestamp}]" + "\x1b[0m" + "\n")
 
         for msg in messages:
-            print(_red(f"{msg['role'].capitalize()} message:"))
-            if isinstance(msg["content"], str):
-                print(msg["content"].strip())
-            else:
-                if isinstance(msg["content"], list):
-                    for c in msg["content"]:
-                        if c["type"] == "text":
-                            print(c["text"].strip())
-                        elif c["type"] == "image_url":
-                            image_str = ""
-                            if "base64" in c["image_url"].get("url", ""):
-                                len_base64 = len(c["image_url"]["url"].split("base64,")[1])
-                                image_str = (
-                                    f"<{c['image_url']['url'].split('base64,')[0]}base64,"
-                                    f"<IMAGE BASE 64 ENCODED({len_base64!s})>"
-                                )
-                            else:
-                                image_str = f"<image_url: {c['image_url']['url']}>"
-                            print(_blue(image_str.strip()))
-                        elif c["type"] == "input_audio":
-                            audio_format = c["input_audio"]["format"]
-                            len_audio = len(c["input_audio"]["data"])
-                            audio_str = f"<audio format='{audio_format}' base64-encoded, length={len_audio}>"
-                            print(_blue(audio_str.strip()))
-                        elif c["type"] == "file" or c["type"] == "input_file":
-                            file = c.get("file", c.get("input_file", {}))
-                            filename = file.get("filename", "")
-                            file_id = file.get("file_id", "")
-                            file_data = file.get("file_data", "")
-                            file_str = f"<file: name:{filename}, id:{file_id}, data_length:{len(file_data)}>"
-                            print(_blue(file_str.strip()))
+            role = msg.get("role", "unknown")
+
+            # Handle tool response messages
+            if role == "tool":
+                tool_call_id = msg.get("tool_call_id", "unknown")
+                print(_yellow(f"Tool response (id: {tool_call_id}):"))
+                content = msg.get("content", "")
+                if content:
+                    print(content.strip() if isinstance(content, str) else str(content))
+                print("\n")
+                continue
+
+            print(_red(f"{role.capitalize()} message:"))
+
+            # Handle tool_calls in assistant messages
+            if role == "assistant" and msg.get("tool_calls"):
+                content = msg.get("content")
+                if content:
+                    print(content.strip() if isinstance(content, str) else str(content))
+                print(_cyan("Tool calls:"))
+                for tool_call in msg["tool_calls"]:
+                    func = tool_call.get("function", {})
+                    tool_id = tool_call.get("id", "unknown")
+                    name = func.get("name", "unknown")
+                    args = func.get("arguments", "{}")
+                    print(_cyan(f"  [{tool_id}] {name}({args})"))
+                print("\n")
+                continue
+
+            content = msg.get("content")
+            if content is None:
+                print("<no content>")
+            elif isinstance(content, str):
+                print(content.strip())
+            elif isinstance(content, list):
+                for c in content:
+                    if c["type"] == "text":
+                        print(c["text"].strip())
+                    elif c["type"] == "image_url":
+                        image_str = ""
+                        if "base64" in c["image_url"].get("url", ""):
+                            len_base64 = len(c["image_url"]["url"].split("base64,")[1])
+                            image_str = (
+                                f"<{c['image_url']['url'].split('base64,')[0]}base64,"
+                                f"<IMAGE BASE 64 ENCODED({len_base64!s})>"
+                            )
+                        else:
+                            image_str = f"<image_url: {c['image_url']['url']}>"
+                        print(_blue(image_str.strip()))
+                    elif c["type"] == "input_audio":
+                        audio_format = c["input_audio"]["format"]
+                        len_audio = len(c["input_audio"]["data"])
+                        audio_str = f"<audio format='{audio_format}' base64-encoded, length={len_audio}>"
+                        print(_blue(audio_str.strip()))
+                    elif c["type"] == "file" or c["type"] == "input_file":
+                        file = c.get("file", c.get("input_file", {}))
+                        filename = file.get("filename", "")
+                        file_id = file.get("file_id", "")
+                        file_data = file.get("file_data", "")
+                        file_str = f"<file: name:{filename}, id:{file_id}, data_length:{len(file_data)}>"
+                        print(_blue(file_str.strip()))
             print("\n")
 
         if isinstance(outputs[0], dict):

--- a/scripts/test_coding_agent.py
+++ b/scripts/test_coding_agent.py
@@ -1,0 +1,18 @@
+import dspy
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+
+interpreter = dspy.PythonInterpreter()
+
+def run_python(code: str) -> str:
+    """Execute Python code and return the output."""
+    return interpreter.execute(code)
+
+agent = dspy.ReAct("request: str -> result: str", tools=[run_python])
+
+try:
+    result = agent(request="Calculate 2+2 and give me the answer")
+    print(f"Result: {result.result}")
+    print(f"Trajectory: {result.trajectory}")
+finally:
+    interpreter.shutdown()

--- a/tests/adapters/test_baml_adapter.py
+++ b/tests/adapters/test_baml_adapter.py
@@ -361,7 +361,8 @@ def test_baml_adapter_with_conversation_history():
         messages=[
             {"question": "What is the patient's age?", "answer": "45 years old"},
             {"question": "Any allergies?", "answer": "Penicillin allergy"},
-        ]
+        ],
+        mode="signature",
     )
 
     adapter = BAMLAdapter()

--- a/tests/adapters/test_baml_adapter.py
+++ b/tests/adapters/test_baml_adapter.py
@@ -357,13 +357,10 @@ def test_baml_adapter_with_conversation_history():
         question: str = dspy.InputField()
         answer: str = dspy.OutputField()
 
-    history = dspy.History(
-        messages=[
-            {"question": "What is the patient's age?", "answer": "45 years old"},
-            {"question": "Any allergies?", "answer": "Penicillin allergy"},
-        ],
-        mode="signature",
-    )
+    history = dspy.History.from_signature([
+        {"question": "What is the patient's age?", "answer": "45 years old"},
+        {"question": "Any allergies?", "answer": "Penicillin allergy"},
+    ])
 
     adapter = BAMLAdapter()
     messages = adapter.format(TestSignature, [], {"history": history, "question": "What medications should we avoid?"})

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -518,13 +518,10 @@ def test_json_adapter_formats_conversation_history():
         history: dspy.History = dspy.InputField()
         answer: str = dspy.OutputField()
 
-    history = dspy.History(
-        messages=[
-            {"question": "What is the capital of France?", "answer": "Paris"},
-            {"question": "What is the capital of Germany?", "answer": "Berlin"},
-        ],
-        mode="signature",
-    )
+    history = dspy.History.from_signature([
+        {"question": "What is the capital of France?", "answer": "Paris"},
+        {"question": "What is the capital of Germany?", "answer": "Berlin"},
+    ])
 
     adapter = dspy.JSONAdapter()
     messages = adapter.format(MySignature, [], {"question": "What is the capital of France?", "history": history})

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -522,7 +522,8 @@ def test_json_adapter_formats_conversation_history():
         messages=[
             {"question": "What is the capital of France?", "answer": "Paris"},
             {"question": "What is the capital of Germany?", "answer": "Berlin"},
-        ]
+        ],
+        mode="signature",
     )
 
     adapter = dspy.JSONAdapter()

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -1,4 +1,3 @@
-import re
 
 import litellm
 import pytest
@@ -46,7 +45,7 @@ def test_tool_observation_preserves_custom_type():
     react = dspy.ReAct("question -> answer", tools=[make_images])
     react(question="Draw me something red")
 
-    sigs_with_obs = [sig for sig, inputs in captured_calls if "observation_0" in inputs]
+    sigs_with_obs = [sig for sig, inputs in captured_calls if "observation_0" in str(inputs)]
     assert sigs_with_obs, "Expected ReAct to format a trajectory containing observation_0"
 
     observation_content = lm.history[1]["messages"][1]["content"]
@@ -111,24 +110,41 @@ def test_tool_calling_with_pydantic_args():
     )
     assert outputs.invitation_letter == "It's my honor to invite Alice to the Science Fair event on Friday."
 
-    expected_trajectory = {
-        "thought_0": "I need to write an invitation letter for Alice to the Science Fair event.",
-        "tool_name_0": "write_invitation_letter",
-        "tool_args_0": {
-            "participant_name": "Alice",
-            "event_info": {
-                "name": "Science Fair",
-                "date": "Friday",
-                "participants": {"Alice": "female", "Bob": "male"},
-            },
-        },
-        "observation_0": "It's my honor to invite Alice to event Science Fair on Friday",
-        "thought_1": "I have successfully written the invitation letter for Alice to the Science Fair. Now I can finish the task.",
-        "tool_name_1": "finish",
-        "tool_args_1": {},
-        "observation_1": "Completed.",
-    }
-    assert outputs.trajectory == expected_trajectory
+    # Verify trajectory is a History object with raw mode (tool call format)
+    traj = outputs.trajectory
+    assert isinstance(traj, dspy.History)
+    assert traj.mode == "raw"
+    # 2 tool calls (write_invitation_letter + finish), each = assistant + tool = 4 messages + 1 extract = 5 messages
+    assert len(traj.messages) == 5
+
+    # Check first message (tool call - assistant)
+    msg0 = traj.messages[0]
+    assert msg0["role"] == "assistant"
+    assert msg0["content"] == "I need to write an invitation letter for Alice to the Science Fair event."
+    assert len(msg0["tool_calls"]) == 1
+    assert msg0["tool_calls"][0]["function"]["name"] == "write_invitation_letter"
+
+    # Check second message (tool response)
+    msg1 = traj.messages[1]
+    assert msg1["role"] == "tool"
+    assert msg1["tool_call_id"] == msg0["tool_calls"][0]["id"]
+    assert "It's my honor to invite Alice to event Science Fair on Friday" in msg1["content"]
+
+    # Check third message (finish - assistant)
+    msg2 = traj.messages[2]
+    assert msg2["role"] == "assistant"
+    assert msg2["tool_calls"][0]["function"]["name"] == "finish"
+
+    # Check fourth message (finish - tool response)
+    msg3 = traj.messages[3]
+    assert msg3["role"] == "tool"
+    assert msg3["content"] == "Completed."
+
+    # Check last message (extract)
+    msg_extract = traj.messages[-1]
+    assert msg_extract["role"] == "assistant"
+    assert "This is a very rigorous reasoning process, trust me bro!" in msg_extract["content"]
+    assert "invitation_letter" in msg_extract["content"]
 
 
 def test_tool_calling_without_typehint():
@@ -147,20 +163,40 @@ def test_tool_calling_without_typehint():
     dspy.configure(lm=lm)
     outputs = react(a=1, b=2)
 
-    expected_trajectory = {
-        "thought_0": "I need to add two numbers.",
-        "tool_name_0": "foo",
-        "tool_args_0": {
-            "a": 1,
-            "b": 2,
-        },
-        "observation_0": 3,
-        "thought_1": "I have the sum, now I can finish.",
-        "tool_name_1": "finish",
-        "tool_args_1": {},
-        "observation_1": "Completed.",
-    }
-    assert outputs.trajectory == expected_trajectory
+    # Verify trajectory is a History object with raw mode
+    traj = outputs.trajectory
+    assert isinstance(traj, dspy.History)
+    assert traj.mode == "raw"
+    # 2 tool calls (each = assistant + tool) + 1 extract = 5 messages
+    assert len(traj.messages) == 5
+
+    # Check first message (tool call - assistant)
+    msg0 = traj.messages[0]
+    assert msg0["role"] == "assistant"
+    assert msg0["content"] == "I need to add two numbers."
+    assert msg0["tool_calls"][0]["function"]["name"] == "foo"
+
+    # Check second message (tool response)
+    msg1 = traj.messages[1]
+    assert msg1["role"] == "tool"
+    assert msg1["content"] == "3"  # JSON serialized
+
+    # Check third message (finish - assistant)
+    msg2 = traj.messages[2]
+    assert msg2["role"] == "assistant"
+    assert msg2["content"] == "I have the sum, now I can finish."
+    assert msg2["tool_calls"][0]["function"]["name"] == "finish"
+
+    # Check fourth message (finish - tool response)
+    msg3 = traj.messages[3]
+    assert msg3["role"] == "tool"
+    assert msg3["content"] == "Completed."
+
+    # Check last message (extract)
+    msg_extract = traj.messages[-1]
+    assert msg_extract["role"] == "assistant"
+    assert "I added the numbers successfully" in msg_extract["content"]
+    assert "c: 3" in msg_extract["content"]
 
 
 def test_trajectory_truncation():
@@ -198,9 +234,19 @@ def test_trajectory_truncation():
     # Call forward and get the result
     result = react(input_text="test input")
 
-    # Verify that older entries in the trajectory were truncated
-    assert "thought_0" not in result.trajectory
-    assert "thought_2" in result.trajectory
+    # Verify trajectory is a History object
+    traj = result.trajectory
+    assert isinstance(traj, dspy.History)
+    assert traj.mode == "raw"
+
+    # Verify that older entries were truncated (first assistant+tool pair removed)
+    # After truncation, we should have messages for: Thought 2 (assistant+tool), finish (assistant+tool), extract
+    assert len(traj.messages) >= 4
+
+    # First message should be Thought 2's assistant message (Thought 1 was truncated)
+    assert traj.messages[0]["role"] == "assistant"
+    assert traj.messages[0]["content"] == "Thought 2"
+
     assert result.output_text == "Final output"
 
 
@@ -232,24 +278,32 @@ def test_error_retry():
     outputs = react(a=1, b=2, max_iters=2)
     traj = outputs.trajectory
 
-    # --- exact-match checks (thoughts + tool calls) -------------------------
-    control_expected = {
-        "thought_0": "I need to add two numbers.",
-        "tool_name_0": "foo",
-        "tool_args_0": {"a": 1, "b": 2},
-        "thought_1": "I need to add two numbers.",
-        "tool_name_1": "foo",
-        "tool_args_1": {"a": 1, "b": 2},
-    }
-    for k, v in control_expected.items():
-        assert traj[k] == v, f"{k} mismatch"
+    # Verify trajectory is a History object with raw mode
+    assert isinstance(traj, dspy.History)
+    assert traj.mode == "raw"
+    # 2 tool calls (each = assistant + tool) + 1 extract = 5 messages
+    assert len(traj.messages) == 5
 
-    # --- flexible checks for observations ----------------------------------
-    # We only care that each observation mentions our error string; we ignore
-    # any extra traceback detail or differing prefixes.
-    for i in range(2):
-        obs = traj[f"observation_{i}"]
-        assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+    # Check tool call messages have the expected structure
+    # Messages 0, 2 are assistant messages with tool_calls
+    # Messages 1, 3 are tool response messages
+    for i in [0, 2]:
+        msg = traj.messages[i]
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "I need to add two numbers."
+        assert msg["tool_calls"][0]["function"]["name"] == "foo"
+
+    for i in [1, 3]:
+        msg = traj.messages[i]
+        assert msg["role"] == "tool"
+        # Observation should contain the error
+        assert "tool error" in msg["content"]
+
+    # Check extract message
+    msg_extract = traj.messages[-1]
+    assert msg_extract["role"] == "assistant"
+    assert "I added the numbers successfully" in msg_extract["content"]
+    assert "c: 3" in msg_extract["content"]
 
 
 @pytest.mark.asyncio
@@ -310,24 +364,37 @@ async def test_async_tool_calling_with_pydantic_args():
         )
     assert outputs.invitation_letter == "It's my honor to invite Alice to the Science Fair event on Friday."
 
-    expected_trajectory = {
-        "thought_0": "I need to write an invitation letter for Alice to the Science Fair event.",
-        "tool_name_0": "write_invitation_letter",
-        "tool_args_0": {
-            "participant_name": "Alice",
-            "event_info": {
-                "name": "Science Fair",
-                "date": "Friday",
-                "participants": {"Alice": "female", "Bob": "male"},
-            },
-        },
-        "observation_0": "It's my honor to invite Alice to event Science Fair on Friday",
-        "thought_1": "I have successfully written the invitation letter for Alice to the Science Fair. Now I can finish the task.",
-        "tool_name_1": "finish",
-        "tool_args_1": {},
-        "observation_1": "Completed.",
-    }
-    assert outputs.trajectory == expected_trajectory
+    # Verify trajectory is a History object with raw mode
+    traj = outputs.trajectory
+    assert isinstance(traj, dspy.History)
+    assert traj.mode == "raw"
+    # 2 tool calls (write_invitation_letter + finish), each = assistant + tool = 4 messages + 1 extract = 5 messages
+    assert len(traj.messages) == 5
+
+    # Check first message (tool call - assistant)
+    msg0 = traj.messages[0]
+    assert msg0["role"] == "assistant"
+    assert msg0["tool_calls"][0]["function"]["name"] == "write_invitation_letter"
+
+    # Check second message (tool response)
+    msg1 = traj.messages[1]
+    assert msg1["role"] == "tool"
+    assert "It's my honor to invite Alice to event Science Fair on Friday" in msg1["content"]
+
+    # Check third message (finish - assistant)
+    msg2 = traj.messages[2]
+    assert msg2["role"] == "assistant"
+    assert msg2["tool_calls"][0]["function"]["name"] == "finish"
+
+    # Check fourth message (finish - tool response)
+    msg3 = traj.messages[3]
+    assert msg3["role"] == "tool"
+    assert msg3["content"] == "Completed."
+
+    # Check last message (extract)
+    msg_extract = traj.messages[-1]
+    assert msg_extract["role"] == "assistant"
+    assert "This is a very rigorous reasoning process, trust me bro!" in msg_extract["content"]
 
 
 @pytest.mark.asyncio
@@ -357,21 +424,27 @@ async def test_async_error_retry():
         outputs = await react.acall(a=1, b=2, max_iters=2)
     traj = outputs.trajectory
 
-    # Exact-match checks (thoughts + tool calls)
-    control_expected = {
-        "thought_0": "I need to add two numbers.",
-        "tool_name_0": "foo",
-        "tool_args_0": {"a": 1, "b": 2},
-        "thought_1": "I need to add two numbers.",
-        "tool_name_1": "foo",
-        "tool_args_1": {"a": 1, "b": 2},
-    }
-    for k, v in control_expected.items():
-        assert traj[k] == v, f"{k} mismatch"
+    # Verify trajectory is a History object with raw mode
+    assert isinstance(traj, dspy.History)
+    assert traj.mode == "raw"
+    # 2 tool calls (each = assistant + tool) + 1 extract = 5 messages
+    assert len(traj.messages) == 5
 
-    # Flexible checks for observations
-    # We only care that each observation mentions our error string; we ignore
-    # any extra traceback detail or differing prefixes.
-    for i in range(2):
-        obs = traj[f"observation_{i}"]
-        assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+    # Check tool call messages have the expected structure
+    for i in [0, 2]:
+        msg = traj.messages[i]
+        assert msg["role"] == "assistant"
+        assert msg["content"] == "I need to add two numbers."
+        assert msg["tool_calls"][0]["function"]["name"] == "foo"
+
+    for i in [1, 3]:
+        msg = traj.messages[i]
+        assert msg["role"] == "tool"
+        # Observation should contain the error
+        assert "tool error" in msg["content"]
+
+    # Check extract message
+    msg_extract = traj.messages[-1]
+    assert msg_extract["role"] == "assistant"
+    assert "I added the numbers successfully" in msg_extract["content"]
+    assert "c: 3" in msg_extract["content"]


### PR DESCRIPTION
**Will be split into 2 PRs. Do not merge**

Refactors both dspy.History and dspy.ReAct.

### Goal
Multi turn chat has been a weaker part of the DSPy dx. It is not clear how you should maintain history, nor particularly easy to do so. These PRs should allow you to build multi turn, (optionally tool use) chatbots more easily.

This PR is the start of efforts to alleviate the concerns brought up in #8798 

### Overview

**History**

DSPy.History used to be set to only a single input type.

All inputs and outputs needed to match the current signature that is being used otherwise each step would be filtered to match those fields. This was done to guarantee that we could separate into proper user/assistant pairs. We relax that constraint and give the user more flexibility on how to collect and display messages.

History now has 4 possible modes that it can handle:
1. signature (the old default) - will filter strictly to the current signature
2. demos - has input/output fields labeled via a nested dict with: `{"input_fields": {"k":"v"}, "output_fields":{"k":"v"}}, but does not require them to match a signature. This still allows you to get user/assistant splitting.
3. flat - a dict of kv pairs - all messages go into the user side
4. raw - uses user/assistant messages

**ReAct**

dspy.ReAct uses two signatures internally. ReAct.react and ReAct.extract. ReAct does "{input_fields}, trajectory:str -> tool: ToolCall" in a loop, and then "{input_fields}, trajectory: str -> {output_fields}"

**Testing**

The primary testing has been done using the following script to ensure that the messages still work properly. Before merging, I will run some tool use benchmarks on both new and old versions across a suite of differently sized models and ensure parity or better for the new versions.

```python
def run_python(code: str) -> str:
    """Execute Python code and return the output."""
    return interpreter.execute(code)


try:
    while True:
        coding_agent = dspy.ReAct("request: str -> result: str", tools=[run_python])
        history = dspy.History(messages=[])
        user_input = "What is 2+2 (use python)"
        result = coding_agent(request=user_input, trajectory=history)
        history = dspy.History(messages=history.messages + result.trajectory.messages)
        user_input = "Multiply the result of my last calculation by 3 (use python)"
        result = coding_agent(request=user_input, trajectory=history)
        dspy.inspect_history(2)
        break
except (KeyboardInterrupt, EOFError):
    print("\nExiting... Shutting down interpreter.")
finally:
    interpreter.shutdown()
```