### PR TITLE
fix: simplify _parse_code to prevent code corruption

### DIFF
--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -134,28 +134,20 @@ class ProgramOfThought(Module):
         return "\n".join(instr)
 
     def _parse_code(self, code_data):
+        """Extract code from markdown code blocks without reformatting.
+
+        The previous implementation had two bugs:
+        1. `.replace("\\n", "\n")` corrupted escape sequences in string literals
+        2. Regex substitutions corrupted code with `=` in strings or complex expressions
+
+        This simplified version only extracts code from markdown blocks.
+        See: https://github.com/stanfordnlp/dspy/issues/9214
+        """
         code = code_data.get("generated_code", "").split("---", 1)[0].split("\n\n\n", 1)[0]
         code_match = re.search(r"```python[ \n](.*?)[ \n]```?", code, re.DOTALL)
-        code_block = (code_match.group(1) if code_match else code).replace("\\n", "\n")
+        code_block = code_match.group(1) if code_match else code
         if not code_block:
             return code, "Error: Empty code after parsing."
-        if "\n" not in code_block and code_block.count("=") > 1:
-            return code, "Error: Code format is not correct."
-        lines = code_block.split("\n")
-        last_line_match = re.match(r"^(\w+)\s*=", lines[-1].strip())
-        if last_line_match and len(lines) > 1:
-            code_block += "\n" + last_line_match.group(1)
-        else:
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)(?=[a-zA-Z_]\w* *=)",
-                r"\1\n",
-                code_block,
-            )
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)([a-zA-Z_]\w*)$",
-                r"\1\n\2",
-                code_block,
-            )
         return code_block, None
 
     def _execute_code(self, code):


### PR DESCRIPTION
## Summary
Fixes two bugs in `_parse_code` that corrupted valid Python code generated by LLMs.

## Bug 1: Escape sequence corruption
The `.replace("\\n", "\n")` call replaced escape sequences inside string literals:

```python
# LLM generates:
print(f"\nTotal Users: {total_users}")

# After _parse_code (broken):
print(f"
Total Users: {total_users}")
```

## Bug 2: Regex substitutions corrupt complex code
The regex patterns inserted newlines inside string literals and broke list comprehensions:

```python
# LLM generates:
data = "users: Alice=25, Bob=30"
youngest = [name for name, age in users.items() if age == min_age]

# After regex (broken):
data = "users: 
Alice=25, 
Bob=30"
youngest = [name for name, age in users.items() if 
age == min_age]
```

## Solution
Simplified `_parse_code` to only extract code from markdown blocks without attempting to reformat. The reformatting logic was causing more harm than good, and the code execution works correctly without it.

## Test
```python
import dspy
from dspy.predict import ProgramOfThought

pot = dspy.ProgramOfThought("question -> answer")
result = pot(question="Print a formatted summary with newlines")
# Now works without syntax errors
```

Fixes #9214

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)