### PR TITLE
fix(dspy): populate InputField default values in Predict

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -2,6 +2,7 @@ import logging
 import random
 
 from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
 
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.clients.base_lm import BaseLM
@@ -151,6 +152,11 @@ class Predict(Module, Parameter):
                 # (https://platform.openai.com/docs/guides/predicted-outputs), we remove it from input kwargs and add it
                 # to the lm kwargs.
                 config["prediction"] = kwargs.pop("prediction")
+
+        # Populate default values for missing input fields.
+        for k, v in signature.input_fields.items():
+            if k not in kwargs and v.default is not PydanticUndefined:
+                kwargs[k] = v.default
 
         if not all(k in kwargs for k in signature.input_fields):
             present = [k for k in signature.input_fields if k in kwargs]

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -763,3 +763,26 @@ def test_per_module_history_disabled():
     for _ in range(10):
         program(question="What is the capital of France?")
     assert len(program.history) == 0
+
+def test_input_field_default_value():
+    class SpyLM(dspy.LM):
+        def __init__(self):
+            super().__init__("dummy")
+            self.calls = []
+
+        def __call__(self, prompt=None, messages=None, **kwargs):
+            self.calls.append({"messages": messages})
+            return ["[[ ## answer ## ]]\ntest"]
+
+    class SignatureWithDefault(dspy.Signature):
+        context: str = dspy.InputField(default="DEFAULT_CONTEXT")
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    lm = SpyLM()
+    dspy.configure(lm=lm)
+    predictor = Predict(SignatureWithDefault)
+    predictor(question="test")
+
+    user_message = lm.calls[0]["messages"][-1]["content"]
+    assert "DEFAULT_CONTEXT" in user_message


### PR DESCRIPTION
Fixes #9166

# Changes Description

- Fix `InputField` default values not being used when the field is omitted at call time
- When a `Signature` defines an `InputField` with a `default` value and the field is not provided during the call, the default value is now automatically populated before processing
- Added unit test to verify default value behavior