### PR TITLE
Expose timeout and straggler_limit params in Parallel

### DIFF
--- a/dspy/predict/parallel.py
+++ b/dspy/predict/parallel.py
@@ -15,6 +15,8 @@ class Parallel:
         return_failed_examples: bool = False,
         provide_traceback: bool | None = None,
         disable_progress_bar: bool = False,
+        timeout: int = 120,
+        straggler_limit: int = 3,
     ):
         super().__init__()
         self.num_threads = num_threads or settings.num_threads
@@ -23,6 +25,8 @@ class Parallel:
         self.return_failed_examples = return_failed_examples
         self.provide_traceback = provide_traceback
         self.disable_progress_bar = disable_progress_bar
+        self.timeout = timeout
+        self.straggler_limit = straggler_limit
 
         self.error_count = 0
         self.error_lock = threading.Lock()
@@ -38,6 +42,8 @@ class Parallel:
             max_errors=self.max_errors,
             provide_traceback=self.provide_traceback,
             disable_progress_bar=self.disable_progress_bar,
+            timeout=self.timeout,
+            straggler_limit=self.straggler_limit,
         )
 
         def process_pair(pair):

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -145,6 +145,8 @@ class Module(BaseModule, metaclass=ProgramMeta):
         return_failed_examples: bool = False,
         provide_traceback: bool | None = None,
         disable_progress_bar: bool = False,
+        timeout: int = 120,
+        straggler_limit: int = 3,
     ) -> list[Example] | tuple[list[Example], list[Example], list[Exception]]:
         """
         Processes a list of dspy.Example instances in parallel using the Parallel module.
@@ -157,6 +159,8 @@ class Module(BaseModule, metaclass=ProgramMeta):
             return_failed_examples: Whether to return failed examples and exceptions.
             provide_traceback: Whether to include traceback information in error logs.
             disable_progress_bar: Whether to display the progress bar.
+            timeout: Seconds before a straggler task is resubmitted. Set to 0 to disable.
+            straggler_limit: Only check for stragglers when this many or fewer tasks remain.
 
         Returns:
             List of results, and optionally failed examples and exceptions.
@@ -171,6 +175,8 @@ class Module(BaseModule, metaclass=ProgramMeta):
             return_failed_examples=return_failed_examples,
             provide_traceback=provide_traceback,
             disable_progress_bar=disable_progress_bar,
+            timeout=timeout,
+            straggler_limit=straggler_limit,
         )
 
         # Execute the forward method of Parallel

--- a/tests/predict/test_parallel.py
+++ b/tests/predict/test_parallel.py
@@ -194,3 +194,30 @@ def test_batch_with_failed_examples():
     assert len(exceptions) == 1
     assert isinstance(exceptions[0], ValueError)
     assert str(exceptions[0]) == "test error"
+
+
+def test_parallel_timeout_and_straggler_limit_params():
+    parallel_default = dspy.Parallel()
+    assert parallel_default.timeout == 120
+    assert parallel_default.straggler_limit == 3
+
+    parallel_custom = dspy.Parallel(timeout=0, straggler_limit=5)
+    assert parallel_custom.timeout == 0
+    assert parallel_custom.straggler_limit == 5
+
+
+def test_batch_timeout_and_straggler_limit_params():
+    class SimpleModule(dspy.Module):
+        def forward(self, value: int) -> int:
+            return value * 2
+
+    module = SimpleModule()
+    examples = [
+        dspy.Example(value=1).with_inputs("value"),
+        dspy.Example(value=2).with_inputs("value"),
+        dspy.Example(value=3).with_inputs("value"),
+    ]
+
+    results = module.batch(examples, timeout=0, straggler_limit=5)
+
+    assert results == [2, 4, 6]


### PR DESCRIPTION
ParallelExecutor has `timeout` (default 120s) and `straggler_limit` (default 3) params but Parallel doesn't expose them.

If you run ≤3 tasks that each take >2 min, they get resubmitted as "stragglers" after the timeout, causing duplicate work.

This adds both params to `Parallel.__init__()` and `Module.batch()`. Setting `timeout=0` disables resubmission.