### PR TITLE
feat(interpreter): Add Pydantic type coercion

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -20,7 +20,7 @@ import pydantic
 
 import dspy
 from dspy.adapters.types.tool import Tool
-from dspy.adapters.utils import parse_value, translate_field_type
+from dspy.adapters.utils import _get_json_schema, parse_value, translate_field_type
 from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeInterpreter, CodeInterpreterError, FinalOutput
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
@@ -208,17 +208,27 @@ class RLM(Module):
 
         lines = ["\nAdditional tools available (use these instead of standard library equivalents):"]
         for tool in tools.values():
-            # Build signature string from Tool's args
             params = []
             for arg_name, arg_schema in (tool.args or {}).items():
-                arg_type = arg_schema.get("type", "Any")
+                # Use the pydantic model title when available (e.g. "Profile" not "object")
+                title = arg_schema.get("title")
+                if title and arg_schema.get("type") == "object":
+                    arg_type = title
+                else:
+                    arg_type = arg_schema.get("type", "Any")
                 params.append(f"{arg_name}: {arg_type}")
             params_str = ", ".join(params)
             sig_str = f"{tool.name}({params_str})"
 
-            # Get description with newlines escaped
             desc = (tool.desc or "No description").replace("\n", "  ")
             lines.append(f"- `{sig_str}` - {desc}")
+
+            # Show field details for object-typed params (pydantic models)
+            for arg_name, arg_schema in (tool.args or {}).items():
+                props = arg_schema.get("properties")
+                if props:
+                    brief = ", ".join(f"{n}: {s.get('type', 'any')}" for n, s in props.items())
+                    lines.append(f"  `{arg_name}` fields: {{{brief}}}")
 
         return "\n".join(lines)
 
@@ -344,10 +354,18 @@ class RLM(Module):
         for name, field in self.signature.output_fields.items():
             annotation = getattr(field, "annotation", str)
             field_info = {"name": name}
-            # Only include type for simple types that work in function signatures
-            # Complex types like Literal, Union, etc. are not included
             if annotation in SIMPLE_TYPES:
                 field_info["type"] = annotation.__name__
+            else:
+                if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+                    field_info["model_type"] = annotation.__name__
+                try:
+                    field_info["json_schema"] = _get_json_schema(annotation)
+                except pydantic.PydanticSchemaGenerationError:
+                    logger.debug(
+                        "Skipping JSON schema for output field '%s' with annotation %r",
+                        name, annotation, exc_info=True,
+                    )
             fields.append(field_info)
         return fields
 

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -514,22 +514,19 @@ class PythonInterpreter:
                 err_output = self.deno_process.stderr.read()
                 raise CodeInterpreterError(f"No output from Deno subprocess. Stderr: {err_output}")
 
-            # Skip non-JSON lines (e.g., Pyodide package loading messages)
-            if not output_line.startswith("{"):
-                skipped += 1
-                if skipped > self._MAX_SKIP_LINES:
-                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) during execution")
-                logger.debug("Skipping non-JSON output: %s", output_line)
-                continue
+            # Try to parse as JSON; skip non-JSON and malformed lines
+            msg = None
+            if output_line.startswith("{"):
+                try:
+                    msg = json.loads(output_line)
+                except json.JSONDecodeError:
+                    pass
 
-            # Parse that line as JSON
-            try:
-                msg = json.loads(output_line)
-            except json.JSONDecodeError:
+            if msg is None:
                 skipped += 1
                 if skipped > self._MAX_SKIP_LINES:
                     raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) during execution")
-                logger.debug("Skipping malformed JSON: %s", output_line[:100])
+                logger.debug("Skipping non-JSON output: %s", output_line[:100])
                 continue
 
             # Handle incoming requests (tool calls from sandbox)

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -339,6 +339,30 @@ class PythonInterpreter:
 
     _MAX_SKIP_LINES = 100
 
+    def _read_response_line(self, context: str) -> str:
+        """Read one stdout line from Deno or raise a process-level error."""
+        response_line = self.deno_process.stdout.readline().strip()
+        if response_line:
+            return response_line
+
+        exit_code = self.deno_process.poll()
+        if exit_code is not None:
+            stderr = self.deno_process.stderr.read() if self.deno_process.stderr else ""
+            raise CodeInterpreterError(f"Deno exited (code {exit_code}) {context}: {stderr}")
+        raise CodeInterpreterError(f"No response {context}")
+
+    def _parse_response_line(self, response_line: str, context: str) -> dict | None:
+        """Parse a JSON-RPC line, returning None for non-JSON or malformed lines."""
+        if not response_line.startswith("{"):
+            logger.debug("Skipping non-JSON output during %s: %s", context, response_line)
+            return None
+
+        try:
+            return json.loads(response_line)
+        except json.JSONDecodeError:
+            logger.debug("Skipping malformed JSON during %s: %s", context, response_line[:100])
+            return None
+
     def _send_request(self, method: str, params: dict, context: str) -> dict:
         """Send a JSON-RPC request and return the parsed response.
 
@@ -352,29 +376,11 @@ class PythonInterpreter:
         self.deno_process.stdin.flush()
 
         skipped = 0
-        while True:
-            response_line = self.deno_process.stdout.readline().strip()
-            if not response_line:
-                exit_code = self.deno_process.poll()
-                if exit_code is not None:
-                    stderr = self.deno_process.stderr.read() if self.deno_process.stderr else ""
-                    raise CodeInterpreterError(f"Deno exited (code {exit_code}) {context}: {stderr}")
-                raise CodeInterpreterError(f"No response {context}")
-
-            if not response_line.startswith("{"):
+        while skipped <= self._MAX_SKIP_LINES:
+            response_line = self._read_response_line(context)
+            response = self._parse_response_line(response_line, context)
+            if response is None:
                 skipped += 1
-                if skipped > self._MAX_SKIP_LINES:
-                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) {context}")
-                logger.debug("Skipping non-JSON output during %s: %s", context, response_line)
-                continue
-
-            try:
-                response = json.loads(response_line)
-            except json.JSONDecodeError:
-                skipped += 1
-                if skipped > self._MAX_SKIP_LINES:
-                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) {context}")
-                logger.debug("Skipping malformed JSON during %s: %s", context, response_line[:100])
                 continue
 
             if response.get("id") != request_id:
@@ -382,6 +388,8 @@ class PythonInterpreter:
             if "error" in response:
                 raise CodeInterpreterError(f"Error {context}: {response['error'].get('message', 'Unknown error')}")
             return response
+
+        raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) {context}")
 
     def _health_check(self) -> None:
         """Verify the subprocess is alive by executing a simple expression."""

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -15,7 +15,9 @@ import os
 import subprocess
 import threading
 from os import PathLike
-from typing import Any, Callable
+from typing import Any, Callable, get_type_hints
+
+import pydantic
 
 from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeInterpreterError, FinalOutput
 
@@ -134,6 +136,7 @@ class PythonInterpreter:
         self.tools = dict(tools) if tools else {}
         self.output_fields = output_fields
         self._tools_registered = False
+        self._tool_adapters: dict[str, dict[str, pydantic.TypeAdapter]] = {}
         # TODO later on add enable_run (--allow-run) by proxying subprocess.run through Deno.run() to fix 'emscripten does not support processes' error
 
         if deno_command:
@@ -245,43 +248,80 @@ class PythonInterpreter:
             self.deno_process.stdin.write(sync_msg + "\n")
             self.deno_process.stdin.flush()
 
-    def _extract_parameters(self, fn: Callable) -> list[dict]:
-        """Extract parameter info from a callable for sandbox registration."""
+    def _resolve_type_hints(self, fn: Callable) -> dict[str, Any]:
+        """Resolve function annotations, including forward refs when possible."""
+        try:
+            return get_type_hints(fn, include_extras=True)
+        except NameError:
+            annotations = getattr(fn, "__annotations__", {})
+            string_annos = {k: v for k, v in annotations.items() if k != "return" and isinstance(v, str)}
+            if string_annos:
+                formatted = ", ".join(f"{k}={v!r}" for k, v in string_annos.items())
+                raise TypeError(
+                    f"Tool '{getattr(fn, '__name__', repr(fn))}' uses unresolved forward-ref string annotation(s): "
+                    f"{formatted}. Forward-ref strings are not supported for tool parameters; "
+                    "use concrete types."
+                )
+            return {}
+        except AttributeError:
+            return {}
+
+    def _build_tool_info(self, fn: Callable) -> tuple[list[dict], dict[str, pydantic.TypeAdapter]]:
+        """Extract parameter info and TypeAdapters for a callable.
+
+        Returns (params, adapters) where params is the registration payload
+        and adapters maps param names to TypeAdapters for call-time coercion.
+        """
         sig = inspect.signature(fn)
+        hints = self._resolve_type_hints(fn)
         params = []
+        adapters = {}
         for name, param in sig.parameters.items():
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                raise TypeError(
+                    f"Tool '{getattr(fn, '__name__', repr(fn))}' uses variadic parameter '{name}', "
+                    "but variadic tool parameters (*args/**kwargs) are not supported."
+                )
+
             p = {"name": name}
-            # Only include type for simple types that work in function signatures
-            # Complex types like Union, Optional, etc. are not included
-            if param.annotation != inspect.Parameter.empty:
-                if param.annotation in SIMPLE_TYPES:
-                    p["type"] = param.annotation.__name__
+            annotation = hints.get(name, param.annotation)
+            if annotation != inspect.Parameter.empty:
+                if annotation in SIMPLE_TYPES:
+                    p["type"] = annotation.__name__
+                else:
+                    try:
+                        adapter = pydantic.TypeAdapter(annotation)
+                        p["json_schema"] = adapter.json_schema()
+                        adapters[name] = adapter
+                    except pydantic.PydanticSchemaGenerationError:
+                        logger.debug(
+                            "Skipping JSON schema for tool parameter '%s' with annotation %r",
+                            name, annotation, exc_info=True,
+                        )
             if param.default != inspect.Parameter.empty:
                 p["default"] = param.default
             params.append(p)
-        return params
+        return params, adapters
 
     def _register_tools(self) -> None:
         """Register tools and output fields with the sandbox."""
         if self._tools_registered:
             return
 
-        # Build registration params with typed tool signatures
         params = {}
 
         if self.tools:
+            self._tool_adapters.clear()
             tools_info = []
             for name, fn in self.tools.items():
-                tools_info.append({
-                    "name": name,
-                    "parameters": self._extract_parameters(fn)
-                })
+                tool_params, adapters = self._build_tool_info(fn)
+                tools_info.append({"name": name, "parameters": tool_params})
+                self._tool_adapters[name] = adapters
             params["tools"] = tools_info
 
         if self.output_fields:
             params["outputs"] = self.output_fields
 
-        # Skip if nothing to register
         if not params:
             self._tools_registered = True
             return
@@ -294,12 +334,17 @@ class PythonInterpreter:
         request_id = request["id"]
         params = request.get("params", {})
         tool_name = params.get("name")
-        kwargs = params.get("kwargs", {})
+        kwargs = dict(params.get("kwargs", {}))
 
         try:
             if tool_name not in self.tools:
                 raise CodeInterpreterError(f"Unknown tool: {tool_name}")
+            for param_name, adapter in self._tool_adapters.get(tool_name, {}).items():
+                if param_name in kwargs:
+                    kwargs[param_name] = adapter.validate_python(kwargs[param_name])
             result = self.tools[tool_name](**kwargs)
+            if isinstance(result, pydantic.BaseModel):
+                result = result.model_dump(mode="json")
             is_json = isinstance(result, (list, dict))
             response = _jsonrpc_result(
                 {"value": json.dumps(result) if is_json else (str(result) if result is not None else ""), "type": "json" if is_json else "string"},
@@ -410,6 +455,8 @@ class PythonInterpreter:
                 return sorted(self._to_json_compatible(v) for v in value)
             except TypeError:
                 return [self._to_json_compatible(v) for v in value]
+        elif isinstance(value, pydantic.BaseModel):
+            return self._to_json_compatible(value.model_dump(mode="json"))
         else:
             raise CodeInterpreterError(f"Unsupported value type: {type(value).__name__}")
 
@@ -453,6 +500,8 @@ class PythonInterpreter:
             return "True" if value else "False"
         elif isinstance(value, (int, float)):
             return str(value)
+        elif isinstance(value, pydantic.BaseModel):
+            return self._serialize_value(value.model_dump(mode="json"))
         elif isinstance(value, (list, tuple)):
             # Tuples become lists for JSON compatibility
             items = ", ".join(self._serialize_value(item) for item in value)

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -515,26 +515,11 @@ class PythonInterpreter:
         # Read and handle messages until we get the final output.
         # Loop is needed because tool calls require back-and-forth communication.
         skipped = 0
-        while True:
-            output_line = self.deno_process.stdout.readline().strip()
-            if not output_line:
-                # Possibly the subprocess died or gave no output
-                err_output = self.deno_process.stderr.read()
-                raise CodeInterpreterError(f"No output from Deno subprocess. Stderr: {err_output}")
-
-            # Try to parse as JSON; skip non-JSON and malformed lines
-            msg = None
-            if output_line.startswith("{"):
-                try:
-                    msg = json.loads(output_line)
-                except json.JSONDecodeError:
-                    pass
-
+        while skipped <= self._MAX_SKIP_LINES:
+            output_line = self._read_response_line("during execution")
+            msg = self._parse_response_line(output_line, "during execution")
             if msg is None:
                 skipped += 1
-                if skipped > self._MAX_SKIP_LINES:
-                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) during execution")
-                logger.debug("Skipping non-JSON output: %s", output_line[:100])
                 continue
 
             # Handle incoming requests (tool calls from sandbox)
@@ -573,6 +558,8 @@ class PythonInterpreter:
 
             # Unexpected message format - neither a recognized method nor a response
             raise CodeInterpreterError(f"Unexpected message format from sandbox: {msg}")
+
+        raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) during execution")
 
     def start(self) -> None:
         """Initialize the Deno/Pyodide sandbox.

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -31,13 +31,6 @@ LARGE_VAR_THRESHOLD = 100 * 1024 * 1024
 # JSON-RPC 2.0 Helpers
 # =============================================================================
 
-# JSON-RPC 2.0 protocol errors (reserved range: -32700 to -32600)
-JSONRPC_PROTOCOL_ERRORS = {
-    "ParseError": -32700,
-    "InvalidRequest": -32600,
-    "MethodNotFound": -32601,
-}
-
 # Application errors (range: -32000 to -32099)
 JSONRPC_APP_ERRORS = {
     "SyntaxError": -32000,
@@ -301,16 +294,15 @@ class PythonInterpreter:
         request_id = request["id"]
         params = request.get("params", {})
         tool_name = params.get("name")
-        args = params.get("args", [])
         kwargs = params.get("kwargs", {})
 
         try:
             if tool_name not in self.tools:
                 raise CodeInterpreterError(f"Unknown tool: {tool_name}")
-            result = self.tools[tool_name](*args, **kwargs)
+            result = self.tools[tool_name](**kwargs)
             is_json = isinstance(result, (list, dict))
             response = _jsonrpc_result(
-                {"value": json.dumps(result) if is_json else str(result or ""), "type": "json" if is_json else "string"},
+                {"value": json.dumps(result) if is_json else (str(result) if result is not None else ""), "type": "json" if is_json else "string"},
                 request_id
             )
         except Exception as e:
@@ -345,28 +337,51 @@ class PythonInterpreter:
                 raise CodeInterpreterError(install_instructions) from e
             self._health_check()
 
+    _MAX_SKIP_LINES = 100
+
     def _send_request(self, method: str, params: dict, context: str) -> dict:
-        """Send a JSON-RPC request and return the parsed response."""
+        """Send a JSON-RPC request and return the parsed response.
+
+        Non-JSON lines (e.g. Pyodide package loading messages) are skipped,
+        up to ``_MAX_SKIP_LINES`` to prevent unbounded blocking.
+        """
         self._request_id += 1
         request_id = self._request_id
         msg = _jsonrpc_request(method, params, request_id)
         self.deno_process.stdin.write(msg + "\n")
         self.deno_process.stdin.flush()
 
-        response_line = self.deno_process.stdout.readline().strip()
-        if not response_line:
-            exit_code = self.deno_process.poll()
-            if exit_code is not None:
-                stderr = self.deno_process.stderr.read() if self.deno_process.stderr else ""
-                raise CodeInterpreterError(f"Deno exited (code {exit_code}) {context}: {stderr}")
-            raise CodeInterpreterError(f"No response {context}")
+        skipped = 0
+        while True:
+            response_line = self.deno_process.stdout.readline().strip()
+            if not response_line:
+                exit_code = self.deno_process.poll()
+                if exit_code is not None:
+                    stderr = self.deno_process.stderr.read() if self.deno_process.stderr else ""
+                    raise CodeInterpreterError(f"Deno exited (code {exit_code}) {context}: {stderr}")
+                raise CodeInterpreterError(f"No response {context}")
 
-        response = json.loads(response_line)
-        if response.get("id") != request_id:
-            raise CodeInterpreterError(f"Response ID mismatch {context}: expected {request_id}, got {response.get('id')}")
-        if "error" in response:
-            raise CodeInterpreterError(f"Error {context}: {response['error'].get('message', 'Unknown error')}")
-        return response
+            if not response_line.startswith("{"):
+                skipped += 1
+                if skipped > self._MAX_SKIP_LINES:
+                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) {context}")
+                logger.debug("Skipping non-JSON output during %s: %s", context, response_line)
+                continue
+
+            try:
+                response = json.loads(response_line)
+            except json.JSONDecodeError:
+                skipped += 1
+                if skipped > self._MAX_SKIP_LINES:
+                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) {context}")
+                logger.debug("Skipping malformed JSON during %s: %s", context, response_line[:100])
+                continue
+
+            if response.get("id") != request_id:
+                raise CodeInterpreterError(f"Response ID mismatch {context}: expected {request_id}, got {response.get('id')}")
+            if "error" in response:
+                raise CodeInterpreterError(f"Error {context}: {response['error'].get('message', 'Unknown error')}")
+            return response
 
     def _health_check(self) -> None:
         """Verify the subprocess is alive by executing a simple expression."""
@@ -491,6 +506,7 @@ class PythonInterpreter:
 
         # Read and handle messages until we get the final output.
         # Loop is needed because tool calls require back-and-forth communication.
+        skipped = 0
         while True:
             output_line = self.deno_process.stdout.readline().strip()
             if not output_line:
@@ -500,15 +516,20 @@ class PythonInterpreter:
 
             # Skip non-JSON lines (e.g., Pyodide package loading messages)
             if not output_line.startswith("{"):
-                logger.debug(f"Skipping non-JSON output: {output_line}")
+                skipped += 1
+                if skipped > self._MAX_SKIP_LINES:
+                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) during execution")
+                logger.debug("Skipping non-JSON output: %s", output_line)
                 continue
 
             # Parse that line as JSON
             try:
                 msg = json.loads(output_line)
             except json.JSONDecodeError:
-                # Malformed JSON starting with '{' - log and continue
-                logger.info(f"Skipping malformed JSON: {output_line[:100]}")
+                skipped += 1
+                if skipped > self._MAX_SKIP_LINES:
+                    raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) during execution")
+                logger.debug("Skipping malformed JSON: %s", output_line[:100])
                 continue
 
             # Handle incoming requests (tool calls from sandbox)

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -40,11 +40,25 @@ const toPythonLiteral = (value) => {
   return JSON.stringify(value);  // Works for strings, numbers, arrays, objects
 };
 
+const JSON_SCHEMA_TYPE_TO_PYTHON = {
+  string: "str",
+  integer: "int",
+  number: "float",
+  boolean: "bool",
+  array: "list",
+  object: "dict",
+  null: "None",
+};
+
 const makeToolWrapper = (toolName, parameters = []) => {
   // Build signature parts: "query: str, limit: int = 10"
   const sigParts = parameters.map(p => {
     let part = p.name;
-    if (p.type) part += `: ${p.type}`;
+    const inferredType = (!p.type && p.json_schema && typeof p.json_schema.type === "string")
+      ? JSON_SCHEMA_TYPE_TO_PYTHON[p.json_schema.type]
+      : null;
+    const pythonType = p.type || inferredType;
+    if (pythonType) part += `: ${pythonType}`;
     if (p.default !== undefined) part += ` = ${toPythonLiteral(p.default)}`;
     return part;
   });
@@ -65,7 +79,7 @@ def ${toolName}(${signature}):
 };
 
 // Generate SUBMIT function with output field signature.
-// Outputs is an array of {name, type?} objects.
+// Outputs is an array of {name, type?, json_schema?} objects.
 const makeSubmitWrapper = (outputs) => {
   if (!outputs || outputs.length === 0) {
     // Fallback to single-arg SUBMIT if no outputs defined
@@ -75,16 +89,42 @@ def SUBMIT(output):
 `;
   }
 
+  const hasModelOutputs = outputs.some(o => o.json_schema);
+
+  // SUBMIT type hints use inferred types (not model_type) since output
+  // model classes may not be registered in the sandbox.
   const sigParts = outputs.map(o => {
     let part = o.name;
-    if (o.type) part += `: ${o.type}`;
+    const inferredType = (!o.type && o.json_schema && typeof o.json_schema.type === "string")
+      ? JSON_SCHEMA_TYPE_TO_PYTHON[o.json_schema.type]
+      : null;
+    const pythonType = o.type || inferredType;
+    if (pythonType) part += `: ${pythonType}`;
     return part;
   });
   const dictParts = outputs.map(o => `"${o.name}": ${o.name}`);
 
+  // Build docstring with schema info for complex output fields
+  const schemaLines = outputs
+    .filter(o => o.json_schema)
+    .map(o => `    ${o.name}: ${JSON.stringify(o.json_schema)}`);
+  const docstring = schemaLines.length > 0
+    ? `    """Expected output schemas:\\n${schemaLines.join('\\n')}\\n    """\n`
+    : '';
+
+  // When model outputs exist, serialize BaseModel instances before raising
+  if (hasModelOutputs) {
+    return `
+def SUBMIT(${sigParts.join(', ')}):
+${docstring}    _out = {${dictParts.join(', ')}}
+    _ser = {_k: _v.model_dump() if hasattr(_v, 'model_dump') else _v for _k, _v in _out.items()}
+    raise FinalOutput(_ser)
+`;
+  }
+
   return `
 def SUBMIT(${sigParts.join(', ')}):
-    raise FinalOutput({${dictParts.join(', ')}})
+${docstring}    raise FinalOutput({${dictParts.join(', ')}})
 `;
 };
 

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -50,25 +50,17 @@ const makeToolWrapper = (toolName, parameters = []) => {
   });
   const signature = sigParts.join(', ');
   const argNames = parameters.map(p => p.name);
-
-  // If no parameters, fall back to *args, **kwargs for flexibility
-  if (parameters.length === 0) {
-    return `
-import json
-from pyodide.ffi import run_sync, JsProxy
-def ${toolName}(*args, **kwargs):
-    result = run_sync(_js_tool_call("${toolName}", json.dumps({"args": args, "kwargs": kwargs})))
-    return result.to_py() if isinstance(result, JsProxy) else result
-`;
-  }
+  const kwargParts = argNames.map(n => `"${n}": ${n}`).join(', ');
 
   return `
 import json
 from pyodide.ffi import run_sync, JsProxy
 def ${toolName}(${signature}):
-    _args = [${argNames.join(', ')}]
-    result = run_sync(_js_tool_call("${toolName}", json.dumps({"args": _args, "kwargs": {}})))
-    return result.to_py() if isinstance(result, JsProxy) else result
+    result = run_sync(_js_tool_call("${toolName}", json.dumps({"kwargs": {${kwargParts}}})))
+    parsed = result.to_py() if isinstance(result, JsProxy) else result
+    if isinstance(parsed, dict) and parsed.get("${TOOL_BRIDGE_ERROR_KEY}"):
+        raise RuntimeError(parsed.get("message", "Tool bridge error"))
+    return parsed
 `;
 };
 
@@ -153,18 +145,18 @@ const pyodide = await pyodideModule.loadPyodide();
 const stdinReader = readLines(Deno.stdin);
 let requestIdCounter = 0;
 
+const TOOL_BRIDGE_ERROR_KEY = "__dspy_tool_bridge_error__";
+
 // This function is called from Python to invoke a host-side tool
 async function toolCallBridge(name, argsJson) {
   const requestId = `tc_${Date.now()}_${++requestIdCounter}`;
 
   try {
-    // Parse args to extract positional and keyword args
     const parsedArgs = JSON.parse(argsJson);
 
     // Send tool call request to host using JSON-RPC
     console.log(jsonrpcRequest("tool_call", {
       name: name,
-      args: parsedArgs.args || [],
       kwargs: parsedArgs.kwargs || {}
     }, requestId));
 
@@ -178,11 +170,19 @@ async function toolCallBridge(name, argsJson) {
 
     // Expect JSON-RPC result or error with matching id
     if (response.id !== requestId) {
-      throw new Error(`Unexpected response: expected id ${requestId}, got ${response.id}`);
+      return {
+        [TOOL_BRIDGE_ERROR_KEY]: true,
+        message: `Tool bridge error for '${name}': Unexpected response: expected id ${requestId}, got ${response.id}`
+      };
     }
 
     if (response.error) {
-      throw new Error(response.error.message || "Tool call failed");
+      const errorType = response.error.data?.type || "ToolError";
+      const errorMessage = response.error.message || "Tool call failed";
+      return {
+        [TOOL_BRIDGE_ERROR_KEY]: true,
+        message: `${errorType}: ${errorMessage}`
+      };
     }
 
     // Deserialize result based on type
@@ -192,8 +192,12 @@ async function toolCallBridge(name, argsJson) {
     }
     return result.value;
   } catch (error) {
-    // Re-throw with context so Python can catch it properly
-    throw new Error(`Tool bridge error for '${name}': ${error.message}`);
+    // Return a structured error payload so Python can raise with full context
+    // without triggering a top-level unhandled rejection in Deno.
+    return {
+      [TOOL_BRIDGE_ERROR_KEY]: true,
+      message: `Tool bridge error for '${name}': ${error.message}`
+    };
   }
 }
 

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -8,6 +8,7 @@ Test organization:
 
 from contextlib import contextmanager
 
+import pydantic
 import pytest
 
 from dspy.adapters.types.tool import Tool
@@ -266,6 +267,32 @@ class TestRLMInitialization:
 
         with pytest.raises(RuntimeError, match="LLM call limit exceeded"):
             tools["llm_query"](prompt="one more")
+
+    def test_output_fields_info_includes_json_schema_for_pydantic_type(self):
+        """Test that complex output types retain JSON schema metadata for sandbox registration."""
+        import dspy
+
+        class Person(pydantic.BaseModel):
+            name: str
+            age: int
+
+        class PersonSig(dspy.Signature):
+            query: str = dspy.InputField()
+            person: Person = dspy.OutputField()
+
+        rlm = RLM(PersonSig)
+        output_fields = rlm._get_output_fields_info()
+
+        assert len(output_fields) == 1
+        field = output_fields[0]
+        assert field["name"] == "person"
+        assert field["model_type"] == "Person"
+        schema = field["json_schema"]
+        assert schema["type"] == "object"
+        assert schema["title"] == "Person"
+        assert "name" in schema["properties"]
+        assert "age" in schema["properties"]
+        assert set(schema["required"]) == {"name", "age"}
 
 
 class TestRLMCodeFenceParsing:
@@ -1106,6 +1133,26 @@ class TestRLMWithDummyLM:
 
             assert result.total == 15
 
+    def test_with_pydantic_input_model_e2e(self):
+        """Test RLM with a pydantic input model instance passed to sandbox."""
+        import dspy
+
+        class Person(pydantic.BaseModel):
+            name: str
+            age: int
+
+        class PersonSig(dspy.Signature):
+            person: Person = dspy.InputField()
+            next_age: int = dspy.OutputField()
+
+        with dummy_lm_context([
+            {"reasoning": "Increment person age", "code": "SUBMIT(person['age'] + 1)"},
+        ]):
+            rlm = RLM(PersonSig, max_iterations=3)
+            result = rlm.forward(person=Person(name="Ada", age=36))
+
+            assert result.next_age == 37
+
     def test_with_tool_e2e(self):
         """Test RLM calling a host-side tool through the sandbox."""
         def lookup(key: str) -> str:
@@ -1154,6 +1201,192 @@ class TestRLMWithDummyLM:
             result = await rlm.aforward(numbers=[1, 2, 3, 4, 5])
 
             assert result.total == 15
+
+
+# ============================================================================
+# Integration Tests: RLM Pydantic Stress Tests
+# ============================================================================
+
+
+@pytest.mark.deno
+class TestRLMPydanticStress:
+    """Stress tests for pydantic models flowing through the full RLM pipeline."""
+
+    def test_pydantic_output_model_e2e(self):
+        """SUBMIT returns a dict that gets parsed into a pydantic output field."""
+        import dspy
+
+        class Person(pydantic.BaseModel):
+            name: str
+            age: int
+
+        class ExtractSig(dspy.Signature):
+            text: str = dspy.InputField()
+            person: Person = dspy.OutputField()
+
+        with dummy_lm_context([
+            {"reasoning": "Extract person", "code": 'SUBMIT(person={"name": "Ada", "age": 36})'},
+        ]):
+            rlm = RLM(ExtractSig, max_iterations=3)
+            result = rlm.forward(text="Ada is 36")
+
+            assert isinstance(result.person, Person)
+            assert result.person.name == "Ada"
+            assert result.person.age == 36
+
+    def test_pydantic_output_nested_model_e2e(self):
+        """SUBMIT with a nested pydantic model as output field."""
+        import dspy
+
+        class Address(pydantic.BaseModel):
+            city: str
+            country: str
+
+        class PersonWithAddr(pydantic.BaseModel):
+            name: str
+            address: Address
+
+        class Sig(dspy.Signature):
+            text: str = dspy.InputField()
+            person: PersonWithAddr = dspy.OutputField()
+
+        with dummy_lm_context([
+            {
+                "reasoning": "Extract nested person",
+                "code": 'SUBMIT(person={"name": "Ada", "address": {"city": "London", "country": "UK"}})',
+            },
+        ]):
+            rlm = RLM(Sig, max_iterations=3)
+            result = rlm.forward(text="Ada lives in London, UK")
+
+            assert isinstance(result.person, PersonWithAddr)
+            assert result.person.address.city == "London"
+
+    def test_pydantic_input_and_output_e2e(self):
+        """Pydantic model as both input variable AND output field."""
+        import dspy
+
+        class Item(pydantic.BaseModel):
+            name: str
+            price: float
+
+        class PriceSig(dspy.Signature):
+            item: Item = dspy.InputField()
+            discounted: Item = dspy.OutputField()
+
+        with dummy_lm_context([
+            {
+                "reasoning": "Apply 50% discount",
+                "code": 'SUBMIT(discounted={"name": item["name"], "price": item["price"] * 0.5})',
+            },
+        ]):
+            rlm = RLM(PriceSig, max_iterations=3)
+            result = rlm.forward(item=Item(name="Widget", price=10.0))
+
+            assert isinstance(result.discounted, Item)
+            assert result.discounted.name == "Widget"
+            assert result.discounted.price == 5.0
+
+    def test_pydantic_tool_and_pydantic_output_e2e(self):
+        """Tool with pydantic arg + pydantic output field in same RLM."""
+        import dspy
+
+        class Query(pydantic.BaseModel):
+            text: str
+            limit: int
+
+        class Result(pydantic.BaseModel):
+            matches: list[str]
+            total: int
+
+        def fake_search(query: Query) -> dict:
+            return {"matches": [f"result_{i}" for i in range(query.limit)], "total": query.limit}
+
+        class SearchSig(dspy.Signature):
+            question: str = dspy.InputField()
+            result: Result = dspy.OutputField()
+
+        with dummy_lm_context([
+            {
+                "reasoning": "Search and submit",
+                "code": 'data = fake_search(query={"text": "hello", "limit": 3})\nSUBMIT(result=data)',
+            },
+        ]):
+            rlm = RLM(SearchSig, max_iterations=3, tools=[fake_search])
+            result = rlm.forward(question="find hello")
+
+            assert isinstance(result.result, Result)
+            assert result.result.total == 3
+            assert len(result.result.matches) == 3
+
+    def test_pydantic_output_validation_error_retry_e2e(self):
+        """Invalid pydantic output triggers type error, LLM retries with correct shape."""
+        import dspy
+
+        class Person(pydantic.BaseModel):
+            name: str
+            age: int
+
+        class Sig(dspy.Signature):
+            text: str = dspy.InputField()
+            person: Person = dspy.OutputField()
+
+        with dummy_lm_context([
+            # First attempt: age is not an int-coercible value
+            {"reasoning": "Try wrong shape", "code": 'SUBMIT(person="Ada is 36")'},
+            # Second attempt: correct dict shape
+            {"reasoning": "Fix it", "code": 'SUBMIT(person={"name": "Ada", "age": 36})'},
+        ]):
+            rlm = RLM(Sig, max_iterations=5)
+            result = rlm.forward(text="Ada is 36")
+
+            assert isinstance(result.person, Person)
+            assert result.person.name == "Ada"
+
+    def test_list_of_pydantic_models_as_input_variable_e2e(self):
+        """List of pydantic models injected as variable, processed in sandbox."""
+        import dspy
+
+        class Score(pydantic.BaseModel):
+            student: str
+            value: int
+
+        class AvgSig(dspy.Signature):
+            scores: list[Score] = dspy.InputField()
+            average: float = dspy.OutputField()
+
+        scores = [Score(student="A", value=80), Score(student="B", value=90), Score(student="C", value=70)]
+
+        with dummy_lm_context([
+            {
+                "reasoning": "Compute average",
+                "code": "avg = sum(s['value'] for s in scores) / len(scores)\nSUBMIT(avg)",
+            },
+        ]):
+            rlm = RLM(AvgSig, max_iterations=3)
+            result = rlm.forward(scores=scores)
+
+            assert result.average == 80.0
+
+    def test_multi_turn_with_pydantic_tool_e2e(self):
+        """Multi-turn: explore data, then call pydantic tool, then SUBMIT."""
+
+        class Record(pydantic.BaseModel):
+            id: int
+            label: str
+
+        def lookup(record: Record) -> str:
+            return f"Found: {record.label} (id={record.id})"
+
+        with dummy_lm_context([
+            {"reasoning": "Explore input", "code": "print(type(data))"},
+            {"reasoning": "Call lookup", "code": 'result = lookup(record={"id": 1, "label": "test"})\nSUBMIT(result)'},
+        ]):
+            rlm = RLM("data -> answer: str", max_iterations=5, tools=[lookup])
+            result = rlm.forward(data="some data")
+
+            assert result.answer == "Found: test (id=1)"
+            assert len(result.trajectory) == 2
 
 
 # ============================================================================

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -297,6 +297,21 @@ def test_tool_default_args():
         assert result == "Hi, World!"
 
 
+def test_tool_all_positional_args():
+    """Test that tools work when all arguments are passed positionally."""
+
+    def add(a: int, b: int, c: int) -> str:
+        return f"{a + b + c}"
+
+    with PythonInterpreter(tools={"add": add}) as sandbox:
+        result = sandbox.execute("add(1, 2, 3)")
+        assert result == "6"
+
+        # Mixed: some positional, some keyword
+        result = sandbox.execute("add(10, 20, c=30)")
+        assert result == "60"
+
+
 # =============================================================================
 # Multi-Output SUBMIT Tests
 # =============================================================================

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -312,6 +312,26 @@ def test_tool_all_positional_args():
         assert result == "60"
 
 
+def test_tool_error_surfaces_as_runtime_error():
+    """Test that exceptions raised by a tool surface as RuntimeError in the sandbox."""
+
+    def failing_tool(x: int) -> str:
+        raise ValueError(f"bad value: {x}")
+
+    with PythonInterpreter(tools={"failing_tool": failing_tool}) as sandbox:
+        result = sandbox.execute(
+            "try:\n"
+            "    failing_tool(42)\n"
+            "    output = 'no error'\n"
+            "except RuntimeError as e:\n"
+            "    output = str(e)\n"
+            "output"
+        )
+        assert "ValueError" in result
+        assert "bad value: 42" in result
+
+
+
 # =============================================================================
 # Multi-Output SUBMIT Tests
 # =============================================================================

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -1,12 +1,18 @@
 import os
 import random
 
+import pydantic
 import pytest
 
 from dspy.primitives.code_interpreter import CodeInterpreterError, FinalOutput
 from dspy.primitives.python_interpreter import PythonInterpreter
 
 pytestmark = pytest.mark.deno
+
+
+class ForwardRefProfile(pydantic.BaseModel):
+    name: str
+    age: int
 
 
 def test_execute_simple_code():
@@ -331,6 +337,63 @@ def test_tool_error_surfaces_as_runtime_error():
         assert "bad value: 42" in result
 
 
+def test_tool_pydantic_arg_parsing():
+    """Test that tool args are parsed into Pydantic models when annotated."""
+
+    class Profile(pydantic.BaseModel):
+        name: str
+        age: int
+
+    def greet(profile: Profile) -> str:
+        return f"hello {profile.name} ({profile.age})"
+
+    with PythonInterpreter(tools={"greet": greet}) as sandbox:
+        result = sandbox.execute('greet(profile={"name": "Ada", "age": "36"})')
+        assert result == "hello Ada (36)"
+
+
+def test_tool_pydantic_arg_parsing_with_forward_ref_annotation():
+    """Test pydantic parsing works for resolvable forward-ref string annotations."""
+
+    def greet(profile: "ForwardRefProfile") -> str:
+        return f"hello {profile.name} ({profile.age})"
+
+    with PythonInterpreter(tools={"greet": greet}) as sandbox:
+        result = sandbox.execute('greet(profile={"name": "Ada", "age": "36"})')
+        assert result == "hello Ada (36)"
+
+
+def test_tool_pydantic_arg_parsing_with_local_forward_ref_annotation_raises():
+    """Local forward-ref string annotations should fail with a clear error."""
+
+    class LocalProfile(pydantic.BaseModel):
+        name: str
+        age: int
+
+    def greet(profile: "LocalProfile") -> str:
+        return f"hello {profile.name} ({profile.age})"
+
+    sandbox = PythonInterpreter()
+    with pytest.raises(TypeError, match=r"Forward-ref strings are not supported"):
+        sandbox._build_tool_info(greet)
+
+
+def test_tool_pydantic_invalid_input_surfaces_validation_details():
+    """Test invalid pydantic input keeps validation details in the surfaced error."""
+
+    class Profile(pydantic.BaseModel):
+        name: str
+        age: int
+
+    def greet(profile: Profile) -> str:
+        return f"hello {profile.name} ({profile.age})"
+
+    with PythonInterpreter(tools={"greet": greet}) as sandbox:
+        with pytest.raises(CodeInterpreterError) as exc_info:
+            sandbox.execute('greet(profile={"name": "Ada", "age": "not-an-int"})')
+        message = str(exc_info.value)
+        assert "validationerror" in message.lower()
+        assert "age" in message.lower()
 
 # =============================================================================
 # Multi-Output SUBMIT Tests
@@ -402,34 +465,129 @@ def test_submit_wrong_arg_count():
         assert "missing 1 required positional argument" in str(exc_info.value)
 
 
-def test_extract_parameters():
-    """Test that _extract_parameters correctly extracts function signatures."""
+def test_build_tool_info():
+    """Test that _build_tool_info correctly extracts function signatures."""
 
     def example_fn(required: str, optional: int = 5, untyped=None) -> str:
         pass
 
     sandbox = PythonInterpreter()
-    params = sandbox._extract_parameters(example_fn)
+    params, adapters = sandbox._build_tool_info(example_fn)
 
     assert len(params) == 3
     assert params[0] == {"name": "required", "type": "str"}
     assert params[1] == {"name": "optional", "type": "int", "default": 5}
     assert params[2] == {"name": "untyped", "default": None}
+    assert adapters == {}
 
 
-def test_extract_parameters_complex_types():
-    """Test that _extract_parameters handles complex types gracefully."""
+@pytest.mark.parametrize(
+    "fn_factory",
+    [
+        lambda: (lambda *values: None),
+        lambda: (lambda **values: None),
+    ],
+)
+def test_build_tool_info_rejects_variadic_tool_params(fn_factory):
+    """Tool signatures with *args/**kwargs should be rejected."""
+    sandbox = PythonInterpreter()
+    fn = fn_factory()
+    with pytest.raises(TypeError, match=r"variadic tool parameters \(\*args/\*\*kwargs\) are not supported"):
+        sandbox._build_tool_info(fn)
+
+
+def test_build_tool_info_complex_types():
+    """Test that _build_tool_info handles complex types gracefully."""
 
     def complex_fn(items: list | None = None, data: dict[str, int] | None = None) -> list:
         pass
 
     sandbox = PythonInterpreter()
-    params = sandbox._extract_parameters(complex_fn)
+    params, adapters = sandbox._build_tool_info(complex_fn)
 
     assert len(params) == 2
-    # Complex types like Union are not included in type annotation
-    assert params[0] == {"name": "items", "default": None}
-    assert params[1] == {"name": "data", "default": None}
+    assert params[0]["name"] == "items"
+    assert params[0]["default"] is None
+    assert "json_schema" in params[0]
+
+    assert params[1]["name"] == "data"
+    assert params[1]["default"] is None
+    assert "json_schema" in params[1]
+
+    assert "items" in adapters
+    assert "data" in adapters
+
+
+def test_build_tool_info_includes_json_schema_and_adapter_for_pydantic_types():
+    class Profile(pydantic.BaseModel):
+        name: str
+        age: int
+
+    def greet(profile: Profile) -> str:
+        return f"hello {profile.name}"
+
+    sandbox = PythonInterpreter()
+    params, adapters = sandbox._build_tool_info(greet)
+
+    assert len(params) == 1
+    assert params[0]["name"] == "profile"
+    assert params[0]["json_schema"] == {
+        "properties": {
+            "name": {"title": "Name", "type": "string"},
+            "age": {"title": "Age", "type": "integer"},
+        },
+        "required": ["name", "age"],
+        "title": "Profile",
+        "type": "object",
+    }
+
+    assert "profile" in adapters
+    profile = adapters["profile"].validate_python({"name": "Ada", "age": "36"})
+    assert isinstance(profile, Profile)
+    assert profile.name == "Ada"
+    assert profile.age == 36
+
+
+def test_build_tool_info_includes_json_schema_for_forward_ref_annotation():
+    def greet(profile: "ForwardRefProfile") -> str:
+        return f"hello {profile.name}"
+
+    sandbox = PythonInterpreter()
+    params, adapters = sandbox._build_tool_info(greet)
+
+    assert len(params) == 1
+    assert params[0]["name"] == "profile"
+    assert "json_schema" in params[0]
+    assert params[0]["json_schema"]["type"] == "object"
+    assert "profile" in adapters
+
+
+def test_build_tool_info_adapter_raises_on_invalid_pydantic_input():
+    class Profile(pydantic.BaseModel):
+        name: str
+        age: int
+
+    def greet(profile: Profile) -> str:
+        return f"hello {profile.name}"
+
+    sandbox = PythonInterpreter()
+    _, adapters = sandbox._build_tool_info(greet)
+
+    with pytest.raises(pydantic.ValidationError):
+        adapters["profile"].validate_python({"name": "Ada", "age": "not-an-int"})
+
+
+def test_execute_with_pydantic_model_variable():
+    """Test that pydantic model instances can be injected as input variables."""
+
+    class Person(pydantic.BaseModel):
+        name: str
+        age: int
+
+    person = Person(name="Ada", age=36)
+    with PythonInterpreter() as interpreter:
+        result = interpreter.execute("person['age'] + 1", variables={"person": person})
+        assert result == 37
 
 
 # =============================================================================
@@ -557,6 +715,231 @@ def test_large_variable_threshold_boundary():
     assert "x" in interpreter._pending_large_vars, "Serialized size over threshold should use filesystem"
 
 
+# =============================================================================
+# Pydantic Stress Tests
+# =============================================================================
+
+
+def test_nested_and_list_pydantic_tool_args():
+    """Deep nesting (3 levels) and list[Model] field coerced from dicts."""
+
+    class Employee(pydantic.BaseModel):
+        name: str
+        role: str
+
+    class Department(pydantic.BaseModel):
+        name: str
+        lead: Employee
+        members: list[Employee]
+
+    def summarize(dept: Department) -> str:
+        names = ", ".join(m.name for m in dept.members)
+        return f"{dept.name} led by {dept.lead.name}: [{names}]"
+
+    with PythonInterpreter(tools={"summarize": summarize}) as sandbox:
+        code = """summarize(dept={
+            "name": "Eng",
+            "lead": {"name": "Ada", "role": "CTO"},
+            "members": [{"name": "Bob", "role": "SWE"}, {"name": "Eve", "role": "SRE"}]
+        })"""
+        result = sandbox.execute(code)
+        assert result == "Eng led by Ada: [Bob, Eve]"
+
+
+def test_pydantic_optional_and_default_fields():
+    """Optional fields (None/omitted) and defaults preserved through coercion."""
+
+    class Config(pydantic.BaseModel):
+        name: str
+        mode: str = "standard"
+        tag: str | None = None
+
+    def show(config: Config) -> str:
+        return f"{config.name}:{config.mode}:{config.tag}"
+
+    with PythonInterpreter(tools={"show": show}) as sandbox:
+        # All provided
+        assert sandbox.execute('show(config={"name": "A", "mode": "fast", "tag": "v1"})') == "A:fast:v1"
+        # Defaults kick in
+        assert sandbox.execute('show(config={"name": "B"})') == "B:standard:None"
+        # Explicit None
+        assert sandbox.execute('show(config={"name": "C", "tag": None})') == "C:standard:None"
+
+
+def test_multi_pydantic_tools_with_mixed_args():
+    """Multiple tools with different pydantic types + simple args; tests adapter isolation."""
+
+    class Cat(pydantic.BaseModel):
+        name: str
+        indoor: bool
+
+    class Dog(pydantic.BaseModel):
+        name: str
+        breed: str
+
+    def describe_cat(cat: Cat, prefix: str = "") -> str:
+        loc = "indoor" if cat.indoor else "outdoor"
+        return f"{prefix}{cat.name} is {loc}"
+
+    def describe_dog(dog: Dog) -> str:
+        return f"{dog.name} is a {dog.breed}"
+
+    with PythonInterpreter(tools={"describe_cat": describe_cat, "describe_dog": describe_dog}) as sandbox:
+        code = """
+c = describe_cat(cat={"name": "Whiskers", "indoor": True}, prefix=">> ")
+d = describe_dog(dog={"name": "Rex", "breed": "Labrador"})
+f"{c} | {d}"
+"""
+        result = sandbox.execute(code)
+        assert result == ">> Whiskers is indoor | Rex is a Labrador"
+
+
+def test_pydantic_constraint_validation_errors():
+    """Constrained fields and nested invalid types surface validation errors."""
+
+    class Inner(pydantic.BaseModel):
+        score: int = pydantic.Field(ge=0, le=100)
+
+    class Outer(pydantic.BaseModel):
+        inner: Inner
+
+    def process(data: Outer) -> str:
+        return str(data.inner.score)
+
+    with PythonInterpreter(tools={"process": process}) as sandbox:
+        # Valid
+        assert sandbox.execute('process(data={"inner": {"score": 85}})') == "85"
+        # Invalid type nested
+        with pytest.raises(CodeInterpreterError, match="(?i)validationerror"):
+            sandbox.execute('process(data={"inner": {"score": "not-a-number"}})')
+        # Constraint violation
+        with pytest.raises(CodeInterpreterError, match="(?i)validationerror"):
+            sandbox.execute('process(data={"inner": {"score": 150}})')
+
+
+def test_pydantic_models_as_input_variables():
+    """Nested model, list of models, and dict of models all injected as variables."""
+
+    class Address(pydantic.BaseModel):
+        city: str
+
+    class Person(pydantic.BaseModel):
+        name: str
+        address: Address
+
+    class Score(pydantic.BaseModel):
+        value: int
+
+    person = Person(name="Ada", address=Address(city="London"))
+    items = [Score(value=80), Score(value=90)]
+    registry = {"alice": Score(value=95), "bob": Score(value=72)}
+
+    with PythonInterpreter() as interpreter:
+        code = """
+city = person['address']['city']
+avg = sum(i['value'] for i in items) / len(items)
+grades = [k + ':' + str(s['value']) for k, s in sorted(registry.items())]
+(city, avg, grades)
+"""
+        result = interpreter.execute(code, variables={
+            "person": person, "items": items, "registry": registry,
+        })
+        assert result == ["London", 85.0, ["alice:95", "bob:72"]]
+
+
+def test_pydantic_variable_passed_to_tool():
+    """Pydantic model injected as variable (dict), then passed to a pydantic-typed tool."""
+
+    class Tag(pydantic.BaseModel):
+        label: str
+        priority: int
+
+    def format_tag(tag: Tag) -> str:
+        return f"[{tag.priority}] {tag.label}"
+
+    tag_instance = Tag(label="urgent", priority=1)
+
+    with PythonInterpreter(tools={"format_tag": format_tag}) as sandbox:
+        code = """
+label_from_var = tag["label"]
+formatted = format_tag(tag={"label": tag["label"], "priority": tag["priority"]})
+f"{label_from_var} -> {formatted}"
+"""
+        result = sandbox.execute(code, variables={"tag": tag_instance})
+        assert result == "urgent -> [1] urgent"
+
+
+def test_tool_return_roundtrip_and_repeated_calls():
+    """Tool returns dict consumed by pydantic tool; repeated calls have no state leak."""
+
+    class Record(pydantic.BaseModel):
+        id: int
+        label: str
+
+    call_count = {"n": 0}
+
+    def fetch(id: int = 0) -> dict:
+        return {"id": id, "label": f"item_{id}"}
+
+    def describe(record: Record) -> str:
+        call_count["n"] += 1
+        return f"#{record.id}:{record.label}"
+
+    with PythonInterpreter(tools={"fetch": fetch, "describe": describe}) as sandbox:
+        code = """
+results = []
+for i in [1, 2, 3]:
+    data = fetch(id=i)
+    results.append(describe(record=data))
+results
+"""
+        result = sandbox.execute(code)
+        assert result == ["#1:item_1", "#2:item_2", "#3:item_3"]
+        assert call_count["n"] == 3
+
+
+def test_tool_falsy_return_values():
+    """Tools returning falsy values (0, False, empty string) should preserve them, not coerce to ''."""
+
+    def return_zero() -> int:
+        return 0
+
+    def return_false() -> bool:
+        return False
+
+    def return_empty_string() -> str:
+        return ""
+
+    def return_none() -> str:
+        return None
+
+    with PythonInterpreter(tools={
+        "return_zero": return_zero,
+        "return_false": return_false,
+        "return_empty_string": return_empty_string,
+        "return_none": return_none,
+    }) as sandbox:
+        assert sandbox.execute("return_zero()") == "0"
+        assert sandbox.execute("return_false()") == "False"
+        assert sandbox.execute("return_empty_string()") == ""
+        assert sandbox.execute("return_none()") == ""
+
+
+def test_tool_returning_pydantic_model():
+    """Tools returning pydantic models should serialize to JSON dict, not repr string."""
+
+    class Profile(pydantic.BaseModel):
+        name: str
+        age: int
+
+    def make_profile(name: str, age: int) -> Profile:
+        return Profile(name=name, age=age)
+
+    with PythonInterpreter(tools={"make_profile": make_profile}) as sandbox:
+        result = sandbox.execute('make_profile(name="Ada", age=36)')
+        assert result == {"name": "Ada", "age": 36}
+
+
 def test_enable_read_paths_multiple_files(tmp_path):
     """Test that enable_read_paths works with multiple files in the same directory.
 
@@ -588,3 +971,10 @@ def test_enable_read_paths_multiple_files(tmp_path):
         assert contents["test1.txt"] == "Content 1"
         assert contents["test2.txt"] == "Content 2"
         assert contents["test3.txt"] == "Content 3"
+
+
+# =============================================================================
+# Battle Tests: Pydantic Models in Sandbox (Phase 3)
+# =============================================================================
+
+


### PR DESCRIPTION
The deno sandbox for RLM communicates with the host Python process via JSON-RPC, meaning everything crossing the boundary must be JSON-serializable. Previously, passing a pydantic model anywhere in this pipeline would fail.

This PR adds automatic pydantic model conversion at every boundary point:

**Input variables** → model_dump() before injection into sandbox; JSON schema shown to LLM in variable metadata
**Tool arguments** → TypeAdapter.validate_python() coerces raw dicts back into models when calling host-side tools
**Tool return values** → model_dump() before sending back through JSON-RPC
**Output fields (SUBMIT)** → JSON schema propagated to sandbox so SUBMIT() knows expected shapes; model_dump() called before FinalOutput

The core pattern at each boundary is the same — serialize with model_dump(mode="json") on the way out, validate with TypeAdapter on the way in.

We do not do any coercion to a specific type inside the REPL inside this PR. That is to come in a follow on pr.