### PR TITLE
docs: clarify max_rounds behavior in BootstrapFewShot

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -62,8 +62,11 @@ class BootstrapFewShot(Teleprompter):
                 Defaults to 4.
             max_labeled_demos (int): Maximum number of labeled demonstrations to include.
                 Defaults to 16.
-            max_rounds (int): Number of iterations to attempt generating the required bootstrap
-                examples. If unsuccessful after `max_rounds`, the program ends. Defaults to 1.
+            max_rounds (int): Maximum number of bootstrap attempts per training example.
+                Each round after the first uses a fresh rollout with ``temperature=1.0``
+                to bypass caches and gather diverse traces. If a successful bootstrap is
+                found on any round, the example is accepted and the optimizer moves to the
+                next one. Defaults to 1.
             max_errors (Optional[int]): Maximum number of errors until program ends.
                 If ``None``, inherits from ``dspy.settings.max_errors``.
         """


### PR DESCRIPTION
## Change Summary

The docstring for `max_rounds` in `BootstrapFewShot` described it as the number of full iterations over the training set, but the actual behavior is per-example: each training example is retried up to `max_rounds` times (with cache-busting via fresh `rollout_id` at `temperature=1.0`) before moving to the next example.

This was causing confusion (see #9250) since users expected round-robin behavior over the dataset. A contributor [confirmed](https://github.com/stanfordnlp/dspy/issues/9250#issuecomment-2640419903) the implementation is intentional — the docstring just didn't describe it accurately.

Updated the docstring to reflect the actual per-example retry semantics.

## Related issue number

fix #9250