### PR TITLE
Add Exa web search retriever and ReAct tools

### DIFF
--- a/dspy/retrievers/exa.py
+++ b/dspy/retrievers/exa.py
@@ -1,0 +1,273 @@
+import os
+
+import dspy
+from dspy.primitives.prediction import Prediction
+
+try:
+    from exa_py import Exa
+except ImportError as err:
+    raise ImportError(
+        "The 'exa' extra is required to use Exa retrievers and tools. Install it with `pip install dspy[exa]`",
+    ) from err
+
+INTEGRATION_HEADER = "exa-dspy"
+
+
+def _make_client(api_key: str | None = None, base_url: str = "https://api.exa.ai") -> Exa:
+    key = api_key or os.environ.get("EXA_API_KEY")
+    if not key:
+        raise ValueError("Exa API key must be provided or set in EXA_API_KEY environment variable")
+    client = Exa(api_key=key, base_url=base_url)
+    client.headers["x-exa-integration"] = INTEGRATION_HEADER
+    return client
+
+
+def _format_results(results: list, max_chars: int = 1000) -> str:
+    parts = []
+    for r in results:
+        title = getattr(r, "title", None) or ""
+        url = getattr(r, "url", None) or ""
+        text = getattr(r, "text", None) or ""
+        if text and len(text) > max_chars:
+            text = text[:max_chars] + "..."
+        summary = getattr(r, "summary", None) or ""
+        highlights = getattr(r, "highlights", None)
+
+        entry = f"Title: {title}\nURL: {url}"
+        if summary:
+            entry += f"\nSummary: {summary}"
+        if text:
+            entry += f"\nContent: {text}"
+        if highlights:
+            entry += f"\nHighlights: {' | '.join(highlights)}"
+        parts.append(entry)
+    return "\n\n---\n\n".join(parts)
+
+
+class ExaRM(dspy.Retrieve):
+    """A retrieval module that uses the Exa API to return the top passages for a given query.
+
+    Unlike vector DB retrievers, ExaRM performs live web search, making it suitable for
+    queries that require up-to-date information.
+
+    Args:
+        exa_api_key: Exa API key. Falls back to EXA_API_KEY env var.
+        k: Number of results to retrieve. Defaults to 3.
+        search_type: One of "auto", "neural", or "keyword". Defaults to "auto".
+        include_domains: Restrict results to these domains.
+        exclude_domains: Exclude results from these domains.
+        start_published_date: Filter for content published after this date (YYYY-MM-DD).
+        end_published_date: Filter for content published before this date (YYYY-MM-DD).
+
+    Examples:
+        Below is a code snippet that shows how to use Exa as the default retriever:
+        ```python
+        import dspy
+        from dspy.retrievers.exa import ExaRM
+
+        lm = dspy.LM("openai/gpt-4o-mini")
+        retriever = ExaRM(k=3)
+        dspy.configure(lm=lm, rm=retriever)
+
+        retrieve = dspy.Retrieve(k=3)
+        results = retrieve("what happened in AI this week").passages
+        ```
+    """
+
+    def __init__(
+        self,
+        exa_api_key: str | None = None,
+        k: int = 3,
+        search_type: str = "auto",
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+    ):
+        super().__init__(k=k)
+        self._client = _make_client(exa_api_key)
+        self._search_type = search_type
+        self._include_domains = include_domains
+        self._exclude_domains = exclude_domains
+        self._start_published_date = start_published_date
+        self._end_published_date = end_published_date
+
+    def forward(self, query_or_queries: str | list[str], k: int | None = None, **kwargs) -> Prediction:
+        """Search the web with Exa for top passages matching the query.
+
+        Args:
+            query_or_queries: The query or queries to search for.
+            k: Number of results to retrieve. Defaults to self.k.
+
+        Returns:
+            dspy.Prediction with `passages` list of strings.
+        """
+        k = k if k is not None else self.k
+        queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
+        queries = [q for q in queries if q]
+
+        all_passages = []
+        all_urls = []
+        for query in queries:
+            search_kwargs: dict = {
+                "num_results": k,
+                "type": self._search_type,
+                "contents": {"text": True},
+            }
+            if self._include_domains:
+                search_kwargs["include_domains"] = self._include_domains
+            if self._exclude_domains:
+                search_kwargs["exclude_domains"] = self._exclude_domains
+            if self._start_published_date:
+                search_kwargs["start_published_date"] = self._start_published_date
+            if self._end_published_date:
+                search_kwargs["end_published_date"] = self._end_published_date
+            search_kwargs.update(kwargs)
+
+            response = self._client.search(query, **search_kwargs)
+            for r in response.results:
+                text = getattr(r, "text", None) or ""
+                all_passages.append(text)
+                all_urls.append(getattr(r, "url", None) or "")
+
+        return Prediction(passages=all_passages, urls=all_urls)
+
+
+class ExaSearchTool:
+    """Web search tool for DSPy ReAct agents using Exa's search API.
+
+    Returns formatted text results that ReAct agents can reason over.
+
+    Args:
+        api_key: Exa API key. Falls back to EXA_API_KEY env var.
+        num_results: Number of results per search. Defaults to 5.
+        search_type: One of "auto", "neural", or "keyword". Defaults to "auto".
+        include_domains: Restrict results to these domains.
+        exclude_domains: Exclude results from these domains.
+        start_published_date: Filter for content published after this date (YYYY-MM-DD).
+        end_published_date: Filter for content published before this date (YYYY-MM-DD).
+        max_chars_per_result: Truncate each result's text to this many characters.
+
+    Examples:
+        ```python
+        import dspy
+        from dspy.retrievers.exa import ExaSearchTool
+
+        tool = ExaSearchTool(num_results=5)
+        agent = dspy.ReAct("question -> answer", tools=[tool])
+        ```
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        num_results: int = 5,
+        search_type: str = "auto",
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        max_chars_per_result: int = 1000,
+    ):
+        self._client = _make_client(api_key)
+        self._num_results = num_results
+        self._search_type = search_type
+        self._include_domains = include_domains
+        self._exclude_domains = exclude_domains
+        self._start_published_date = start_published_date
+        self._end_published_date = end_published_date
+        self._max_chars_per_result = max_chars_per_result
+
+    def __call__(self, query: str) -> str:
+        """Search the web using Exa. Returns titles, URLs, and content for the most relevant pages."""
+        kwargs: dict = {
+            "num_results": self._num_results,
+            "type": self._search_type,
+            "contents": {"text": {"max_characters": self._max_chars_per_result}},
+        }
+        if self._include_domains:
+            kwargs["include_domains"] = self._include_domains
+        if self._exclude_domains:
+            kwargs["exclude_domains"] = self._exclude_domains
+        if self._start_published_date:
+            kwargs["start_published_date"] = self._start_published_date
+        if self._end_published_date:
+            kwargs["end_published_date"] = self._end_published_date
+
+        response = self._client.search(query, **kwargs)
+        return _format_results(response.results, self._max_chars_per_result)
+
+
+class ExaContentsTool:
+    """Content fetching tool for DSPy ReAct agents using Exa's contents API.
+
+    Fetches and extracts clean text from a URL. Useful when a ReAct agent
+    has a URL and needs to read the page content.
+
+    Args:
+        api_key: Exa API key. Falls back to EXA_API_KEY env var.
+        max_characters: Max characters to extract per page. Defaults to 5000.
+
+    Examples:
+        ```python
+        import dspy
+        from dspy.retrievers.exa import ExaSearchTool, ExaContentsTool
+
+        agent = dspy.ReAct("question -> answer", tools=[ExaSearchTool(), ExaContentsTool()])
+        ```
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        max_characters: int = 5000,
+    ):
+        self._client = _make_client(api_key)
+        self._max_characters = max_characters
+
+    def __call__(self, url: str) -> str:
+        """Fetch and extract clean text content from a URL using Exa."""
+        response = self._client.get_contents([url], text={"max_characters": self._max_characters})
+        if not response.results:
+            return f"No content found for URL: {url}"
+        return _format_results(response.results, self._max_characters)
+
+
+class ExaFindSimilarTool:
+    """Find similar pages tool for DSPy ReAct agents using Exa's find_similar API.
+
+    Given a URL, finds other pages with similar content.
+
+    Args:
+        api_key: Exa API key. Falls back to EXA_API_KEY env var.
+        num_results: Number of similar pages to return. Defaults to 5.
+        max_chars_per_result: Truncate each result's text to this many characters.
+
+    Examples:
+        ```python
+        import dspy
+        from dspy.retrievers.exa import ExaFindSimilarTool
+
+        tool = ExaFindSimilarTool()
+        agent = dspy.ReAct("question -> answer", tools=[tool])
+        ```
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        num_results: int = 5,
+        max_chars_per_result: int = 1000,
+    ):
+        self._client = _make_client(api_key)
+        self._num_results = num_results
+        self._max_chars_per_result = max_chars_per_result
+
+    def __call__(self, url: str) -> str:
+        """Find web pages similar to a given URL using Exa."""
+        response = self._client.find_similar(
+            url,
+            num_results=self._num_results,
+            contents={"text": {"max_characters": self._max_chars_per_result}},
+        )
+        return _format_results(response.results, self._max_chars_per_result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.18.0,<1.0.0"]
+exa = ["exa-py>=2.0.0"]
 weaviate = ["weaviate-client~=4.5.4"]
 mcp = ["mcp; python_version >= '3.10'"]
 langchain = ["langchain_core"]

--- a/tests/retrievers/test_exa.py
+++ b/tests/retrievers/test_exa.py
@@ -1,0 +1,237 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_exa_import(monkeypatch):
+    """Ensure exa_py is importable even if not installed."""
+    import sys
+
+    if "exa_py" not in sys.modules:
+        mock_exa_module = MagicMock()
+        monkeypatch.setitem(sys.modules, "exa_py", mock_exa_module)
+
+
+@pytest.fixture
+def mock_exa_client():
+    with patch("dspy.retrievers.exa._make_client") as mock:
+        client = MagicMock()
+        mock.return_value = client
+        yield client
+
+
+def _make_search_result(title="Test", url="https://example.com", text="Some text"):
+    result = MagicMock()
+    result.title = title
+    result.url = url
+    result.text = text
+    result.summary = None
+    result.highlights = None
+    return result
+
+
+class TestExaRM:
+    def test_forward_single_query(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaRM
+
+        mock_result = _make_search_result(text="passage one")
+        mock_exa_client.search.return_value = MagicMock(results=[mock_result])
+
+        rm = ExaRM(exa_api_key="test-key", k=3)
+        prediction = rm.forward("test query")
+
+        assert prediction.passages == ["passage one"]
+        assert prediction.urls == ["https://example.com"]
+        mock_exa_client.search.assert_called_once()
+
+    def test_forward_multiple_queries(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaRM
+
+        r1 = _make_search_result(text="result 1", url="https://a.com")
+        r2 = _make_search_result(text="result 2", url="https://b.com")
+        mock_exa_client.search.side_effect = [
+            MagicMock(results=[r1]),
+            MagicMock(results=[r2]),
+        ]
+
+        rm = ExaRM(exa_api_key="test-key", k=1)
+        prediction = rm.forward(["query 1", "query 2"])
+
+        assert len(prediction.passages) == 2
+        assert prediction.passages[0] == "result 1"
+        assert prediction.passages[1] == "result 2"
+
+    def test_forward_empty_query_filtered(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaRM
+
+        rm = ExaRM(exa_api_key="test-key")
+        mock_exa_client.search.return_value = MagicMock(results=[])
+        rm.forward(["", "valid query"])
+
+        # Only the valid query should be searched
+        assert mock_exa_client.search.call_count == 1
+
+    def test_forward_passes_filters(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaRM
+
+        mock_exa_client.search.return_value = MagicMock(results=[])
+
+        rm = ExaRM(
+            exa_api_key="test-key",
+            include_domains=["example.com"],
+            exclude_domains=["bad.com"],
+            start_published_date="2024-01-01",
+            end_published_date="2024-12-31",
+            search_type="neural",
+        )
+        rm.forward("test")
+
+        call_kwargs = mock_exa_client.search.call_args
+        assert call_kwargs[1]["include_domains"] == ["example.com"]
+        assert call_kwargs[1]["exclude_domains"] == ["bad.com"]
+        assert call_kwargs[1]["start_published_date"] == "2024-01-01"
+        assert call_kwargs[1]["end_published_date"] == "2024-12-31"
+        assert call_kwargs[1]["type"] == "neural"
+
+    def test_k_override(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaRM
+
+        mock_exa_client.search.return_value = MagicMock(results=[])
+
+        rm = ExaRM(exa_api_key="test-key", k=3)
+        rm.forward("test", k=10)
+
+        call_kwargs = mock_exa_client.search.call_args
+        assert call_kwargs[1]["num_results"] == 10
+
+
+class TestExaSearchTool:
+    def test_call(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaSearchTool
+
+        r = _make_search_result(title="Result", url="https://example.com", text="content here")
+        mock_exa_client.search.return_value = MagicMock(results=[r])
+
+        tool = ExaSearchTool(api_key="test-key")
+        output = tool("test query")
+
+        assert "Result" in output
+        assert "https://example.com" in output
+        assert "content here" in output
+
+    def test_call_with_filters(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaSearchTool
+
+        mock_exa_client.search.return_value = MagicMock(results=[])
+
+        tool = ExaSearchTool(
+            api_key="test-key",
+            include_domains=["example.com"],
+            search_type="keyword",
+        )
+        tool("test")
+
+        call_kwargs = mock_exa_client.search.call_args
+        assert call_kwargs[1]["include_domains"] == ["example.com"]
+        assert call_kwargs[1]["type"] == "keyword"
+
+    def test_docstring_present(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaSearchTool
+
+        tool = ExaSearchTool(api_key="test-key")
+        assert tool.__call__.__doc__ is not None
+
+
+class TestExaContentsTool:
+    def test_call(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaContentsTool
+
+        r = _make_search_result(title="Page", url="https://example.com/page", text="extracted content")
+        mock_exa_client.get_contents.return_value = MagicMock(results=[r])
+
+        tool = ExaContentsTool(api_key="test-key")
+        output = tool("https://example.com/page")
+
+        assert "extracted content" in output
+        mock_exa_client.get_contents.assert_called_once()
+
+    def test_no_content_found(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaContentsTool
+
+        mock_exa_client.get_contents.return_value = MagicMock(results=[])
+
+        tool = ExaContentsTool(api_key="test-key")
+        output = tool("https://example.com/empty")
+
+        assert "No content found" in output
+
+
+class TestExaFindSimilarTool:
+    def test_call(self, mock_exa_client):
+        from dspy.retrievers.exa import ExaFindSimilarTool
+
+        r = _make_search_result(title="Similar", url="https://similar.com", text="similar content")
+        mock_exa_client.find_similar.return_value = MagicMock(results=[r])
+
+        tool = ExaFindSimilarTool(api_key="test-key")
+        output = tool("https://example.com")
+
+        assert "Similar" in output
+        assert "similar content" in output
+        mock_exa_client.find_similar.assert_called_once()
+
+
+class TestMakeClient:
+    def test_missing_api_key(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError, match="Exa API key"):
+                from dspy.retrievers.exa import _make_client
+
+                _make_client()
+
+    def test_env_var_fallback(self):
+        with patch.dict(os.environ, {"EXA_API_KEY": "env-key"}):
+            with patch("dspy.retrievers.exa.Exa") as mock_exa_cls:
+                mock_instance = MagicMock()
+                mock_instance.headers = {}
+                mock_exa_cls.return_value = mock_instance
+
+                from dspy.retrievers.exa import _make_client
+
+                client = _make_client()
+                mock_exa_cls.assert_called_once_with(api_key="env-key", base_url="https://api.exa.ai")
+                assert client.headers["x-exa-integration"] == "exa-dspy"
+
+
+class TestFormatResults:
+    def test_basic_formatting(self):
+        from dspy.retrievers.exa import _format_results
+
+        r = _make_search_result(title="Test Title", url="https://test.com", text="Test content")
+        output = _format_results([r])
+
+        assert "Title: Test Title" in output
+        assert "URL: https://test.com" in output
+        assert "Content: Test content" in output
+
+    def test_truncation(self):
+        from dspy.retrievers.exa import _format_results
+
+        r = _make_search_result(text="x" * 2000)
+        output = _format_results([r], max_chars=100)
+
+        assert "..." in output
+
+    def test_with_summary_and_highlights(self):
+        from dspy.retrievers.exa import _format_results
+
+        r = _make_search_result()
+        r.summary = "A brief summary"
+        r.highlights = ["highlight one", "highlight two"]
+        output = _format_results([r])
+
+        assert "Summary: A brief summary" in output
+        assert "highlight one" in output
+        assert "highlight two" in output


### PR DESCRIPTION
## Summary

Adds [Exa](https://exa.ai) as a native integration in DSPy, providing both a retriever module for RAG pipelines and tool classes for ReAct agents.

Exa is a web search API purpose-built for AI — it returns clean, parsed content (not just links) and supports neural, keyword, and auto search modes.

## What's included

### `ExaRM` — Retriever module (`dspy.Retrieve` subclass)
For use in declarative RAG pipelines. Performs live web search, making it suitable for queries requiring up-to-date information.

```python
from dspy.retrievers.exa import ExaRM

retriever = ExaRM(k=3)
dspy.configure(lm=lm, rm=retriever)
results = dspy.Retrieve(k=3)("what happened in AI this week").passages
```

### `ExaSearchTool` — Web search tool for ReAct agents
```python
from dspy.retrievers.exa import ExaSearchTool

tool = ExaSearchTool(num_results=5)
agent = dspy.ReAct("question -> answer", tools=[tool])
```

### `ExaContentsTool` — URL content extraction tool for ReAct agents
```python
from dspy.retrievers.exa import ExaContentsTool

agent = dspy.ReAct("question -> answer", tools=[ExaSearchTool(), ExaContentsTool()])
```

### `ExaFindSimilarTool` — Find similar pages tool for ReAct agents
```python
from dspy.retrievers.exa import ExaFindSimilarTool

tool = ExaFindSimilarTool()
agent = dspy.ReAct("question -> answer", tools=[tool])
```

## Installation

```bash
pip install dspy[exa]
```

Requires an Exa API key (pass as `exa_api_key` parameter or set `EXA_API_KEY` env var). Get one at https://exa.ai.

## Changes

- `dspy/retrievers/exa.py` — ExaRM retriever + ExaSearchTool, ExaContentsTool, ExaFindSimilarTool
- `tests/retrievers/test_exa.py` — 16 unit tests (all passing)
- `pyproject.toml` — Added `exa` optional dependency (`exa-py>=2.0.0`)

All API calls include `x-exa-integration: exa-dspy` header for usage tracking.

---

[Link to Devin run](https://app.devin.ai/sessions/91a0b735355242bfa8292e0eed2fe2d4)
Requested by Tanishq Jaiswal (@10ishq)