### PR TITLE
fix(deno): use analyzePath for reliable cross-platform directory checks

### DIFF
--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -261,12 +261,10 @@ while (true) {
       let cur = '';
       for (const d of dirs) {
         cur += '/' + d;
-        // Check if directory exists before creating
-        try {
-          pyodide.FS.stat(cur);
-          // Directory exists, continue to next
-        } catch {
-          // Directory doesn't exist, create it
+        // Check if directory exists before creating using analyzePath
+        // This is more reliable than catching exceptions across platforms
+        const pathInfo = pyodide.FS.analyzePath(cur);
+        if (!pathInfo.exists) {
           pyodide.FS.mkdir(cur);
         }
       }
@@ -310,8 +308,9 @@ while (true) {
   if (method === "inject_var") {
     const { name, value } = params;
     try {
-      try { pyodide.FS.mkdir('/tmp'); } catch (e) { /* exists */ }
-      try { pyodide.FS.mkdir('/tmp/dspy_vars'); } catch (e) { /* exists */ }
+      // Use analyzePath for reliable cross-platform directory existence check
+      if (!pyodide.FS.analyzePath('/tmp').exists) { pyodide.FS.mkdir('/tmp'); }
+      if (!pyodide.FS.analyzePath('/tmp/dspy_vars').exists) { pyodide.FS.mkdir('/tmp/dspy_vars'); }
       pyodide.FS.writeFile(`/tmp/dspy_vars/${name}.json`, new TextEncoder().encode(value));
       console.log(jsonrpcResult({ injected: name }, requestId));
     } catch (e) {


### PR DESCRIPTION
## Summary
Fixes #9107 — Deno code execution fails on Windows due to error message mismatch when checking directory existence.

## Problem
The current code in `runner.js` uses try/catch blocks to handle "directory already exists" errors when creating directories in Pyodide's virtual filesystem. However, this relies on matching specific error messages like `'File exists'`, which varies across platforms and Deno versions. On Windows, the error message is empty, causing the check to fail.

## Solution
Replace the try/catch pattern with `pyodide.FS.analyzePath()` which:
- Returns an object with an `exists` property
- Works reliably across all platforms (Windows, Linux, Mac)
- Doesn't depend on error message text

## Changes
- Updated directory creation in the file path setup loop
- Updated `inject_var` method's `/tmp` and `/tmp/dspy_vars` directory creation

## Testing
The fix is JavaScript-only and uses the documented Pyodide FS API. The `analyzePath` approach is:
- Recommended by the issue reporter who tested on Windows
- A standard Emscripten FS method that Pyodide exposes
- More semantically correct (ask "does this exist?" vs "try and catch failure")

Tested that existing Deno-based tests still pass on Mac/Linux.