### PR TITLE
Add safe (pickle-free) module serialization

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -64,6 +64,7 @@ class Predict(Module, Parameter):
 
         state["signature"] = self.signature.dump_state()
         state["lm"] = self.lm.dump_state() if self.lm else None
+        state["config"] = self.config
         return state
 
     def load_state(self, state: dict) -> "Predict":
@@ -75,7 +76,7 @@ class Predict(Module, Parameter):
         Returns:
             Self to allow method chaining.
         """
-        excluded_keys = ["signature", "extended_signature", "lm"]
+        excluded_keys = ["signature", "extended_signature", "lm", "config"]
         for name, value in state.items():
             # `excluded_keys` are fields that go through special handling.
             if name not in excluded_keys:
@@ -83,6 +84,9 @@ class Predict(Module, Parameter):
 
         self.signature = self.signature.load_state(state["signature"])
         self.lm = LM(**state["lm"]) if state["lm"] else None
+
+        if "config" in state:
+            self.config = state["config"]
 
         if "extended_signature" in state:  # legacy, up to and including 2.5, for CoT.
             raise NotImplementedError("Loading extended_signature is no longer supported in DSPy 2.6+")

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -160,31 +160,79 @@ class BaseModule:
         for name, param in self.named_parameters():
             param.load_state(state[name])
 
-    def save(self, path, save_program=False, modules_to_serialize=None):
+    def _collect_module_tree(self):
+        """Walk the module graph and record each sub-module's path and class.
+
+        Returns a list ordered so that parents appear before their children,
+        which is the order needed for reconstruction.
+        """
+        tree = []
+
+        def _walk(obj, prefix):
+            for attr_name, attr_value in obj.__dict__.items():
+                if isinstance(attr_value, BaseModule):
+                    path = f"{prefix}.{attr_name}" if prefix else attr_name
+                    tree.append(
+                        {
+                            "path": path,
+                            "class": f"{attr_value.__class__.__module__}.{attr_value.__class__.__qualname__}",
+                        }
+                    )
+                    _walk(attr_value, path)
+                elif isinstance(attr_value, list):
+                    for i, item in enumerate(attr_value):
+                        if isinstance(item, BaseModule):
+                            path = f"{prefix}.{attr_name}[{i}]" if prefix else f"{attr_name}[{i}]"
+                            tree.append(
+                                {
+                                    "path": path,
+                                    "class": f"{item.__class__.__module__}.{item.__class__.__qualname__}",
+                                }
+                            )
+                            _walk(item, path)
+                elif isinstance(attr_value, dict):
+                    for key, item in attr_value.items():
+                        if isinstance(item, BaseModule):
+                            path = f"{prefix}.{attr_name}['{key}']" if prefix else f"{attr_name}['{key}']"
+                            tree.append(
+                                {
+                                    "path": path,
+                                    "class": f"{item.__class__.__module__}.{item.__class__.__qualname__}",
+                                }
+                            )
+                            _walk(item, path)
+
+        _walk(self, "")
+        return tree
+
+    def save(self, path, save_program=False, modules_to_serialize=None, safe=False):
         """Save the module.
 
         Save the module to a directory or a file. There are two modes:
-        - `save_program=False`: Save only the state of the module to a json or pickle file, based on the value of
+        - ``save_program=False``: Save only the state of the module to a json or pickle file, based on the value of
             the file extension.
-        - `save_program=True`: Save the whole module to a directory via cloudpickle, which contains both the state and
-            architecture of the model.
+        - ``save_program=True``: Save the whole module to a directory.  By default this uses cloudpickle.
+            Pass ``safe=True`` to use a JSON-based format that avoids pickle entirely.
 
-        If `save_program=True` and `modules_to_serialize` are provided, it will register those modules for serialization
-        with cloudpickle's `register_pickle_by_value`. This causes cloudpickle to serialize the module by value rather
-        than by reference, ensuring the module is fully preserved along with the saved program. This is useful
-        when you have custom modules that need to be serialized alongside your program. If None, then no modules
-        will be registered for serialization.
+        If ``save_program=True`` and ``modules_to_serialize`` are provided, it will register those modules for
+        serialization with cloudpickle's ``register_pickle_by_value``. This causes cloudpickle to serialize the
+        module by value rather than by reference, ensuring the module is fully preserved along with the saved
+        program. This is useful when you have custom modules that need to be serialized alongside your program.
+        If None, then no modules will be registered for serialization.
 
         We also save the dependency versions, so that the loaded model can check if there is a version mismatch on
         critical dependencies or DSPy version.
 
         Args:
-            path (str): Path to the saved state file, which should be a .json or .pkl file when `save_program=False`,
-                and a directory when `save_program=True`.
-            save_program (bool): If True, save the whole module to a directory via cloudpickle, otherwise only save
-                the state.
-            modules_to_serialize (list): A list of modules to serialize with cloudpickle's `register_pickle_by_value`.
+            path (str): Path to the saved state file, which should be a .json or .pkl file when ``save_program=False``,
+                and a directory when ``save_program=True``.
+            save_program (bool): If True, save the whole module to a directory via cloudpickle (or JSON when
+                ``safe=True``), otherwise only save the state.
+            modules_to_serialize (list): A list of modules to serialize with cloudpickle's
+                ``register_pickle_by_value``. Only used when ``safe=False``.
                 If None, then no modules will be registered for serialization.
+            safe (bool): If True and ``save_program=True``, save using a JSON-based format that avoids cloudpickle.
+                The module class must be importable at load time (same pattern as PyTorch's ``state_dict``).
 
         """
         metadata = {}
@@ -200,10 +248,25 @@ class BaseModule:
                 raise NotADirectoryError(f"The path '{path}' exists but is not a directory.")
 
             if not path.exists():
-                # Create the directory (and any parent directories)
                 path.mkdir(parents=True)
-            logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
-                          'this, prefer saving using json format using module.save("module.json").')
+
+            if safe:
+                program_state = {
+                    "module_class": f"{self.__class__.__module__}.{self.__class__.__qualname__}",
+                    "module_tree": self._collect_module_tree(),
+                    "state": self.dump_state(),
+                }
+                with open(path / "program.json", "wb") as f:
+                    f.write(orjson.dumps(program_state, option=orjson.OPT_INDENT_2 | orjson.OPT_APPEND_NEWLINE))
+                metadata["format"] = "safe_v1"
+                with open(path / "metadata.json", "wb") as f:
+                    f.write(orjson.dumps(metadata, option=orjson.OPT_INDENT_2 | orjson.OPT_APPEND_NEWLINE))
+                return
+
+            logger.warning(
+                "Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
+                'this, prefer saving using json format using module.save("module.json").'
+            )
             try:
                 modules_to_serialize = modules_to_serialize or []
                 for module in modules_to_serialize:
@@ -234,8 +297,10 @@ class BaseModule:
                     "with `.pkl`, or saving the whole program by setting `save_program=True`."
                 )
         elif path.suffix == ".pkl":
-            logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
-                          'this, prefer saving using json format using module.save("module.json").')
+            logger.warning(
+                "Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
+                'this, prefer saving using json format using module.save("module.json").'
+            )
             state = self.dump_state(json_mode=False)
             state["metadata"] = metadata
             with open(path, "wb") as f:
@@ -259,9 +324,11 @@ class BaseModule:
                 state = orjson.loads(f.read())
         elif path.suffix == ".pkl":
             if not allow_pickle:
-                raise ValueError("Loading .pkl files can run arbitrary code, which may be dangerous. Prefer "
-                                 "saving with .json files if possible. Set `allow_pickle=True` "
-                                 "if you are sure about the source of the file and in a trusted environment.")
+                raise ValueError(
+                    "Loading .pkl files can run arbitrary code, which may be dangerous. Prefer "
+                    "saving with .json files if possible. Set `allow_pickle=True` "
+                    "if you are sure about the source of the file and in a trusted environment."
+                )
             with open(path, "rb") as f:
                 state = cloudpickle.load(f)
         else:

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -141,6 +141,7 @@ class SignatureMeta(type(BaseModel)):
         if sys.version_info >= (3, 14):
             try:
                 import annotationlib
+
                 # Try to get from explicit __annotations__ first (e.g., from __future__ import annotations)
                 raw_annotations = namespace.get("__annotations__")
 
@@ -149,8 +150,7 @@ class SignatureMeta(type(BaseModel)):
                     annotate_func = annotationlib.get_annotate_from_class_namespace(namespace)
                     if annotate_func:
                         raw_annotations = annotationlib.call_annotate_function(
-                            annotate_func,
-                            format=annotationlib.Format.FORWARDREF
+                            annotate_func, format=annotationlib.Format.FORWARDREF
                         )
                     else:
                         raw_annotations = {}
@@ -484,26 +484,90 @@ class Signature(BaseModel, metaclass=SignatureMeta):
     @classmethod
     def dump_state(cls):
         state = {"instructions": cls.instructions, "fields": []}
-        for field in cls.fields:
+        for name, field in cls.fields.items():
             state["fields"].append(
                 {
-                    "prefix": cls.fields[field].json_schema_extra["prefix"],
-                    "description": cls.fields[field].json_schema_extra["desc"],
+                    "name": name,
+                    "field_type": field.json_schema_extra["__dspy_field_type"],
+                    "prefix": field.json_schema_extra["prefix"],
+                    "description": field.json_schema_extra["desc"],
+                    "type": _type_to_str(field.annotation),
                 }
             )
-
         return state
 
     @classmethod
     def load_state(cls, state):
-        signature_copy = Signature(deepcopy(cls.fields), cls.instructions)
+        fields = state.get("fields", [])
 
+        if fields and "name" in fields[0]:
+            saved_names = [f["name"] for f in fields]
+            current_names = list(cls.fields.keys())
+
+            if saved_names == current_names:
+                # Fields match the current signature: update prefix/desc in place
+                # so we preserve the original json_schema_extra key ordering.
+                signature_copy = Signature(deepcopy(cls.fields), cls.instructions)
+                signature_copy.instructions = state["instructions"]
+                for field_info, saved_field in zip(signature_copy.fields.values(), fields, strict=False):
+                    field_info.json_schema_extra["prefix"] = saved_field["prefix"]
+                    field_info.json_schema_extra["desc"] = saved_field["description"]
+                return signature_copy
+
+            # Fields differ (e.g. loading into a placeholder): reconstruct from
+            # scratch using the full structural info.  This is the path taken by
+            # safe (non-pickle) program loading.
+            field_dict = {}
+            for f in fields:
+                type_ = _str_to_type(f["type"]) if "type" in f else str
+                if f["field_type"] == "input":
+                    field_info = InputField()
+                else:
+                    field_info = OutputField()
+                field_info.json_schema_extra["prefix"] = f["prefix"]
+                field_info.json_schema_extra["desc"] = f["description"]
+                field_dict[f["name"]] = (type_, field_info)
+            return make_signature(field_dict, state["instructions"])
+
+        # Legacy format (no "name" key): update fields by position.
+        signature_copy = Signature(deepcopy(cls.fields), cls.instructions)
         signature_copy.instructions = state["instructions"]
-        for field, saved_field in zip(signature_copy.fields.values(), state["fields"], strict=False):
+        for field, saved_field in zip(signature_copy.fields.values(), fields, strict=False):
             field.json_schema_extra["prefix"] = saved_field["prefix"]
             field.json_schema_extra["desc"] = saved_field["description"]
-
         return signature_copy
+
+
+def _type_to_str(type_: type) -> str:
+    """Serialize a Python type annotation to a JSON-safe string."""
+    if type_ is type(None):
+        return "NoneType"
+
+    origin = typing.get_origin(type_)
+    args = typing.get_args(type_)
+
+    if origin is not None:
+        if origin is types.UnionType or origin is typing.Union:
+            args_str = ", ".join(_type_to_str(a) for a in args)
+            return f"Union[{args_str}]"
+        origin_name = getattr(origin, "__name__", str(origin))
+        if args:
+            args_str = ", ".join(_type_to_str(a) for a in args)
+            return f"{origin_name}[{args_str}]"
+        return origin_name
+
+    if hasattr(type_, "__name__"):
+        return type_.__name__
+
+    return str(type_)
+
+
+def _str_to_type(type_str: str) -> type:
+    """Deserialize a type string back to a Python type."""
+    if type_str == "NoneType":
+        return type(None)
+    node = ast.parse(type_str, mode="eval").body
+    return _parse_type_node(node)
 
 
 def ensure_signature(signature: str | type[Signature], instructions=None) -> type[Signature]:

--- a/dspy/utils/saving.py
+++ b/dspy/utils/saving.py
@@ -1,4 +1,7 @@
+import importlib
 import logging
+import random
+import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,21 +27,129 @@ def get_dependency_versions():
     }
 
 
-def load(path: str, allow_pickle: bool = False) -> "Module":
-    """Load saved DSPy model.
+def _import_class(class_path: str) -> type:
+    """Import a class given its fully qualified path (e.g. 'dspy.predict.predict.Predict')."""
+    module_path, class_name = class_path.rsplit(".", 1)
+    module = importlib.import_module(module_path)
+    return getattr(module, class_name)
 
-    This method is used to load a saved DSPy model with `save_program=True`, i.e., the model is saved with cloudpickle.
+
+def _init_predict_skeleton(obj):
+    """Set minimum viable attributes on a Predict created via ``object.__new__``.
+
+    These placeholders let ``load_state()`` run correctly. All values
+    are overwritten by ``load_state()`` except ``stage``, which is a
+    random identifier regenerated each time.
+    """
+    from dspy.signatures.signature import Signature
+
+    obj.stage = random.randbytes(8).hex()
+    obj.config = {}
+    obj.lm = None
+    obj.traces = []
+    obj.train = []
+    obj.demos = []
+    obj.signature = Signature("placeholder_input -> placeholder_output")
+
+
+_BRACKET_RE = re.compile(r"^(\w+)\[(\d+|'[^']*')\]$")
+
+
+def _set_by_path(obj, path: str, value):
+    """Set an attribute on *obj* using a dotted/bracketed path.
+
+    Supports paths like ``"cot.predict"``, ``"layers[0]"``, and
+    ``"layers[0].predict"``.
+    """
+    parts = path.split(".")
+    current = obj
+    for part in parts[:-1]:
+        current = _resolve_part(current, part)
+    _assign_part(current, parts[-1], value)
+
+
+def _resolve_part(obj, part: str):
+    m = _BRACKET_RE.match(part)
+    if m:
+        container = getattr(obj, m.group(1))
+        idx = m.group(2)
+        if idx.startswith("'"):
+            return container[idx.strip("'")]
+        return container[int(idx)]
+    return getattr(obj, part)
+
+
+def _assign_part(obj, part: str, value):
+    m = _BRACKET_RE.match(part)
+    if m:
+        container_name = m.group(1)
+        idx = m.group(2)
+        if not hasattr(obj, container_name):
+            # Create an empty list or dict depending on the index type.
+            if idx.startswith("'"):
+                setattr(obj, container_name, {})
+            else:
+                setattr(obj, container_name, [])
+        container = getattr(obj, container_name)
+        if isinstance(container, list):
+            idx_int = int(idx)
+            while len(container) <= idx_int:
+                container.append(None)
+            container[idx_int] = value
+        else:
+            container[idx.strip("'")] = value
+    else:
+        setattr(obj, part, value)
+
+
+def _reconstruct_module(program_data: dict) -> "Module":
+    """Reconstruct a module from safe-serialized program data.
+
+    This creates module instances via ``object.__new__`` (bypassing
+    ``__init__``), wires them into the saved tree structure, then calls
+    ``load_state()`` to restore all parameter values.
+    """
+    from dspy.predict.predict import Predict
+    from dspy.primitives.module import Module
+
+    # Create the top-level module.
+    top_class = _import_class(program_data["module_class"])
+    obj = object.__new__(top_class)
+    Module._base_init(obj)
+
+    if issubclass(top_class, Predict):
+        _init_predict_skeleton(obj)
+
+    # Recreate each sub-module in tree order (parents before children).
+    for entry in program_data["module_tree"]:
+        sub_class = _import_class(entry["class"])
+        sub_obj = object.__new__(sub_class)
+        Module._base_init(sub_obj)
+
+        if issubclass(sub_class, Predict):
+            _init_predict_skeleton(sub_obj)
+
+        _set_by_path(obj, entry["path"], sub_obj)
+
+    # Restore parameter state.
+    obj.load_state(program_data["state"])
+    return obj
+
+
+def load(path: str, allow_pickle: bool = False) -> "Module":
+    """Load a saved DSPy model.
+
+    When the saved directory uses the safe format (``save_program=True, safe=True``),
+    no pickle is involved and ``allow_pickle`` is not required.  For legacy
+    cloudpickle saves, ``allow_pickle=True`` must be passed explicitly.
 
     Args:
-        path (str): Path to the saved model.
-        allow_pickle (bool): Whether to allow loading the model with pickle. This is dangerous and should only be used if you are sure you trust the source of the model.
+        path: Path to the saved model directory.
+        allow_pickle: Whether to allow loading legacy cloudpickle models.
 
     Returns:
-        The loaded model, a `dspy.Module` instance.
+        The loaded model, a ``dspy.Module`` instance.
     """
-    if not allow_pickle:
-        raise ValueError("Loading with pickle is not allowed. Please set `allow_pickle=True` if you are sure you trust the source of the model.")
-
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"The path '{path}' does not exist.")
@@ -46,16 +157,31 @@ def load(path: str, allow_pickle: bool = False) -> "Module":
     with open(path / "metadata.json") as f:
         metadata = orjson.loads(f.read())
 
+    # Version mismatch warnings.
     dependency_versions = get_dependency_versions()
     saved_dependency_versions = metadata["dependency_versions"]
     for key, saved_version in saved_dependency_versions.items():
-        if dependency_versions[key] != saved_version:
+        current = dependency_versions.get(key)
+        if current is not None and current != saved_version:
             logger.warning(
                 f"There is a mismatch of {key} version between saved model and current environment. You saved with "
-                f"`{key}=={saved_version}`, but now you have `{key}=={dependency_versions[key]}`. This might cause "
+                f"`{key}=={saved_version}`, but now you have `{key}=={current}`. This might cause "
                 "errors or performance downgrade on the loaded model, please consider loading the model in the same "
                 "environment as the saving environment."
             )
+
+    # Safe JSON format: no pickle needed.
+    if metadata.get("format") == "safe_v1":
+        with open(path / "program.json") as f:
+            program_data = orjson.loads(f.read())
+        return _reconstruct_module(program_data)
+
+    # Legacy cloudpickle format.
+    if not allow_pickle:
+        raise ValueError(
+            "Loading with pickle is not allowed. Please set `allow_pickle=True` if you are sure "
+            "you trust the source of the model."
+        )
 
     with open(path / "program.pkl", "rb") as f:
         return cloudpickle.load(f)

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -214,12 +214,18 @@ def test_dump_and_load_state():
         "instructions": "I am just an instruction.",
         "fields": [
             {
+                "name": "sentence",
+                "field_type": "input",
                 "prefix": "Sentence:",
                 "description": "I am an innocent input!",
+                "type": "str",
             },
             {
+                "name": "sentiment",
+                "field_type": "output",
                 "prefix": "Sentiment:",
                 "description": "${sentiment}",
+                "type": "str",
             },
         ],
     }

--- a/tests/utils/test_safe_saving.py
+++ b/tests/utils/test_safe_saving.py
@@ -1,0 +1,370 @@
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import orjson
+import pytest
+
+import dspy
+from dspy.signatures.signature import _str_to_type, _type_to_str
+from dspy.utils.saving import get_dependency_versions
+
+# ---------------------------------------------------------------------------
+# Type serialization round-trips
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("type_", "expected_str"),
+    [
+        (str, "str"),
+        (int, "int"),
+        (float, "float"),
+        (bool, "bool"),
+        (list, "list"),
+        (dict, "dict"),
+        (type(None), "NoneType"),
+        (list[str], "list[str]"),
+        (dict[str, int], "dict[str, int]"),
+    ],
+)
+def test_type_round_trip(type_, expected_str):
+    serialized = _type_to_str(type_)
+    assert serialized == expected_str
+    assert _str_to_type(serialized) == type_
+
+
+# ---------------------------------------------------------------------------
+# Signature enhanced dump_state / load_state
+# ---------------------------------------------------------------------------
+
+
+def test_signature_dump_state_includes_field_metadata():
+    sig = dspy.Signature("question: str, context: list[str] -> answer: int")
+    state = sig.dump_state()
+
+    assert len(state["fields"]) == 3
+
+    q = state["fields"][0]
+    assert q["name"] == "question"
+    assert q["field_type"] == "input"
+    assert q["type"] == "str"
+
+    ctx = state["fields"][1]
+    assert ctx["name"] == "context"
+    assert ctx["field_type"] == "input"
+    assert ctx["type"] == "list[str]"
+
+    ans = state["fields"][2]
+    assert ans["name"] == "answer"
+    assert ans["field_type"] == "output"
+    assert ans["type"] == "int"
+
+
+def test_signature_load_state_reconstructs_from_scratch():
+    """When field names don't match, load_state rebuilds from the saved metadata."""
+    original = dspy.Signature("question, context -> answer")
+    state = original.dump_state()
+
+    # Use a totally different base signature.
+    placeholder = dspy.Signature("x -> y")
+    loaded = placeholder.load_state(state)
+
+    assert list(loaded.fields.keys()) == ["question", "context", "answer"]
+    assert list(loaded.input_fields.keys()) == ["question", "context"]
+    assert list(loaded.output_fields.keys()) == ["answer"]
+    assert loaded.instructions == original.instructions
+
+
+def test_signature_load_state_updates_in_place_when_fields_match():
+    """When field names match, load_state updates prefix/desc in place."""
+    sig = dspy.Signature("q -> a")
+    state = sig.dump_state()
+
+    # Modify the prefix in the saved state.
+    state["fields"][0]["prefix"] = "Custom Question:"
+
+    loaded = sig.load_state(state)
+    assert loaded.fields["q"].json_schema_extra["prefix"] == "Custom Question:"
+
+
+def test_signature_load_state_backward_compat_legacy_format():
+    """Legacy state without 'name' key still loads correctly."""
+    sig = dspy.Signature("q -> a")
+    legacy_state = {
+        "instructions": "Legacy instructions",
+        "fields": [
+            {"prefix": "Q:", "description": "the question"},
+            {"prefix": "A:", "description": "the answer"},
+        ],
+    }
+
+    loaded = sig.load_state(legacy_state)
+    assert loaded.instructions == "Legacy instructions"
+    assert loaded.fields["q"].json_schema_extra["prefix"] == "Q:"
+    assert loaded.fields["a"].json_schema_extra["desc"] == "the answer"
+
+
+# ---------------------------------------------------------------------------
+# Predict config in state
+# ---------------------------------------------------------------------------
+
+
+def test_predict_dump_state_includes_config():
+    predict = dspy.Predict("q -> a", temperature=0.7, max_tokens=100)
+    state = predict.dump_state()
+
+    assert "config" in state
+    assert state["config"] == {"temperature": 0.7, "max_tokens": 100}
+
+
+def test_predict_load_state_restores_config():
+    predict = dspy.Predict("q -> a", temperature=0.7)
+    state = predict.dump_state()
+
+    new_predict = dspy.Predict("q -> a")
+    assert new_predict.config == {}
+    new_predict.load_state(state)
+    assert new_predict.config == {"temperature": 0.7}
+
+
+def test_predict_load_state_backward_compat_no_config():
+    """State from older versions without 'config' keeps the existing config."""
+    predict = dspy.Predict("q -> a")
+    state = predict.dump_state()
+    del state["config"]
+
+    new_predict = dspy.Predict("q -> a", my_param=42)
+    new_predict.load_state(state)
+    assert new_predict.config == {"my_param": 42}
+
+
+# ---------------------------------------------------------------------------
+# Safe program save / load
+# ---------------------------------------------------------------------------
+
+
+def test_safe_save_creates_correct_files(tmp_path):
+    cot = dspy.ChainOfThought("question -> answer")
+    save_dir = tmp_path / "model"
+
+    cot.save(str(save_dir), save_program=True, safe=True)
+
+    assert (save_dir / "metadata.json").exists()
+    assert (save_dir / "program.json").exists()
+    assert not (save_dir / "program.pkl").exists()
+
+    metadata = orjson.loads((save_dir / "metadata.json").read_bytes())
+    assert metadata["format"] == "safe_v1"
+    assert "dependency_versions" in metadata
+
+
+def test_safe_save_program_json_structure(tmp_path):
+    cot = dspy.ChainOfThought("question -> answer")
+    save_dir = tmp_path / "model"
+
+    cot.save(str(save_dir), save_program=True, safe=True)
+
+    program = orjson.loads((save_dir / "program.json").read_bytes())
+
+    assert program["module_class"] == "dspy.predict.chain_of_thought.ChainOfThought"
+    assert len(program["module_tree"]) == 1
+    assert program["module_tree"][0]["path"] == "predict"
+    assert program["module_tree"][0]["class"] == "dspy.predict.predict.Predict"
+    assert "predict" in program["state"]
+
+
+def test_safe_round_trip_chain_of_thought(tmp_path):
+    cot = dspy.ChainOfThought("question -> answer")
+    cot.predict.signature = cot.predict.signature.with_instructions("You are a helpful assistant.")
+    cot.predict.demos = [
+        dspy.Example(question="What is 2+2?", answer="4", reasoning="Basic math").with_inputs("question"),
+    ]
+
+    save_dir = tmp_path / "model"
+    cot.save(str(save_dir), save_program=True, safe=True)
+
+    loaded = dspy.load(str(save_dir))
+
+    assert isinstance(loaded, dspy.ChainOfThought)
+    assert loaded.predict.signature.instructions == "You are a helpful assistant."
+    assert loaded.predict.signature.signature == cot.predict.signature.signature
+    assert list(loaded.predict.signature.fields.keys()) == list(cot.predict.signature.fields.keys())
+    assert len(loaded.predict.demos) == 1
+    assert loaded.predict.demos[0]["question"] == "What is 2+2?"
+
+
+def test_safe_round_trip_predict(tmp_path):
+    predict = dspy.Predict("question -> answer", temperature=0.5)
+    predict.demos = [
+        dspy.Example(question="Hi", answer="Hello").with_inputs("question"),
+    ]
+
+    save_dir = tmp_path / "model"
+    predict.save(str(save_dir), save_program=True, safe=True)
+
+    loaded = dspy.load(str(save_dir))
+
+    assert isinstance(loaded, dspy.Predict)
+    assert list(loaded.signature.fields.keys()) == ["question", "answer"]
+    assert loaded.config == {"temperature": 0.5}
+    assert len(loaded.demos) == 1
+
+
+def test_safe_round_trip_nested_custom_module(tmp_path):
+    # Create a custom module file so it can be imported by class path.
+    custom_module_path = tmp_path / "custom_module.py"
+    custom_module_path.write_text(
+        """\
+import dspy
+
+class InnerModule(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.predict = dspy.Predict("question -> answer")
+
+    def forward(self, question):
+        return self.predict(question=question)
+
+class OuterModule(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.inner = InnerModule()
+        self.summarize = dspy.Predict("text -> summary")
+
+    def forward(self, question, text):
+        answer = self.inner(question=question)
+        summary = self.summarize(text=text)
+        return answer, summary
+"""
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        import custom_module
+
+        module = custom_module.OuterModule()
+        module.inner.predict.demos = [
+            dspy.Example(question="Hi", answer="Hello").with_inputs("question"),
+        ]
+        module.summarize.demos = [
+            dspy.Example(text="Long text", summary="Short").with_inputs("text"),
+        ]
+
+        save_dir = tmp_path / "nested_model"
+        module.save(str(save_dir), save_program=True, safe=True)
+
+        loaded = dspy.load(str(save_dir))
+
+        assert isinstance(loaded, custom_module.OuterModule)
+        assert isinstance(loaded.inner, custom_module.InnerModule)
+        assert isinstance(loaded.inner.predict, dspy.Predict)
+        assert isinstance(loaded.summarize, dspy.Predict)
+        assert list(loaded.inner.predict.signature.fields.keys()) == ["question", "answer"]
+        assert list(loaded.summarize.signature.fields.keys()) == ["text", "summary"]
+        assert len(loaded.inner.predict.demos) == 1
+        assert loaded.inner.predict.demos[0]["question"] == "Hi"
+        assert len(loaded.summarize.demos) == 1
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("custom_module", None)
+
+
+def test_safe_load_does_not_require_allow_pickle(tmp_path):
+    """Safe format loads without allow_pickle=True."""
+    predict = dspy.Predict("q -> a")
+    save_dir = tmp_path / "model"
+    predict.save(str(save_dir), save_program=True, safe=True)
+
+    loaded = dspy.load(str(save_dir))
+    assert isinstance(loaded, dspy.Predict)
+
+
+def test_legacy_load_still_requires_allow_pickle(tmp_path):
+    """Legacy cloudpickle format still requires allow_pickle=True."""
+    predict = dspy.Predict("q -> a")
+    save_dir = tmp_path / "legacy_model"
+    predict.save(str(save_dir), save_program=True)
+
+    with pytest.raises(ValueError, match="allow_pickle"):
+        dspy.load(str(save_dir))
+
+    loaded = dspy.load(str(save_dir), allow_pickle=True)
+    assert isinstance(loaded, dspy.Predict)
+
+
+def test_safe_load_version_mismatch_warning(tmp_path):
+    import logging
+
+    from dspy.utils.saving import logger as saving_logger
+
+    predict = dspy.Predict("q -> a")
+    save_dir = tmp_path / "model"
+    predict.save(str(save_dir), save_program=True, safe=True)
+
+    class ListHandler(logging.Handler):
+        def __init__(self):
+            super().__init__()
+            self.messages = []
+
+        def emit(self, record):
+            self.messages.append(record.getMessage())
+
+    handler = ListHandler()
+    original_level = saving_logger.level
+    saving_logger.addHandler(handler)
+    saving_logger.setLevel(logging.WARNING)
+
+    try:
+        mismatch_versions = {"python": "3.9", "dspy": "2.4.0", "cloudpickle": "2.0"}
+        with patch("dspy.utils.saving.get_dependency_versions", return_value=mismatch_versions):
+            loaded = dspy.load(str(save_dir))
+
+        assert isinstance(loaded, dspy.Predict)
+        # Should have logged warnings for version mismatches.
+        assert len(handler.messages) >= 1
+        assert any("mismatch" in msg for msg in handler.messages)
+    finally:
+        saving_logger.setLevel(original_level)
+        saving_logger.removeHandler(handler)
+
+
+def test_safe_save_rejects_non_directory_path(tmp_path):
+    predict = dspy.Predict("q -> a")
+
+    with pytest.raises(ValueError, match="directory"):
+        predict.save(str(tmp_path / "model.json"), save_program=True, safe=True)
+
+
+def test_module_tree_collection():
+    cot = dspy.ChainOfThought("q -> a")
+    tree = cot._collect_module_tree()
+
+    assert len(tree) == 1
+    assert tree[0]["path"] == "predict"
+    assert tree[0]["class"] == "dspy.predict.predict.Predict"
+
+
+def test_safe_load_missing_class_raises():
+    """If the saved class is not importable, safe load raises ImportError."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        save_dir = Path(tmpdir) / "model"
+        save_dir.mkdir()
+
+        metadata = {
+            "format": "safe_v1",
+            "dependency_versions": get_dependency_versions(),
+        }
+        (save_dir / "metadata.json").write_bytes(orjson.dumps(metadata, option=orjson.OPT_INDENT_2))
+
+        program = {
+            "module_class": "nonexistent.module.FakeClass",
+            "module_tree": [],
+            "state": {},
+        }
+        (save_dir / "program.json").write_bytes(orjson.dumps(program, option=orjson.OPT_INDENT_2))
+
+        with pytest.raises(ModuleNotFoundError):
+            dspy.load(str(save_dir))


### PR DESCRIPTION
Closes #9164

## What changes are proposed

This PR adds a JSON-based save/load path that avoids cloudpickle entirely, addressing CVE concerns with untrusted `.pkl` files. Users can now save and load DSPy programs without any pickle involvement:

```python
# Save
module.save("my_model", save_program=True, safe=True)

# Load (no allow_pickle needed)
loaded = dspy.load("my_model")
```

The safe format stores:
- `metadata.json` with `"format": "safe_v1"` for auto-detection
- `program.json` with the module class, sub-module tree, and full state

On load, modules are reconstructed via `object.__new__()` + `_base_init()` + `load_state()`, following the same pattern as PyTorch's `state_dict`.

### Key changes

**Signature serialization** (`dspy/signatures/signature.py`):
- `dump_state()` now emits field metadata: `name`, `field_type` (input/output), and `type` (serialized Python type annotation)
- `load_state()` has three paths: (1) update in-place when field names match, (2) reconstruct from scratch when fields differ (safe load path), (3) legacy format backward compat
- Added `_type_to_str()` / `_str_to_type()` for round-tripping Python type annotations through JSON

**Predict config** (`dspy/predict/predict.py`):
- `dump_state()` now includes `config` (temperature, max_tokens, etc.)
- `load_state()` restores config with backward compat for older state dicts

**Module tree** (`dspy/primitives/base_module.py`):
- Added `_collect_module_tree()` that walks `__dict__` recursively to record sub-module paths and classes (handles attributes, lists, dicts)
- Added `safe=True` parameter to `save()` which writes `program.json` + `metadata.json` instead of `program.pkl`

**Safe loading** (`dspy/utils/saving.py`):
- `dspy.load()` auto-detects `safe_v1` format from metadata and loads without requiring `allow_pickle`
- `_reconstruct_module()` creates modules via `object.__new__()`, wires the sub-module tree, then calls `load_state()`
- Handles bracketed paths like `layers[0].predict` and `modules['key']`
- Legacy cloudpickle format continues to work unchanged

### Backward compatibility

- Existing `save_program=True` (without `safe=True`) behavior is unchanged
- `load_state()` handles both new enhanced format and legacy format transparently
- `dspy.load()` auto-detects format; legacy `.pkl` models still work with `allow_pickle=True`

## How is this PR tested

27 new tests in `tests/utils/test_safe_saving.py`:
- Type serialization round-trips (str, int, list[str], dict[str, int], etc.)
- Signature dump/load with field metadata (in-place update, reconstruction from scratch, legacy compat)
- Predict config serialization and backward compat
- Safe save file structure validation
- Full round-trip for ChainOfThought, Predict, and nested custom modules
- Version mismatch warnings
- Error cases (missing class, non-directory path)

All 41 existing signature tests pass. All 13 relevant base_module tests pass.