### PR TITLE
docs: add Google-style docstrings to MultiChainComparison class

### DIFF
--- a/dspy/predict/multi_chain_comparison.py
+++ b/dspy/predict/multi_chain_comparison.py
@@ -5,7 +5,56 @@ from dspy.signatures.signature import ensure_signature
 
 
 class MultiChainComparison(Module):
+    """Multi-chain comparison module for aggregating multiple reasoning attempts.
+
+    This module takes multiple candidate completions (e.g., from chain-of-thought
+    prompting with different samples) and produces a refined answer by comparing
+    and synthesizing the different reasoning attempts.
+
+    The module works by:
+    1. Extracting rationale and answer from each completion attempt
+    2. Presenting all attempts to the LM with a comparison prompt
+    3. Generating a refined "accurate reasoning" that synthesizes the best parts
+
+    Attributes:
+        M: Number of reasoning attempts to compare.
+        last_key: The name of the final output field from the signature.
+        predict: The underlying Predict module with the comparison signature.
+
+    Example:
+        ```python
+        import dspy
+
+        # Define a signature for the task
+        class QA(dspy.Signature):
+            question = dspy.InputField()
+            answer = dspy.OutputField()
+
+        # Create multi-chain comparison with 3 attempts
+        mcc = MultiChainComparison(QA, M=3)
+
+        # Generate multiple completions (e.g., using ChainOfThought)
+        cot = dspy.ChainOfThought(QA)
+        completions = [cot(question="What is 2+2?") for _ in range(3)]
+
+        # Compare and synthesize
+        result = mcc(completions, question="What is 2+2?")
+        ```
+    """
+
     def __init__(self, signature, M=3, temperature=0.7, **config):  # noqa: N803
+        """Initialize the multi-chain comparison module.
+
+        Args:
+            signature: The DSPy signature defining input/output fields.
+                The signature should have at least one output field.
+            M: Number of reasoning attempts to compare. Must match the
+                number of completions passed to forward(). Defaults to 3.
+            temperature: Temperature for the comparison LM call.
+                Higher values increase diversity. Defaults to 0.7.
+            **config: Additional configuration passed to the underlying
+                Predict module.
+        """
         super().__init__()
 
         self.M = M
@@ -33,6 +82,21 @@ class MultiChainComparison(Module):
         self.predict = Predict(signature, temperature=temperature, **config)
 
     def forward(self, completions, **kwargs):
+        """Compare multiple completions and generate a refined answer.
+
+        Args:
+            completions: List of completion objects from previous predictions.
+                Each completion should have either a 'rationale' or 'reasoning'
+                key, plus the output field defined in the signature.
+                Length must equal M.
+            **kwargs: Input field values for the signature (e.g., question="...").
+
+        Returns:
+            dspy.Prediction containing the refined rationale and answer.
+
+        Raises:
+            AssertionError: If len(completions) != M.
+        """
         attempts = []
 
         for c in completions:


### PR DESCRIPTION
## Summary
Add comprehensive Google-style docstrings to `dspy/predict/multi_chain_comparison.py` MultiChainComparison class.

## Changes
- Class-level docstring with:
  - Description of module purpose and multi-chain comparison workflow
  - Attributes documentation
  - Usage example showing integration with ChainOfThought
- `__init__` method docstring with all parameters documented
- `forward` method docstring with:
  - Args documentation
  - Returns section
  - Raises section for AssertionError

Follows the Google Python Style Guide.

Fixes #9132

Related to #8926 (docstring coverage initiative)