### PR TITLE
Added docstrings to JSON and XML adapter main classes

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -39,7 +39,26 @@ def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
 
 
 class JSONAdapter(ChatAdapter):
+    """An adapter that formats inputs and parses outputs in JSON format.
+
+    This adapter ensures that the language model (LM) receives instructions to respond with a
+    JSON object and parses the resulting JSON string back into a dictionary matching the
+    signature's output fields. It supports OpenAI-style Structured Outputs when possible,
+    falling back to standard JSON mode if the model or signature is not compatible.
+
+    Key features:
+        - Structures outputs using JSON schema for models that support it.
+        - Provides robust parsing with fallback mechanisms for non-conforming responses.
+        - Automatically handles Structured Outputs for OpenAI and compatible providers.
+    """
+
     def __init__(self, callbacks: list[BaseCallback] | None = None, use_native_function_calling: bool = True):
+        """
+        Args:
+            callbacks: List of callback functions to execute during adapter methods.
+            use_native_function_calling: Whether to use native function calling for tool calls.
+                Defaults to True for JSONAdapter.
+        """
         # JSONAdapter uses native function calling by default.
         super().__init__(callbacks=callbacks, use_native_function_calling=use_native_function_calling)
 

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -10,7 +10,23 @@ from dspy.utils.callback import BaseCallback
 
 
 class XMLAdapter(ChatAdapter):
+    """An adapter that wraps fields in XML tags for communication with the language model.
+
+    This adapter formats input fields into XML-tagged blocks (e.g., `<field_name>value</field_name>`)
+    and expects the model to respond in the same format. It is particularly useful for models
+    that have been trained to handle XML-structured prompts or when clear field separation
+    is required without using JSON.
+
+    Key features:
+        - Structures inputs and outputs using customizable XML-style tags.
+        - Provides regex-based parsing to extract values from tagged sections.
+    """
+
     def __init__(self, callbacks: list[BaseCallback] | None = None):
+        """
+        Args:
+            callbacks: List of callback functions to execute during adapter methods.
+        """
         super().__init__(callbacks)
         self.field_pattern = re.compile(r"<(?P<name>\w+)>((?P<content>.*?))</\1>", re.DOTALL)
 


### PR DESCRIPTION
This PR adds a Google-style docstring for the JSON and XML adapters in: 
- dspy/adapters/json_adapter.py
- dspy/adapters/xml_adapter.py

Original issue: #8926 
My issue: #9184 
cc: @chenmoneygithub 