### PR TITLE
fix: dspy.Parallel breaks streaming with RuntimeError from non-AnyIO worker threads

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -338,8 +338,28 @@ def _get_stream_completion_fn(
         return litellm.stream_chunk_builder(chunks)
 
     def sync_stream_completion():
-        syncified_stream_completion = syncify(stream_completion)
-        return syncified_stream_completion(request, cache_kwargs)
+        try:
+            syncified_stream_completion = syncify(stream_completion)
+            return syncified_stream_completion(request, cache_kwargs)
+        except RuntimeError:
+            # Not in an AnyIO worker thread (e.g. dspy.Parallel's ThreadPoolExecutor).
+            # Fall back to litellm's synchronous streaming API and forward chunks
+            # via sync_send_to_stream which is safe to call from any thread.
+            from dspy.streaming.messages import sync_send_to_stream
+
+            response = litellm.completion(
+                cache=cache_kwargs,
+                stream=True,
+                headers=headers,
+                **request,
+            )
+            chunks = []
+            for chunk in response:
+                if caller_predict_id:
+                    chunk.predict_id = caller_predict_id
+                chunks.append(chunk)
+                sync_send_to_stream(stream, chunk)
+            return litellm.stream_chunk_builder(chunks)
 
     async def async_stream_completion():
         return await stream_completion(request, cache_kwargs)

--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -1,9 +1,7 @@
 import asyncio
-import concurrent.futures
+import threading
 from dataclasses import dataclass
 from typing import Any
-
-from asyncer import syncify
 
 from dspy.dsp.utils.settings import settings
 from dspy.utils.callback import BaseCallback
@@ -24,30 +22,50 @@ class StatusMessage:
     message: str
 
 
+# Module-level cache of the event loop that owns the stream consumer.
+# Set by streamify() so that background threads (e.g. dspy.Parallel) can
+# safely schedule items onto the correct loop.
+_consumer_loop: asyncio.AbstractEventLoop | None = None
+_consumer_loop_lock = threading.Lock()
+
+
+def _set_consumer_loop(loop: asyncio.AbstractEventLoop):
+    global _consumer_loop
+    with _consumer_loop_lock:
+        _consumer_loop = loop
+
+
 def sync_send_to_stream(stream, message):
-    """Send message to stream in a sync context, regardless of event loop state."""
-
-    async def _send():
-        await stream.send(message)
-
+    """Send a message to an anyio MemoryObjectSendStream from any thread."""
     try:
         asyncio.get_running_loop()
-
-        # If we're in an event loop, offload to a new thread with its own event loop
-        def run_in_new_loop():
-            new_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(new_loop)
-            try:
-                return new_loop.run_until_complete(_send())
-            finally:
-                new_loop.close()
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            future = executor.submit(run_in_new_loop)
-            return future.result()
+        # Inside a running event loop — send_nowait is safe here.
+        stream.send_nowait(message)
     except RuntimeError:
-        # Not in an event loop, safe to use a new event loop in this thread
-        return syncify(_send)()
+        # No running event loop (e.g. dspy.Parallel's ThreadPoolExecutor).
+        # Use call_soon_threadsafe to schedule the send on the consumer's loop.
+        with _consumer_loop_lock:
+            loop = _consumer_loop
+
+        if loop is None:
+            stream.send_nowait(message)
+            return
+
+        done = threading.Event()
+        exc_holder = []
+
+        def _do_send():
+            try:
+                stream.send_nowait(message)
+            except Exception as e:
+                exc_holder.append(e)
+            finally:
+                done.set()
+
+        loop.call_soon_threadsafe(_do_send)
+        done.wait()
+        if exc_holder:
+            raise exc_holder[0]
 
 
 class StatusMessageProvider:

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -14,7 +14,7 @@ from litellm import ModelResponseStream
 
 from dspy.dsp.utils.settings import settings
 from dspy.primitives.prediction import Prediction
-from dspy.streaming.messages import StatusMessage, StatusMessageProvider, StatusStreamingCallback
+from dspy.streaming.messages import StatusMessage, StatusMessageProvider, StatusStreamingCallback, _set_consumer_loop
 from dspy.streaming.streaming_listener import StreamListener, find_predictor_for_stream_listeners
 from dspy.utils.asyncify import asyncify
 
@@ -173,6 +173,7 @@ def streamify(
         await stream.send(prediction)
 
     async def async_streamer(*args, **kwargs):
+        _set_consumer_loop(asyncio.get_running_loop())
         send_stream, receive_stream = create_memory_object_stream(16)
         async with create_task_group() as tg, send_stream, receive_stream:
             tg.start_soon(generator, args, kwargs, send_stream)


### PR DESCRIPTION
## Problem

I was building a module that runs multiple LM calls in parallel using dspy.Parallel and streams results back to the user via dspy.streamify. Every parallel call crashed with:

`
RuntimeError: This function can only be run from an AnyIO worker thread
`

The single-call (sequential) version worked fine  only the Parallel path broke.

## Root Cause

dspy.Parallel dispatches work to a standard ThreadPoolExecutor. The streaming infrastructure (both sync_send_to_stream in messages.py and sync_stream_completion in lm.py) relied on syncer.syncify() which internally calls nyio.from_thread.run()  but that only works from AnyIO-managed worker threads, not from plain TPE threads.

Two crash sites:

1. **dspy/streaming/messages.py  sync_send_to_stream()**: The StatusStreamingCallback sends status messages from TPE threads via syncify()  crash.
2. **dspy/clients/lm.py  sync_stream_completion()**: The LM streaming path calls syncify(stream_completion) from TPE threads  crash.

## Fix

**messages.py**: Replaced the syncify-based approach with send_nowait() + call_soon_threadsafe(). When called from a thread without a running event loop (the TPE case), we schedule the send_nowait on the consumer's event loop via call_soon_threadsafe, which is the standard thread-safe way to poke an asyncio loop from another thread. The consumer loop reference is cached when streamify() starts.

**lm.py**: Wrapped the existing syncify() call in a try/except. On RuntimeError, falls back to litellm's synchronous completion(stream=True) API and forwards chunks via the fixed sync_send_to_stream.

**streamify.py**: One-line addition to cache the running event loop so background threads can find it.

## Testing

- All 7 existing 	ests/predict/test_parallel.py tests pass
- Verified end-to-end with a real LLM (Gemini via Vertex AI)  Parallel + streamify completes without errors

Closes #9154