### PR TITLE
Stabilize real LM tests with deterministic temperature

### DIFF
--- a/tests/primitives/test_base_module.py
+++ b/tests/primitives/test_base_module.py
@@ -247,7 +247,7 @@ def test_load_with_version_mismatch(tmp_path):
 
 @pytest.mark.llm_call
 def test_single_module_call_with_usage_tracker(lm_for_test):
-    dspy.configure(lm=dspy.LM(lm_for_test, cache=False), track_usage=True)
+    dspy.configure(lm=dspy.LM(lm_for_test, cache=False, temperature=0.0), track_usage=True)
 
     predict = dspy.ChainOfThought("question -> answer")
     output = predict(question="What is the capital of France?")
@@ -259,7 +259,7 @@ def test_single_module_call_with_usage_tracker(lm_for_test):
     assert lm_usage[lm_for_test]["total_tokens"] > 0
 
     # Test no usage being tracked when cache is enabled
-    dspy.configure(lm=dspy.LM(lm_for_test, cache=True), track_usage=True)
+    dspy.configure(lm=dspy.LM(lm_for_test, cache=True, temperature=0.0), track_usage=True)
     for _ in range(2):
         output = predict(question="What is the capital of France?")
 
@@ -268,7 +268,7 @@ def test_single_module_call_with_usage_tracker(lm_for_test):
 
 @pytest.mark.llm_call
 def test_multi_module_call_with_usage_tracker(lm_for_test):
-    dspy.configure(lm=dspy.LM(lm_for_test, cache=False), track_usage=True)
+    dspy.configure(lm=dspy.LM(lm_for_test, cache=False, temperature=0.0), track_usage=True)
 
     class MyProgram(dspy.Module):
         def __init__(self):

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -138,7 +138,7 @@ def test_track_usage_with_multiple_models():
 
 
 def test_track_usage_context_manager(lm_for_test):
-    lm = dspy.LM(lm_for_test, cache=False)
+    lm = dspy.LM(lm_for_test, cache=False, temperature=0.0)
     dspy.configure(lm=lm)
 
     predict = dspy.ChainOfThought("question -> answer")


### PR DESCRIPTION
### Motivation

- Real-LM tests that initialize an `LM` via the `lm_for_test` fixture were sporadically failing due to nondeterministic sampling when the temperature was not set to 0.0.

### Description

- Set `temperature=0.0` when constructing `dspy.LM` instances used in real-LM tests to make outputs deterministic.
- Updated `tests/primitives/test_base_module.py` to add `temperature=0.0` for the `LM` used by `test_single_module_call_with_usage_tracker` and `test_multi_module_call_with_usage_tracker`.
- Updated `tests/utils/test_usage_tracker.py` to add `temperature=0.0` in `test_track_usage_context_manager` where an `LM` is created.
- Only test files were modified; no core DSPy code was changed.

### Testing

- Ran pre-commit hooks (lint and checks) during the commit, and they passed.
- No full test suite (`pytest`) was run as part of this change in the local rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ecc8627748329aeca77bf978e3673)