### PR TITLE
fix(copro): make eval_kwargs parameter optional in COPRO.compile

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -120,7 +120,7 @@ class COPRO(Teleprompter):
         assert hasattr(predictor, "signature")
         predictor.signature = updated_signature
 
-    def compile(self, student, *, trainset, eval_kwargs):
+    def compile(self, student, *, trainset, eval_kwargs=None):
         """
         optimizes `signature` of `student` program - note that it may be zero-shot or already pre-optimized (demos already chosen - `demos != []`)
 
@@ -133,6 +133,7 @@ class COPRO(Teleprompter):
         Returns optimized version of `student`.
         """
         module = student.deepcopy()
+        eval_kwargs = eval_kwargs or {}
         evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
         total_calls = 0
         results_best = {

--- a/tests/teleprompt/test_copro_optimizer.py
+++ b/tests/teleprompt/test_copro_optimizer.py
@@ -154,3 +154,23 @@ def test_statistics_tracking_during_optimization():
     ), "Optimizer did not properly populate the latest results statistics"
 
     # Additional detailed checks can be added here to verify the contents of the tracked statistics
+
+
+def test_copro_compile_without_eval_kwargs():
+    """Test that COPRO.compile works without providing eval_kwargs (issue #9080)."""
+    lm = DummyLM(
+        [
+            {"proposed_instruction": "Optimized Prompt", "proposed_prefix_for_output_field": "Optimized Prefix"},
+            {"reasoning": "reasoning", "output": "blue"},
+            {"reasoning": "reasoning", "output": "Ring-ding-ding-ding-dingeringeding!"},
+        ]
+    )
+    dspy.configure(lm=lm)
+    optimizer = COPRO(metric=simple_metric, breadth=2, depth=1, init_temperature=1.4)
+
+    student = SimpleModule("input -> output")
+
+    # Compile without eval_kwargs - this should not raise an error
+    optimized_student = optimizer.compile(student, trainset=trainset)
+
+    assert optimized_student is not student, "Optimization did not return a new student"


### PR DESCRIPTION
## Summary

- Make `eval_kwargs` parameter truly optional in `COPRO.compile()` by setting default value to `None`
- Handle `None` case by using empty dict internally

## Test Plan

- Added test `test_copro_compile_without_eval_kwargs` to verify the fix
- All existing COPRO tests pass

Fixes #9080