### PR TITLE
fix(gepa): preserve list[Type] inputs in make_reflective_dataset

### DIFF
--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -266,6 +266,8 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                     if isinstance(input_val, Type) and self.custom_instruction_proposer is not None:
                         # Keep original object - will be properly formatted when sent to reflection LM
                         new_inputs[input_key] = input_val
+                    elif isinstance(input_val, list) and len(input_val) > 0 and isinstance(input_val[0], Type) and self.custom_instruction_proposer is not None:
+                        new_inputs[input_key] = input_val
                     else:
                         new_inputs[input_key] = str(input_val)
 

--- a/tests/teleprompt/test_gepa_instruction_proposer.py
+++ b/tests/teleprompt/test_gepa_instruction_proposer.py
@@ -130,6 +130,72 @@ def test_reflection_lm_gets_structured_images():
     assert not images_in_history.has_text_serialized_images, "Reflection LM received serialized images in prompts"
 
 
+def test_reflection_lm_gets_structured_images_list():
+    """
+    Verify reflection LM receives structured image messages when input is list[dspy.Image],
+    not serialized text. Regression test for list[Type] being stringified in make_reflective_dataset.
+    """
+    student = dspy.Predict("images: list[dspy.Image] -> label: str")
+    images = [
+        dspy.Image("https://example.com/test1.jpg"),
+        dspy.Image("https://example.com/test2.jpg"),
+    ]
+    example = dspy.Example(images=images, label="dog").with_inputs("images")
+
+    reflection_lm = DummyLM(
+        [
+            {"improved_instruction": "Better instruction"},
+            {"improved_instruction": "Enhanced visual analysis instruction"},
+            {"improved_instruction": "Focus on key features"},
+            {"improved_instruction": "Analyze visual patterns systematically"},
+            {"improved_instruction": "Consider distinctive visual elements"},
+            {"improved_instruction": "Enhance recognition accuracy"},
+            {"improved_instruction": "Improve classification methodology"},
+        ]
+    )
+    lm = DummyLM(
+        [
+            {"label": "cat"},
+            {"label": "dog"},
+            {"label": "animal"},
+            {"label": "pet"},
+            {"label": "feline"},
+            {"label": "canine"},
+            {"label": "mammal"},
+            {"label": "creature"},
+            {"label": "species"},
+            {"label": "domestic"},
+            {"label": "wild"},
+            {"label": "carnivore"},
+            {"label": "herbivore"},
+            {"label": "quadruped"},
+            {"label": "vertebrate"},
+        ]
+    )
+    dspy.configure(lm=lm)
+
+    gepa = dspy.GEPA(
+        metric=lambda gold, pred, trace=None, pred_name=None, pred_trace=None: 0.3,
+        max_metric_calls=2,
+        reflection_lm=reflection_lm,
+        instruction_proposer=instruction_proposal.MultiModalInstructionProposer(),
+    )
+
+    gepa.compile(student, trainset=[example], valset=[example])
+
+    assert len(lm.history) > 0, "LM should have been called"
+    assert len(reflection_lm.history) > 0, "Reflection LM should have been called"
+
+    images_in_history = check_images_in_history(reflection_lm.history)
+
+    assert images_in_history.has_structured_images, (
+        "Reflection LM should have received structured images from list[dspy.Image] input"
+    )
+    assert not images_in_history.has_text_serialized_images, (
+        "Reflection LM should not receive serialized images when input is list[dspy.Image]"
+    )
+
+
 def test_custom_proposer_without_reflection_lm():
     """Test that custom instruction proposers can work without reflection_lm when using updated GEPA core."""
 


### PR DESCRIPTION
## Summary

When `MultiModalInstructionProposer` is used with an input field of type `list[dspy.Image]`, the reflective dataset creation in `make_reflective_dataset()` was stringifying the entire list. This happened because `isinstance(list_of_images, Type)` returns `False` for a list, so it fell through to `str(input_val)` — embedding images as base64 text in the proposer prompt instead of passing them as proper `image_url` content blocks.

A single `dspy.Image` was already handled correctly; this fix extends that to `list[Type]` inputs.

## Changes

- `dspy/teleprompt/gepa/gepa_utils.py`: add an `elif` branch that preserves lists whose first element is a `Type` instance, matching the existing behaviour for single `Type` inputs
- `tests/teleprompt/test_gepa_instruction_proposer.py`: add regression test `test_reflection_lm_gets_structured_images_list` that mirrors the existing `test_reflection_lm_gets_structured_images` test but uses `list[dspy.Image]`

## Reproduction

```python
student = dspy.Predict("images: list[dspy.Image] -> label: str")
# Before fix: reflection LM receives images as stringified base64 text
# After fix: reflection LM receives structured image_url content blocks
```