### PR TITLE
DNM feat(History): refactor to accept more flexible formats

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -6,7 +6,7 @@ from dspy.teleprompt import *
 
 from dspy.evaluate import Evaluate  # isort: skip
 from dspy.clients import *  # isort: skip
-from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, File, History, Type, Tool, ToolCalls, Code, Reasoning  # isort: skip
+from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, File, History, HistoryMessage, HistoryResumeState, Type, Tool, ToolCalls, Code, Reasoning  # isort: skip
 from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, enable_logging
 from dspy.utils.asyncify import asyncify
 from dspy.utils.syncify import syncify

--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -2,7 +2,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.two_step_adapter import TwoStepAdapter
-from dspy.adapters.types import Audio, Code, File, History, Image, Reasoning, Tool, ToolCalls, Type
+from dspy.adapters.types import Audio, Code, File, History, HistoryMessage, HistoryResumeState, Image, Reasoning, Tool, ToolCalls, Type
 from dspy.adapters.xml_adapter import XMLAdapter
 
 __all__ = [
@@ -10,6 +10,8 @@ __all__ = [
     "ChatAdapter",
     "Type",
     "History",
+    "HistoryMessage",
+    "HistoryResumeState",
     "Image",
     "Audio",
     "File",

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -9,6 +9,7 @@ from dspy.adapters.types.base_type import split_message_content_for_custom_types
 from dspy.adapters.types.reasoning import Reasoning
 from dspy.adapters.types.tool import Tool, ToolCalls
 from dspy.experimental import Citations
+from dspy.signatures.field import InputField
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback, with_callbacks
 
@@ -458,6 +459,12 @@ class Adapter:
                 return name
         return None
 
+    def _format_history_message_content(self, fields: dict[str, Any]) -> str:
+        if not fields:
+            return ""
+        synthetic_signature = Signature({key: InputField() for key in fields}, "")
+        return self.format_user_message_content(synthetic_signature, fields)
+
     def _get_tool_call_input_field_name(self, signature: type[Signature]) -> bool:
         for name, field in signature.input_fields.items():
             # Look for annotation `list[dspy.Tool]` or `dspy.Tool`
@@ -492,23 +499,36 @@ class Adapter:
         Returns:
             A list of multiturn messages.
         """
-        conversation_history = inputs[history_field_name].messages if history_field_name in inputs else None
+        history = inputs[history_field_name] if history_field_name in inputs else None
+        conversation_history = history.messages if history else None
 
         if conversation_history is None:
             return []
 
         messages = []
         for message in conversation_history:
+            if message.role == "assistant":
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": self.format_assistant_message_content(signature, message.fields),
+                    }
+                )
+                continue
+
+            if message.role == "user":
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": self.format_user_message_content(signature, message.fields),
+                    }
+                )
+                continue
+
             messages.append(
                 {
                     "role": "user",
-                    "content": self.format_user_message_content(signature, message),
-                }
-            )
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": self.format_assistant_message_content(signature, message),
+                    "content": self._format_history_message_content(message.fields),
                 }
             )
 

--- a/dspy/adapters/types/__init__.py
+++ b/dspy/adapters/types/__init__.py
@@ -2,9 +2,21 @@ from dspy.adapters.types.audio import Audio
 from dspy.adapters.types.base_type import Type
 from dspy.adapters.types.code import Code
 from dspy.adapters.types.file import File
-from dspy.adapters.types.history import History
+from dspy.adapters.types.history import History, HistoryMessage, HistoryResumeState
 from dspy.adapters.types.image import Image
 from dspy.adapters.types.reasoning import Reasoning
 from dspy.adapters.types.tool import Tool, ToolCalls
 
-__all__ = ["History", "Image", "Audio", "File", "Type", "Tool", "ToolCalls", "Code", "Reasoning"]
+__all__ = [
+    "History",
+    "HistoryMessage",
+    "HistoryResumeState",
+    "Image",
+    "Audio",
+    "File",
+    "Type",
+    "Tool",
+    "ToolCalls",
+    "Code",
+    "Reasoning",
+]

--- a/dspy/adapters/types/history.py
+++ b/dspy/adapters/types/history.py
@@ -1,64 +1,17 @@
-from typing import Any
+from typing import Any, Literal
 
+import json
 import pydantic
 
 
-class History(pydantic.BaseModel):
-    """Class representing the conversation history.
+class HistoryMessage(pydantic.BaseModel):
+    """A role-tagged history event.
 
-    The conversation history is a list of messages, each message entity should have keys from the associated signature.
-    For example, if you have the following signature:
-
-    ```
-    class MySignature(dspy.Signature):
-        question: str = dspy.InputField()
-        history: dspy.History = dspy.InputField()
-        answer: str = dspy.OutputField()
-    ```
-
-    Then the history should be a list of dictionaries with keys "question" and "answer".
-
-    Example:
-        ```
-        import dspy
-
-        dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
-
-        class MySignature(dspy.Signature):
-            question: str = dspy.InputField()
-            history: dspy.History = dspy.InputField()
-            answer: str = dspy.OutputField()
-
-        history = dspy.History(
-            messages=[
-                {"question": "What is the capital of France?", "answer": "Paris"},
-                {"question": "What is the capital of Germany?", "answer": "Berlin"},
-            ]
-        )
-
-        predict = dspy.Predict(MySignature)
-        outputs = predict(question="What is the capital of France?", history=history)
-        ```
-
-    Example of capturing the conversation history:
-        ```
-        import dspy
-
-        dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
-
-        class MySignature(dspy.Signature):
-            question: str = dspy.InputField()
-            history: dspy.History = dspy.InputField()
-            answer: str = dspy.OutputField()
-
-        predict = dspy.Predict(MySignature)
-        outputs = predict(question="What is the capital of France?")
-        history = dspy.History(messages=[{"question": "What is the capital of France?", **outputs}])
-        outputs_with_history = predict(question="Are you sure?", history=history)
-        ```
+    Each message represents one event with arbitrary structured fields.
     """
 
-    messages: list[dict[str, Any]]
+    role: Literal["user", "assistant", "tool"]
+    fields: dict[str, Any]
 
     model_config = pydantic.ConfigDict(
         frozen=True,
@@ -66,3 +19,169 @@ class History(pydantic.BaseModel):
         validate_assignment=True,
         extra="forbid",
     )
+
+
+class HistoryResumeState(pydantic.BaseModel):
+    completed_turns: int
+    last_completed_tool_name: str | None
+    pending_tool_call: tuple[str, dict[str, Any]] | None
+
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+
+class History(pydantic.BaseModel):
+    """Role/event-based conversation history.
+
+    `History` stores explicit events, each with a `role` (`user`, `assistant`, or
+    `tool`) and arbitrary structured `fields`.
+    """
+
+    messages: list[HistoryMessage]
+    max_chars: int = 200_000
+    overflow_drop_strategy: Literal["oldest_pair", "oldest_message"] = "oldest_pair"
+
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+    def estimated_size(self) -> int:
+        return sum(len(json.dumps(message.model_dump(), ensure_ascii=False)) for message in self.messages)
+
+    def trimmed(self) -> "History":
+        if self.estimated_size() <= self.max_chars:
+            return self
+
+        history = self
+        while history.messages and history.estimated_size() > history.max_chars:
+            history = history.drop_for_overflow()
+
+        return history
+
+    def append(self, message: HistoryMessage) -> "History":
+        return self.model_copy(update={"messages": [*self.messages, message]}).trimmed()
+
+    def append_many(self, messages: list[HistoryMessage]) -> "History":
+        history = self
+        for message in messages:
+            history = history.append(message)
+        return history
+
+    def drop_oldest_pair(self) -> "History":
+        if len(self.messages) < 2:
+            raise ValueError("Cannot truncate history further because it does not contain a full assistant/tool pair.")
+        return self.model_copy(update={"messages": self.messages[2:]})
+
+    def drop_oldest_message(self) -> "History":
+        if not self.messages:
+            raise ValueError("Cannot truncate history further because it has no messages.")
+        return self.model_copy(update={"messages": self.messages[1:]})
+
+    def drop_for_overflow(self) -> "History":
+        if self.overflow_drop_strategy == "oldest_pair":
+            return self.drop_oldest_pair()
+        if self.overflow_drop_strategy == "oldest_message":
+            return self.drop_oldest_message()
+        raise ValueError(f"Unknown history overflow_drop_strategy: {self.overflow_drop_strategy}")
+
+    def parse_resume_state(
+        self,
+        *,
+        input_args: dict[str, Any],
+        input_keys: set[str],
+        available_tools: set[str],
+        resume_mode: Literal["off", "auto", "strict"],
+        assistant_required_fields: set[str] | None = None,
+        assistant_tool_name_field: str = "next_tool_name",
+        assistant_tool_args_field: str = "next_tool_args",
+        tool_message_tool_name_field: str = "tool_name",
+        tool_message_observation_field: str = "observation",
+    ) -> HistoryResumeState:
+        if resume_mode == "off":
+            return HistoryResumeState(completed_turns=0, last_completed_tool_name=None, pending_tool_call=None)
+
+        if resume_mode not in {"auto", "strict"}:
+            raise ValueError("History `resume_mode` must be one of: 'off', 'auto', 'strict'.")
+
+        required_assistant_fields = assistant_required_fields or {
+            "next_thought",
+            assistant_tool_name_field,
+            assistant_tool_args_field,
+        }
+
+        completed_turns = 0
+        last_completed_tool_name = None
+        i = 0
+        while i < len(self.messages):
+            message = self.messages[i]
+
+            if message.role == "user":
+                if resume_mode == "strict":
+                    overlapping_keys = input_keys.intersection(message.fields.keys())
+                    for key in overlapping_keys:
+                        if key in input_args and input_args[key] != message.fields[key]:
+                            raise ValueError(
+                                f"Cannot resume trajectory: history input field `{key}` does not match current input."
+                            )
+                i += 1
+                continue
+
+            if message.role == "tool":
+                if resume_mode == "strict":
+                    raise ValueError("Cannot resume trajectory: found tool observation without a preceding assistant step.")
+                i += 1
+                continue
+
+            fields = message.fields
+            if not required_assistant_fields.issubset(fields):
+                if resume_mode == "strict":
+                    raise ValueError("Cannot resume trajectory: assistant history message is missing required fields.")
+                i += 1
+                continue
+
+            next_tool_name = fields[assistant_tool_name_field]
+            if next_tool_name not in available_tools:
+                if resume_mode == "strict":
+                    raise ValueError(f"Cannot resume trajectory: tool `{next_tool_name}` is not available.")
+                i += 1
+                continue
+
+            next_message_index = i + 1
+            has_following_tool_observation = (
+                next_message_index < len(self.messages) and self.messages[next_message_index].role == "tool"
+            )
+            if has_following_tool_observation:
+                tool_fields = self.messages[next_message_index].fields
+                observed_tool_name = tool_fields.get(tool_message_tool_name_field, next_tool_name)
+                if observed_tool_name != next_tool_name and resume_mode == "strict":
+                    raise ValueError(
+                        f"Cannot resume trajectory: tool observation `{observed_tool_name}` does not match preceding tool call `{next_tool_name}`."
+                    )
+                if tool_message_observation_field in tool_fields:
+                    completed_turns += 1
+                    last_completed_tool_name = next_tool_name
+                    i += 2
+                    continue
+
+            return HistoryResumeState(
+                completed_turns=completed_turns,
+                last_completed_tool_name=last_completed_tool_name,
+                pending_tool_call=(next_tool_name, fields[assistant_tool_args_field]),
+            )
+
+        return HistoryResumeState(
+            completed_turns=completed_turns,
+            last_completed_tool_name=last_completed_tool_name,
+            pending_tool_call=None,
+        )
+
+
+def _estimated_size(messages: list[HistoryMessage]) -> int:
+    return sum(len(json.dumps(message.model_dump(), ensure_ascii=False)) for message in messages)

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -1,8 +1,6 @@
 import logging
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
-from litellm import ContextWindowExceededError
-
 import dspy
 from dspy.adapters.types.tool import Tool
 from dspy.primitives.module import Module
@@ -51,10 +49,13 @@ class ReAct(Module):
 
         instr.extend(
             [
-                f"You are an Agent. In each episode, you will be given the fields {inputs} as input. And you can see your past trajectory so far.",
+                (
+                    f"You are an Agent. In each episode, you will be given the fields {inputs} as input. "
+                    "And you can see your prior tool-use turns via `history`."
+                ),
                 f"Your goal is to use one or more of the supplied tools to collect any necessary information for producing {outputs}.\n",
                 "To do this, you will interleave next_thought, next_tool_name, and next_tool_args in each turn, and also when finishing the task.",
-                "After each tool call, you receive a resulting observation, which gets appended to your trajectory.\n",
+                "After each tool call, you receive a resulting observation, which gets appended to history as a tool event.\n",
                 "When writing next_thought, you may reason about the current situation and plan for future steps.",
                 "When selecting the next_tool_name and its next_tool_args, the tool must be one of:\n",
             ]
@@ -73,7 +74,7 @@ class ReAct(Module):
 
         react_signature = (
             dspy.Signature({**signature.input_fields}, "\n".join(instr))
-            .append("trajectory", dspy.InputField(), type_=str)
+            .append("history", dspy.InputField(), type_=dspy.History)
             .append("next_thought", dspy.OutputField(), type_=str)
             .append("next_tool_name", dspy.OutputField(), type_=Literal[tuple(tools.keys())])
             .append("next_tool_args", dspy.OutputField(), type_=dict[str, Any])
@@ -82,108 +83,186 @@ class ReAct(Module):
         fallback_signature = dspy.Signature(
             {**signature.input_fields, **signature.output_fields},
             signature.instructions,
-        ).append("trajectory", dspy.InputField(), type_=str)
+        ).append("history", dspy.InputField(), type_=dspy.History)
 
         self.tools = tools
         self.react = dspy.Predict(react_signature)
         self.extract = dspy.ChainOfThought(fallback_signature)
 
-    def _format_trajectory(self, trajectory: dict[str, Any]):
-        adapter = dspy.settings.adapter or dspy.ChatAdapter()
-        trajectory_signature = dspy.Signature(f"{', '.join(trajectory.keys())} -> x")
-        return adapter.format_user_message_content(trajectory_signature, trajectory)
+    def _prepare_execution(
+        self, input_args: dict[str, Any]
+    ) -> tuple[dict[str, Any], dspy.History, dspy.HistoryResumeState, int]:
+        run_args = dict(input_args)
+        resume_mode = run_args.pop("resume", "off")
+        if resume_mode not in {"off", "auto", "strict"}:
+            raise ValueError("ReAct `resume` must be one of: 'off', 'auto', 'strict'.")
+
+        history = self._coerce_history(run_args.pop("history", None))
+        resume_state = self._initialize_resume_state(history, run_args, resume_mode)
+        max_iters = run_args.pop("max_iters", self.max_iters)
+        return run_args, history, resume_state, max_iters
+
+    def _coerce_history(self, provided_history: Any) -> dspy.History:
+        if provided_history is None:
+            return dspy.History(messages=[])
+        if isinstance(provided_history, dspy.History):
+            return provided_history.trimmed()
+        raise TypeError("ReAct `history` must be a dspy.History instance.")
+
+    def _initialize_resume_state(
+        self,
+        history: dspy.History,
+        input_args: dict[str, Any],
+        resume_mode: Literal["off", "auto", "strict"],
+    ) -> dspy.HistoryResumeState:
+        return history.parse_resume_state(
+            input_args=input_args,
+            input_keys=set(self.signature.input_fields.keys()),
+            available_tools=set(self.tools.keys()),
+            resume_mode=resume_mode,
+            assistant_required_fields={"next_thought", "next_tool_name", "next_tool_args"},
+            assistant_tool_name_field="next_tool_name",
+            assistant_tool_args_field="next_tool_args",
+            tool_message_tool_name_field="tool_name",
+            tool_message_observation_field="observation",
+        )
+
+    async def _aexecute_tool_call(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+        try:
+            observation = await self.tools[tool_name].acall(**tool_args)
+        except Exception as err:
+            observation = f"Execution error in {tool_name}: {_fmt_exc(err)}"
+        return observation
+
+    def _execute_tool_call(self, tool_name: str, tool_args: dict[str, Any]) -> Any:
+        try:
+            observation = self.tools[tool_name](**tool_args)
+        except Exception as err:
+            observation = f"Execution error in {tool_name}: {_fmt_exc(err)}"
+        return observation
+
+    def _append_tool_observation(self, history: dspy.History, tool_name: str, observation: Any) -> dspy.History:
+        return history.append(
+            dspy.HistoryMessage(
+                role="tool",
+                fields={"tool_name": tool_name, "observation": observation},
+            )
+        )
+
+    def _apply_pending_tool_call(
+        self, history: dspy.History, resume_state: dspy.HistoryResumeState
+    ) -> tuple[dspy.History, int, str | None]:
+        completed_turns = resume_state.completed_turns
+        last_completed_tool_name = resume_state.last_completed_tool_name
+        pending_tool_call = resume_state.pending_tool_call
+
+        if pending_tool_call is None:
+            return history, completed_turns, last_completed_tool_name
+
+        pending_tool_name, pending_tool_args = pending_tool_call
+        observation = self._execute_tool_call(pending_tool_name, pending_tool_args)
+        history = self._append_tool_observation(history, pending_tool_name, observation)
+        completed_turns += 1
+        last_completed_tool_name = pending_tool_name
+        return history, completed_turns, last_completed_tool_name
+
+    async def _aapply_pending_tool_call(
+        self, history: dspy.History, resume_state: dspy.HistoryResumeState
+    ) -> tuple[dspy.History, int, str | None]:
+        completed_turns = resume_state.completed_turns
+        last_completed_tool_name = resume_state.last_completed_tool_name
+        pending_tool_call = resume_state.pending_tool_call
+
+        if pending_tool_call is None:
+            return history, completed_turns, last_completed_tool_name
+
+        pending_tool_name, pending_tool_args = pending_tool_call
+        observation = await self._aexecute_tool_call(pending_tool_name, pending_tool_args)
+        history = self._append_tool_observation(history, pending_tool_name, observation)
+        completed_turns += 1
+        last_completed_tool_name = pending_tool_name
+        return history, completed_turns, last_completed_tool_name
+
+    def _call_inputs_from_history(self, history: dspy.History, **input_args) -> dict[str, Any]:
+        call_inputs = dict(input_args)
+        if history.messages:
+            call_inputs["history"] = history
+
+        return call_inputs
+
+    def _step_to_history_messages(self, pred: dspy.Prediction, observation: Any) -> list[dspy.HistoryMessage]:
+        return [
+            dspy.HistoryMessage(
+                role="assistant",
+                fields={
+                    "next_thought": pred.next_thought,
+                    "next_tool_name": pred.next_tool_name,
+                    "next_tool_args": pred.next_tool_args,
+                },
+            ),
+            dspy.HistoryMessage(
+                role="tool",
+                fields={
+                    "tool_name": pred.next_tool_name,
+                    "observation": observation,
+                },
+            ),
+        ]
+
+    def _warn_invalid_tool_selection(self, err: ValueError) -> None:
+        logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {_fmt_exc(err)}")
 
     def forward(self, **input_args):
-        trajectory = {}
-        max_iters = input_args.pop("max_iters", self.max_iters)
-        for idx in range(max_iters):
-            try:
-                pred = self._call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
-            except ValueError as err:
-                logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {_fmt_exc(err)}")
+        input_args, history, resume_state, max_iters = self._prepare_execution(input_args)
+        history, completed_turns, last_completed_tool_name = self._apply_pending_tool_call(history, resume_state)
+
+        for _ in range(completed_turns, max_iters):
+            if last_completed_tool_name == "finish":
                 break
 
-            trajectory[f"thought_{idx}"] = pred.next_thought
-            trajectory[f"tool_name_{idx}"] = pred.next_tool_name
-            trajectory[f"tool_args_{idx}"] = pred.next_tool_args
-
             try:
-                trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](**pred.next_tool_args)
-            except Exception as err:
-                trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
+                pred = self.react(**self._call_inputs_from_history(history, **input_args))
+            except ValueError as err:
+                self._warn_invalid_tool_selection(err)
+                break
+
+            observation = self._execute_tool_call(pred.next_tool_name, pred.next_tool_args)
+
+            history = history.append_many(self._step_to_history_messages(pred, observation))
+            completed_turns += 1
+            last_completed_tool_name = pred.next_tool_name
 
             if pred.next_tool_name == "finish":
                 break
 
-        extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        return dspy.Prediction(trajectory=trajectory, **extract)
+        extract = self.extract(**self._call_inputs_from_history(history, **input_args))
+        return dspy.Prediction(history=history, **extract)
 
     async def aforward(self, **input_args):
-        trajectory = {}
-        max_iters = input_args.pop("max_iters", self.max_iters)
-        for idx in range(max_iters):
-            try:
-                pred = await self._async_call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
-            except ValueError as err:
-                logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {_fmt_exc(err)}")
+        input_args, history, resume_state, max_iters = self._prepare_execution(input_args)
+        history, completed_turns, last_completed_tool_name = await self._aapply_pending_tool_call(history, resume_state)
+
+        for _ in range(completed_turns, max_iters):
+            if last_completed_tool_name == "finish":
                 break
 
-            trajectory[f"thought_{idx}"] = pred.next_thought
-            trajectory[f"tool_name_{idx}"] = pred.next_tool_name
-            trajectory[f"tool_args_{idx}"] = pred.next_tool_args
-
             try:
-                trajectory[f"observation_{idx}"] = await self.tools[pred.next_tool_name].acall(**pred.next_tool_args)
-            except Exception as err:
-                trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
+                pred = await self.react.acall(**self._call_inputs_from_history(history, **input_args))
+            except ValueError as err:
+                self._warn_invalid_tool_selection(err)
+                break
+
+            observation = await self._aexecute_tool_call(pred.next_tool_name, pred.next_tool_args)
+
+            history = history.append_many(self._step_to_history_messages(pred, observation))
+            completed_turns += 1
+            last_completed_tool_name = pred.next_tool_name
 
             if pred.next_tool_name == "finish":
                 break
 
-        extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        return dspy.Prediction(trajectory=trajectory, **extract)
-
-    def _call_with_potential_trajectory_truncation(self, module, trajectory, **input_args):
-        for _ in range(3):
-            try:
-                return module(
-                    **input_args,
-                    trajectory=self._format_trajectory(trajectory),
-                )
-            except ContextWindowExceededError:
-                logger.warning("Trajectory exceeded the context window, truncating the oldest tool call information.")
-                trajectory = self.truncate_trajectory(trajectory)
-        raise ValueError("The context window was exceeded even after 3 attempts to truncate the trajectory.")
-
-    async def _async_call_with_potential_trajectory_truncation(self, module, trajectory, **input_args):
-        for _ in range(3):
-            try:
-                return await module.acall(
-                    **input_args,
-                    trajectory=self._format_trajectory(trajectory),
-                )
-            except ContextWindowExceededError:
-                logger.warning("Trajectory exceeded the context window, truncating the oldest tool call information.")
-                trajectory = self.truncate_trajectory(trajectory)
-        raise ValueError("The context window was exceeded even after 3 attempts to truncate the trajectory.")
-
-    def truncate_trajectory(self, trajectory):
-        """Truncates the trajectory so that it fits in the context window.
-
-        Users can override this method to implement their own truncation logic.
-        """
-        keys = list(trajectory.keys())
-        if len(keys) < 4:
-            # Every tool call has 4 keys: thought, tool_name, tool_args, and observation.
-            raise ValueError(
-                "The trajectory is too long so your prompt exceeded the context window, but the trajectory cannot be "
-                "truncated because it only has one tool call."
-            )
-
-        for key in keys[:4]:
-            trajectory.pop(key)
-
-        return trajectory
+        extract = await self.extract.acall(**self._call_inputs_from_history(history, **input_args))
+        return dspy.Prediction(history=history, **extract)
 
 
 def _fmt_exc(err: BaseException, *, limit: int = 5) -> str:

--- a/tests/adapters/test_baml_adapter.py
+++ b/tests/adapters/test_baml_adapter.py
@@ -373,8 +373,10 @@ def test_baml_adapter_with_conversation_history():
 
     history = dspy.History(
         messages=[
-            {"question": "What is the patient's age?", "answer": "45 years old"},
-            {"question": "Any allergies?", "answer": "Penicillin allergy"},
+            dspy.HistoryMessage(role="user", fields={"question": "What is the patient's age?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "45 years old"}),
+            dspy.HistoryMessage(role="user", fields={"question": "Any allergies?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Penicillin allergy"}),
         ]
     )
 

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -439,8 +439,10 @@ def test_chat_adapter_formats_conversation_history():
 
     history = dspy.History(
         messages=[
-            {"question": "What is the capital of France?", "answer": "Paris"},
-            {"question": "What is the capital of Germany?", "answer": "Berlin"},
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of France?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Paris"}),
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of Germany?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Berlin"}),
         ]
     )
 
@@ -452,6 +454,30 @@ def test_chat_adapter_formats_conversation_history():
     assert messages[2]["content"] == "[[ ## answer ## ]]\nParis\n\n[[ ## completed ## ]]\n"
     assert messages[3]["content"] == "[[ ## question ## ]]\nWhat is the capital of Germany?"
     assert messages[4]["content"] == "[[ ## answer ## ]]\nBerlin\n\n[[ ## completed ## ]]\n"
+
+
+def test_chat_adapter_formats_conversation_history_with_tool_message():
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        history: dspy.History = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    history = dspy.History(
+        messages=[
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of France?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Paris"}),
+            dspy.HistoryMessage(role="tool", fields={"tool_name": "search", "observation": "capital=Paris"}),
+        ]
+    )
+
+    adapter = dspy.ChatAdapter()
+    messages = adapter.format(MySignature, [], {"question": "What is the capital of Germany?", "history": history})
+
+    assert len(messages) == 5
+    assert messages[1]["content"] == "[[ ## question ## ]]\nWhat is the capital of France?"
+    assert messages[2]["content"] == "[[ ## answer ## ]]\nParis\n\n[[ ## completed ## ]]\n"
+    assert messages[3]["content"] == "[[ ## tool_name ## ]]\nsearch\n\n[[ ## observation ## ]]\ncapital=Paris"
+    assert messages[4]["content"].startswith("[[ ## question ## ]]\nWhat is the capital of Germany?")
 
 
 def test_chat_adapter_fallback_to_json_adapter_on_exception():

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -520,8 +520,10 @@ def test_json_adapter_formats_conversation_history():
 
     history = dspy.History(
         messages=[
-            {"question": "What is the capital of France?", "answer": "Paris"},
-            {"question": "What is the capital of Germany?", "answer": "Berlin"},
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of France?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Paris"}),
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of Germany?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Berlin"}),
         ]
     )
 
@@ -533,6 +535,30 @@ def test_json_adapter_formats_conversation_history():
     assert messages[2]["content"] == '{\n  "answer": "Paris"\n}'
     assert messages[3]["content"] == "[[ ## question ## ]]\nWhat is the capital of Germany?"
     assert messages[4]["content"] == '{\n  "answer": "Berlin"\n}'
+
+
+def test_json_adapter_formats_conversation_history_with_tool_message():
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        history: dspy.History = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    history = dspy.History(
+        messages=[
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of France?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Paris"}),
+            dspy.HistoryMessage(role="tool", fields={"tool_name": "search", "observation": "capital=Paris"}),
+        ]
+    )
+
+    adapter = dspy.JSONAdapter()
+    messages = adapter.format(MySignature, [], {"question": "What is the capital of Germany?", "history": history})
+
+    assert len(messages) == 5
+    assert messages[1]["content"] == "[[ ## question ## ]]\nWhat is the capital of France?"
+    assert messages[2]["content"] == '{\n  "answer": "Paris"\n}'
+    assert messages[3]["content"] == "[[ ## tool_name ## ]]\nsearch\n\n[[ ## observation ## ]]\ncapital=Paris"
+    assert messages[4]["content"].startswith("[[ ## question ## ]]\nWhat is the capital of Germany?")
 
 
 @pytest.mark.asyncio

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -280,13 +280,16 @@ def test_evaluate_save_as_json_with_history():
     # Create history objects
     history1 = dspy.History(
         messages=[
-            {"question": "Previous Q1", "answer": "Previous A1"},
+            dspy.HistoryMessage(role="user", fields={"question": "Previous Q1"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Previous A1"}),
         ]
     )
     history2 = dspy.History(
         messages=[
-            {"question": "Previous Q2", "answer": "Previous A2"},
-            {"question": "Previous Q3", "answer": "Previous A3"},
+            dspy.HistoryMessage(role="user", fields={"question": "Previous Q2"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Previous A2"}),
+            dspy.HistoryMessage(role="user", fields={"question": "Previous Q3"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Previous A3"}),
         ]
     )
 
@@ -323,16 +326,19 @@ def test_evaluate_save_as_json_with_history():
         assert "history" in data[0]
         assert isinstance(data[0]["history"], dict)
         assert "messages" in data[0]["history"]
-        assert len(data[0]["history"]["messages"]) == 1
-        assert data[0]["history"]["messages"][0] == {"question": "Previous Q1", "answer": "Previous A1"}
+        assert len(data[0]["history"]["messages"]) == 2
+        assert data[0]["history"]["messages"][0] == {"role": "user", "fields": {"question": "Previous Q1"}}
+        assert data[0]["history"]["messages"][1] == {"role": "assistant", "fields": {"answer": "Previous A1"}}
 
         # Verify history was properly serialized in second record
         assert "history" in data[1]
         assert isinstance(data[1]["history"], dict)
         assert "messages" in data[1]["history"]
-        assert len(data[1]["history"]["messages"]) == 2
-        assert data[1]["history"]["messages"][0] == {"question": "Previous Q2", "answer": "Previous A2"}
-        assert data[1]["history"]["messages"][1] == {"question": "Previous Q3", "answer": "Previous A3"}
+        assert len(data[1]["history"]["messages"]) == 4
+        assert data[1]["history"]["messages"][0] == {"role": "user", "fields": {"question": "Previous Q2"}}
+        assert data[1]["history"]["messages"][1] == {"role": "assistant", "fields": {"answer": "Previous A2"}}
+        assert data[1]["history"]["messages"][2] == {"role": "user", "fields": {"question": "Previous Q3"}}
+        assert data[1]["history"]["messages"][3] == {"role": "assistant", "fields": {"answer": "Previous A3"}}
 
     finally:
         import os
@@ -354,7 +360,8 @@ def test_evaluate_save_as_csv_with_history():
     # Create history object
     history = dspy.History(
         messages=[
-            {"question": "Previous Q", "answer": "Previous A"},
+            dspy.HistoryMessage(role="user", fields={"question": "Previous Q"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Previous A"}),
         ]
     )
 
@@ -395,4 +402,3 @@ def test_evaluate_save_as_csv_with_history():
         import os
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
-

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -481,7 +481,12 @@ def test_call_predict_with_chat_history(adapter_type):
 
     program(
         question="are you sure that's correct?",
-        history=dspy.History(messages=[{"question": "what's the capital of france?", "answer": "paris"}]),
+        history=dspy.History(
+            messages=[
+                dspy.HistoryMessage(role="user", fields={"question": "what's the capital of france?"}),
+                dspy.HistoryMessage(role="assistant", fields={"answer": "paris"}),
+            ]
+        ),
     )
 
     # Verify the LM was called with correct messages

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -8,6 +8,37 @@ import dspy
 from dspy.utils.dummies import DummyLM
 
 
+def _history_to_trajectory(history: dspy.History) -> dict[str, object]:
+    trajectory = {}
+    turn_idx = 0
+    messages = history.messages
+    i = 0
+    while i < len(messages):
+        message = messages[i]
+        if message.role != "assistant":
+            i += 1
+            continue
+
+        fields = message.fields
+        if not {"next_thought", "next_tool_name", "next_tool_args"}.issubset(fields):
+            i += 1
+            continue
+
+        trajectory[f"thought_{turn_idx}"] = fields["next_thought"]
+        trajectory[f"tool_name_{turn_idx}"] = fields["next_tool_name"]
+        trajectory[f"tool_args_{turn_idx}"] = fields["next_tool_args"]
+
+        if i + 1 < len(messages) and messages[i + 1].role == "tool":
+            trajectory[f"observation_{turn_idx}"] = messages[i + 1].fields.get("observation")
+            i += 2
+        else:
+            i += 1
+
+        turn_idx += 1
+
+    return trajectory
+
+
 @pytest.mark.extra
 def test_tool_observation_preserves_custom_type():
     pytest.importorskip("PIL.Image")
@@ -46,10 +77,13 @@ def test_tool_observation_preserves_custom_type():
     react = dspy.ReAct("question -> answer", tools=[make_images])
     react(question="Draw me something red")
 
-    sigs_with_obs = [sig for sig, inputs in captured_calls if "observation_0" in inputs]
-    assert sigs_with_obs, "Expected ReAct to format a trajectory containing observation_0"
+    sigs_with_obs = [sig for sig, inputs in captured_calls if "observation" in inputs]
+    assert sigs_with_obs, "Expected ReAct to include `observation` in later turns"
+    assert all("question" not in inputs for _, inputs in captured_calls if "observation" in inputs)
+    assert all("question" not in inputs for _, inputs in captured_calls if "next_thought" in inputs)
 
-    observation_content = lm.history[1]["messages"][1]["content"]
+    second_turn_messages = lm.history[1]["messages"]
+    observation_content = next(msg["content"] for msg in second_turn_messages if isinstance(msg["content"], list))
     assert sum(1 for part in observation_content if isinstance(part, dict) and part.get("type") == "image_url") == 2
 
 
@@ -128,7 +162,7 @@ def test_tool_calling_with_pydantic_args():
         "tool_args_1": {},
         "observation_1": "Completed.",
     }
-    assert outputs.trajectory == expected_trajectory
+    assert _history_to_trajectory(outputs.history) == expected_trajectory
 
 
 def test_tool_calling_without_typehint():
@@ -160,7 +194,7 @@ def test_tool_calling_without_typehint():
         "tool_args_1": {},
         "observation_1": "Completed.",
     }
-    assert outputs.trajectory == expected_trajectory
+    assert _history_to_trajectory(outputs.history) == expected_trajectory
 
 
 def test_trajectory_truncation():
@@ -195,17 +229,12 @@ def test_trajectory_truncation():
     react.react = mock_react
     react.extract = lambda **kwargs: dspy.Prediction(output_text="Final output")
 
-    # Call forward and get the result
-    result = react(input_text="test input")
-
-    # Verify that older entries in the trajectory were truncated
-    assert "thought_0" not in result.trajectory
-    assert "thought_2" in result.trajectory
-    assert result.output_text == "Final output"
+    with pytest.raises(litellm.ContextWindowExceededError):
+        react(input_text="test input")
 
 
 @pytest.mark.asyncio
-async def test_context_window_exceeded_after_retries():
+async def test_context_window_exceeded_propagates():
     def echo(text: str) -> str:
         return f"Echoed: {text}"
 
@@ -214,42 +243,21 @@ async def test_context_window_exceeded_after_retries():
     def mock_react(**kwargs):
         raise litellm.ContextWindowExceededError("Context window exceeded", "dummy_model", "dummy_provider")
 
-    # Test sync version
-    extract_calls = []
-
-    def mock_extract(**kwargs):
-        extract_calls.append(kwargs)
-        return dspy.Prediction(output_text="Fallback output")
-
     react.react = mock_react
-    react.extract = mock_extract
+    react.extract = lambda **kwargs: dspy.Prediction(output_text="Fallback output")
 
-    result = react(input_text="test input")
-    assert result.trajectory == {}
-    assert result.output_text == "Fallback output"
-    assert len(extract_calls) == 1
-    assert extract_calls[0]["input_text"] == "test input"
-    assert "trajectory" in extract_calls[0]
+    with pytest.raises(litellm.ContextWindowExceededError):
+        react(input_text="test input")
 
     # Test async version
-    async_extract_calls = []
-
     async def mock_react_async(**kwargs):
         raise litellm.ContextWindowExceededError("Context window exceeded", "dummy_model", "dummy_provider")
 
-    async def mock_extract_async(**kwargs):
-        async_extract_calls.append(kwargs)
-        return dspy.Prediction(output_text="Fallback output")
-
     react.react.acall = mock_react_async
-    react.extract.acall = mock_extract_async
+    react.extract.acall = lambda **kwargs: dspy.Prediction(output_text="Fallback output")
 
-    result = await react.acall(input_text="test input")
-    assert result.trajectory == {}
-    assert result.output_text == "Fallback output"
-    assert len(async_extract_calls) == 1
-    assert async_extract_calls[0]["input_text"] == "test input"
-    assert "trajectory" in async_extract_calls[0]
+    with pytest.raises(litellm.ContextWindowExceededError):
+        await react.acall(input_text="test input")
 
 
 def test_error_retry():
@@ -278,7 +286,7 @@ def test_error_retry():
     dspy.configure(lm=lm)
 
     outputs = react(a=1, b=2, max_iters=2)
-    traj = outputs.trajectory
+    traj = _history_to_trajectory(outputs.history)
 
     # --- exact-match checks (thoughts + tool calls) -------------------------
     control_expected = {
@@ -375,7 +383,7 @@ async def test_async_tool_calling_with_pydantic_args():
         "tool_args_1": {},
         "observation_1": "Completed.",
     }
-    assert outputs.trajectory == expected_trajectory
+    assert _history_to_trajectory(outputs.history) == expected_trajectory
 
 
 @pytest.mark.asyncio
@@ -403,7 +411,7 @@ async def test_async_error_retry():
     )
     with dspy.context(lm=lm):
         outputs = await react.acall(a=1, b=2, max_iters=2)
-    traj = outputs.trajectory
+    traj = _history_to_trajectory(outputs.history)
 
     # Exact-match checks (thoughts + tool calls)
     control_expected = {
@@ -423,3 +431,86 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_resume_strict_from_completed_history():
+    def foo(a, b):
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[foo])
+    history = dspy.History(
+        messages=[
+            dspy.HistoryMessage(role="user", fields={"a": 1, "b": 2}),
+            dspy.HistoryMessage(
+                role="assistant",
+                fields={
+                    "next_thought": "Add the numbers first.",
+                    "next_tool_name": "foo",
+                    "next_tool_args": {"a": 1, "b": 2},
+                },
+            ),
+            dspy.HistoryMessage(role="tool", fields={"tool_name": "foo", "observation": 3}),
+        ]
+    )
+
+    lm = DummyLM(
+        [
+            {"next_thought": "Now I can finish.", "next_tool_name": "finish", "next_tool_args": {}},
+            {"reasoning": "We already computed the sum", "c": 3},
+        ]
+    )
+    dspy.configure(lm=lm)
+
+    outputs = react(a=1, b=2, history=history, resume="strict", max_iters=3)
+    assert outputs.c == 3
+    trajectory = _history_to_trajectory(outputs.history)
+    assert trajectory["thought_0"] == "Add the numbers first."
+    assert trajectory["observation_0"] == 3
+    assert trajectory["tool_name_1"] == "finish"
+    assert trajectory["observation_1"] == "Completed."
+
+
+def test_resume_executes_pending_tool_call():
+    def foo(a, b):
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[foo])
+    history = dspy.History(
+        messages=[
+            dspy.HistoryMessage(role="user", fields={"a": 1, "b": 2}),
+            dspy.HistoryMessage(
+                role="assistant",
+                fields={
+                    "next_thought": "I should add the two inputs.",
+                    "next_tool_name": "foo",
+                    "next_tool_args": {"a": 1, "b": 2},
+                },
+            ),
+        ]
+    )
+
+    lm = DummyLM(
+        [
+            {"next_thought": "Now I can finish.", "next_tool_name": "finish", "next_tool_args": {}},
+            {"reasoning": "The pending call was completed before continuing", "c": 3},
+        ]
+    )
+    dspy.configure(lm=lm)
+
+    outputs = react(a=1, b=2, history=history, resume="strict", max_iters=3)
+    assert outputs.c == 3
+    trajectory = _history_to_trajectory(outputs.history)
+    assert trajectory["tool_name_0"] == "foo"
+    assert trajectory["observation_0"] == 3
+
+
+def test_resume_strict_rejects_input_mismatch():
+    def foo(a, b):
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[foo])
+    history = dspy.History(messages=[dspy.HistoryMessage(role="user", fields={"a": 9, "b": 2})])
+    dspy.configure(lm=DummyLM([]))
+
+    with pytest.raises(ValueError, match="does not match current input"):
+        react(a=1, b=2, history=history, resume="strict")

--- a/tests/primitives/test_example.py
+++ b/tests/primitives/test_example.py
@@ -129,8 +129,10 @@ def test_example_to_dict_with_history():
     """Test that Example.toDict() properly serializes dspy.History objects."""
     history = dspy.History(
         messages=[
-            {"question": "What is the capital of France?", "answer": "Paris"},
-            {"question": "What is the capital of Germany?", "answer": "Berlin"},
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of France?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Paris"}),
+            dspy.HistoryMessage(role="user", fields={"question": "What is the capital of Germany?"}),
+            dspy.HistoryMessage(role="assistant", fields={"answer": "Berlin"}),
         ]
     )
     example = Example(question="Test question", history=history, answer="Test answer")
@@ -145,8 +147,10 @@ def test_example_to_dict_with_history():
     assert isinstance(result["history"], dict)
     assert "messages" in result["history"]
     assert result["history"]["messages"] == [
-        {"question": "What is the capital of France?", "answer": "Paris"},
-        {"question": "What is the capital of Germany?", "answer": "Berlin"},
+        {"role": "user", "fields": {"question": "What is the capital of France?"}},
+        {"role": "assistant", "fields": {"answer": "Paris"}},
+        {"role": "user", "fields": {"question": "What is the capital of Germany?"}},
+        {"role": "assistant", "fields": {"answer": "Berlin"}},
     ]
 
     # Verify JSON serialization works
@@ -154,3 +158,15 @@ def test_example_to_dict_with_history():
     json_str = json.dumps(result)
     restored = json.loads(json_str)
     assert restored["history"]["messages"] == result["history"]["messages"]
+
+
+def test_history_overflow_drop_strategy_oldest_message():
+    history = dspy.History(messages=[], max_chars=10, overflow_drop_strategy="oldest_message")
+    history = history.append(dspy.HistoryMessage(role="user", fields={"text": "this message is too long"}))
+    assert history.messages == []
+
+
+def test_history_overflow_drop_strategy_oldest_pair_requires_pair():
+    history = dspy.History(messages=[], max_chars=10, overflow_drop_strategy="oldest_pair")
+    with pytest.raises(ValueError, match="full assistant/tool pair"):
+        history.append(dspy.HistoryMessage(role="user", fields={"text": "this message is too long"}))


### PR DESCRIPTION
dspy.History has not been giving the desired level of chat experience. inspired by # 8798, we make a few major changes to history which should allow it to be compatible with dspy.ReAct, and eventually dspy.RLM too.

The big changes:
History:
1. Store all items as user/assistant/tool calls.
2. Create the ability to resume a trajectory from halfway through
3. Automatic truncation with compaction planned as a future upgrade
4. 

ReAct:
1. 

Notes/todos:
- Tutorial on making a chat agent
- estimated_size is ugly
- truncation methods are ugly