### PR TITLE
Moss Integration

### DIFF
--- a/dspy/retrievers/moss.py
+++ b/dspy/retrievers/moss.py
@@ -1,0 +1,99 @@
+import asyncio
+
+from dspy.dsp.utils import dotdict
+from dspy.primitives.prediction import Prediction
+from dspy.retrievers.retrieve import Retrieve
+
+try:
+    from inferedge_moss import DocumentInfo, MossClient, QueryOptions
+except ImportError as err:
+    raise ImportError(
+        "The 'moss' extra is required to use MossRM. Install it with `pip install dspy-ai[moss]`",
+    ) from err
+
+
+class MossRM(Retrieve):
+    """A retrieval module that uses Moss (InferEdge) to return the top passages for a given query.
+
+    Args:
+        index_name (str): The name of the Moss index.
+        moss_client (MossClient): An instance of the Moss client.
+        k (int, optional): The default number of top passages to retrieve. Default to 3.
+
+    Examples:
+        Below is a code snippet that shows how to use Moss as the default retriever:
+        ```python
+        from inferedge_moss import MossClient
+        import dspy
+
+        moss_client = MossClient("your-project-id", "your-project-key")
+        retriever_model = MossRM("my_index_name", moss_client=moss_client)
+        dspy.configure(rm=retriever_model)
+
+        retrieve = dspy.Retrieve(k=1)
+        topK_passages = retrieve("what are the stages in planning, sanctioning and execution of public works").passages
+        ```
+    """
+
+    def __init__(
+        self,
+        index_name: str,
+        moss_client: MossClient,
+        k: int = 3,
+        alpha: float = 0.5,
+    ):
+        self._index_name = index_name
+        self._moss_client = moss_client
+        self._alpha = alpha
+
+        super().__init__(k=k)
+
+    def forward(self, query_or_queries: str | list[str], k: int | None = None, **kwargs) -> Prediction:
+        """Search with Moss for self.k top passages for query or queries.
+
+        Args:
+            query_or_queries (Union[str, list[str]]): The query or queries to search for.
+            k (Optional[int]): The number of top passages to retrieve. Defaults to self.k.
+            kwargs : Additional arguments for Moss client.
+
+        Returns:
+            dspy.Prediction: An object containing the retrieved passages.
+        """
+        k = k if k is not None else self.k
+        queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
+        queries = [q for q in queries if q]
+        passages = []
+
+        for query in queries:
+            options = QueryOptions(top_k=k, alpha=self._alpha, **kwargs)
+            # Since MossClient methods are async, we use asyncio.run to call them synchronously.
+            # This assumes the loop is not already running, which is typical for DSPy RM calls.
+            result = asyncio.run(self._moss_client.query(self._index_name, query, options=options))
+
+            for doc in result.docs:
+                passages.append(
+                    dotdict({"long_text": doc.text, "id": doc.id, "metadata": doc.metadata, "score": doc.score})
+                )
+
+        return passages
+
+    def get_objects(self, num_samples: int = 5) -> list[dict]:
+        """Get objects from Moss."""
+        # Note: Moss's get_docs might return all docs or have limits.
+        # Here we attempt to fetch and return up to num_samples.
+        result = asyncio.run(self._moss_client.get_docs(self._index_name))
+        # result is likely a list of DocumentInfo or similar
+        objects = []
+        for i, doc in enumerate(result):
+            if i >= num_samples:
+                break
+            objects.append({"id": doc.id, "text": doc.text, "metadata": doc.metadata})
+        return objects
+
+    def insert(self, new_object_properties: dict | list[dict]):
+        """Insert one or more objects into Moss."""
+        if isinstance(new_object_properties, dict):
+            new_object_properties = [new_object_properties]
+
+        docs = [DocumentInfo(**props) for props in new_object_properties]
+        asyncio.run(self._moss_client.add_docs(self._index_name, docs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client~=4.5.4"]
+moss = ["inferedge-moss>=1.0.0b12"]
 mcp = ["mcp; python_version >= '3.10'"]
 langchain = ["langchain_core"]
 dev = [

--- a/tests/retrievers/test_moss.py
+++ b/tests/retrievers/test_moss.py
@@ -1,0 +1,69 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dspy.retrievers.moss import MossRM
+
+
+@pytest.fixture
+def mock_moss_client():
+    return MagicMock()
+
+
+def test_moss_rm_init(mock_moss_client):
+    moss_rm = MossRM(index_name="test_index", moss_client=mock_moss_client, k=5)
+    assert moss_rm._index_name == "test_index"
+    assert moss_rm._moss_client == mock_moss_client
+    assert moss_rm.k == 5
+
+
+@patch("dspy.retrievers.moss.asyncio.run")
+def test_moss_rm_forward(mock_asyncio_run, mock_moss_client):
+    moss_rm = MossRM(index_name="test_index", moss_client=mock_moss_client, k=2)
+
+    # Mock the search result
+    mock_doc = MagicMock()
+    mock_doc.text = "test text"
+    mock_doc.id = "test_id"
+    mock_doc.metadata = {"key": "value"}
+    mock_doc.score = 0.9
+
+    mock_result = MagicMock()
+    mock_result.docs = [mock_doc]
+
+    mock_asyncio_run.return_value = mock_result
+
+    results = moss_rm.forward("test query")
+
+    assert len(results) == 1
+    assert results[0].long_text == "test text"
+    assert results[0].id == "test_id"
+    assert results[0].score == 0.9
+    mock_asyncio_run.assert_called_once()
+
+
+@patch("dspy.retrievers.moss.asyncio.run")
+def test_moss_rm_insert(mock_asyncio_run, mock_moss_client):
+    moss_rm = MossRM(index_name="test_index", moss_client=mock_moss_client)
+
+    moss_rm.insert({"id": "doc1", "text": "content"})
+
+    mock_asyncio_run.assert_called_once()
+
+
+@patch("dspy.retrievers.moss.asyncio.run")
+def test_moss_rm_get_objects(mock_asyncio_run, mock_moss_client):
+    moss_rm = MossRM(index_name="test_index", moss_client=mock_moss_client)
+
+    mock_doc = MagicMock()
+    mock_doc.id = "doc1"
+    mock_doc.text = "content"
+    mock_doc.metadata = {}
+
+    mock_asyncio_run.return_value = [mock_doc]
+
+    objects = moss_rm.get_objects(num_samples=1)
+
+    assert len(objects) == 1
+    assert objects[0]["id"] == "doc1"
+    mock_asyncio_run.assert_called_once()


### PR DESCRIPTION
# PR Description: Add MossRM Retriever

## Summary

This PR introduces the `MossRM` retriever module, enabling integration with [Moss (InferEdge)](https://moss.dev), a real-time semantic search engine optimized for conversational AI.

## Related Issue

Fixes #[Feature] Moss as Retriever for Conversational AI #9254

## Changes

- **New Retriever**: Added `dspy/retrievers/moss.py` implementing the `MossRM` class.
- **Asynchronous Integration**: Bridged DSPy's synchronous interface with Moss's asynchronous Python SDK (`inferedge-moss`) using `asyncio.run`.
- **Hybrid Search Support**: Added support for the `alpha` parameter in `MossRM` to allow users to tune the balance between semantic and keyword search.
- **Unit Tests**: Added comprehensive unit tests in `tests/retrievers/test_moss.py` using mock objects.
- **Optional Dependency**: Updated `pyproject.toml` to include `moss` as an optional dependency.

## Installation

Users can install the necessary dependencies using:

```bash
pip install "dspy-ai[moss]"
```

## Usage Example

```python
import dspy
from inferedge_moss import MossClient
from dspy.retrievers.moss import MossRM

moss_client = MossClient("YOUR_PROJECT_ID", "YOUR_PROJECT_KEY")
retriever_model = MossRM(index_name="my_index", moss_client=moss_client, alpha=0.5)

dspy.configure(rm=retriever_model)

retrieve = dspy.Retrieve(k=3)
results = retrieve("How do I return a product?").passages
```

## Verification Plan

- **Automated Tests**: Ran `pytest tests/retrievers/test_moss.py` (All 4 tests passed).
- **Linting**: Verified that `dspy/retrievers/moss.py` and `tests/retrievers/test_moss.py` pass `ruff check`.
- **Manual Verification**: Successfully tested with a live Moss index and `alpha` parameter overrides.
