### PR TITLE
Update pyproject.toml to update gepa from 0.0.22 -> 0.0.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "cloudpickle>=3.0.0",
     "numpy>=1.26.0",
     "xxhash>=3.5.0",
-    "gepa[dspy]==0.0.22",
+    "gepa[dspy]==0.0.24",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
GEPA 0.0.24 introduces Multi Objectives. PR #8888 will use this version change to implement multiple-objective scores in dspy.GEPA