### PR TITLE
feat(local): support extra_args in launch_kwargs for SGLang server

### DIFF
--- a/dspy/clients/lm_local.py
+++ b/dspy/clients/lm_local.py
@@ -67,6 +67,14 @@ class LocalProvider(Provider):
             "0.0.0.0",
         ]
 
+        # Allow user to supply extra CLI arguments (e.g., CUDA graph flags, KV cache tuning)
+        extra_args = launch_kwargs.get("extra_args")
+        if extra_args:
+            if isinstance(extra_args, str):
+                command.extend(extra_args.split())
+            elif isinstance(extra_args, list):
+                command.extend(extra_args)
+
         # We will manually stream & capture logs.
         process = subprocess.Popen(
             command,

--- a/tests/clients/test_lm_local.py
+++ b/tests/clients/test_lm_local.py
@@ -95,3 +95,65 @@ def test_command_is_list_not_string(mock_wait, mock_port, mock_popen, mock_threa
         assert "--model-path" in command
         assert "--port" in command
         assert "--host" in command
+
+
+@patch("dspy.clients.lm_local.threading.Thread")
+@patch("dspy.clients.lm_local.subprocess.Popen")
+@patch("dspy.clients.lm_local.get_free_port")
+@patch("dspy.clients.lm_local.wait_for_server")
+def test_extra_args_string(mock_wait, mock_port, mock_popen, mock_thread):
+    """Test that extra_args as a string are correctly appended to the command."""
+    mock_port.return_value = 8000
+    mock_process = mock.Mock()
+    mock_process.pid = 12345
+    mock_process.stdout.readline.return_value = ""
+    mock_process.poll.return_value = 0
+    mock_popen.return_value = mock_process
+
+    lm = mock.Mock(spec=[])
+    lm.model = "meta-llama/Llama-2-7b"
+    lm.launch_kwargs = {"extra_args": "--cuda-graph-max-bs 96 --disable-cuda-graph"}
+    lm.kwargs = {}
+
+    with mock.patch.dict("sys.modules", {"sglang": mock.Mock(), "sglang.utils": mock.Mock()}):
+        LocalProvider.launch(lm, launch_kwargs=lm.launch_kwargs)
+
+        assert mock_popen.called
+        call_args = mock_popen.call_args
+        command = call_args[0][0]
+
+        assert isinstance(command, list)
+        assert "--cuda-graph-max-bs" in command
+        assert "96" in command
+        assert "--disable-cuda-graph" in command
+
+
+@patch("dspy.clients.lm_local.threading.Thread")
+@patch("dspy.clients.lm_local.subprocess.Popen")
+@patch("dspy.clients.lm_local.get_free_port")
+@patch("dspy.clients.lm_local.wait_for_server")
+def test_extra_args_list(mock_wait, mock_port, mock_popen, mock_thread):
+    """Test that extra_args as a list are correctly appended to the command."""
+    mock_port.return_value = 8000
+    mock_process = mock.Mock()
+    mock_process.pid = 12345
+    mock_process.stdout.readline.return_value = ""
+    mock_process.poll.return_value = 0
+    mock_popen.return_value = mock_process
+
+    lm = mock.Mock(spec=[])
+    lm.model = "meta-llama/Llama-2-7b"
+    lm.launch_kwargs = {"extra_args": ["--cuda-graph-max-bs", "96", "--disable-cuda-graph"]}
+    lm.kwargs = {}
+
+    with mock.patch.dict("sys.modules", {"sglang": mock.Mock(), "sglang.utils": mock.Mock()}):
+        LocalProvider.launch(lm, launch_kwargs=lm.launch_kwargs)
+
+        assert mock_popen.called
+        call_args = mock_popen.call_args
+        command = call_args[0][0]
+
+        assert isinstance(command, list)
+        assert "--cuda-graph-max-bs" in command
+        assert "96" in command
+        assert "--disable-cuda-graph" in command


### PR DESCRIPTION
## Summary

Adds support for passing additional CLI arguments to the SGLang server when launching local models via `LocalProvider.launch()`.

This enables advanced users to control SGLang server configuration like:
- CUDA graph settings (`--cuda-graph-max-bs`, `--disable-cuda-graph`)
- KV cache tuning
- Memory limits
- Other SGLang-specific flags

## Usage

```python
lm.launch_kwargs = {
    'timeout': 1800,
    'extra_args': '--cuda-graph-max-bs 96 --disable-cuda-graph'
}
# or as a list:
lm.launch_kwargs = {
    'extra_args': ['--cuda-graph-max-bs', '96']
}
lm.launch()
```

## Changes

- Added `extra_args` support in `LocalProvider.launch()` (~8 lines)
- Accepts both string (space-separated) and list formats
- Added unit tests for both string and list forms

## Backward Compatibility

This change is fully backward compatible - `extra_args` is optional and the default behavior is unchanged.

Closes #9100