### PR TITLE
fix: pass metric_threshold to BootstrapFewShot for unshuffled case

### DIFF
--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -383,6 +383,7 @@ def create_n_fewshot_demo_sets(
             program = BootstrapFewShot(
                 metric=metric,
                 max_errors=max_errors,
+                metric_threshold=metric_threshold,
                 max_bootstrapped_demos=max_bootstrapped_demos,
                 max_labeled_demos=max_labeled_demos,
                 teacher_settings=teacher_settings,

--- a/tests/teleprompt/test_utils.py
+++ b/tests/teleprompt/test_utils.py
@@ -1,7 +1,8 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import dspy
-from dspy.teleprompt.utils import eval_candidate_program
+from dspy.teleprompt.utils import create_n_fewshot_demo_sets, eval_candidate_program
+from dspy.utils.dummies import DummyLM
 
 
 class DummyModule(dspy.Module):
@@ -50,3 +51,47 @@ def test_eval_candidate_program_failure():
     result = eval_candidate_program(batch_size, trainset, candidate_program, evaluate)
 
     assert result.score == 0.0
+
+
+def test_create_n_fewshot_demo_sets_passes_metric_threshold_for_unshuffled():
+    """Verify that metric_threshold is passed to BootstrapFewShot for the unshuffled (seed=-1) case.
+
+    Regression test for https://github.com/stanfordnlp/dspy/issues/9308
+    """
+    student = DummyModule()
+    student.predictor = dspy.Predict("input -> output")
+    trainset = [dspy.Example(input="test", output="test").with_inputs("input")]
+
+    lm = DummyLM([{"output": "test"}])
+    dspy.configure(lm=lm)
+
+    with patch("dspy.teleprompt.utils.BootstrapFewShot") as MockBootstrap:
+        mock_instance = Mock()
+        mock_instance.compile.return_value = student
+        MockBootstrap.return_value = mock_instance
+
+        create_n_fewshot_demo_sets(
+            student=student,
+            num_candidate_sets=4,  # -3, -2, -1, 0 → hits seed=-1
+            trainset=trainset,
+            max_labeled_demos=1,
+            max_bootstrapped_demos=1,
+            metric=lambda ex, pred, trace=None: 1.0,
+            teacher_settings={},
+            metric_threshold=0.9,
+        )
+
+        # Find the call where seed == -1 (unshuffled few-shot)
+        # BootstrapFewShot should be called at least twice: once for seed=-1, once for seed>=0
+        calls = MockBootstrap.call_args_list
+        assert len(calls) >= 1, "BootstrapFewShot was never called"
+
+        # Every BootstrapFewShot call should include metric_threshold
+        for call in calls:
+            _, kwargs = call
+            assert "metric_threshold" in kwargs, (
+                f"metric_threshold missing from BootstrapFewShot call: {kwargs}"
+            )
+            assert kwargs["metric_threshold"] == 0.9, (
+                f"metric_threshold={kwargs['metric_threshold']}, expected 0.9"
+            )


### PR DESCRIPTION
## Summary

- Passes `metric_threshold` to `BootstrapFewShot` in the unshuffled (`seed == -1`) branch of `create_n_fewshot_demo_sets`
- Without this, examples below `metric_threshold` are incorrectly included as bootstrapped demos in MIPROv2

## Root Cause

In `dspy/teleprompt/utils.py`, the shuffled branch (`seed >= 0`) passes `metric_threshold`, but the unshuffled branch (`seed == -1`) omits it. One-line fix.

## Test plan

- [x] Added regression test verifying `metric_threshold` is passed in all `BootstrapFewShot` calls
- [x] All existing `test_utils.py` tests pass (4/4)

Fixes #9308