### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/tests/teleprompt/test_gepa_instruction_proposer.py
+++ b/tests/teleprompt/test_gepa_instruction_proposer.py
@@ -357,7 +357,7 @@ def test_default_proposer(reasoning: bool, caplog):
 
         dspy_logger.propagate = original_propagate
 
-        # Check that no internal GEPA reflection errors occured
+        # Check that no internal GEPA reflection errors occurred
         assert "Exception during reflection/proposal" not in caplog.text
 
     assert len(lm.history) > 0, "LM should have been called"


### PR DESCRIPTION
Fixes typo in test comment.