### PR TITLE
fix(tests): Skip Deno-dependent tests in test_rlm.py when Deno is missing

### DIFF
--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -6,9 +6,13 @@ Test organization:
 - Integration tests (@pytest.mark.integration): PythonInterpreter with Deno
 """
 
+import shutil
 from contextlib import contextmanager
 
 import pytest
+
+# Check if Deno is available for integration tests
+is_deno_available = shutil.which("deno") is not None
 
 from dspy.adapters.types.tool import Tool
 from dspy.predict.rlm import RLM
@@ -550,6 +554,7 @@ class TestRLMDynamicSignature:
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(not is_deno_available, reason="Deno is not installed or not in PATH")
 class TestPythonInterpreter:
     """Integration tests for the secure sandbox with tool support."""
 
@@ -709,6 +714,7 @@ print(f"Count: {info['count']}")
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(not is_deno_available, reason="Deno is not installed or not in PATH")
 class TestSandboxSecurity:
     """Integration tests for sandbox security restrictions."""
 
@@ -829,6 +835,7 @@ class TestRLMTypeCoercionMock:
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(not is_deno_available, reason="Deno is not installed or not in PATH")
 class TestRLMTypeCoercion:
     """Tests for RLM type coercion through full forward pass with PythonInterpreter.
 
@@ -873,6 +880,7 @@ class TestRLMTypeCoercion:
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(not is_deno_available, reason="Deno is not installed or not in PATH")
 class TestRLMMultipleOutputs:
     """Tests for signatures with multiple typed output fields.
 
@@ -960,6 +968,7 @@ class TestRLMMultipleOutputs:
 
 
 @pytest.mark.integration
+@pytest.mark.skipif(not is_deno_available, reason="Deno is not installed or not in PATH")
 class TestRLMWithDummyLM:
     """End-to-end tests using DummyLM with RLM and PythonInterpreter.
 


### PR DESCRIPTION
## Summary
- Adds `@pytest.mark.skipif(not is_deno_available, ...)` decorators to all integration test classes in `tests/predict/test_rlm.py`
- Aligns with the existing pattern used in `test_code_act.py` and `test_program_of_thought.py`

## The Problem
When running `uv run pytest tests/predict` on machines without Deno installed, tests in `test_rlm.py` fail with `FileNotFoundError: 'deno'` instead of being skipped.

Other Deno-dependent test files already skip cleanly:
- `tests/primitives/test_python_interpreter.py`
- `tests/predict/test_code_act.py`
- `tests/predict/test_program_of_thought.py`

## Changes
1. Added `import shutil` and `is_deno_available = shutil.which("deno") is not None`
2. Added `@pytest.mark.skipif(not is_deno_available, ...)` to all `@pytest.mark.integration` test classes:
   - `TestPythonInterpreter`
   - `TestSandboxSecurity`
   - `TestRLMTypeCoercion`
   - `TestRLMMultipleOutputs`
   - `TestRLMWithDummyLM`

## Test plan
- [ ] Run `pytest tests/predict/test_rlm.py` without Deno installed - integration tests should be skipped
- [ ] Run `pytest tests/predict/test_rlm.py` with Deno installed - all tests should run normally

Fixes #9265

🤖 Generated with [Claude Code](https://claude.com/claude-code)