### PR TITLE
fix(predict): remove code corruption in ProgramOfThought._parse_code

### DIFF
--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -136,7 +136,7 @@ class ProgramOfThought(Module):
     def _parse_code(self, code_data):
         code = code_data.get("generated_code", "").split("---", 1)[0].split("\n\n\n", 1)[0]
         code_match = re.search(r"```python[ \n](.*?)[ \n]```?", code, re.DOTALL)
-        code_block = (code_match.group(1) if code_match else code).replace("\\n", "\n")
+        code_block = code_match.group(1) if code_match else code
         if not code_block:
             return code, "Error: Empty code after parsing."
         if "\n" not in code_block and code_block.count("=") > 1:
@@ -145,17 +145,6 @@ class ProgramOfThought(Module):
         last_line_match = re.match(r"^(\w+)\s*=", lines[-1].strip())
         if last_line_match and len(lines) > 1:
             code_block += "\n" + last_line_match.group(1)
-        else:
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)(?=[a-zA-Z_]\w* *=)",
-                r"\1\n",
-                code_block,
-            )
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)([a-zA-Z_]\w*)$",
-                r"\1\n\2",
-                code_block,
-            )
         return code_block, None
 
     def _execute_code(self, code):


### PR DESCRIPTION
## Summary
Fix code corruption bug in `ProgramOfThought._parse_code` that was breaking valid Python code containing escape sequences and equals signs in strings.

## Problem
Fixes #9214

The `_parse_code` method was corrupting valid Python code in two ways:

1. **Escape sequence corruption**: `.replace("\\\\n", "\\n")` converted literal backslash-n in strings to actual newlines
2. **String literal corruption**: Regex substitutions broke code containing `=` inside string literals

### Reproduction:
```python
# This valid code:
print(f"\\nTotal: {x}")
code = "a=b"

# Was being corrupted to:
print(f"
Total: {x}")  # Syntax error!
code = "a" b"  # Broken!
```

## Solution
Removed the problematic transformations:

1. Removed `.replace("\\\\n", "\\n")` - escape sequences should be preserved
2. Removed regex substitutions that incorrectly parsed `=` signs

The code block extraction logic remains intact; only the corruption-causing post-processing was removed.

## Testing
- [x] Verified fix with code containing `\\n` escape sequences
- [x] Verified fix with code containing `=` in strings
- [x] No regression in normal code parsing
- [x] Backward compatible

## Checklist
- [x] Minimal, focused change
- [x] Self-reviewed
- [x] Root cause addressed, not just symptoms