### PR TITLE
docs: add docstrings for InputField and OutputField

### DIFF
--- a/dspy/signatures/field.py
+++ b/dspy/signatures/field.py
@@ -52,10 +52,36 @@ def _translate_pydantic_field_constraints(**kwargs):
 
 
 def InputField(**kwargs): # noqa: N802
+    """Create a DSPy input field with DSPy-specific metadata.
+
+    This is a thin wrapper around ``pydantic.Field`` that stores DSPy metadata
+    (for example ``desc`` and ``prefix``) under ``json_schema_extra`` while
+    preserving standard Pydantic field arguments.
+
+    Args:
+        **kwargs: Standard ``pydantic.Field`` keyword arguments plus DSPy
+            extras such as ``desc``, ``prefix``, ``format``, and ``parser``.
+
+    Returns:
+        A configured Pydantic field object marked as an input field for DSPy.
+    """
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="input"))
 
 
 def OutputField(**kwargs): # noqa: N802
+    """Create a DSPy output field with DSPy-specific metadata.
+
+    This is a thin wrapper around ``pydantic.Field`` that stores DSPy metadata
+    (for example ``desc`` and ``prefix``) under ``json_schema_extra`` while
+    preserving standard Pydantic field arguments.
+
+    Args:
+        **kwargs: Standard ``pydantic.Field`` keyword arguments plus DSPy
+            extras such as ``desc``, ``prefix``, ``format``, and ``parser``.
+
+    Returns:
+        A configured Pydantic field object marked as an output field for DSPy.
+    """
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="output"))
 
 


### PR DESCRIPTION
## Summary
Adds docstrings for `InputField` and `OutputField` to improve readability/discoverability of the public API.

## Changes
- Updated `dspy/signatures/field.py`
  - Added concise docstrings describing intent and return behavior for `InputField` / `OutputField`.

## Why
These functions are part of the public API surface and are commonly used by contributors and users. Clear docstrings improve readability and IDE help.

## Verification
- Documentation-only change
- No runtime logic modified

Related: #8926