### PR TITLE
Add filters for noisy warnings

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -1,8 +1,5 @@
 import warnings
 
-# Suppress warnings from upstream dependencies that users can't act on.
-# These are all issues in openai/litellm internals that don't affect dspy functionality.
-
 # openai 1.x imports from pydantic.v1 for typing utilities that still work correctly.
 # Fixed in openai >=2.0.0 (Sep 30, 2025).
 warnings.filterwarnings(


### PR DESCRIPTION
Suppress upstream warnings from dependencies that appear during normal dspy usage.

| Warning | Source | Trigger | Fixed In | Release Date |
|---------|--------|---------|----------|--------------|
| "Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater" | `openai/_compat.py` | Import | openai ≥2.0.0 | Sep 30, 2025 |
| "Pydantic serializer warnings: PydanticSerializationUnexpectedValue" | `litellm/litellm_logging.py` | Runtime | litellm ≥1.80.16 | Jan 13, 2026 |
| "'asyncio.iscoroutinefunction' is deprecated" | `litellm/logging_utils.py` | Import | TBD | TBD |
| "Support for class-based `config` is deprecated" | `litellm/integrations/deepeval/types.py` | Import | TBD | TBD |


Better to suppress than to bump the versions.

- **openai ≥2.0.0**: Major version bump could break users with dependencies pinning openai 1.x
- **litellm ≥1.80.16**: Fix merged only 3 days ago - too recent to require as minimum