### PR TITLE
fix(BAMLAdapter): Use docstrings to describe BaseModels

### DIFF
--- a/dspy/adapters/baml_adapter.py
+++ b/dspy/adapters/baml_adapter.py
@@ -209,28 +209,6 @@ class BAMLAdapter(JSONAdapter):
     ```
     """
 
-    def format_field_description(self, signature: type[Signature]) -> str:
-        """Format the field description for the system message."""
-        sections = []
-
-        # Add input field descriptions
-        if signature.input_fields:
-            sections.append("Your input fields are:")
-            for i, (name, field) in enumerate(signature.input_fields.items(), 1):
-                type_name = getattr(field.annotation, "__name__", str(field.annotation))
-                description = f": {field.description}" if field.description else ":"
-                sections.append(f"{i}. `{name}` ({type_name}){description}")
-
-        # Add output field descriptions
-        if signature.output_fields:
-            sections.append("Your output fields are:")
-            for i, (name, field) in enumerate(signature.output_fields.items(), 1):
-                type_name = getattr(field.annotation, "__name__", str(field.annotation))
-                description = f": {field.description}" if field.description else ":"
-                sections.append(f"{i}. `{name}` ({type_name}){description}")
-
-        return "\n".join(sections)
-
     def format_field_structure(self, signature: type[Signature]) -> str:
         """Overrides the base method to generate a simplified schema for Pydantic models."""
 

--- a/tests/adapters/test_baml_adapter.py
+++ b/tests/adapters/test_baml_adapter.py
@@ -515,9 +515,9 @@ def test_baml_adapter_multiple_pydantic_input_fields():
         endpoints: list[str]
 
     class TestSignature(dspy.Signature):
-        input_1: UserProfile = dspy.InputField()
-        input_2: SystemConfig = dspy.InputField()
-        result: str = dspy.OutputField()
+        input_1: UserProfile = dspy.InputField(desc="User profile information")
+        input_2: SystemConfig = dspy.InputField(desc="System configuration settings")
+        result: str = dspy.OutputField(desc="Resulting output after processing")
 
     adapter = BAMLAdapter()
 
@@ -535,7 +535,10 @@ def test_baml_adapter_multiple_pydantic_input_fields():
     # Test field descriptions are in the correct method
     field_desc = adapter.format_field_description(TestSignature)
     assert "Your input fields are:" in field_desc
+    assert "1. `input_1` (UserProfile): User profile information" in field_desc
+    assert "2. `input_2` (SystemConfig): System configuration settings" in field_desc
     assert "Your output fields are:" in field_desc
+    assert "1. `result` (str): Resulting output after processing" in field_desc
 
     # Test message formatting with actual Pydantic instances
     user_profile = UserProfile(name="John Doe", email="john@example.com", age=30)


### PR DESCRIPTION
This PR fixes an issue in which pydantic basemodels do not have their docstrings exposed to the generated signature as they do with other adapters.

Before:

```
All interactions will be structured in the following way, with the appropriate values filled in.

[[ ## input ## ]]
{input}

[[ ## complex ## ]]
Output field `complex` should be of type: {
  # Unique identifier
  id: int,
  details:   {
    # Full name of the patient
    name: string,
    age: int,
    address:     {
      street: string,
      city: string,
      country: "US" or "CA",
    } or null,
  },
  tags: string[],
  metadata: dict[string, string],
}

[[ ## completed ## ]]
```

After:

```
All interactions will be structured in the following way, with the appropriate values filled in.

[[ ## input ## ]]
{input}

[[ ## complex ## ]]
Output field `complex` should be of type: # Complex model docstring
{
  # Unique identifier
  id: int,
  # Patient Details model docstring
  # Multiline docstring support test
  details:   {
    # Full name of the patient
    name: string,
    age: int,
    # Patient Address model docstring
    address:     {
      street: string,
      city: string,
      country: "US" or "CA",
    } or null,
  },
  tags: string[],
  metadata: dict[string, string],
}

[[ ## completed ## ]]
```

Additionally closes #8657 