### PR TITLE
fix(streaming): prevent silent exception swallowing in apply_sync_streaming

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -224,38 +224,52 @@ def streamify(
         return sync_streamer
 
 
-def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
-    """Convert the async streaming generator to a sync generator."""
-    queue = Queue()  # Queue to hold items from the async generator
-    stop_sentinel = object()  # Sentinel to signal the generator is complete
 
-    # To propagate prediction request ID context to the child thread
+def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
+    """
+    Convert an async streaming generator to a sync generator.
+    """
+    queue = Queue()
+    stop_sentinel = object()
+    exception_sentinel = object()
+
     context = contextvars.copy_context()
 
     def producer():
         """Runs in a background thread to fetch items asynchronously."""
-
         async def runner():
             try:
                 async for item in async_generator:
                     queue.put(item)
-            finally:
-                # Signal completion
                 queue.put(stop_sentinel)
+            except BaseException as e:
+                # Catch BaseException (KeyboardInterrupt, SystemExit, etc.)
+                # and transport it to the main thread via the queue.
+                queue.put((exception_sentinel, e))
 
         context.run(asyncio.run, runner())
 
-    # Start the producer in a background thread
     thread = threading.Thread(target=producer, daemon=True)
     thread.start()
 
-    # Consume items from the queue
-    while True:
-        item = queue.get()  # Block until an item is available
-        if item is stop_sentinel:
-            break
-        yield item
+    try:
+        while True:
+            item = queue.get()
 
+            if item is stop_sentinel:
+                break
+
+            if isinstance(item, tuple) and len(item) == 2 and item[0] is exception_sentinel:
+                exc = item[1]
+
+                if hasattr(exc, "exceptions") and len(exc.exceptions) == 1:
+                    raise exc.exceptions[0]
+
+                raise exc
+
+            yield item
+    finally:
+        thread.join(timeout=1.0)
 
 async def streaming_response(streamer: AsyncGenerator) -> AsyncGenerator:
     """

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -395,7 +395,7 @@ def test_sync_streaming_keyboard_interrupt_propagation():
         yield "Starting..."
         raise KeyboardInterrupt()
 
-    sync_output = apply_sync_streaming(interrupt_gen())
+    sync_output = dspy.streaming.apply_sync_streaming(interrupt_gen())
 
     with pytest.raises(KeyboardInterrupt):
         for _ in sync_output:

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -389,6 +389,17 @@ def test_sync_streaming(lm_for_test):
     assert all_chunks[-2].predict_name == "predict2"
     assert all_chunks[-2].signature_field_name == "judgement"
 
+def test_sync_streaming_keyboard_interrupt_propagation():
+    """Verifies that BaseExceptions like KeyboardInterrupt are also propagated."""
+    async def interrupt_gen():
+        yield "Starting..."
+        raise KeyboardInterrupt()
+
+    sync_output = apply_sync_streaming(interrupt_gen())
+
+    with pytest.raises(KeyboardInterrupt):
+        for _ in sync_output:
+            pass
 
 def test_sync_status_streaming():
     class MyProgram(dspy.Module):
@@ -414,6 +425,31 @@ def test_sync_status_streaming():
     assert status_messages[0].message == "Calling tool generate_question..."
     assert status_messages[1].message == "Tool calling finished! Querying the LLM with tool calling results..."
 
+def test_sync_status_streaming_with_error_propagation():
+    class FailingProgram(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.generate_question = dspy.Tool(
+                lambda x: exec('raise RuntimeError("Simulated Tool Failure")'),
+                name="failing_tool"
+            )
+        def forward(self, x: str):
+            return self.generate_question(x=x)
+
+    lm = dspy.utils.DummyLM([])
+    with dspy.context(lm=lm):
+        program = dspy.streamify(FailingProgram(), async_streaming=False)
+        sync_output = program(x="test")
+        status_messages = []
+
+        with pytest.raises(RuntimeError, match="Simulated Tool Failure"):
+            for value in sync_output:
+                if isinstance(value, StatusMessage):
+                    status_messages.append(value)
+
+        # Verify status messages arrived before the crash
+        assert len(status_messages) > 0
+        assert any("failing_tool" in msg.message for msg in status_messages)
 
 @pytest.mark.anyio
 async def test_stream_listener_returns_correct_chunk_chat_adapter():


### PR DESCRIPTION
 This PR fixes a bug where `apply_sync_streaming` silently swallowed exceptions from the background `async` generator. Previously, the `finally` block always sent a `stop_sentinel`; allowing the synchronous caller to proceed as though no error had occurred!
 
**Changes:**
- Catch `BaseException` in the producer thread and send it through the queue.    
- Use a `sentinel` tuple to distinguish exceptions from regular data (in case someone's yielding Exception objects as actual content).     
- Unwrap `anyio ExceptionGroups` when there's only a single exception—this way callers get the actual error instead of a wrapper.     
- Added test that verifies exceptions propagate correctly while status messages before the crash are still received. 

Fixes #9142 