### PR TITLE
docs: add security warning about executing external code in tool_use tutorial

### DIFF
--- a/docs/docs/tutorials/tool_use/index.ipynb
+++ b/docs/docs/tutorials/tool_use/index.ipynb
@@ -108,6 +108,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "security-warning",
+   "metadata": {},
+   "source": [
+    "\u26a0\ufe0f **Security Warning**: The code below executes Python functions from an external dataset. ",
+    "This is inherently risky as malicious code in the dataset could compromise your system. ",
+    "Only run this notebook with datasets from trusted sources, and consider using sandboxed ",
+    "execution environments for production use cases."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},


### PR DESCRIPTION
## Summary

This PR adds a security warning to the `tool_use` tutorial notebook that executes code from an external dataset.

### The Issue

The tutorial downloads functions from the ToolHop dataset and executes them using `exec()`:

```python
exec(cleaned_code, {}, local_vars)
fn_obj = local_vars.get(fn_name)
```

While the ToolHop dataset is from a trusted research source (ByteDance Research), executing code from any external source without sandboxing is a security risk. Poisoned datasets could lead to arbitrary code execution on the user's machine.

### The Fix

Added a prominent warning cell before the code execution section alerting users about:
- The inherent risks of executing code from external sources
- Recommendation to only use datasets from trusted sources
- Suggestion to consider sandboxed execution for production use cases

### Why This Matters

Users following tutorials often copy code without fully understanding the security implications. A clear warning helps them make informed decisions about the risks they're accepting.

---

*Identified using [aisentry](https://aisentry.co), an AI/LLM security scanner for OWASP LLM Top 10 vulnerabilities.*