### PR TITLE
fix: effective_max_tokens when using a `load`'ed OpenAI reasoning model

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -40,6 +40,35 @@ def _sanitize_lm_state(lm_state: dict, allow_unsafe_lm_state: bool) -> dict:
     return sanitized_lm_state
 
 
+def _normalize_lm_token_state(lm_state: dict) -> dict:
+    """Normalize serialized LM token fields before reconstructing `LM(...)`.
+
+    OpenAI reasoning models are configured with `max_tokens` at construction time, but
+    their persisted LM kwargs use `max_completion_tokens`. During `Predict.load_state()`,
+    this key mismatch or key conflict can produce ambiguous behavior if state includes
+    one or both keys.
+    This normalization maps `max_completion_tokens` into `max_tokens` and gives
+    `max_completion_tokens` precedence when both are present.
+    """
+    normalized_lm_state = dict(lm_state)
+    if "max_completion_tokens" not in normalized_lm_state:
+        return normalized_lm_state
+
+    max_completion_tokens = normalized_lm_state.pop("max_completion_tokens")
+    has_max_tokens_defined = "max_tokens" in normalized_lm_state
+    previous_max_tokens = normalized_lm_state.get("max_tokens")
+
+    if has_max_tokens_defined and previous_max_tokens != max_completion_tokens:
+        logger.debug(
+            "Overriding serialized LM token setting during state load: max_tokens=%s -> max_completion_tokens=%s.",
+            previous_max_tokens,
+            max_completion_tokens,
+        )
+
+    normalized_lm_state["max_tokens"] = max_completion_tokens
+    return normalized_lm_state
+
+
 class Predict(Module, Parameter):
     """Basic DSPy module that maps inputs to outputs using a language model.
 
@@ -108,7 +137,8 @@ class Predict(Module, Parameter):
 
         self.signature = self.signature.load_state(state["signature"])
         sanitized_lm_state = _sanitize_lm_state(state["lm"], allow_unsafe_lm_state) if state["lm"] else None
-        self.lm = LM(**sanitized_lm_state) if sanitized_lm_state else None
+        normalized_lm_state = _normalize_lm_token_state(sanitized_lm_state) if sanitized_lm_state else None
+        self.lm = LM(**normalized_lm_state) if normalized_lm_state else None
 
         if "extended_signature" in state:  # legacy, up to and including 2.5, for CoT.
             raise NotImplementedError("Loading extended_signature is no longer supported in DSPy 2.6+")

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -363,6 +363,46 @@ def test_reasoning_model_requirements(model_name):
     assert lm.kwargs["max_completion_tokens"] is None
 
 
+@pytest.mark.parametrize("max_tokens", [16_000, None])
+def test_predict_load_normalizes_serialized_openai_reasoning_tokens(tmp_path, max_tokens):
+    """Regression for OpenAI reasoning token-key normalization during load.
+
+    OpenAI reasoning LMs are constructed with `max_tokens`, but serialized LM
+    state stores token limits under `max_completion_tokens`.
+
+    This test verifies the persisted token key and confirms that
+    `Predict.load()` preserves equivalent OpenAI reasoning-model kwargs after
+    a save/load round-trip.
+    """
+    # Construct with the shared constructor token key.
+    lm = dspy.LM(
+        model="openai/gpt-5-nano-2025-08-07",
+        temperature=1.0,
+        max_tokens=max_tokens,
+    )
+
+    predict = dspy.Predict("question -> answer")
+    predict.lm = lm
+
+    save_path = tmp_path / "predict.json"
+    predict.save(save_path)
+
+    # Saved state for OpenAI reasoning models should use `max_completion_tokens`.
+    serialized_state = json.loads(save_path.read_text())
+    assert serialized_state["lm"]["max_completion_tokens"] == max_tokens
+    assert "max_tokens" not in serialized_state["lm"]
+
+    reloaded_predict = dspy.Predict("question -> answer")
+
+    # Reload from disk; load-time normalization handles serialized token keys.
+    reloaded_predict.load(save_path)
+    assert reloaded_predict.lm is not None
+
+    # Runtime kwargs should continue to use the OpenAI reasoning token key.
+    assert reloaded_predict.lm.kwargs["max_completion_tokens"] == max_tokens
+    assert "max_tokens" not in reloaded_predict.lm.kwargs
+
+
 def test_gpt_5_chat_not_reasoning_model():
     """Test that gpt-5-chat is NOT treated as a reasoning model."""
     # Should NOT raise validation error - gpt-5-chat is not a reasoning model

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -259,6 +259,76 @@ def test_lm_field_after_dump_and_load_state(tmp_path, filename):
     assert original_predict.dump_state() == loaded_predict.dump_state()
 
 
+def test_load_state_prefers_max_completion_tokens_for_openai_reasoning_models_with_debug_log():
+    """Regression for mixed and conflicting token keys in serialized OpenAI reasoning LM state.
+
+    Some saved states may include both `max_tokens` and `max_completion_tokens`. During
+    `Predict.load_state()`, `max_completion_tokens` intentionally takes precedence because
+    that is the key emitted by OpenAI reasoning-model LM state. This test also verifies
+    that a debug log is emitted when the loaded value overrides an existing `max_tokens` entry.
+    """
+    original_predict = dspy.Predict("q->a")
+    original_predict.lm = dspy.LM(
+        model="openai/gpt-5-nano",
+        temperature=1.0,
+        max_tokens=16_000,
+    )
+    saved_state = copy.deepcopy(original_predict.dump_state())
+    assert "max_completion_tokens" in saved_state["lm"]
+    assert "max_tokens" not in saved_state["lm"]
+
+    # Simulate a mixed-key payload with a token conflict from transitional or manually-edited state.
+    saved_state["lm"]["max_tokens"] = 16_000
+    saved_state["lm"]["max_completion_tokens"] = 32_000
+
+    with patch("dspy.predict.predict.logger.debug") as debug_mock:
+        loaded_predict = dspy.Predict("q->a")
+        loaded_predict.load_state(saved_state)
+
+    assert loaded_predict.lm is not None
+    assert loaded_predict.lm.kwargs["max_completion_tokens"] == 32_000
+
+    # `max_tokens` should not remain in final LM kwargs; `max_completion_tokens` takes precedence.
+    assert "max_tokens" not in loaded_predict.lm.kwargs
+
+    # The debug logger should record one override event with old and new token values.
+    debug_mock.assert_called_once()
+    assert debug_mock.call_args.args[1] == 16_000
+    assert debug_mock.call_args.args[2] == 32_000
+
+
+def test_load_state_normalizes_reasoning_token_keys_before_lm_construction():
+    """Ensure mixed and conflicting serialized token keys are normalized before calling `LM(...)`.
+
+    OpenAI reasoning LM state is persisted with `max_completion_tokens`, but
+    constructing `LM(...)` expects `max_tokens`. If saved state contains both
+    keys with conflicting values, `Predict.load_state()` should resolve
+    precedence first and call `LM(...)` with only `max_tokens`.
+    """
+    original_predict = dspy.Predict("q->a")
+    original_predict.lm = dspy.LM(
+        model="openai/gpt-5-nano",
+        temperature=1.0,
+        max_tokens=16_000,
+    )
+    saved_state = copy.deepcopy(original_predict.dump_state())
+
+    # Force mixed keys with conflicting values in serialized state.
+    saved_state["lm"]["max_tokens"] = 16_000
+    saved_state["lm"]["max_completion_tokens"] = 32_000
+
+    with patch("dspy.predict.predict.LM") as lm_mock:
+        loaded_predict = dspy.Predict("q->a")
+        loaded_predict.load_state(saved_state)
+
+    # Normalization should happen before constructor call.
+    assert loaded_predict.lm is lm_mock.return_value
+    assert lm_mock.call_count == 1
+    # The winning `max_completion_tokens` value is passed through `max_tokens`.
+    assert lm_mock.call_args.kwargs["max_tokens"] == 32_000
+    assert "max_completion_tokens" not in lm_mock.call_args.kwargs
+
+
 @pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
 def test_load_ignores_serialized_endpoint_override_by_default(tmp_path, endpoint_override_key):
     file_path = tmp_path / "model.json"


### PR DESCRIPTION
Fix OpenAI reasoning-model save/load by normalizing token keys in `Predict.load_state()`. It prevents constructor key collisions during reload, enforces clear precedence (`max_completion_tokens` > `max_tokens`), and logs overrides at debug level.

## Problem

OpenAI reasoning models are constructed with `max_tokens`, but persisted LM kwargs use `max_completion_tokens`.

During round-trip loading, `Predict.load_state()` previously reconstructed LMs via:

`LM(**state["lm"])`

If serialized state included `max_completion_tokens` (or mixed token keys), reconstruction could become ambiguous and, in conflict/mixed-key cases, trigger constructor-level key collisions.

## Root Cause

`Predict.load_state()` passed serialized LM token keys directly into `LM(...)` with no normalization layer.

For OpenAI reasoning models, this creates a key-shape mismatch between:
- constructor input (`max_tokens`)
- persisted state (`max_completion_tokens`)

and may introduce key conflicts when both appear.

## Solution

- Add `_normalize_lm_token_state()` in `dspy/predict/predict.py`.
- Normalize serialized LM token keys before `LM(...)` construction:
  - map `max_completion_tokens` -> `max_tokens`
  - if both keys exist, `max_completion_tokens` takes precedence
- Emit `logger.debug(...)` when normalization overrides an existing `max_tokens` value.
- Keep constructor behavior unchanged; this fix is scoped to load-time state reconstruction.

## Tests

Added regressions covering three layers:

1. **Round-trip shape and behavior**
   - `test_predict_load_normalizes_serialized_openai_reasoning_tokens`
   - Verifies persisted state uses `max_completion_tokens` and load preserves equivalent OpenAI reasoning kwargs.

2. **Precedence + debug logging**
   - `test_load_state_prefers_max_completion_tokens_for_openai_reasoning_models_with_debug_log`
   - Verifies mixed/conflicting keys resolve in favor of `max_completion_tokens` and emit one debug override log.

3. **Constructor-call normalization boundary**
   - `test_load_state_normalizes_reasoning_token_keys_before_lm_construction`
   - Verifies `Predict.load_state()` calls `LM(...)` with normalized `max_tokens` only (no `max_completion_tokens` kwarg passed through).
