### PR TITLE
feat(interpreter): use deno pypi package for bundled binary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client~=4.5.4"]
 mcp = ["mcp; python_version >= '3.10'"]
+deno = ["deno>=2.0.0"]
 langchain = ["langchain_core"]
 dev = [
     "pytest>=6.2.5",


### PR DESCRIPTION
## Summary
Uses the official [deno pypi package](https://github.com/denoland/deno_pypi) for the Deno runtime binary instead of requiring manual installation.

## Changes
- Add `_get_deno_binary()` helper that tries the deno package first, falls back to system deno
- Add `deno` as optional dependency: `pip install dspy[deno]`
- Update docstring to reflect new installation option

## Usage
```bash
# Install with bundled deno binary
pip install dspy[deno]

# Or continue using system deno
pip install dspy
```

The interpreter automatically uses the pypi-bundled deno if available, otherwise falls back to system deno. This is fully backwards compatible.

Fixes #9228