### PR TITLE
fix(settings): add allow_pickle flag to settings loading

### DIFF
--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -226,16 +226,24 @@ class Settings:
             )
 
     @classmethod
-    def load(cls, path: str) -> dict[str, Any]:
+    def load(cls, path: str, allow_pickle: bool = False) -> dict[str, Any]:
         """
         Load the settings from a file using cloudpickle.
 
         Args:
             path: The file path to load the settings from.
+            allow_pickle: Whether to allow loading with pickle. Loading untrusted .pkl files
+                can run arbitrary code. Set to True only if you trust the source of the file.
 
         Returns:
             A dict that stores the loaded settings.
         """
+        if not allow_pickle:
+            raise ValueError(
+                "Loading .pkl files can run arbitrary code, which may be dangerous. "
+                "Set `allow_pickle=True` if you trust the source of the file."
+            )
+
         with open(path, "rb") as f:
             configs = cloudpickle.load(f)
 

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -200,7 +200,7 @@ def test_dspy_settings_save_load(tmp_path):
     dspy.settings.save(tmp_path / "settings.pkl")
     dspy.configure(lm=None, adapter=None, callbacks=None)
 
-    loaded_settings = dspy.load_settings(tmp_path / "settings.pkl")
+    loaded_settings = dspy.load_settings(tmp_path / "settings.pkl", allow_pickle=True)
     dspy.configure(**loaded_settings)
     assert dspy.settings.lm.model == "openai/gpt-4o"
     assert isinstance(dspy.settings.adapter, dspy.JSONAdapter)
@@ -213,7 +213,7 @@ def test_dspy_settings_save_exclude_keys(tmp_path):
     dspy.settings.save(tmp_path / "settings.pkl", exclude_keys=["adapter", "track_usage"])
     dspy.configure(lm=None, adapter=None, track_usage=False)
 
-    loaded_settings = dspy.load_settings(tmp_path / "settings.pkl")
+    loaded_settings = dspy.load_settings(tmp_path / "settings.pkl", allow_pickle=True)
     dspy.configure(**loaded_settings)
     assert dspy.settings.lm.model == "openai/gpt-4o"
     assert dspy.settings.adapter is None
@@ -253,7 +253,7 @@ def callback(x):
         dspy.configure(callbacks=None)
 
         # Loading should now succeed and preserve the adapter instance
-        loaded_settings = dspy.load_settings(settings_path)
+        loaded_settings = dspy.load_settings(settings_path, allow_pickle=True)
         dspy.settings.configure(**loaded_settings)
 
         assert dspy.settings.callbacks[0](3) == 4


### PR DESCRIPTION
Settings.load() previously deserialized pickle files without any warning or confirmation. Since pickle deserialization can execute arbitrary code, this is a security risk with untrusted files.

This PR adds a required allow_pickle=True flag to Settings.load() settings.py:229. Without it, the call raises a ValueError:

```python
# Before
dspy.load_settings("file.pkl")
# After — raises ValueError
dspy.load_settings("file.pkl")
# After — works
dspy.load_settings(
    "file.pkl",
    allow_pickle=True
)
```