### PR TITLE
Full program trace reflection modes for GEPA

### DIFF
--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -357,7 +357,7 @@ class GEPA(Teleprompter):
         reflection_minibatch_size: int = 3,
         candidate_selection_strategy: Literal["pareto", "current_best"] = "pareto",
         reflection_lm: LM | None = None,
-        reasoning_lm: LM | None = None,
+        use_rlm: bool = False,
         skip_perfect_score: bool = True,
         add_format_failure_as_feedback: bool = False,
         instruction_proposer: "ProposalFn | None" = None,
@@ -411,15 +411,15 @@ class GEPA(Teleprompter):
         self.reflection_minibatch_size = reflection_minibatch_size
         self.candidate_selection_strategy = candidate_selection_strategy
 
-        assert reflection_lm is not None or reasoning_lm is not None or instruction_proposer is not None, (
-            "GEPA requires a reflection language model (reflection_lm), a reasoning language model (reasoning_lm), "
-            "or a custom instruction proposer to be provided. "
+        assert reflection_lm is not None or instruction_proposer is not None, (
+            "GEPA requires a reflection language model, or custom instruction proposer to be provided. "
             "Typically, you can use `dspy.LM(model='gpt-5', temperature=1.0, max_tokens=32000)` to get a good reflection model. "
-            "For long traces, consider using a reasoning model via reasoning_lm for better analysis. "
+            "Reflection LM is used by GEPA to reflect on the behavior of the program and propose new instructions, and will benefit from a strong model. "
+            "For long traces, consider setting use_rlm=True to use dspy.RLM for programmatic trace analysis. "
         )
 
         self.reflection_lm = reflection_lm
-        self.reasoning_lm = reasoning_lm
+        self.use_rlm = use_rlm
         self.skip_perfect_score = skip_perfect_score
         self.add_format_failure_as_feedback = add_format_failure_as_feedback
 
@@ -674,7 +674,7 @@ class GEPA(Teleprompter):
             enable_tool_optimization=self.enable_tool_optimization,
             use_full_trace_reflection=self.use_full_trace_reflection,
             use_full_trace_dataset=self.use_full_trace_dataset,
-            reasoning_lm=self.reasoning_lm,
+            use_rlm=self.use_rlm,
             reflection_minibatch_size=self.reflection_minibatch_size,
         )
 

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -163,7 +163,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         enable_tool_optimization: bool = False,
         use_full_trace_reflection: bool = False,
         use_full_trace_dataset: bool = False,
-        reasoning_lm=None,
+        use_rlm: bool = False,
         reflection_minibatch_size: int | None = None,
     ):
         self.student = student_module
@@ -179,7 +179,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         self.enable_tool_optimization = enable_tool_optimization
         self.use_full_trace_reflection = use_full_trace_reflection
         self.use_full_trace_dataset = use_full_trace_dataset
-        self.reasoning_lm = reasoning_lm
+        self.use_rlm = use_rlm
         self.reflection_minibatch_size = reflection_minibatch_size
 
     def propose_new_texts(
@@ -255,20 +255,17 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         Propose updates to all components at once based on full trace reflection.
         This method is used when use_full_trace_reflection is enabled.
 
-        When a reasoning_lm is configured, it is used instead of reflection_lm with
-        a streamlined signature (no explicit trace_analysis output field, since
-        reasoning models perform chain-of-thought internally).
+        When use_rlm is enabled, uses dspy.RLM (Recursive Language Model) which
+        lets the LLM programmatically explore long traces via a sandboxed REPL.
         """
         from dspy.teleprompt.gepa.instruction_proposal import FullTraceInstructionProposer
 
         current_config = candidate[FULL_TRACE_CANDIDATE_KEY]
         dataset_with_feedback = reflective_dataset[FULL_TRACE_CANDIDATE_KEY]
 
-        use_rlm = self.reasoning_lm is not None
-        proposer = FullTraceInstructionProposer(use_reasoning_lm=use_rlm)
-        lm_to_use = self.reasoning_lm if use_rlm else reflection_lm
+        proposer = FullTraceInstructionProposer(use_rlm=self.use_rlm)
 
-        with dspy.context(lm=lm_to_use):
+        with dspy.context(lm=reflection_lm):
             new_config = proposer(
                 current_config=current_config,
                 dataset_with_feedback=dataset_with_feedback,

--- a/dspy/teleprompt/gepa/instruction_proposal.py
+++ b/dspy/teleprompt/gepa/instruction_proposal.py
@@ -64,43 +64,22 @@ class GenerateImprovedConfigFromFullTrace(dspy.Signature):
 
 
 class GenerateImprovedConfigFromFullTraceRLM(dspy.Signature):
-    """I provided an LLM-based program with instructions for each of its components to perform a task.
+    """Analyze execution traces of a multi-component LLM program and produce an improved XML configuration.
 
-    The program has multiple components (predictors), each with its own instruction text.
-
-    Below you will see:
-    1. The current configuration as XML, mapping component names to their instruction text
-    2. Execution examples showing the full program trace - all component calls with their inputs, outputs, and feedback
-
-    Your task is to write improved instructions for the components based on analyzing these execution traces.
-
-    Think deeply about:
-    - The task the program is solving and what makes executions succeed or fail
-    - How the different components interact — errors in early components cascade to later ones
-    - Domain-specific factual information visible in the traces that should be encoded in instructions
-    - Generalizable strategies vs. example-specific fixes
-
-    ## Output Requirements
-
-    - The new configuration MUST be valid XML with the exact same structure as the current configuration
-    - Use the same <candidate_config> root element with <predictor name="..."> child elements
-    - Each component's instruction should be improved based on the observed patterns or retained if it works well
-    - Focus on making instructions that help each component perform better in the context of the overall program execution
-    - Be specific and actionable - include concrete guidance, domain knowledge, and strategies
-    - If a component's current instruction works well, refine it rather than rewriting entirely
+    You have access to the current configuration (XML mapping component names to instructions)
+    and execution examples showing the full program trace. Use code to programmatically explore
+    the traces — filter failures, compare successful vs failed patterns, extract domain knowledge.
+    Then produce an improved XML configuration with the same structure.
     """
 
     current_config: str = dspy.InputField(
-        desc="The current configuration as XML, mapping component names to their instruction text. "
-        'Format: <candidate_config><predictor name="...">instruction</predictor>...</candidate_config>'
+        desc="Current configuration as XML with predictor name to instruction mapping"
     )
     execution_examples: str = dspy.InputField(
-        desc="Execution examples showing program inputs, outputs, full traces of all predictor calls, and feedback"
+        desc="Execution examples showing program inputs, outputs, full traces, and feedback"
     )
-
     new_config: str = dspy.OutputField(
-        desc="The new configuration as valid XML with the exact same structure and predictor names as current_config. "
-        'Format: <candidate_config><predictor name="...">improved instruction</predictor>...</candidate_config>'
+        desc="Improved configuration as valid XML with the same structure as current_config"
     )
 
 
@@ -115,15 +94,19 @@ class FullTraceInstructionProposer(dspy.Module):
     The candidate configuration is serialized as XML, which provides clear structural
     delimiters for LLM parsing and generation.
 
-    When `use_reasoning_lm=True`, uses a simplified signature without explicit
-    trace_analysis output, since reasoning models (o1, o3, gpt-5) perform
-    chain-of-thought internally and benefit from a streamlined output format.
+    When `use_rlm=True`, uses `dspy.RLM` (Recursive Language Model) which lets the
+    LLM programmatically explore long traces via a sandboxed REPL — writing code to
+    analyze patterns, filter trace entries, and build improvements iteratively.
+    This is especially effective for long execution traces.
     """
 
-    def __init__(self, use_reasoning_lm: bool = False):
+    def __init__(self, use_rlm: bool = False):
         super().__init__()
-        sig = GenerateImprovedConfigFromFullTraceRLM if use_reasoning_lm else GenerateImprovedConfigFromFullTrace
-        self.propose_config = dspy.Predict(sig)
+        self.use_rlm = use_rlm
+        if use_rlm:
+            self.propose_config = dspy.RLM(GenerateImprovedConfigFromFullTraceRLM)
+        else:
+            self.propose_config = dspy.Predict(GenerateImprovedConfigFromFullTrace)
 
     def forward(self, current_config: str, dataset_with_feedback: list[dict[str, Any]]) -> str:
         """


### PR DESCRIPTION
## Summary

Adds new reflection modes and reasoning model support to the GEPA optimizer, giving the reflection LM full visibility into the entire DSPy program execution trace.

### New modes

| Flag | Candidate structure | Reflective dataset | Description |
|---|---|---|---|
| (default) | Per-component dict | Single predictor trace | Standard GEPA — round-robin, one predictor at a time |
| `use_full_trace_reflection=True` | Single XML blob | Full program trace | All predictors serialized as XML `<candidate_config>`, updated holistically |
| `use_full_trace_dataset=True` | Per-component dict | Full program trace | Round-robin single-predictor updates, but reflection LM sees entire execution |

The two new flags are mutually exclusive.

### Reasoning model support (`reasoning_lm`)

For long execution traces, reasoning models (o1, o3, gpt-5) can analyze the full trajectory more effectively by thinking internally. The new `reasoning_lm` parameter enables this:

- When set, used instead of `reflection_lm` for the full-trace proposer step
- Uses a streamlined signature without explicit `trace_analysis` output (reasoning happens internally in the model's chain-of-thought)
- Can be used alongside `reflection_lm` (reasoning_lm handles full-trace proposals, reflection_lm handles everything else)
- `reasoning_lm` alone satisfies the LM requirement (no `reflection_lm` needed)

### Key changes

**`gepa_utils.py`**
- `candidate_dict_to_xml()` / `xml_to_candidate_dict()` — robust XML serialization with fallback parsing (markdown fences, regex)
- `_make_full_trace_reflective_dataset()` — builds full-trace dataset with per-component feedback for every predictor call in the trace
- `_make_full_trace_dataset_for_components()` — full-trace dataset keyed by individual components (new `use_full_trace_dataset` mode)
- `build_program()` — deserializes XML candidate config when in full-trace reflection mode
- `_propose_full_trace_update()` — uses `reasoning_lm` with streamlined RLM signature when available

**`gepa.py`**
- `use_full_trace_dataset` parameter (mutually exclusive with `use_full_trace_reflection`)
- `reasoning_lm` parameter for reasoning model support
- `_build_seed_candidate()` — emits XML instead of JSON for full-trace reflection mode

**`instruction_proposal.py`**
- `GenerateImprovedConfigFromFullTrace` signature updated for XML format
- `GenerateImprovedConfigFromFullTraceRLM` — streamlined signature for reasoning models (no `trace_analysis` output)
- `FullTraceInstructionProposer` — accepts `use_reasoning_lm` flag to select appropriate signature
- Per-component feedback rendered in formatted trace examples

### Experiment results

HotpotQA benchmark from [gepa-artifact](https://github.com/gepa-ai/gepa-artifact) (150 train / 300 val / 300 test), `HotpotMultiHop` program, `XMLAdapter`, same metric and per-component feedback functions across all runs.

| # | Mode | Model | Baseline | Optimized | Gain | Time |
|---|---|---|---|---|---|---|
| 1 | Standard | gpt-5-mini | 48.3% | 74.3% | +26.0pp | 93m |
| 2 | FullTrace-XML | gpt-5-mini | 46.0% | 74.3% | +28.3pp | 149m |
| 3 | FullTrace-Dataset | gpt-5-mini | 47.7% | 66.0% | +18.3pp | 37m |
| 4 | **FullTrace-XML + Edit** | **gpt-5-mini** | 47.7% | **76.0%** | **+28.3pp** | 135m |
| 5 | FullTrace-Dataset + Edit | gpt-5-mini | 47.7% | 70.7% | +23.0pp | 37m |
| 6 | Standard | gpt-5.4 | 56.7% | 73.0% | +16.3pp | 16m |
| 7 | FullTrace-XML | gpt-5.4 | 56.7% | 73.0% | +16.3pp | 32m |
| 8 | FullTrace-Dataset | gpt-5.4 | 56.7% | 74.3% | +17.7pp | 12m |
| 9 | **FullTrace-XML + Edit** | **gpt-5.4** | 56.7% | **76.3%** | **+19.7pp** | 35m |
| 10 | FullTrace-Dataset + Edit | gpt-5.4 | 56.7% | 74.7% | +18.0pp | 21m |

**FullTrace-XML + Edit mode** (rows 4, 9) achieves the highest test scores for both models, outperforming standard GEPA by 1.7–3.3pp. Edit mode uses GEPA's search/replace proposal mechanism from [gepa-ai/gepa#248](https://github.com/gepa-ai/gepa/pull/248).

W&B project: https://wandb.ai/lakshyaaagrawal-university-of-california-berkeley/gepa-hotpotqa

### Usage

```python
# Full-trace XML mode (holistic update of all predictors)
optimizer = GEPA(
    metric=metric,
    max_metric_calls=4000,
    reflection_lm=reflection_lm,
    use_full_trace_reflection=True,
    # Optional: combine with edit mode (requires gepa >= 0.1.1)
    # gepa_kwargs={"proposal_mode": "edit"},
)

# Full-trace dataset mode (round-robin single predictor, full context)
optimizer = GEPA(
    metric=metric,
    max_metric_calls=4000,
    reflection_lm=reflection_lm,
    use_full_trace_dataset=True,
)

# Reasoning model for long traces (works with both full-trace modes)
optimizer = GEPA(
    metric=metric,
    max_metric_calls=4000,
    reasoning_lm=dspy.LM("openai/o3", temperature=1.0, max_tokens=32000),
    use_full_trace_reflection=True,
)
```

## TODO
- [ ] Update minimum gepa version dependency once gepa-ai/gepa#248 is merged
- [ ] Add RLM experiment results once runs complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)