### PR TITLE
Add typing to `dspy.datasets.dataset`

### DIFF
--- a/dspy/datasets/dataset.py
+++ b/dspy/datasets/dataset.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import random
 import uuid
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from dspy import Example
 from dspy.dsp.utils import dotdict


### PR DESCRIPTION
This PR adds a basic level typing to the `dspy.datasets.dataset` module, primarily for external users who currently hit false positives when using the `Dataset` class. Python type-checkers will generally assume types based on defaults when not provided, meaning users will hit FPs with their type-checkers when passing in arguments like `train_seed` or `test_size`.