### PR TITLE
fix(rlm): ensure tools are added back after deno subprocess dies

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -12,7 +12,7 @@ import json
 import keyword
 import logging
 import os
-import select
+import queue
 import subprocess
 import threading
 from os import PathLike
@@ -193,6 +193,7 @@ class PythonInterpreter:
         self._request_id = 0
         self._owner_thread: int | None = None
         self._pending_large_vars = {}
+        self._line_queue: queue.Queue[str | None] = queue.Queue()
 
     def _check_thread_ownership(self) -> None:
         """Ensure this interpreter is only used from a single thread."""
@@ -234,15 +235,31 @@ class PythonInterpreter:
                 raise _SubprocessDied(desc)
             raise CodeInterpreterError(desc)
 
+    def _start_reader_thread(self) -> None:
+        """Start a daemon thread that feeds stdout lines into ``_line_queue``."""
+        self._line_queue = queue.Queue()
+        stdout = self.deno_process.stdout
+
+        def _reader() -> None:
+            try:
+                for line in iter(stdout.readline, ""):
+                    self._line_queue.put(line.strip())
+            except (ValueError, OSError):
+                pass
+            self._line_queue.put(None)
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.start()
+
     def _read_line(self, context: str) -> str:
         """Read a line from the subprocess. Raises _SubprocessDied on EOF or timeout."""
-        ready, _, _ = select.select([self.deno_process.stdout], [], [], SUBPROCESS_READ_TIMEOUT)
-        if not ready:
+        try:
+            line = self._line_queue.get(timeout=SUBPROCESS_READ_TIMEOUT)
+        except queue.Empty:
             raise _SubprocessDied(
                 f"Deno subprocess timed out after {SUBPROCESS_READ_TIMEOUT}s during {context}"
             )
-        line = self.deno_process.stdout.readline().strip()
-        if not line:
+        if line is None:
             exit_code = self.deno_process.poll()
             stderr = self.deno_process.stderr.read() if self.deno_process.stderr else ""
             parts = [f"Deno subprocess produced no output during {context} (exit code: {exit_code})"]
@@ -402,6 +419,7 @@ class PythonInterpreter:
                     "For additional configurations: https://docs.deno.com/runtime/getting_started/installation/"
                 )
                 raise CodeInterpreterError(install_instructions) from e
+            self._start_reader_thread()
             self._health_check()
 
     def _send_request(self, method: str, params: dict, context: str) -> dict:

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -614,8 +614,8 @@ def test_execute_retries_once_on_subprocess_death():
             raise _SubprocessDied("simulated death")
         return "recovered"
 
-    with patch.object(interp, '_execute_inner', side_effect=mock_inner):
-        with patch.object(interp, '_kill_process'):
+    with patch.object(interp, "_execute_inner", side_effect=mock_inner):
+        with patch.object(interp, "_kill_process"):
             result = interp.execute("print(1)")
 
     assert result == "recovered"
@@ -633,8 +633,8 @@ def test_execute_raises_after_second_failure():
     def always_fail(code):
         raise _SubprocessDied("process died again")
 
-    with patch.object(interp, '_execute_inner', side_effect=always_fail):
-        with patch.object(interp, '_kill_process'):
+    with patch.object(interp, "_execute_inner", side_effect=always_fail):
+        with patch.object(interp, "_kill_process"):
             with pytest.raises(CodeInterpreterError, match="failed after automatic restart"):
                 interp.execute("print(1)")
 
@@ -654,7 +654,7 @@ def test_error_message_includes_exit_code():
     interp.deno_process.wait()
 
     # Prevent auto-restart to observe the raw _SubprocessDied error
-    with patch.object(interp, '_ensure_deno_process'):
+    with patch.object(interp, "_ensure_deno_process"):
         with pytest.raises(_SubprocessDied) as exc_info:
             interp._execute_inner("print(1)")
 
@@ -666,7 +666,6 @@ def test_error_message_includes_exit_code():
 
 def test_tool_call_death_does_not_retry():
     """Subprocess death during tool response write raises CodeInterpreterError, not _SubprocessDied."""
-    from dspy.primitives.python_interpreter import _SubprocessDied
 
     call_count = 0
 
@@ -720,7 +719,7 @@ def test_read_line_timeout():
     """_read_line raises _SubprocessDied when subprocess produces no output within timeout."""
     from unittest.mock import patch
 
-    from dspy.primitives.python_interpreter import SUBPROCESS_READ_TIMEOUT, _SubprocessDied
+    from dspy.primitives.python_interpreter import _SubprocessDied
 
     interp = PythonInterpreter()
     interp._ensure_deno_process()

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -716,18 +716,31 @@ def test_write_msg_retryable_false_raises_code_interpreter_error():
 
 
 def test_read_line_timeout():
-    """_read_line raises _SubprocessDied when subprocess produces no output within timeout."""
-    from unittest.mock import patch
+    """_read_line raises _SubprocessDied when the queue produces nothing within the timeout."""
+    import queue as _queue
 
     from dspy.primitives.python_interpreter import _SubprocessDied
 
     interp = PythonInterpreter()
     interp._ensure_deno_process()
 
-    # Patch select.select to simulate timeout (returns empty ready list)
-    with patch("dspy.primitives.python_interpreter.select.select", return_value=([], [], [])):
+    # Drain the health-check response that's already queued, then swap in
+    # an empty queue so the next _read_line hits the timeout.
+    while not interp._line_queue.empty():
+        try:
+            interp._line_queue.get_nowait()
+        except _queue.Empty:
+            break
+    interp._line_queue = _queue.Queue()
+
+    import dspy.primitives.python_interpreter as _mod
+    original = _mod.SUBPROCESS_READ_TIMEOUT
+    _mod.SUBPROCESS_READ_TIMEOUT = 0.1
+    try:
         with pytest.raises(_SubprocessDied, match="timed out"):
             interp._read_line("test operation")
+    finally:
+        _mod.SUBPROCESS_READ_TIMEOUT = original
 
     interp._kill_process()
 


### PR DESCRIPTION
PythonInterpreter runs sandboxed Python code in a Deno/Pyodide subprocess, communicating via JSON-RPC over stdin/stdout. Previously, if the subprocess died mid-execution, the caller got an opaque CodeInterpreterError or BrokenPipeError. There was a narrow inline retry for BrokenPipeError on the initial write, but it didn't cover reads, tool calls, or other failure modes.

This PR introduces a general retry-on-death mechanism: execute() delegates to _execute_inner(), and if the subprocess dies at any point during execution, it kills the process and retries once with a fresh subprocess. To support this:

A new internal exception `_SubprocessDied` distinguishes recoverable process death from permanent errors

All stdin/stdout I/O is centralized through `_write_msg()` / `_read_line()`, which detect broken pipes, EOF, and timeouts
`_ensure_deno_process()` resets tool/mount registration state when spawning a new process, so everything is re-registered on restart

One key design decision: tool call responses use retryable=False python_interpreter.py:379 because the host-side tool has already executed (possibly with side effects), so retrying the whole execution could double-execute the tool.