### PR TITLE
Fix false rollout_id warning when LM temperature is unset

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -111,7 +111,7 @@ class LM(BaseLM):
         self._warn_zero_temp_rollout(self.kwargs.get("temperature"), self.kwargs.get("rollout_id"))
 
     def _warn_zero_temp_rollout(self, temperature: float | None, rollout_id):
-        if not self._warned_zero_temp_rollout and rollout_id is not None and (temperature is None or temperature == 0):
+        if not self._warned_zero_temp_rollout and rollout_id is not None and temperature == 0:
             warnings.warn(
                 "rollout_id has no effect when temperature=0; set temperature>0 to bypass the cache.",
                 stacklevel=3,


### PR DESCRIPTION
### Motivation
- The `LM` constructor warned whenever `rollout_id` was set and `temperature` was `None` or `0`, which produced false warnings for models that accept an unset/default temperature (e.g., `openai/gpt-5-nano`).

### Description
- Update `LM._warn_zero_temp_rollout` to only warn when `temperature == 0` instead of treating `None` as zero by using the condition `temperature == 0`.
- Make the existing warning test explicit by constructing the LM with `temperature=0` so it validates the intended zero-temperature behavior.
- Add a regression test `test_rollout_id_with_default_temperature_does_not_warn` to ensure creating an LM with a default/unspecified temperature does not emit the rollout warning.

### Testing
- Ran the focused tests with `pytest -q tests/clients/test_lm.py -k "zero_temperature_rollout_warns_once or rollout_id_with_default_temperature_does_not_warn"`, and the selected tests passed (`2 passed, 32 deselected, 3 warnings`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999eb2c6c308329b1427e4df0bdc3aa)