### PR TITLE
fix(typing): add py.typed marker file for type checking support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ include = ["dspy", "dspy.*"]
 exclude = ["tests", "tests.*"]
 
 [tool.setuptools.package-data]
-dspy = ["primitives/*.js"]
+dspy = ["primitives/*.js", "py.typed"]
 
 [project.urls]
 homepage = "https://github.com/stanfordnlp/dspy"


### PR DESCRIPTION
## Summary

- Add `py.typed` marker file to the dspy package
- Update `pyproject.toml` to include `py.typed` in package distribution

This allows type checkers like mypy to properly recognize dspy as a typed package.

## Test Plan

- Verified `py.typed` is included in the built wheel
- Existing tests continue to pass

Fixes #8873