### PR TITLE
fix: typo in variable name 'itinery_database' to 'itinerary_database'

### DIFF
--- a/docs/docs/tutorials/customer_service_agent/index.ipynb
+++ b/docs/docs/tutorials/customer_service_agent/index.ipynb
@@ -210,7 +210,7 @@
         "    ),\n",
         "}\n",
         "\n",
-        "itinery_database = {}\n",
+        "itinerary_database = {}\n",
         "ticket_database = {}"
       ]
     },
@@ -260,7 +260,7 @@
         "\n",
         "def fetch_itinerary(confirmation_number: str):\n",
         "    \"\"\"Fetch a booked itinerary information from database\"\"\"\n",
-        "    return itinery_database.get(confirmation_number)\n",
+        "    return itinerary_database.get(confirmation_number)\n",
         "\n",
         "\n",
         "def pick_flight(flights: list[Flight]):\n",
@@ -283,20 +283,20 @@
         "def book_flight(flight: Flight, user_profile: UserProfile):\n",
         "    \"\"\"Book a flight on behalf of the user.\"\"\"\n",
         "    confirmation_number = _generate_id()\n",
-        "    while confirmation_number in itinery_database:\n",
+        "    while confirmation_number in itinerary_database:\n",
         "        confirmation_number = _generate_id()\n",
-        "    itinery_database[confirmation_number] = Itinerary(\n",
+        "    itinerary_database[confirmation_number] = Itinerary(\n",
         "        confirmation_number=confirmation_number,\n",
         "        user_profile=user_profile,\n",
         "        flight=flight,\n",
         "    )\n",
-        "    return confirmation_number, itinery_database[confirmation_number]\n",
+        "    return confirmation_number, itinerary_database[confirmation_number]\n",
         "\n",
         "\n",
         "def cancel_itinerary(confirmation_number: str, user_profile: UserProfile):\n",
         "    \"\"\"Cancel an itinerary on behalf of the user.\"\"\"\n",
-        "    if confirmation_number in itinery_database:\n",
-        "        del itinery_database[confirmation_number]\n",
+        "    if confirmation_number in itinerary_database:\n",
+        "        del itinerary_database[confirmation_number]\n",
         "        return\n",
         "    raise ValueError(\"Cannot find the itinerary, please check your confirmation number.\")\n",
         "\n",
@@ -443,7 +443,7 @@
         "id": "5kwbgMNUWQUX"
       },
       "source": [
-        "We can see the booked itinerarie in the database."
+        "We can see the booked itinerary in the database."
       ]
     },
     {
@@ -466,7 +466,7 @@
         }
       ],
       "source": [
-        "print(itinery_database)"
+        "print(itinerary_database)"
       ]
     },
     {


### PR DESCRIPTION
Itinerary is misspelt across the example (itenary, itenararie), this commit fixes the typos.