### PR TITLE
Fix JSON parsing: Removing initial regex extraction.

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -152,7 +152,7 @@ class JSONAdapter(ChatAdapter):
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
         fields = json_repair.loads(completion)
-        
+
         if not isinstance(fields, dict):
             pattern = r"\{(?:[^{}]|(?R))*\}"
             match = regex.search(pattern, completion, regex.DOTALL)


### PR DESCRIPTION
The default parsing of JSON responses from LM responses breaks complex JSON documents that are perfectly fine JSON: The following example shows such an example where the regex breaks a well defined JSON document and extracts the wrong content:
[test2.py](https://github.com/user-attachments/files/24544952/test2.py)

I left the regex extraction in as a fallback if json_repair is unable to extract a JSON object. However, it is unclear to me what this regex capture is supposed to fix in the first place that can not be extracted by json_repair.

This bug has been throwing wrenches in me talking about and reasoning about JSON data for a while now.