### PR TITLE
ci: install Deno in release workflow

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -31,6 +31,12 @@ jobs:
           python-version: "3.11"
       - name: Install dependencies
         run: python3 -m pip install --upgrade setuptools wheel twine build semver packaging
+      - name: Install Deno
+        run: |
+          curl -fsSL https://deno.land/install.sh | sh
+          echo "${HOME}/.deno/bin" >> $GITHUB_PATH
+      - name: Verify Deno installation
+        run: deno --version
       - name: Get correct version for TestPyPI release
         id: check_version
         run: |
@@ -82,6 +88,12 @@ jobs:
           python-version: "3.11"
       - name: Install dependencies
         run: python3 -m pip install --upgrade setuptools wheel twine build
+      - name: Install Deno
+        run: |
+          curl -fsSL https://deno.land/install.sh | sh
+          echo "${HOME}/.deno/bin" >> $GITHUB_PATH
+      - name: Verify Deno installation
+        run: deno --version
       - name: Update version in pyproject.toml
         run: sed -i '/#replace_package_version_marker/{n;s/version *= *"[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
       - name: Update version in __metadata__.py


### PR DESCRIPTION
### Motivation
- Ensure the release publishing workflow has the same prerequisites as CI so tests that depend on Deno can run during TestPyPI and PyPI jobs.
- Prevent failures in release-time test steps that expect `deno` to be available.

### Description
- Added an `Install Deno` step to both `build-and-publish-test-pypi` and `build-and-publish-pypi` jobs that runs `curl -fsSL https://deno.land/install.sh | sh` and appends `${HOME}/.deno/bin` to `GITHUB_PATH`.
- Added a `Verify Deno installation` step that runs `deno --version` in both release jobs.
- Kept existing Python dependency installation and package build/test steps unchanged.

### Testing
- Ran `pre-commit` via the commit hook which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e1fc31cbc83298d14809066a5bda6)