### PR TITLE
fix(gepa): warn once for blank metric feedback

### DIFF
--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -529,6 +529,8 @@ class GEPA(Teleprompter):
 
         rng = random.Random(self.seed)
 
+        warned_empty_feedback_predictors: set[str] = set()
+
         def feedback_fn_creator(pred_name: str, predictor) -> "PredictorFeedbackFn":
             def feedback_fn(
                 predictor_output: dict[str, Any],
@@ -546,7 +548,15 @@ class GEPA(Teleprompter):
                     trace_for_pred,
                 )
                 if hasattr(o, "feedback"):
-                    if o["feedback"] is None:
+                    feedback = o["feedback"]
+                    if feedback is None or (isinstance(feedback, str) and not feedback.strip()):
+                        if pred_name not in warned_empty_feedback_predictors:
+                            logger.warning(
+                                f"Metric for predictor '{pred_name}' returned empty feedback. "
+                                "GEPA relies on textual feedback for optimization. "
+                                "Using default score-based feedback."
+                            )
+                            warned_empty_feedback_predictors.add(pred_name)
                         o["feedback"] = f"This trajectory got a score of {o['score']}."
                     return o
                 else:

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import threading
+from types import SimpleNamespace
 from typing import Any
 from unittest import mock
 
@@ -41,6 +43,58 @@ def simple_metric(example, prediction, trace=None, pred_name=None, pred_trace=No
 
 def bad_metric(example, prediction):
     return 0.0
+
+
+def test_gepa_warns_once_for_blank_metric_feedback(monkeypatch, caplog):
+    feedback_results = []
+
+    def blank_feedback_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
+        return dspy.Prediction(score=0.5, feedback="  ")
+
+    def fake_optimize(seed_candidate, adapter, **kwargs):
+        feedback_fn = adapter.feedback_map["predictor"]
+        for _ in range(2):
+            feedback_results.append(
+                feedback_fn(
+                    predictor_output={},
+                    predictor_inputs={},
+                    module_inputs=Example(input="question", output="answer"),
+                    module_outputs=dspy.Prediction(output="wrong"),
+                    captured_trace=[],
+                )
+            )
+        return SimpleNamespace(best_candidate=seed_candidate)
+
+    monkeypatch.setattr("gepa.optimize", fake_optimize)
+
+    optimizer = dspy.GEPA(
+        metric=blank_feedback_metric,
+        reflection_lm=DictDummyLM([]),
+        max_metric_calls=1,
+    )
+
+    gepa_logger = logging.getLogger("dspy.teleprompt.gepa.gepa")
+    gepa_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="dspy.teleprompt.gepa.gepa"):
+            optimizer.compile(
+                SimpleModule("input -> output"),
+                trainset=[Example(input="question", output="answer")],
+            )
+    finally:
+        gepa_logger.removeHandler(caplog.handler)
+
+    assert [result["feedback"] for result in feedback_results] == [
+        "This trajectory got a score of 0.5.",
+        "This trajectory got a score of 0.5.",
+    ]
+    warning = (
+        "Metric for predictor 'predictor' returned empty feedback. "
+        "GEPA relies on textual feedback for optimization. "
+        "Using default score-based feedback."
+    )
+    matching_warnings = [record for record in caplog.records if record.message == warning]
+    assert len(matching_warnings) == 1
 
 
 @pytest.mark.parametrize("reflection_minibatch_size, batch, expected_callback_metadata", [


### PR DESCRIPTION
### Summary
Adds a warning when a GEPA metric returns missing or blank textual feedback.

GEPA already falls back to score-based feedback in this case; this change makes that fallback visible so users can catch metric bugs or empty LLM-judge responses more easily. The warning is emitted once per predictor to avoid noisy logs during optimization.

Closes #8920

### Test Plan
- `uv run pytest tests/teleprompt/test_gepa.py::test_gepa_warns_once_for_blank_metric_feedback -q`
- `uv run ruff check --select I,F dspy/teleprompt/gepa/gepa.py tests/teleprompt/test_gepa.py`
- `git diff --check`