### PR TITLE
Fix download bug in RAG tutorial

### DIFF
--- a/dspy/utils/__init__.py
+++ b/dspy/utils/__init__.py
@@ -16,7 +16,7 @@ def download(url):
     remote_size = int(requests.head(url, allow_redirects=True).headers.get("Content-Length", 0))
     local_size = os.path.getsize(filename) if os.path.exists(filename) else 0
 
-    if local_size != remote_size:
+    if not os.path.exists(filename) or local_size != remote_size:
         print(f"Downloading '{filename}'...")
         with requests.get(url, stream=True) as r, open(filename, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):


### PR DESCRIPTION
In the [RAG tutorial](https://dspy.ai/tutorials/rag/), `download("https://huggingface.co/dspy/cache/resolve/main/ragqa_arena_tech_examples.jsonl")` never downloads `ragqa_arena_tech_examples.jsonl` because the HTTP response for the file does not contain the `Content-Length` header, so the pre-download check `local_size != remote_size` evaluates to `False` (`local_size` = `remote_size` = 0). This file seems to be the only one in https://huggingface.co/dspy/cache for which the HTTP response does not contain this header.

Checking the existence of the local file before comparing the sizes fixes the issue. I have also checked that all other calls to `download()` in this and other tutorials work as normal.

However, the caching mechanism in `downloads()` does not work for this JSON file, i.e. the file is redownloaded even if it already exists locally, since this file's `remote_size` is 0. The caching mechanism works as normal for all other files in https://huggingface.co/dspy/cache. I am not sure how to solve this properly or if this is a problem.