### PR TITLE
fix: _parse_code must not corrupt valid Python code

### DIFF
--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -136,7 +136,11 @@ class ProgramOfThought(Module):
     def _parse_code(self, code_data):
         code = code_data.get("generated_code", "").split("---", 1)[0].split("\n\n\n", 1)[0]
         code_match = re.search(r"```python[ \n](.*?)[ \n]```?", code, re.DOTALL)
-        code_block = (code_match.group(1) if code_match else code).replace("\\n", "\n")
+        # Extract the code block without any post-processing transformations.
+        # Previously, a global .replace("\\n", "\n") was applied here, which
+        # corrupted escape sequences inside string literals (e.g. f"\\nTotal: {x}"
+        # became a literal newline mid-string, producing a SyntaxError).
+        code_block = code_match.group(1) if code_match else code
         if not code_block:
             return code, "Error: Empty code after parsing."
         if "\n" not in code_block and code_block.count("=") > 1:
@@ -144,18 +148,14 @@ class ProgramOfThought(Module):
         lines = code_block.split("\n")
         last_line_match = re.match(r"^(\w+)\s*=", lines[-1].strip())
         if last_line_match and len(lines) > 1:
+            # Append the assigned variable as a bare expression so the
+            # interpreter can capture and return its value.
             code_block += "\n" + last_line_match.group(1)
-        else:
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)(?=[a-zA-Z_]\w* *=)",
-                r"\1\n",
-                code_block,
-            )
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)([a-zA-Z_]\w*)$",
-                r"\1\n\2",
-                code_block,
-            )
+        # NOTE: the previous fallback used context-unaware regex substitutions
+        # (splitting on "=" without regard for string boundaries) that corrupted
+        # valid Python such as `data = "users: Alice=25"`.  LLM-generated code
+        # already contains proper newlines when extracted from a markdown block,
+        # so no further reformatting is needed.
         return code_block, None
 
     def _execute_code(self, code):

--- a/tests/predict/test_program_of_thought.py
+++ b/tests/predict/test_program_of_thought.py
@@ -130,3 +130,78 @@ def test_pot_code_parse_error():
     ):
         pot(question="What is 1+1?")
     mock_execute_code.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #9214: _parse_code must not corrupt valid Python
+# ---------------------------------------------------------------------------
+
+
+def _make_pot():
+    """Return a ProgramOfThought instance without requiring a real LM."""
+    lm = DummyLM([])
+    dspy.configure(lm=lm)
+    return ProgramOfThought(BasicQA)
+
+
+def test_parse_code_preserves_escape_sequences_in_strings():
+    """Literal \\n inside a string must not be converted to a real newline.
+
+    Previously `.replace("\\\\n", "\\n")` was applied globally, so
+    `print(f"\\\\nTotal: {x}")` became `print(f"\\nTotal: {x}")` with a
+    literal line-break inside the f-string, producing a SyntaxError.
+    """
+    pot = _make_pot()
+    code_with_escape = 'result = "line1\\nline2"'
+    code_data = {"generated_code": f"```python\n{code_with_escape}\n```"}
+    parsed, error = pot._parse_code(code_data)
+    assert error is None
+    # The escape sequence must survive unchanged
+    assert "\\n" in parsed, f"Escape sequence was corrupted; got: {parsed!r}"
+    assert "\n" not in parsed.split("=", 1)[1], (
+        "A real newline was inserted inside the string literal"
+    )
+
+
+def test_parse_code_preserves_equals_inside_strings():
+    """A '=' inside a string literal in multi-line code must not trigger
+    spurious line-splitting.
+
+    Previously the context-unaware regex on the else-branch matched '='
+    inside string literals and inserted newlines mid-string, producing
+    broken Python like `data = "users: Alice\\n=25"`.
+    """
+    pot = _make_pot()
+    # Multi-line code: the LLM already emits proper newlines, so only the
+    # regex branch (now removed) could corrupt the second line.
+    code_lines = 'data = "users: Alice=25, Bob=30"\nresult = len(data)'
+    code_data = {"generated_code": f"```python\n{code_lines}\n```"}
+    parsed, error = pot._parse_code(code_data)
+    assert error is None, f"Unexpected parse error: {error}"
+    # The string content must be intact — no spurious newlines injected
+    assert '"users: Alice=25, Bob=30"' in parsed, (
+        f"String content was corrupted by regex splitting; got: {parsed!r}"
+    )
+
+
+def test_parse_code_extracts_bare_code_without_markdown():
+    """Code supplied without a markdown fence must be returned as-is."""
+    pot = _make_pot()
+    raw = "result = 1 + 1"
+    code_data = {"generated_code": raw}
+    parsed, error = pot._parse_code(code_data)
+    assert error is None
+    assert "result = 1 + 1" in parsed
+
+
+def test_parse_code_appends_result_variable_for_capture():
+    """When the last line is a bare assignment, the variable name should be
+    appended so the interpreter can capture and return its value."""
+    pot = _make_pot()
+    code_data = {"generated_code": "```python\nx = 10\nresult = x * 2\n```"}
+    parsed, error = pot._parse_code(code_data)
+    assert error is None
+    lines = [l for l in parsed.splitlines() if l.strip()]
+    assert lines[-1].strip() == "result", (
+        f"Expected last line to be 'result' for interpreter capture; got {lines[-1]!r}"
+    )


### PR DESCRIPTION
Two related bugs in ProgramOfThought._parse_code() silently produced syntactically invalid code, causing the interpreter to fail on correct LLM output:

1. Global escape-sequence substitution (`.replace("\n", "\n")`) was applied to the entire code block, converting the two-character literal sequence `\n` to a real newline even inside string literals. A common f-string such as `print(f"\nTotal: {x}")` became `print(f"\nTotal: {x}")` with a literal line-break mid-string, producing an immediate SyntaxError.

2. The fallback regex substitutions matched `=` without string-boundary awareness.  Code like `data = "users: Alice=25"` was rewritten to `data = "users: Alice\n=25"`, breaking the string literal and the assignment on the same line.

Fix: extract the code block from its markdown fence and return it directly without any post-processing transformations.  LLM-generated code already contains correct newlines once extracted from the fence, so no reformatting is required.  The variable-echo logic (appending the last assigned name as a bare expression for interpreter capture) is preserved unchanged.

Fixes #9214