### PR TITLE
Add example of dump_state and load_state to existing tutorial

### DIFF
--- a/docs/docs/tutorials/saving/index.md
+++ b/docs/docs/tutorials/saving/index.md
@@ -74,6 +74,51 @@ for original_demo, loaded_demo in zip(compiled_dspy_program.demos, loaded_dspy_p
 assert str(compiled_dspy_program.signature) == str(loaded_dspy_program.signature)
 ```
 
+### Loading from Memory (Databases, Object Storage, etc.)
+
+Instead of saving to and loading from files, you can work directly with state dictionaries in memory. This is particularly useful when you want to store compiled results in databases, object storage systems like S3, or other storage backends.
+
+Use `dump_state()` to get the state as a dictionary, which you can then serialize and store wherever you need:
+
+```python
+# Get the state as a dictionary
+state_dict = compiled_dspy_program.dump_state()
+
+# Now you can serialize and store this dictionary in various ways:
+# - Store in a database (e.g., PostgreSQL, MongoDB)
+# - Upload to object storage (e.g., S3, GCS, Azure Blob Storage)
+# - Cache in Redis or Memcached
+# - Send over a network API
+
+# Example: storing in a hypothetical database
+# db.store("my_program_state", state_dict)
+
+# Example: uploading to S3
+# import json
+# s3_client.put_object(
+#     Bucket='my-bucket',
+#     Key='dspy_program_state.json',
+#     Body=json.dumps(state_dict)
+# )
+```
+
+Later, you can retrieve the state dictionary and load it directly into your program:
+
+```python
+# Retrieve the state from your storage backend
+# state_dict = db.retrieve("my_program_state")
+# or
+# state_dict = json.loads(s3_client.get_object(Bucket='my-bucket', Key='dspy_program_state.json')['Body'].read())
+
+# Recreate the program architecture
+loaded_dspy_program = dspy.ChainOfThought("question -> answer")
+
+# Load the state directly from the dictionary
+loaded_dspy_program.load_state(state_dict)
+```
+
+This approach gives you complete flexibility in how and where you store your compiled DSPy programs, without being limited to local file storage.
+
 ## Whole Program Saving
 
 !!! warning "Security Notice: Whole Program Saving Uses Pickle"


### PR DESCRIPTION
Updates the saving tutorial to document the dump_state() and load_state() methods for working with DSPy program state as dictionaries in memory.

This feature enables users to store compiled DSPy programs in databases, object storage systems (S3, GCS, Azure), caching layers, or any custom storage backend - not just local files. This is particularly valuable for:

* Production deployments using cloud storage
* Distributed systems sharing compiled programs
* Applications requiring database-backed state management
* API services that need to load programs from remote storage