### PR TITLE
fix: use collections.deque for O(1) history eviction instead of O(n) list.pop(0)

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils import settings
@@ -7,7 +8,7 @@ from dspy.utils.callback import with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
 
 MAX_HISTORY_SIZE = 10_000
-GLOBAL_HISTORY = []
+GLOBAL_HISTORY = deque(maxlen=MAX_HISTORY_SIZE)
 
 
 class BaseLM:
@@ -47,7 +48,7 @@ class BaseLM:
         self.model_type = model_type
         self.cache = cache
         self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
-        self.history = []
+        self.history = deque(maxlen=settings.max_history_size or MAX_HISTORY_SIZE)
 
     def _process_lm_response(self, response, prompt, messages, **kwargs):
         merged_kwargs = {**self.kwargs, **kwargs}
@@ -145,7 +146,7 @@ class BaseLM:
         import copy
 
         new_instance = copy.deepcopy(self)
-        new_instance.history = []
+        new_instance.history = deque(maxlen=self.history.maxlen)
 
         for key, value in kwargs.items():
             if hasattr(self, key):
@@ -167,26 +168,18 @@ class BaseLM:
         if settings.disable_history:
             return
 
-        # Global LM history
-        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
-            GLOBAL_HISTORY.pop(0)
-
+        # Global LM history (deque with maxlen auto-evicts oldest entries)
         GLOBAL_HISTORY.append(entry)
 
         if settings.max_history_size == 0:
             return
 
-        # dspy.LM.history
-        if len(self.history) >= settings.max_history_size:
-            self.history.pop(0)
-
+        # dspy.LM.history (deque with maxlen auto-evicts oldest entries)
         self.history.append(entry)
 
-        # Per-module history
+        # Per-module history (deque with maxlen auto-evicts oldest entries)
         caller_modules = settings.caller_modules or []
         for module in caller_modules:
-            if len(module.history) >= settings.max_history_size:
-                module.history.pop(0)
             module.history.append(entry)
 
     def _process_completion(self, response, merged_kwargs):

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -3,6 +3,7 @@ import os
 import re
 import threading
 import warnings
+from collections import deque
 from typing import Any, Literal, cast
 
 import litellm
@@ -11,6 +12,7 @@ from anyio.streams.memory import MemoryObjectSendStream
 from asyncer import syncify
 
 import dspy
+from dspy.clients.base_lm import MAX_HISTORY_SIZE
 from dspy.clients.cache import request_cache
 from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, ReinforceJob, TrainingJob
@@ -74,7 +76,7 @@ class LM(BaseLM):
         self.cache = cache
         self.provider = provider or self.infer_provider()
         self.callbacks = callbacks or []
-        self.history = []
+        self.history = deque(maxlen=settings.max_history_size or MAX_HISTORY_SIZE)
         self.num_retries = num_retries
         self.finetuning_model = finetuning_model
         self.launch_kwargs = launch_kwargs or {}

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from collections import deque
 from typing import Callable
 
 import dspy
@@ -39,7 +40,7 @@ class CodeAct(ReAct, ProgramOfThought):
         """
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
-        self.history = []
+        self.history = deque()
 
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
         if any(

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils.settings import settings
@@ -33,7 +34,7 @@ class ProgramMeta(type):
             if not hasattr(obj, "callbacks"):
                 obj.callbacks = []
             if not hasattr(obj, "history"):
-                obj.history = []
+                obj.history = deque(maxlen=settings.max_history_size or None)
         return obj
 
 
@@ -69,13 +70,13 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def _base_init(self):
         self._compiled = False
         self.callbacks = []
-        self.history = []
+        self.history = deque(maxlen=settings.max_history_size or None)
 
     def __init__(self, callbacks=None):
         self.callbacks = callbacks or []
         self._compiled = False
         # LM calling history of the module.
-        self.history = []
+        self.history = deque(maxlen=settings.max_history_size or None)
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -86,7 +87,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def __setstate__(self, state):
         self.__dict__.update(state)
         if not hasattr(self, "history"):
-            self.history = []
+            self.history = deque(maxlen=settings.max_history_size or None)
         if not hasattr(self, "callbacks"):
             self.callbacks = []
 

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -13,7 +13,7 @@ def _blue(text: str, end: str = "\n"):
 def pretty_print_history(history, n: int = 1):
     """Prints the last n prompts and their completions."""
 
-    for item in history[-n:]:
+    for item in list(history)[-n:]:
         messages = item["messages"] or [{"role": "user", "content": item["prompt"]}]
         outputs = item["outputs"]
         timestamp = item.get("timestamp", "Unknown time")

--- a/tests/clients/test_inspect_global_history.py
+++ b/tests/clients/test_inspect_global_history.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import deque
+
 import dspy
 from dspy.clients.base_lm import GLOBAL_HISTORY
 from dspy.utils.dummies import DummyLM
@@ -25,7 +27,7 @@ def test_inspect_history_basic(capsys):
     history = GLOBAL_HISTORY
     print(capsys)
     assert len(history) > 0
-    assert isinstance(history, list)
+    assert isinstance(history, deque)
     assert all(isinstance(entry, dict) for entry in history)
     assert all("messages" in entry for entry in history)
 
@@ -60,7 +62,7 @@ def test_inspect_empty_history(capsys):
     dspy.inspect_history()
     history = GLOBAL_HISTORY
     assert len(history) == 0
-    assert isinstance(history, list)
+    assert isinstance(history, deque)
 
 
 def test_inspect_history_n_larger_than_history(capsys):


### PR DESCRIPTION
## Problem

`GLOBAL_HISTORY`, `BaseLM.history`, `Module.history`, and `CodeAct.history` all use Python lists with `list.pop(0)` for capacity management. `list.pop(0)` is O(n) because it requires shifting all remaining elements, making each append O(n) when the history is at capacity (default 10,000 entries).

## Solution

Replace all history lists with `collections.deque(maxlen=...)`:

- `deque` with `maxlen` automatically evicts the oldest entry when full — **O(1) amortized**
- Eliminates manual `len(history) >= MAX; history.pop(0)` guard code
- Reduces `update_history()` from 3 conditional blocks to 3 simple `.append()` calls

## Changes

| File | Change |
|------|--------|
| `dspy/clients/base_lm.py` | `GLOBAL_HISTORY = deque(maxlen=MAX_HISTORY_SIZE)`, `self.history = deque(maxlen=...)` |
| `dspy/clients/lm.py` | `self.history = deque(maxlen=...)` |
| `dspy/primitives/module.py` | `self.history = deque(maxlen=...)` in `__init__`, `_base_init`, `__setstate__`, and `ProgramMeta.__call__` |
| `dspy/predict/code_act.py` | `self.history = deque()` |
| `dspy/utils/inspect_history.py` | `list(history)[-n:]` for slice compatibility (deque doesn't support slicing) |
| `tests/clients/test_inspect_global_history.py` | Updated type assertions to `deque` |

## Performance Impact

For a full history of 10,000 entries, each `update_history()` call drops from **O(10,000)** (element shift) to **O(1)** amortized.

Fixes #9347