### PR TITLE
 Fix Responses API cache retrieval error

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -122,7 +122,6 @@ class Cache:
         if hasattr(response, "usage"):
             # Clear the usage data when cache is hit, because no LM call is made
             response.usage = {}
-            response.cache_hit = True
         return response
 
     def put(

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -163,7 +163,7 @@ class LM(BaseLM):
 
         self._check_truncation(results)
 
-        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
+        if dspy.settings.usage_tracker and hasattr(results, "usage"):
             settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 
@@ -201,7 +201,7 @@ class LM(BaseLM):
 
         self._check_truncation(results)
 
-        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
+        if dspy.settings.usage_tracker and hasattr(results, "usage"):
             settings.usage_tracker.add_usage(self.model, dict(results.usage))
         return results
 


### PR DESCRIPTION
Previous PR: https://github.com/stanfordnlp/dspy/pull/9123

### Cache retrieval fix

While implementing the fix outlined in https://github.com/stanfordnlp/dspy/pull/9130 I additionally stumbled on an error pertaining to responses models when using caching.
When an item is successfully retrieved from the cache, an ad-hoc attribute `.cache_hit` is created and set to `True` on the `response` object.

 Unfortunately, this is only possible for `litellm.ModelResponse` (the response for chat models) and not for `litellm.ResponsesAPIResponse` (the response for response models), because the latter is a Pydantic model without `extra="allow"` set in its config.

My proposed fix for this is to simply remove this ad-hoc attribute alltogether, since it is actually superflueous: the `response.usage` attribute is cleared on cache hit anyways, which makes `settings.usage_tracker.add_usage(self.model, dict(results.usage)` a null-op.