### PR TITLE
feat(evaluate): add async evaluation method to Evaluate class

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -1,7 +1,11 @@
+import asyncio
 import csv
 import importlib
+import inspect
 import json
 import logging
+import sys
+import traceback
 import types
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -146,16 +150,16 @@ class Evaluate:
 
             - results: a list of (example, prediction, score) tuples for each example in devset
         """
-        metric = metric if metric is not None else self.metric
-        devset = devset if devset is not None else self.devset
-        num_threads = num_threads if num_threads is not None else self.num_threads
-        display_progress = display_progress if display_progress is not None else self.display_progress
-        display_table = display_table if display_table is not None else self.display_table
-        save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
-        save_as_json = save_as_json if save_as_json is not None else self.save_as_json
-
-        if callback_metadata:
-            logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
+        metric, devset, num_threads, display_progress, display_table, save_as_csv, save_as_json = self._resolve_runtime_args(
+            metric=metric,
+            devset=devset,
+            num_threads=num_threads,
+            display_progress=display_progress,
+            display_table=display_table,
+            save_as_csv=save_as_csv,
+            save_as_json=save_as_json,
+            callback_metadata=callback_metadata,
+        )
 
         tqdm.tqdm._instances.clear()
 
@@ -172,58 +176,244 @@ class Evaluate:
             score = metric(example, prediction)
             return prediction, score
 
-        results = executor.execute(process_item, devset)
-        assert len(devset) == len(results)
+        raw_results = executor.execute(process_item, devset)
+        return self._finalize_results(
+            raw_results=raw_results,
+            devset=devset,
+            metric=metric,
+            display_table=display_table,
+            save_as_csv=save_as_csv,
+            save_as_json=save_as_json,
+        )
 
-        results = [((dspy.Prediction(), self.failure_score) if r is None else r) for r in results]
-        results = [(example, prediction, score) for example, (prediction, score) in zip(devset, results, strict=False)]
+    @with_callbacks
+    async def acall(
+        self,
+        program: "dspy.Module",
+        metric: Callable | None = None,
+        devset: list["dspy.Example"] | None = None,
+        num_threads: int | None = None,
+        display_progress: bool | None = None,
+        display_table: bool | int | None = None,
+        callback_metadata: dict[str, Any] | None = None,
+        save_as_csv: str | None = None,
+        save_as_json: str | None = None,
+    ) -> EvaluationResult:
+        """Async version of __call__. Runs evaluation with native asyncio concurrency.
+
+        Programs that define ``aforward`` are awaited directly. Sync-only programs are
+        automatically wrapped via ``dspy.asyncify`` to run in a thread pool.
+
+        Args and return value match ``__call__``.
+        """
+        metric, devset, num_threads, display_progress, display_table, save_as_csv, save_as_json = self._resolve_runtime_args(
+            metric=metric,
+            devset=devset,
+            num_threads=num_threads,
+            display_progress=display_progress,
+            display_table=display_table,
+            save_as_csv=save_as_csv,
+            save_as_json=save_as_json,
+            callback_metadata=callback_metadata,
+        )
+
+        tqdm.tqdm._instances.clear()
+        effective_num_threads = num_threads or dspy.settings.num_threads
+        effective_max_errors = self.max_errors if self.max_errors is not None else dspy.settings.max_errors
+
+        with dspy.context(async_max_workers=effective_num_threads):
+            raw_results = await self._execute_async(
+                program=program,
+                metric=metric,
+                data=devset,
+                num_threads=effective_num_threads,
+                disable_progress_bar=not display_progress,
+                max_errors=effective_max_errors,
+                provide_traceback=self.provide_traceback,
+            )
+
+        return self._finalize_results(
+            raw_results=raw_results,
+            devset=devset,
+            metric=metric,
+            display_table=display_table,
+            save_as_csv=save_as_csv,
+            save_as_json=save_as_json,
+        )
+
+    def _resolve_runtime_args(
+        self,
+        *,
+        metric: Callable | None,
+        devset: list["dspy.Example"] | None,
+        num_threads: int | None,
+        display_progress: bool | None,
+        display_table: bool | int | None,
+        save_as_csv: str | None,
+        save_as_json: str | None,
+        callback_metadata: dict[str, Any] | None,
+    ) -> tuple[Callable, list["dspy.Example"], int | None, bool, bool | int, str | None, str | None]:
+        metric = metric if metric is not None else self.metric
+        devset = devset if devset is not None else self.devset
+        num_threads = num_threads if num_threads is not None else self.num_threads
+        display_progress = display_progress if display_progress is not None else self.display_progress
+        display_table = display_table if display_table is not None else self.display_table
+        save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
+        save_as_json = save_as_json if save_as_json is not None else self.save_as_json
+
+        if callback_metadata:
+            logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
+
+        return metric, devset, num_threads, display_progress, display_table, save_as_csv, save_as_json
+
+    @staticmethod
+    def _metric_name(metric: Callable) -> str:
+        return metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
+
+    def _finalize_results(
+        self,
+        *,
+        raw_results: list[Any],
+        devset: list["dspy.Example"],
+        metric: Callable,
+        display_table: bool | int,
+        save_as_csv: str | None,
+        save_as_json: str | None,
+    ) -> EvaluationResult:
+        assert len(devset) == len(raw_results)
+        raw_results = [((dspy.Prediction(), self.failure_score) if r is None else r) for r in raw_results]
+        results = [(example, prediction, score) for example, (prediction, score) in zip(devset, raw_results, strict=False)]
         ncorrect, ntotal = sum(score for *_, score in results), len(devset)
 
         logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
 
         if display_table:
             if importlib.util.find_spec("pandas") is not None:
-                # Rename the 'correct' column to the name of the metric object
-                metric_name = metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
-                # Construct a pandas DataFrame from the results
+                metric_name = self._metric_name(metric)
                 result_df = self._construct_result_table(results, metric_name)
-
                 self._display_result_table(result_df, display_table, metric_name)
             else:
                 logger.warning("Skipping table display since `pandas` is not installed.")
 
         if save_as_csv:
-            metric_name = (
-                metric.__name__
-                if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__
-            )
+            metric_name = self._metric_name(metric)
             data = self._prepare_results_output(results, metric_name)
-
             with open(save_as_csv, "w", newline="") as csvfile:
                 fieldnames = data[0].keys()
                 writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-
                 writer.writeheader()
                 for row in data:
                     writer.writerow(row)
         if save_as_json:
-            metric_name = (
-                metric.__name__
-                if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__
-            )
+            metric_name = self._metric_name(metric)
             data = self._prepare_results_output(results, metric_name)
-            with open(
-                    save_as_json,
-                    "w",
-            ) as f:
+            with open(save_as_json, "w") as f:
                 json.dump(data, f)
 
-        return EvaluationResult(
-            score=round(100 * ncorrect / ntotal, 2),
-            results=results,
+        return EvaluationResult(score=round(100 * ncorrect / ntotal, 2), results=results)
+
+    @staticmethod
+    def _is_async_callable(fn: Any) -> bool:
+        return inspect.iscoroutinefunction(fn) or inspect.iscoroutinefunction(getattr(fn, "__call__", None))
+
+    async def _invoke_program_async(self, program: Any, inputs: dict[str, Any]) -> Any:
+        if hasattr(program, "aforward"):
+            return await program.acall(**inputs)
+
+        if self._is_async_callable(program):
+            return await program(**inputs)
+
+        return await dspy.asyncify(program)(**inputs)
+
+    async def _invoke_metric_async(self, metric: Callable, example: Any, prediction: Any) -> Any:
+        if self._is_async_callable(metric):
+            return await metric(example, prediction)
+
+        return metric(example, prediction)
+
+    @staticmethod
+    def _update_progress_bar(pbar, results):
+        vals = [r[-1] for r in results if r is not None]
+        nresults = sum(vals)
+        metric_denominator = len(vals)
+        pct = round(100 * nresults / metric_denominator, 1) if metric_denominator else 0
+        pbar.set_description(f"Average Metric: {nresults:.2f} / {metric_denominator} ({pct}%)")
+        pbar.update()
+
+    async def _execute_async(
+        self,
+        *,
+        program: Any,
+        metric: Callable,
+        data: list[Any],
+        num_threads: int,
+        disable_progress_bar: bool,
+        max_errors: int,
+        provide_traceback: bool | None,
+    ) -> list[Any]:
+        results: list[Any] = [None] * len(data)
+        error_count = 0
+        cancel_jobs = asyncio.Event()
+        semaphore = asyncio.Semaphore(num_threads)
+
+        pbar = tqdm.tqdm(
+            total=len(data),
+            dynamic_ncols=True,
+            disable=disable_progress_bar,
+            file=sys.stdout,
         )
+
+        async def process_item(index: int, example: Any):
+            nonlocal error_count
+
+            if cancel_jobs.is_set():
+                return index, None
+
+            async with semaphore:
+                if cancel_jobs.is_set():
+                    return index, None
+
+                try:
+                    prediction = await self._invoke_program_async(program, example.inputs())
+                    score = await self._invoke_metric_async(metric, example, prediction)
+                    return index, (prediction, score)
+                except Exception as e:
+                    error_count += 1
+                    if error_count >= max_errors:
+                        cancel_jobs.set()
+                    if provide_traceback:
+                        logger.error(f"Error for {example}: {e}\n{traceback.format_exc()}")
+                    else:
+                        logger.error(f"Error for {example}: {e}. Set `provide_traceback=True` for traceback.")
+                    return index, None
+
+        tasks = [asyncio.create_task(process_item(index, item)) for index, item in enumerate(data)]
+        try:
+            for completed_task in asyncio.as_completed(tasks):
+                try:
+                    index, outcome = await completed_task
+                except asyncio.CancelledError:
+                    continue
+
+                if outcome is not None and results[index] is None:
+                    results[index] = outcome
+
+                self._update_progress_bar(pbar, results)
+
+                if cancel_jobs.is_set():
+                    for task in tasks:
+                        if not task.done():
+                            task.cancel()
+
+            await asyncio.gather(*tasks, return_exceptions=True)
+        finally:
+            pbar.close()
+
+        if cancel_jobs.is_set():
+            logger.warning("Execution cancelled due to errors or interruption.")
+            raise RuntimeError("Execution cancelled due to errors or interruption.")
+
+        return results
 
     @staticmethod
     def _prepare_results_output(

--- a/tests/evaluate/test_evaluate_async.py
+++ b/tests/evaluate/test_evaluate_async.py
@@ -1,0 +1,117 @@
+import asyncio
+
+import pytest
+
+import dspy
+from dspy.evaluate.evaluate import Evaluate
+from dspy.evaluate.metrics import answer_exact_match
+from dspy.predict import Predict
+from dspy.utils.dummies import DummyLM
+
+
+def new_example(question: str, answer: str):
+    return dspy.Example(question=question, answer=answer).with_inputs("question")
+
+
+class AsyncPredictProgram(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.predict = Predict("question -> answer")
+
+    async def aforward(self, question: str):
+        return await self.predict.acall(question=question)
+
+
+class SyncOnlyProgram(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.predict = Predict("question -> answer")
+
+    def forward(self, question: str):
+        return self.predict(question=question)
+
+
+class FlakyAsyncProgram(dspy.Module):
+    async def aforward(self, question: str):
+        if question == "boom":
+            raise ValueError("boom")
+        return dspy.Prediction(answer="ok")
+
+
+@pytest.mark.anyio
+async def test_evaluate_acall_async_program_sync_metric():
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    evaluator = Evaluate(devset=devset, metric=answer_exact_match, num_threads=2, display_progress=False)
+    with dspy.context(lm=DummyLM({"What is 1+1?": {"answer": "2"}, "What is 2+2?": {"answer": "4"}})):
+        result = await evaluator.acall(AsyncPredictProgram())
+
+    assert result.score == 100.0
+
+
+@pytest.mark.anyio
+async def test_evaluate_acall_sync_program_async_metric():
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    program = Predict("question -> answer")
+
+    async def async_metric(example, pred):
+        await asyncio.sleep(0)
+        return answer_exact_match(example, pred)
+
+    evaluator = Evaluate(devset=devset, metric=async_metric, num_threads=2, display_progress=False)
+    with dspy.context(lm=DummyLM({"What is 1+1?": {"answer": "2"}, "What is 2+2?": {"answer": "4"}})):
+        result = await evaluator.acall(program)
+
+    assert result.score == 100.0
+
+
+@pytest.mark.anyio
+async def test_evaluate_acall_uses_failure_score_on_exceptions():
+    devset = [new_example("ok", "ok"), new_example("boom", "ok")]
+
+    def metric(example, pred):
+        return float(example.answer == pred.answer)
+
+    evaluator = Evaluate(
+        devset=devset,
+        metric=metric,
+        num_threads=2,
+        display_progress=False,
+        failure_score=0.25,
+        max_errors=10,
+    )
+
+    result = await evaluator.acall(FlakyAsyncProgram())
+
+    assert [row[2] for row in result.results] == [1.0, 0.25]
+    assert result.score == 62.5
+
+
+@pytest.mark.anyio
+async def test_evaluate_acall_sync_only_program():
+    """Sync-only programs (no aforward) are automatically wrapped via asyncify."""
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    evaluator = Evaluate(devset=devset, metric=answer_exact_match, num_threads=2, display_progress=False)
+    with dspy.context(lm=DummyLM({"What is 1+1?": {"answer": "2"}, "What is 2+2?": {"answer": "4"}})):
+        result = await evaluator.acall(SyncOnlyProgram())
+
+    assert result.score == 100.0
+
+
+@pytest.mark.anyio
+async def test_evaluate_acall_max_errors_raises():
+    """When max_errors is exceeded, acall raises RuntimeError."""
+    devset = [new_example("boom", "ok")] * 3
+
+    def metric(example, pred):
+        return 0.0
+
+    evaluator = Evaluate(
+        devset=devset,
+        metric=metric,
+        num_threads=1,
+        display_progress=False,
+        max_errors=2,
+    )
+
+    with pytest.raises(RuntimeError, match="Execution cancelled"):
+        await evaluator.acall(FlakyAsyncProgram())


### PR DESCRIPTION
Adds Evaluate.acall() for running evaluation with native asyncio concurrency instead of threads.

Started by @chenmoneygithub in #8504


## When async is faster:

With real LLM calls the bottleneck is the provider, so sync and async perform similarly (as noted in #8504). Async wins when client-side overhead matters -- high concurrency with many lightweight IO-bound tasks:

```python
import asyncio, time, dspy

class SimulatedIOProgram(dspy.Module):
    def forward(self, question: str):
        time.sleep(0.05)  # blocks an OS thread
        return dspy.Prediction(answer=question)

   async def aforward(self, question: str):
       await asyncio.sleep(0.05)  # non-blocking
       return dspy.Prediction(answer=question)

devset = [dspy.Example(question=f"q{i}", answer=f"q{i}").with_inputs("question") for i in range(500)]
metric = lambda ex, pred: 1.0 if pred.answer == ex.answer else 0.0
evaluator = dspy.Evaluate(devset=devset, metric=metric, num_threads=500, display_table=False, display_progress=True)
program = SimulatedIOProgram()

start = time.time()
evaluator(program, metric=metric)
print(f"[SYNC]  {time.time() - start:.2f}s")  # ~0.35s (500 OS threads)

async def run():
   return await evaluator.acall(program, metric=metric)

start = time.time()
asyncio.run(run())
print(f"[ASYNC] {time.time() - start:.2f}s")  # ~0.07s (500 coroutines, 1 thread)
# Async is ~5x faster
```