### PR TITLE
Fix responses structured outputs + cache retrieval error

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -122,7 +122,6 @@ class Cache:
         if hasattr(response, "usage"):
             # Clear the usage data when cache is hit, because no LM call is made
             response.usage = {}
-            response.cache_hit = True
         return response
 
     def put(

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -164,7 +164,7 @@ class LM(BaseLM):
 
         self._check_truncation(results)
 
-        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
+        if dspy.settings.usage_tracker and hasattr(results, "usage"):
             settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 
@@ -202,7 +202,7 @@ class LM(BaseLM):
 
         self._check_truncation(results)
 
-        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
+        if dspy.settings.usage_tracker and hasattr(results, "usage"):
             settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 


### PR DESCRIPTION
Closes #9122. See the linked issue  for an extended problem description + minimal reproducible example.

### Structured outputs fix

My proposed fix mutates the `response_format` request argument into the proper form if it is passed as a Pydantic model.
Documentation around this is somewhat unreliable: the litellm docs related to this are outdated/incorrect and the OpenAI docs seem to imply that passing a Pydantic model into `text.format` is valid, but this causes JSON serialization errors down the line. 

So far, the specific formulation as presented in this PR has rendered no issues with our testing.

### Cache retrieval fix

While implementing the fix above, I additionally stumbled on an error pertaining to responses models when using caching.
When an item is successfully retrieved from the cache, an ad-hoc attribute `.cache_hit` is created and set to `True` on the `response` object.

 Unfortunately, this is only possible for `litellm.ModelResponse` (the response for chat models) and not for `litellm.ResponsesAPIResponse` (the response for response models), because the latter is a Pydantic model without `extra="allow"` set in its config.

My proposed fix for this is to simply remove this ad-hoc attribute alltogether, since it is actually superflueous: the `response.usage` attribute is cleared on cache hit anyways, which makes `settings.usage_tracker.add_usage(self.model, dict(results.usage)` a null-op.