### PR TITLE
fix(StatusMessageProvider): remove default message in StatusMessageProvider to maintain consistency

### DIFF
--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -72,11 +72,11 @@ class StatusMessageProvider:
 
     def tool_start_status_message(self, instance: Any, inputs: dict[str, Any]):
         """Status message before a `dspy.Tool` is called."""
-        return f"Calling tool {instance.name}..."
+        pass
 
     def tool_end_status_message(self, outputs: Any):
         """Status message after a `dspy.Tool` is called."""
-        return "Tool calling finished! Querying the LLM with tool calling results..."
+        pass
 
     def module_start_status_message(self, instance: Any, inputs: dict[str, Any]):
         """Status message before a `dspy.Module` or `dspy.Predict` is called."""


### PR DESCRIPTION
Remove the default status messages in StatusMessageProvider for tool_start and tool_end to maintain consistency with other methods.

closes #9177 