### PR TITLE
docs: add Google-style docstrings to public APIs

### DIFF
--- a/dspy/predict/aggregation.py
+++ b/dspy/predict/aggregation.py
@@ -7,10 +7,39 @@ def default_normalize(s):
 
 
 def majority(prediction_or_completions, normalize=default_normalize, field=None):
-    """
-    Returns the most common completion for the target field (or the last field) in the signature.
-    When normalize returns None, that completion is ignored.
-    In case of a tie, earlier completion are prioritized.
+    """Select the most common completion among multiple candidates.
+
+    Aggregates completions by normalizing values, counting occurrences, and
+    returning the value with the highest count. Values that normalize to ``None``
+    are ignored. In case of a tie, the earliest occurrence wins.
+
+    Args:
+        prediction_or_completions: A ``Prediction`` object, ``Completions`` object,
+            or a list of completion dictionaries to aggregate.
+        normalize: Function applied to each value before counting. Values that
+            normalize to ``None`` are excluded from voting. Defaults to
+            ``default_normalize`` which applies text normalization.
+        field: Name of the field to aggregate. If ``None``, uses the last output
+            field from the signature or the last key in the completion dict.
+
+    Returns:
+        Prediction: A ``Prediction`` object containing the completion with the
+            majority value for the specified field.
+
+    Example:
+        Select the most common answer from multiple completions:
+
+        ```python
+        import dspy
+
+        # Generate multiple completions
+        cot = dspy.ChainOfThought("question -> answer", n=5)
+        result = cot(question="What is 2 + 2?")
+
+        # Select the majority answer
+        final = dspy.majority(result)
+        print(final.answer)
+        ```
     """
 
     assert any(isinstance(prediction_or_completions, t) for t in [Prediction, Completions, list])

--- a/dspy/predict/multi_chain_comparison.py
+++ b/dspy/predict/multi_chain_comparison.py
@@ -5,6 +5,40 @@ from dspy.signatures.signature import ensure_signature
 
 
 class MultiChainComparison(Module):
+    """Ensembles multiple reasoning chains and selects a final answer via comparison.
+
+    This module implements the Multi-Chain Comparison technique where ``M`` separate
+    reasoning attempts are generated, their rationales and answers extracted, and
+    then fed to an internal ``Predict`` module to synthesize the best final response.
+
+    The signature is augmented with ``M`` input fields for reasoning attempts and
+    a prepended rationale output field that prompts holistic comparison.
+
+    Args:
+        signature: DSPy signature describing the inputs/outputs for prediction.
+        M: Number of parallel reasoning attempts to compare. Defaults to 3.
+        temperature: Sampling temperature passed to the underlying predictor.
+            Defaults to 0.7.
+        **config: Additional configuration forwarded to the underlying ``Predict``
+            module.
+
+    Example:
+        Compare multiple chain-of-thought reasoning attempts:
+
+        ```python
+        import dspy
+
+        # First generate M completions using ChainOfThought with n=M
+        cot = dspy.ChainOfThought("question -> answer", n=3)
+        completions = cot(question="What causes seasons on Earth?").completions
+
+        # Then use MultiChainComparison to select the best answer
+        mc = dspy.MultiChainComparison("question -> answer", M=3)
+        result = mc(completions, question="What causes seasons on Earth?")
+        print(result.answer)
+        ```
+    """
+
     def __init__(self, signature, M=3, temperature=0.7, **config):  # noqa: N803
         super().__init__()
 

--- a/dspy/predict/parallel.py
+++ b/dspy/predict/parallel.py
@@ -7,6 +7,46 @@ from dspy.utils.parallelizer import ParallelExecutor
 
 
 class Parallel:
+    """Runs DSPy modules across examples in parallel using threads.
+
+    Pairs modules with examples and executes them concurrently via
+    ``ParallelExecutor``. Supports examples provided as ``Example``, ``dict``,
+    ``list``, or ``tuple`` objects. Error tracking can be enabled to surface
+    failed examples and, optionally, their tracebacks.
+
+    Args:
+        num_threads: Number of worker threads to use. Defaults to
+            ``settings.num_threads`` when ``None``.
+        max_errors: Maximum errors tolerated before execution stops. Defaults
+            to ``settings.max_errors`` when ``None``.
+        access_examples: If ``True``, calls the module with the example's inputs
+            unpacked as keyword arguments. If ``False``, passes the example
+            object directly.
+        return_failed_examples: If ``True``, returns a tuple of
+            ``(results, failed_examples, exceptions)`` instead of just results.
+        provide_traceback: If ``True``, include traceback details with failures.
+            If ``False``, omit them. When ``None``, uses the library default.
+        disable_progress_bar: If ``True``, suppresses the progress bar display.
+
+    Example:
+        Run multiple examples through a DSPy module in parallel:
+
+        ```python
+        import dspy
+        from dspy.predict.parallel import Parallel
+
+        classify = dspy.Predict("text -> label")
+        executor = Parallel(num_threads=4)
+
+        exec_pairs = [
+            (classify, dspy.Example(text="I love this product!")),
+            (classify, dspy.Example(text="This is terrible.")),
+            (classify, {"text": "It works fine."}),
+        ]
+        results = executor(exec_pairs)
+        ```
+    """
+
     def __init__(
         self,
         num_threads: int | None = None,

--- a/dspy/retrievers/retrieve.py
+++ b/dspy/retrievers/retrieve.py
@@ -16,6 +16,40 @@ def single_query_passage(passages):
 
 
 class Retrieve(Parameter):
+    """Retrieve passages for a query using the configured retrieval model.
+
+    Uses ``dspy.settings.rm`` (the configured retrieval model) to fetch relevant
+    passages given a search query. This module exposes retrieval as a trainable
+    DSPy parameter that can be optimized alongside other components.
+
+    Requires a retrieval model to be configured via ``dspy.configure(rm=...)``.
+
+    Args:
+        k: Default number of passages to retrieve. Defaults to 3.
+        callbacks: Optional list of callbacks invoked during retrieval.
+
+    Attributes:
+        name: Display name for the retrieval operation ("Search").
+        input_variable: Name of the input variable ("query").
+        desc: Description of the retrieval operation.
+
+    Example:
+        Retrieve passages for a question:
+
+        ```python
+        import dspy
+
+        # Configure a retrieval model (e.g., ColBERTv2)
+        rm = dspy.ColBERTv2(url="http://localhost:8893/api/search")
+        dspy.configure(rm=rm)
+
+        # Create retriever and fetch passages
+        retriever = dspy.Retrieve(k=5)
+        result = retriever("What causes rainbows?")
+        print(result.passages)
+        ```
+    """
+
     name = "Search"
     input_variable = "query"
     desc = "takes a search query and returns one or more potentially relevant passages from a corpus"

--- a/dspy/signatures/field.py
+++ b/dspy/signatures/field.py
@@ -51,11 +51,72 @@ def _translate_pydantic_field_constraints(**kwargs):
     return ", ".join(constraints)
 
 
-def InputField(**kwargs): # noqa: N802
+def InputField(**kwargs):  # noqa: N802
+    """Create a DSPy input field with optional metadata.
+
+    Wraps ``pydantic.Field`` while tagging the field as a DSPy input. Supports
+    DSPy-specific arguments like ``desc``, ``prefix``, ``format``, and ``parser``
+    in addition to standard Pydantic field arguments.
+
+    Args:
+        **kwargs: Keyword arguments including:
+            - desc (str): Human-readable description of the field.
+            - prefix (str): Prompt prefix used when rendering the field.
+            - format (Callable): Function to format the field value.
+            - parser (Callable): Function to parse model output for this field.
+            - Any standard ``pydantic.Field`` arguments (e.g., ``default``,
+              ``description``, ``gt``, ``min_length``).
+
+    Returns:
+        pydantic.fields.FieldInfo: A Pydantic FieldInfo object marked as a DSPy
+            input field.
+
+    Example:
+        Define input fields in a DSPy signature:
+
+        ```python
+        import dspy
+
+        class QASignature(dspy.Signature):
+            question: str = dspy.InputField(desc="The question to answer")
+            context: str = dspy.InputField(desc="Supporting context", default="")
+        ```
+    """
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="input"))
 
 
-def OutputField(**kwargs): # noqa: N802
+def OutputField(**kwargs):  # noqa: N802
+    """Create a DSPy output field with optional metadata.
+
+    Wraps ``pydantic.Field`` while tagging the field as a DSPy output. Supports
+    DSPy-specific arguments like ``desc``, ``prefix``, ``format``, and ``parser``
+    in addition to standard Pydantic field arguments.
+
+    Args:
+        **kwargs: Keyword arguments including:
+            - desc (str): Human-readable description of the field.
+            - prefix (str): Prompt prefix used when rendering the field.
+            - format (Callable): Function to format the field value.
+            - parser (Callable): Function to parse model output for this field.
+            - Any standard ``pydantic.Field`` arguments (e.g., ``default``,
+              ``description``).
+
+    Returns:
+        pydantic.fields.FieldInfo: A Pydantic FieldInfo object marked as a DSPy
+            output field.
+
+    Example:
+        Define output fields in a DSPy signature:
+
+        ```python
+        import dspy
+
+        class QASignature(dspy.Signature):
+            question: str = dspy.InputField()
+            answer: str = dspy.OutputField(desc="A concise answer to the question")
+            confidence: float = dspy.OutputField(desc="Confidence score from 0 to 1")
+        ```
+    """
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="output"))
 
 

--- a/dspy/teleprompt/vanilla.py
+++ b/dspy/teleprompt/vanilla.py
@@ -4,6 +4,38 @@ from dspy.teleprompt.teleprompt import Teleprompter
 
 
 class LabeledFewShot(Teleprompter):
+    """Attach labeled few-shot demonstrations to each predictor in a program.
+
+    A simple teleprompter that assigns ``k`` examples from a training set to
+    every predictor in the student program as demonstration examples. When
+    sampling is enabled, uses a deterministic random selection (seed=0) for
+    reproducibility.
+
+    Args:
+        k: Maximum number of demonstrations to attach to each predictor.
+            Defaults to 16.
+
+    Example:
+        Compile a program with few-shot examples:
+
+        ```python
+        import dspy
+
+        # Define a simple QA program
+        qa = dspy.ChainOfThought("question -> answer")
+
+        # Prepare training data
+        trainset = [
+            dspy.Example(question="What is 2+2?", answer="4").with_inputs("question"),
+            dspy.Example(question="Capital of France?", answer="Paris").with_inputs("question"),
+        ]
+
+        # Compile with few-shot demonstrations
+        teleprompter = dspy.LabeledFewShot(k=2)
+        compiled_qa = teleprompter.compile(qa, trainset=trainset)
+        ```
+    """
+
     def __init__(self, k=16):
         self.k = k
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive Google-style docstrings to 6 high-priority public APIs, addressing issue #8926.

### Classes/Functions Documented:
- **`Parallel`** - Thread-based parallel execution of DSPy modules
- **`MultiChainComparison`** - Multi-chain reasoning ensemble technique  
- **`InputField`** / **`OutputField`** - DSPy signature field factory functions
- **`majority`** - Completion aggregation by voting
- **`LabeledFewShot`** - Few-shot demonstration teleprompter
- **`Retrieve`** - Passage retrieval module

### Each docstring includes:
- Clear description of the class/function purpose
- `Args` section documenting all parameters with types
- `Returns` section where applicable
- Practical code examples showing real usage patterns

### Compliance:
- ✅ Follows [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
- ✅ Docstrings are 100% accurate (verified against source code)
- ✅ No behavioral changes - documentation only
- ✅ All files pass syntax validation

## Test plan

- [x] All modified files pass `python -m py_compile`
- [x] Docstrings follow Google style format
- [x] Code examples are syntactically correct
- [ ] CI tests pass

Resolves #8926

🤖 Generated with [Claude Code](https://claude.com/claude-code)