### PR TITLE
feat(rlm): multimodal media, budget controls, multi-model routing, LocalInterpreter, depth>1, GEPA resilience

### DIFF
--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -122,6 +122,27 @@ class Audio(Type):
         length = len(self.data)
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
 
+    # RLM Sandbox Support
+
+    def rlm_preview(self, max_chars: int = 500) -> str:
+        """Generate LLM-friendly preview of Audio contents."""
+        return f"<Audio: format={self.audio_format}, {len(self.data)} base64 chars>"
+
+    def to_sandbox(self) -> bytes:
+        """Serialize Audio for sandbox injection (descriptor string, not raw data).
+
+        Audio data cannot be meaningfully processed as code in the sandbox.
+        The agent should use llm_query() with multimodal content to perceive audio.
+        """
+        return self.rlm_preview().encode("utf-8")
+
+    def sandbox_setup(self) -> str:
+        return ""
+
+    def sandbox_assignment(self, var_name: str, data_expr: str) -> str:
+        """Return code that assigns the audio descriptor string in the sandbox."""
+        return f"{var_name} = {data_expr}"
+
 def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:
     """
     Encode audio to a dict with 'data' and 'audio_format'.

--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -129,6 +129,16 @@ class Type(pydantic.BaseModel):
         """
         return None
 
+    # RLM Sandbox Support
+    #
+    # To opt-in to RLM sandbox injection, subclasses should implement:
+    #   sandbox_setup() -> str           (imports needed in sandbox)
+    #   to_sandbox() -> bytes            (serialize for injection)
+    #   sandbox_assignment(var_name, data_expr) -> str  (reconstruction code)
+    #   rlm_preview(max_chars) -> str    (LLM-friendly preview)
+    #
+    # See dspy.DataFrame for a reference implementation.
+
 
 def split_message_content_for_custom_types(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Split user message content into a list of content blocks.

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -169,6 +169,10 @@ class RLM(Module):
         self.sub_lm = sub_lm
         self.sub_lms = sub_lms or {}
         self._interpreter = interpreter
+        if max_depth < 1:
+            raise ValueError(f"max_depth must be >= 1, got {max_depth}")
+        if depth < 0:
+            raise ValueError(f"depth must be >= 0, got {depth}")
         self.depth = depth
         self.max_depth = max_depth
         self._user_tools = self._normalize_tools(tools)

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -20,10 +20,10 @@ from typing import TYPE_CHECKING, Any, Callable, Iterator
 import pydantic
 
 import dspy
-from dspy.adapters.types.tool import Tool
-from dspy.adapters.utils import parse_value, translate_field_type
 from dspy.adapters.types.audio import Audio
 from dspy.adapters.types.image import Image
+from dspy.adapters.types.tool import Tool
+from dspy.adapters.utils import parse_value, translate_field_type
 from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeInterpreter, CodeInterpreterError, FinalOutput
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
@@ -187,7 +187,7 @@ class RLM(Module):
 
     def _validate_tools(self, tools: dict[str, Tool]) -> None:
         """Validate user-provided tools have valid names."""
-        for name, tool in tools.items():
+        for name, _tool in tools.items():
             if not name.isidentifier():
                 raise ValueError(f"Invalid tool name '{name}': must be a valid Python identifier")
             if name in self._RESERVED_TOOL_NAMES:
@@ -382,7 +382,7 @@ class RLM(Module):
             media_guidelines_str = (
                 f"\n   FOR MEDIA INPUTS (Audio/Image): Variables like {media_var_list} are media objects. "
                 f"In the sandbox they appear as descriptor strings — you CANNOT decode or process them as raw data. "
-                f"Use `llm_query_with_media(prompt, {list(media_fields.keys())[0]!r})` to send media to a sub-LLM that can perceive it."
+                f"Use `llm_query_with_media(prompt, {next(iter(media_fields.keys()))!r})` to send media to a sub-LLM that can perceive it."
             )
         else:
             media_tools_str = ""

--- a/dspy/primitives/local_interpreter.py
+++ b/dspy/primitives/local_interpreter.py
@@ -1,0 +1,175 @@
+"""
+Unsandboxed local Python interpreter for RLM.
+
+Implements the CodeInterpreter protocol but executes code directly in the host
+Python process via exec(). This gives the RLM agent full access to any installed
+Python package (PIL, pydub, numpy, scipy, etc.).
+
+Use this when the sandboxed PythonInterpreter (Deno/Pyodide) is too restrictive —
+e.g., when the RLM agent needs to manipulate images with PIL or process audio
+with pydub directly in its generated code.
+
+Security: This is intentionally UNSANDBOXED. The LLM-generated code runs with
+full host process privileges. Only use for local experiments or trusted workloads.
+
+Usage:
+    from dspy.primitives.local_interpreter import LocalInterpreter
+
+    rlm = dspy.RLM("context -> answer", interpreter=LocalInterpreter())
+"""
+
+import io
+import sys
+import traceback
+from typing import Any, Callable
+
+from dspy.primitives.code_interpreter import CodeInterpreterError, FinalOutput
+
+
+class _SubmitCalled(Exception):
+    """Internal signal raised when SUBMIT() is called in user code."""
+    def __init__(self, output: Any):
+        self.output = output
+
+
+class LocalInterpreter:
+    """Unsandboxed Python interpreter implementing the CodeInterpreter protocol.
+
+    Executes code directly in the host process via exec(). State persists
+    across execute() calls within a session. Tools are injected as callable
+    functions in the execution namespace.
+
+    This gives the RLM agent full access to the host Python environment:
+    - PIL/Pillow for image manipulation
+    - pydub/ffmpeg for audio manipulation
+    - numpy, scipy, scikit-image, etc.
+    - Any installed Python package
+
+    Note: Not thread-safe. Create separate instances for concurrent use.
+    """
+
+    def __init__(
+        self,
+        tools: dict[str, Callable[..., str]] | None = None,
+        output_fields: list[dict] | None = None,
+    ):
+        """
+        Args:
+            tools: Dictionary mapping tool names to callable functions.
+                   Tools are available as top-level functions in the namespace.
+            output_fields: Output field definitions for typed SUBMIT signature.
+        """
+        self._tools: dict[str, Callable[..., str]] = dict(tools) if tools else {}
+        self.output_fields = output_fields
+        self._namespace: dict[str, Any] = {}
+        self._started = False
+
+    @property
+    def tools(self) -> dict[str, Callable[..., str]]:
+        """Tools available for interpreter code to call."""
+        return self._tools
+
+    @tools.setter
+    def tools(self, value: dict[str, Callable[..., str]]) -> None:
+        self._tools = value
+
+    def start(self) -> None:
+        """Initialize the interpreter namespace."""
+        if self._started:
+            return
+        self._namespace = {"__builtins__": __builtins__}
+        self._started = True
+
+    def execute(
+        self,
+        code: str,
+        variables: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute Python code in the host process.
+
+        Args:
+            code: Python code to execute.
+            variables: Variables to inject into the namespace before execution.
+                      Media objects (Audio, Image) are injected AS-IS, giving
+                      code direct access to their data for manipulation.
+
+        Returns:
+            - FinalOutput: If SUBMIT() was called
+            - str: Captured stdout (from print() calls)
+            - None: If no output was produced
+
+        Raises:
+            CodeInterpreterError: On runtime errors
+            SyntaxError: On invalid Python syntax
+        """
+        if not self._started:
+            self.start()
+
+        # Inject variables directly into namespace (no serialization — objects stay live)
+        if variables:
+            self._namespace.update(variables)
+
+        # Inject tools as callable functions
+        for name, func in self._tools.items():
+            self._namespace[name] = func
+
+        # Inject SUBMIT function — maps args to output field names (matching PythonInterpreter)
+        output_fields = self.output_fields or []
+        field_names = [f["name"] for f in output_fields]
+
+        def SUBMIT(*args, **kwargs):
+            if not args and not kwargs:
+                raise ValueError("SUBMIT requires at least one argument")
+            if args and kwargs:
+                raise ValueError("SUBMIT accepts either positional args or keyword args, not both")
+            if kwargs:
+                output = kwargs
+            elif field_names:
+                if len(args) != len(field_names):
+                    expected = ", ".join(field_names)
+                    raise TypeError(
+                        f"SUBMIT() takes {len(field_names)} positional argument(s) "
+                        f"({expected}), but {len(args)} were given"
+                    )
+                output = dict(zip(field_names, args))
+            elif len(args) == 1:
+                output = {"output": args[0]}
+            else:
+                output = {"output": args}
+            raise _SubmitCalled(output)
+
+        self._namespace["SUBMIT"] = SUBMIT
+
+        # Capture stdout
+        old_stdout = sys.stdout
+        captured = io.StringIO()
+        sys.stdout = captured
+
+        try:
+            exec(code, self._namespace)
+        except _SubmitCalled as e:
+            return FinalOutput(e.output)
+        except SyntaxError:
+            raise
+        except Exception as e:
+            tb = traceback.format_exc()
+            raise CodeInterpreterError(f"{type(e).__name__}: {e}\n{tb}") from e
+        finally:
+            sys.stdout = old_stdout
+
+        output = captured.getvalue()
+        if output:
+            return output.rstrip("\n")
+        return None
+
+    def shutdown(self) -> None:
+        """Release resources and clear the namespace."""
+        self._namespace.clear()
+        self._started = False
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        self.shutdown()

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -19,6 +19,7 @@ from typing import Any, Callable
 
 from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeInterpreterError, FinalOutput
 
+
 # Lazy import helpers for multimodal types to avoid circular imports
 def _is_media_type(value: Any) -> bool:
     """Check if value is a DSPy Audio or Image type."""

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -343,7 +343,7 @@ class PythonInterpreter:
             if tool_name not in self.tools:
                 raise CodeInterpreterError(f"Unknown tool: {tool_name}")
             result = self.tools[tool_name](*args, **kwargs)
-            is_json = isinstance(result, (list, dict))
+            is_json = isinstance(result, list | dict)
             response = _jsonrpc_result(
                 {"value": json.dumps(result) if is_json else str(result or ""), "type": "json" if is_json else "string"},
                 request_id
@@ -411,13 +411,13 @@ class PythonInterpreter:
 
     def _to_json_compatible(self, value: Any) -> Any:
         """Recursively convert Python values to JSON-compatible types."""
-        if value is None or isinstance(value, (str, int, float, bool)):
+        if value is None or isinstance(value, str | int | float | bool):
             return value
         elif _is_media_type(value):
             return _media_descriptor(value)
         elif isinstance(value, dict):
             return {k: self._to_json_compatible(v) for k, v in value.items()}
-        elif isinstance(value, (list, tuple)):
+        elif isinstance(value, list | tuple):
             return [self._to_json_compatible(v) for v in value]
         elif isinstance(value, set):
             try:
@@ -465,9 +465,9 @@ class PythonInterpreter:
         elif isinstance(value, bool):
             # Must check bool before int since bool is a subclass of int
             return "True" if value else "False"
-        elif isinstance(value, (int, float)):
+        elif isinstance(value, int | float):
             return str(value)
-        elif isinstance(value, (list, tuple)):
+        elif isinstance(value, list | tuple):
             # Tuples become lists for JSON compatibility
             items = ", ".join(self._serialize_value(item) for item in value)
             return f"[{items}]"

--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -107,6 +107,13 @@ def bootstrap_trace_data(
                     )
 
                 return failed_pred, trace
+            except Exception as e:
+                # Catch non-parse failures (e.g. RLM timeout, interpreter crash,
+                # cost overrun). Preserve whatever partial trace was captured so
+                # GEPA can still reflect on the calls that happened before failure.
+                trace = dspy.settings.trace.copy()
+                failed_pred = FailedPrediction(completion_text=str(e))
+                return failed_pred, trace
 
     program.forward = MethodType(patched_forward, program)
 

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -1521,7 +1521,6 @@ class TestBudgetTracking:
 
     def test_budget_reflects_llm_calls(self):
         """Test that budget() shows correct remaining LLM calls after usage."""
-        rlm = RLM("query -> answer", max_iterations=5, max_llm_calls=10)
         execution_state = {"start_time": __import__("time").monotonic(), "iteration": 0}
 
         from unittest.mock import MagicMock
@@ -1572,7 +1571,6 @@ class TestBudgetTracking:
 
     def test_max_time_triggers_extract_fallback(self):
         """Test that exceeding max_time triggers extract fallback (not exception)."""
-        import time
 
         mock = MockInterpreter(responses=[
             "exploring...",

--- a/tests/primitives/test_local_interpreter.py
+++ b/tests/primitives/test_local_interpreter.py
@@ -1,0 +1,313 @@
+"""Tests for LocalInterpreter — unsandboxed host-process Python execution."""
+
+import pytest
+
+from dspy.primitives.code_interpreter import CodeInterpreterError, FinalOutput
+from dspy.primitives.local_interpreter import LocalInterpreter
+
+
+# =============================================================================
+# Basic Execution
+# =============================================================================
+
+
+def test_execute_simple_print():
+    with LocalInterpreter() as interp:
+        result = interp.execute("print('Hello, World!')")
+        assert result == "Hello, World!"
+
+
+def test_execute_no_output():
+    with LocalInterpreter() as interp:
+        result = interp.execute("x = 42")
+        assert result is None
+
+
+def test_execute_multiline():
+    with LocalInterpreter() as interp:
+        code = "a = 3\nb = 4\nprint(a + b)"
+        result = interp.execute(code)
+        assert result == "7"
+
+
+def test_import_stdlib():
+    with LocalInterpreter() as interp:
+        result = interp.execute("import math\nprint(math.sqrt(16))")
+        assert result == "4.0"
+
+
+def test_import_third_party():
+    """LocalInterpreter can import any installed package (unlike Pyodide sandbox)."""
+    with LocalInterpreter() as interp:
+        result = interp.execute("import numpy as np\nprint(np.array([1,2,3]).sum())")
+        assert result == "6"
+
+
+# =============================================================================
+# State Persistence
+# =============================================================================
+
+
+def test_state_persists_across_calls():
+    with LocalInterpreter() as interp:
+        interp.execute("x = 10")
+        interp.execute("x += 5")
+        result = interp.execute("print(x)")
+        assert result == "15"
+
+
+def test_state_cleared_on_shutdown():
+    interp = LocalInterpreter()
+    interp.start()
+    interp.execute("x = 42")
+    interp.shutdown()
+    interp.start()
+    with pytest.raises(CodeInterpreterError, match="NameError"):
+        interp.execute("print(x)")
+    interp.shutdown()
+
+
+def test_auto_start():
+    """execute() auto-starts if not already started."""
+    interp = LocalInterpreter()
+    result = interp.execute("print('auto')")
+    assert result == "auto"
+    interp.shutdown()
+
+
+# =============================================================================
+# Variable Injection
+# =============================================================================
+
+
+def test_variable_injection():
+    with LocalInterpreter() as interp:
+        result = interp.execute("print(number + 1)", variables={"number": 4})
+        assert result == "5"
+
+
+def test_variable_injection_objects():
+    """Variables are injected AS-IS, not serialized — live Python objects."""
+    with LocalInterpreter() as interp:
+        data = {"key": [1, 2, 3]}
+        result = interp.execute("print(type(data).__name__, len(data['key']))", variables={"data": data})
+        assert result == "dict 3"
+
+
+def test_variable_injection_persists():
+    with LocalInterpreter() as interp:
+        interp.execute("pass", variables={"x": 100})
+        result = interp.execute("print(x)")
+        assert result == "100"
+
+
+# =============================================================================
+# Error Handling
+# =============================================================================
+
+
+def test_syntax_error():
+    with LocalInterpreter() as interp:
+        with pytest.raises(SyntaxError):
+            interp.execute("def foo(")
+
+
+def test_runtime_error():
+    with LocalInterpreter() as interp:
+        with pytest.raises(CodeInterpreterError, match="ZeroDivisionError"):
+            interp.execute("1 / 0")
+
+
+def test_name_error():
+    with LocalInterpreter() as interp:
+        with pytest.raises(CodeInterpreterError, match="NameError"):
+            interp.execute("print(undefined_var)")
+
+
+def test_error_includes_traceback():
+    with LocalInterpreter() as interp:
+        with pytest.raises(CodeInterpreterError, match="Traceback"):
+            interp.execute("raise RuntimeError('test error')")
+
+
+def test_stdout_restored_after_error():
+    """sys.stdout must be restored even if execution raises."""
+    import sys
+    original_stdout = sys.stdout
+    interp = LocalInterpreter()
+    interp.start()
+    with pytest.raises(CodeInterpreterError):
+        interp.execute("raise ValueError('boom')")
+    assert sys.stdout is original_stdout
+    interp.shutdown()
+
+
+# =============================================================================
+# SUBMIT / FinalOutput
+# =============================================================================
+
+
+def test_submit_single_arg():
+    """Single-arg SUBMIT wraps in {"output": value}."""
+    with LocalInterpreter() as interp:
+        result = interp.execute('SUBMIT("the answer")')
+        assert isinstance(result, FinalOutput)
+        assert result.output == {"output": "the answer"}
+
+
+def test_submit_kwargs():
+    with LocalInterpreter() as interp:
+        result = interp.execute('SUBMIT(answer="hello", score=42)')
+        assert isinstance(result, FinalOutput)
+        assert result.output == {"answer": "hello", "score": 42}
+
+
+def test_submit_typed_positional():
+    """Positional args mapped to output_fields names."""
+    output_fields = [
+        {"name": "answer", "type": "str"},
+        {"name": "confidence", "type": "float"},
+    ]
+    with LocalInterpreter(output_fields=output_fields) as interp:
+        result = interp.execute('SUBMIT("the answer", 0.95)')
+        assert isinstance(result, FinalOutput)
+        assert result.output == {"answer": "the answer", "confidence": 0.95}
+
+
+def test_submit_typed_kwargs():
+    output_fields = [
+        {"name": "answer", "type": "str"},
+        {"name": "confidence", "type": "float"},
+    ]
+    with LocalInterpreter(output_fields=output_fields) as interp:
+        result = interp.execute('SUBMIT(answer="the answer", confidence=0.95)')
+        assert isinstance(result, FinalOutput)
+        assert result.output == {"answer": "the answer", "confidence": 0.95}
+
+
+def test_submit_wrong_arg_count():
+    output_fields = [
+        {"name": "answer", "type": "str"},
+        {"name": "score", "type": "int"},
+    ]
+    with LocalInterpreter(output_fields=output_fields) as interp:
+        with pytest.raises(CodeInterpreterError, match="takes 2 positional"):
+            interp.execute("SUBMIT('only one')")
+
+
+def test_submit_no_args():
+    with LocalInterpreter() as interp:
+        with pytest.raises(CodeInterpreterError, match="SUBMIT requires at least one argument"):
+            interp.execute("SUBMIT()")
+
+
+def test_submit_mixed_args_and_kwargs():
+    with LocalInterpreter() as interp:
+        with pytest.raises(CodeInterpreterError, match="SUBMIT accepts either positional"):
+            interp.execute('SUBMIT("pos", key="val")')
+
+
+def test_submit_stops_execution():
+    """Code after SUBMIT should not execute."""
+    with LocalInterpreter() as interp:
+        result = interp.execute('SUBMIT(answer="done")\nprint("should not print")')
+        assert isinstance(result, FinalOutput)
+        assert result.output == {"answer": "done"}
+
+
+# =============================================================================
+# Tools
+# =============================================================================
+
+
+def test_tool_basic():
+    def greet(name: str) -> str:
+        return f"Hello, {name}!"
+
+    with LocalInterpreter(tools={"greet": greet}) as interp:
+        result = interp.execute('print(greet("World"))')
+        assert result == "Hello, World!"
+
+
+def test_tool_default_args():
+    def search(query: str, limit: int = 10) -> str:
+        return f"query={query}, limit={limit}"
+
+    with LocalInterpreter(tools={"search": search}) as interp:
+        result = interp.execute('print(search("test"))')
+        assert result == "query=test, limit=10"
+        result = interp.execute('print(search("test", limit=5))')
+        assert result == "query=test, limit=5"
+
+
+def test_tools_via_setter():
+    """Tools can be added/updated after construction via the tools setter."""
+    interp = LocalInterpreter()
+
+    def my_tool() -> str:
+        return "tool_result"
+
+    interp.tools = {"my_tool": my_tool}
+    interp.start()
+    result = interp.execute("print(my_tool())")
+    assert result == "tool_result"
+    interp.shutdown()
+
+
+def test_tools_refreshed_each_execute():
+    """Tools dict is re-injected on each execute(), so updates are visible."""
+    interp = LocalInterpreter()
+    interp.start()
+
+    interp.tools["counter"] = lambda: "v1"
+    result = interp.execute("print(counter())")
+    assert result == "v1"
+
+    interp.tools["counter"] = lambda: "v2"
+    result = interp.execute("print(counter())")
+    assert result == "v2"
+
+    interp.shutdown()
+
+
+# =============================================================================
+# Context Manager
+# =============================================================================
+
+
+def test_context_manager():
+    with LocalInterpreter() as interp:
+        assert interp._started is True
+        result = interp.execute("print('inside')")
+        assert result == "inside"
+    assert interp._started is False
+
+
+def test_context_manager_cleanup_on_error():
+    with pytest.raises(CodeInterpreterError):
+        with LocalInterpreter() as interp:
+            interp.execute("raise RuntimeError('fail')")
+    assert interp._started is False
+
+
+# =============================================================================
+# Stdout Capture
+# =============================================================================
+
+
+def test_multiple_prints():
+    with LocalInterpreter() as interp:
+        result = interp.execute("print('a')\nprint('b')\nprint('c')")
+        assert result == "a\nb\nc"
+
+
+def test_trailing_newlines_stripped():
+    with LocalInterpreter() as interp:
+        result = interp.execute("print('hello')")
+        assert result == "hello"  # No trailing newline
+
+
+def test_empty_print():
+    with LocalInterpreter() as interp:
+        result = interp.execute("print()")
+        assert result == ""  # Empty print produces empty string after strip

--- a/tests/primitives/test_local_interpreter.py
+++ b/tests/primitives/test_local_interpreter.py
@@ -5,7 +5,6 @@ import pytest
 from dspy.primitives.code_interpreter import CodeInterpreterError, FinalOutput
 from dspy.primitives.local_interpreter import LocalInterpreter
 
-
 # =============================================================================
 # Basic Execution
 # =============================================================================

--- a/tests/primitives/test_media_serialization.py
+++ b/tests/primitives/test_media_serialization.py
@@ -1,0 +1,78 @@
+"""
+Tests for media type helpers in python_interpreter.py.
+
+These tests do NOT require Deno — they test pure Python serialization logic
+for Audio and Image objects in the sandboxed interpreter.
+"""
+
+
+from dspy.primitives.python_interpreter import _is_media_type, _media_descriptor
+
+
+class TestIsMediaType:
+    """Tests for _is_media_type helper."""
+
+    def test_audio(self):
+        from dspy.adapters.types.audio import Audio
+
+        audio = Audio(data="dGVzdA==", audio_format="wav")
+        assert _is_media_type(audio) is True
+
+    def test_image(self):
+        from dspy.adapters.types.image import Image
+
+        img = Image(url="data:image/png;base64,iVBORw0KGgo=")
+        assert _is_media_type(img) is True
+
+    def test_string(self):
+        assert _is_media_type("hello") is False
+
+    def test_int(self):
+        assert _is_media_type(42) is False
+
+    def test_none(self):
+        assert _is_media_type(None) is False
+
+    def test_dict(self):
+        assert _is_media_type({"data": "abc"}) is False
+
+    def test_list(self):
+        assert _is_media_type([1, 2, 3]) is False
+
+
+class TestMediaDescriptor:
+    """Tests for _media_descriptor helper."""
+
+    def test_audio_descriptor(self):
+        from dspy.adapters.types.audio import Audio
+
+        audio = Audio(data="dGVzdA==", audio_format="wav")
+        desc = _media_descriptor(audio)
+        assert "Audio" in desc
+        assert "wav" in desc
+        assert "8" in desc  # len("dGVzdA==") == 8
+
+    def test_image_descriptor(self):
+        from dspy.adapters.types.image import Image
+
+        img = Image(url="data:image/png;base64,iVBORw0KGgo=")
+        desc = _media_descriptor(img)
+        assert "Image" in desc
+
+    def test_non_media_falls_back_to_repr(self):
+        desc = _media_descriptor("just a string")
+        assert desc == repr("just a string")
+
+    def test_audio_descriptor_includes_format(self):
+        from dspy.adapters.types.audio import Audio
+
+        audio = Audio(data="AAAA", audio_format="mpeg")
+        desc = _media_descriptor(audio)
+        assert "mpeg" in desc
+
+    def test_audio_descriptor_includes_data_length(self):
+        from dspy.adapters.types.audio import Audio
+
+        audio = Audio(data="A" * 100, audio_format="wav")
+        desc = _media_descriptor(audio)
+        assert "100" in desc


### PR DESCRIPTION
## Making RLM production-ready: multimodal media, budget controls, multi-model routing, LocalInterpreter, depth>1, and GEPA compatibility

Closes #9289

### Summary

Seven additive features that came from using RLM + GEPA on real multimodal tasks. Each addresses a failure mode hit in practice. All changes are backwards-compatible — default behavior is unchanged.

**+3,115 lines** across 10 files. **206 tests pass** (0 failures, 38 deno-skips). Rebased on current `main`.

### The seven changes

#### 1. Multimodal media support via the `dspy.Type` sandbox protocol

**Problem:** RLM can only work with text. Audio/Image inputs are invisible to the agent.

**Solution:** Implements the `to_sandbox()` / `rlm_preview()` / `sandbox_setup()` / `sandbox_assignment()` protocol (from #9283) on `Audio` and `Image`. Any `dspy.Type` implementing this protocol is automatically:
- Detected as a multimodal input field (`_detect_multimodal_fields`)
- Injected into the sandbox via `to_sandbox()` (descriptor string for media)
- Previewed via `rlm_preview()` in the agent's variable context
- Available for `llm_query_with_media(prompt, *media_var_names)` which sends the actual content parts to the sub-LLM

Also adds `_wrap_rlm_inputs()` to auto-wrap raw values into their annotated `dspy.Type`, and `_inject_pending_vars()` for unified sandbox injection — both patterns from #9283.

Documents the protocol on the `Type` base class so future type authors know what to implement for RLM support.

```python
class DescribeImage(dspy.Signature):
    image: dspy.Image = dspy.InputField()
    description: str = dspy.OutputField()

rlm = dspy.RLM(DescribeImage)
result = rlm(image=dspy.Image("photo.jpg"))
# Agent code: text = llm_query_with_media("Describe this", "image")
```

#### 2. Multi-model sub-call routing via `sub_lms`

**Problem:** Some tasks benefit from cheap exploration + strong verification. RLM only supports a single `sub_lm`.

**Solution:** `sub_lms={"flash": lm_fast, "pro": lm_pro}` — sandbox code selects with `llm_query(prompt, model="flash")`. Falls back to `sub_lm` → `dspy.settings.lm`.

#### 3. LocalInterpreter — unsandboxed host-process execution

**Problem:** Deno/Pyodide sandbox can't access host packages (PIL, numpy, soundfile, etc.).

**Solution:** New `LocalInterpreter` (175 lines) implements `CodeInterpreter` via `exec()`. State persists, tools injected, `SUBMIT()` identical. Intentionally unsandboxed for local experiments.

```python
from dspy.primitives.local_interpreter import LocalInterpreter
rlm = dspy.RLM(MySignature, interpreter=LocalInterpreter())
```

#### 4. Budget awareness — `budget()`, `max_time`, `max_cost`

**Problem:** Agents burn through iterations blindly. A single runaway example can blow your API budget in optimization loops.

**Solution:**
- `max_time=120` — wall-clock limit, triggers extract fallback (not crash)
- `max_cost=0.50` — dollar limit via litellm cost + BYOK `upstream_inference_cost`
- `budget()` — sandbox tool showing remaining resources with low-resource warnings

#### 5. GEPA bootstrap_trace resilience

**Problem:** RLM timeouts/cost overruns raise exceptions that `bootstrap_trace_data` doesn't catch, losing all trace data.

**Solution:** Broad `except Exception` handler preserves partial trace as `FailedPrediction` (+7 lines in `bootstrap_trace.py`). `KeyboardInterrupt` is NOT caught.

#### 6. Depth > 1 — recursive subcalls

**Problem:** `llm_query()` makes plain LM completions — no tools, no iteration. Sub-LLMs miss information in long contexts ("lost in the middle").

**Solution:** `max_depth=2` makes `llm_query()` spawn a child RLM with its own REPL. Child can write code, call its own `llm_query()`, and iterate before SUBMITting.

```python
rlm = dspy.RLM(
    MySignature,
    interpreter=LocalInterpreter(),
    max_depth=2,          # child RLMs get own REPLs
    max_iterations=15,    # per-level
    max_llm_calls=30,     # per-level (independent counters)
    max_time=300,         # remaining propagated to children
    max_cost=2.00,        # remaining propagated to children
)
```

Budget propagation: children get *remaining* time/cost, own iteration/call counters. Interpreter type matches parent (LocalInterpreter→LocalInterpreter, PythonInterpreter→PythonInterpreter). Tested E2E: 5/5 on LongMemEval_S with Gemini 3 Flash. Adapted from [vanilla RLM depth>1](https://github.com/alexzhang13/rlm/pull/84).

#### 7. Type protocol documentation on base class

Adds protocol comments to `dspy.Type` base class documenting the four methods for RLM sandbox opt-in, matching the pattern established by #9283.

### File-by-file

| File | Lines | What |
|---|---|---|
| `dspy/adapters/types/audio.py` | +21 | `rlm_preview`, `to_sandbox`, `sandbox_setup`, `sandbox_assignment` |
| `dspy/adapters/types/image.py` | +25 | Same protocol methods |
| `dspy/adapters/types/base_type.py` | +10 | Protocol documentation |
| `dspy/predict/rlm.py` | +567 | All features: media protocol, sub_lms, budget, cost, depth>1, _subcall, _wrap_rlm_inputs |
| `dspy/primitives/local_interpreter.py` | +175 | New: unsandboxed exec()-based interpreter |
| `dspy/primitives/python_interpreter.py` | +76/-40 | Generic `_has_rlm_support` + `to_sandbox` injection |
| `dspy/teleprompt/bootstrap_trace.py` | +7 | GEPA exception handler |
| `tests/predict/test_rlm.py` | +1,792 | All feature tests + depth>1 tests |
| `tests/primitives/test_local_interpreter.py` | +312 | LocalInterpreter unit tests |
| `tests/primitives/test_media_serialization.py` | +170 | Type protocol tests (Audio, Image, custom types) |

### How they compose

```python
rlm = dspy.RLM(
    MyMultimodalSignature,
    sub_lms={"pro": lm_pro},        # multi-model routing
    max_time=120, max_cost=0.50,     # budget controls
    max_llm_calls=25,
    max_depth=2,                     # recursive subcalls
    interpreter=LocalInterpreter(),  # full Python access
)

# GEPA can optimize this without crashing on budget-exceeded examples
optimizer = dspy.GEPA(metric=my_metric, max_rounds=5)
optimized = optimizer.compile(rlm, trainset=examples)
```

### Test summary

**206 passed, 0 failures, 38 skipped** (skips are pre-existing Deno-dependent tests)

| Test Area | Count |
|---|---|
| Multimodal detection & registry (types protocol) | 8 |
| llm_query_with_media validation | 5 |
| Media instructions | 2 |
| Media content construction (LM calls) | 4 |
| Sub_lms routing | 8 |
| Budget/cost tracking | 12 |
| LocalInterpreter | 33 |
| Type protocol (Audio, Image, custom) | 21 |
| GEPA resilience | 3 |
| Depth > 1 (init, propagation, E2E) | 30 |
| _wrap_rlm_inputs / auto-wrapping | 2 |

### Relationship to #9283

The multimodal media support adopts the same `dspy.Type` sandbox protocol that #9283 introduces for `DataFrame`. We implemented `to_sandbox()` / `rlm_preview()` / `sandbox_setup()` / `sandbox_assignment()` on `Audio` and `Image`, and use the same generic `_has_rlm_support()` detection in `PythonInterpreter`. This means any future `dspy.Type` with the protocol works automatically with RLM — no RLM-specific code needed.

### Implementation notes

- All changes additive — no breaking changes to existing behavior
- Default values preserve current behavior (`max_time=None`, `max_cost=None`, `sub_lms={}`, `max_depth=1`, default `PythonInterpreter`)
- Generic type detection: uses protocol checks (`hasattr(annotation, 'to_sandbox')`) not hardcoded type lists
- All files pass `ruff check`
