### PR TITLE
fix: make DummyLM delegate to forward() instead of overriding __call__

### DIFF
--- a/dspy/utils/dummies.py
+++ b/dspy/utils/dummies.py
@@ -8,7 +8,6 @@ from dspy.adapters.chat_adapter import FieldInfoWithName, field_header_pattern
 from dspy.clients.lm import LM
 from dspy.dsp.utils.utils import dotdict
 from dspy.signatures.field import OutputField
-from dspy.utils.callback import with_callbacks
 
 
 class DummyLM(LM):
@@ -104,60 +103,51 @@ class DummyLM(LM):
             if any(field in output["content"] for field in output_fields) and final_input in input["content"]:
                 return output["content"]
 
-    @with_callbacks
-    def __call__(self, prompt=None, messages=None, **kwargs):
-        def format_answer_fields(field_names_and_values: dict[str, Any]):
-            fields_with_values = {
-                FieldInfoWithName(name=field_name, info=OutputField()): value
-                for field_name, value in field_names_and_values.items()
-            }
-            # The reason why DummyLM needs an adapter is because it needs to know which output format to mimic.
-            # Normally LMs should not have any knowledge of an adapter, because the output format is defined in the prompt.
-            adapter = self.adapter
+    def _format_answer_fields(self, field_names_and_values: dict[str, Any]):
+        fields_with_values = {
+            FieldInfoWithName(name=field_name, info=OutputField()): value
+            for field_name, value in field_names_and_values.items()
+        }
+        # The reason why DummyLM needs an adapter is because it needs to know which output format to mimic.
+        # Normally LMs should not have any knowledge of an adapter, because the output format is defined in the prompt.
+        adapter = self.adapter
 
-            # Try to use role="assistant" if the adapter supports it (like JSONAdapter)
-            try:
-                return adapter.format_field_with_value(fields_with_values, role="assistant")
-            except TypeError:
-                # Fallback for adapters that don't support role parameter (like ChatAdapter)
-                return adapter.format_field_with_value(fields_with_values)
+        # Try to use role="assistant" if the adapter supports it (like JSONAdapter)
+        try:
+            return adapter.format_field_with_value(fields_with_values, role="assistant")
+        except TypeError:
+            # Fallback for adapters that don't support role parameter (like ChatAdapter)
+            return adapter.format_field_with_value(fields_with_values)
 
-        # Build the request.
-        outputs = []
+    def forward(self, prompt=None, messages=None, **kwargs):
+        messages = messages or [{"role": "user", "content": prompt}]
+        kwargs = {**self.kwargs, **kwargs}
+
+        choices = []
         for _ in range(kwargs.get("n", 1)):
-            messages = messages or [{"role": "user", "content": prompt}]
-            kwargs = {**self.kwargs, **kwargs}
-
             if self.follow_examples:
                 current_output = self._use_example(messages)
             elif isinstance(self.answers, dict):
                 current_output = next(
-                    (format_answer_fields(v) for k, v in self.answers.items() if k in messages[-1]["content"]),
+                    (self._format_answer_fields(v) for k, v in self.answers.items() if k in messages[-1]["content"]),
                     "No more responses",
                 )
             else:
-                current_output = format_answer_fields(next(self.answers, {"answer": "No more responses"}))
+                current_output = self._format_answer_fields(next(self.answers, {"answer": "No more responses"}))
 
-            # Mock reasoning
+            message = dotdict(content=current_output, tool_calls=None)
             if self.reasoning:
-                current_output = {
-                    "text": current_output,
-                    "reasoning_content": "Some reasoning",
-                }
-            # Store the output
-            outputs.append(current_output)
+                message.reasoning_content = "Some reasoning"
+            choices.append(dotdict(message=message, finish_reason="stop"))
 
-            # Logging, with removed api key & where `cost` is None on cache hit.
-            kwargs = {k: v for k, v in kwargs.items() if not k.startswith("api_")}
-            entry = {"prompt": prompt, "messages": messages, "kwargs": kwargs}
-            entry = {**entry, "outputs": outputs, "usage": 0}
-            entry = {**entry, "cost": 0}
-            self.update_history(entry)
+        return dotdict(
+            choices=choices,
+            usage=dotdict(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+            model="dummy",
+        )
 
-        return outputs
-
-    async def acall(self, prompt=None, messages=None, **kwargs):
-        return self.__call__(prompt=prompt, messages=messages, **kwargs)
+    async def aforward(self, prompt=None, messages=None, **kwargs):
+        return self.forward(prompt=prompt, messages=messages, **kwargs)
 
     def get_convo(self, index):
         """Get the prompt + answer from the ith message."""

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -16,7 +16,6 @@ from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response_reasoning_item import Summary
 
 import dspy
-from dspy.utils.dummies import DummyLM
 from dspy.utils.usage_tracker import track_usage
 
 
@@ -122,9 +121,8 @@ def test_disabled_cache_skips_cache_key(monkeypatch):
 
             monkeypatch.setattr(litellm, "completion", fake_completion)
 
-            dummy_lm = DummyLM([{"answer": "ignored"}])
-            # TODO(isaacbmiller): Change from dummy_lm.forward to just dummy_lm.__call__ #8864
-            dummy_lm.forward(messages=[{"role": "user", "content": "Hello"}])
+            lm = dspy.LM("dummy", model_type="chat")
+            lm(messages=[{"role": "user", "content": "Hello"}])
 
             cache_key_spy.assert_not_called()
             cache_get_spy.assert_called_once()


### PR DESCRIPTION
## Summary

- `DummyLM` overrode `__call__` directly, bypassing the `BaseLM.__call__` → `forward()` contract. This meant subclasses couldn't extend DummyLM by overriding `forward()`, and DummyLM skipped the standard response processing pipeline.
- Moved the response-building logic into `forward()`, which returns a mock response object compatible with `BaseLM._process_lm_response()`. Removed the `__call__` and `acall` overrides so DummyLM inherits the standard pipeline.
- Updated `test_disabled_cache_skips_cache_key` to use `dspy.LM` directly, resolving the TODO from #8862.

Fixes #8864

## Changes

- **`dspy/utils/dummies.py`**: Replaced `__call__`/`acall` overrides with `forward()`/`aforward()`. Extracted `format_answer_fields` into `_format_answer_fields` method. `forward()` returns a `dotdict` response with `choices`, `usage`, and `model` fields that `BaseLM._process_completion()` processes correctly.
- **`tests/clients/test_lm.py`**: Updated `test_disabled_cache_skips_cache_key` to use `dspy.LM("dummy")` instead of `DummyLM.forward()`, per the TODO. Removed unused `DummyLM` import.

## Test plan

- [x] Basic `DummyLM.__call__()` returns correct outputs (list of strings)
- [x] `DummyLM.forward()` returns a proper response object with choices/usage/model
- [x] Reasoning mode returns dict outputs with `text` and `reasoning_content`
- [x] Dict-based answers work correctly
- [x] History is properly logged through `_process_lm_response`
- [x] `get_convo()` still works with new history format
- [x] `acall()` async path works
- [x] All 28 tests in `tests/clients/test_lm.py` pass
- [x] All 39 tests in `tests/predict/test_predict.py` pass
- [x] All 27 tests in `tests/adapters/test_chat_adapter.py` pass
- [x] All 70 tests in bootstrap/json_adapter/reasoning/streaming pass
- [x] All 38 tests in chain_of_thought/react/evaluate/callback/parallel pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)