### PR TITLE
fix: propagate exceptions from async generator in apply_sync_streaming

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -228,6 +228,7 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
     """Convert the async streaming generator to a sync generator."""
     queue = Queue()  # Queue to hold items from the async generator
     stop_sentinel = object()  # Sentinel to signal the generator is complete
+    error_sentinel = object()  # Sentinel to signal an exception occurred
 
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
@@ -239,6 +240,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as exc:
+                queue.put((error_sentinel, exc))
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +257,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if isinstance(item, tuple) and len(item) == 2 and item[0] is error_sentinel:
+            raise item[1]
         yield item
 
 

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2062,3 +2062,32 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+def test_apply_sync_streaming_propagates_exceptions():
+    """apply_sync_streaming must re-raise exceptions from the async generator."""
+
+    async def failing_generator():
+        yield "first"
+        yield "second"
+        raise ValueError("generator exploded")
+
+    sync_gen = dspy.streaming.apply_sync_streaming(failing_generator())
+    collected = []
+    with pytest.raises(ValueError, match="generator exploded"):
+        for item in sync_gen:
+            collected.append(item)
+
+    assert collected == ["first", "second"]
+
+
+def test_apply_sync_streaming_propagates_runtime_error():
+    """apply_sync_streaming must propagate RuntimeError from the async generator."""
+
+    async def failing_generator():
+        raise RuntimeError("immediate failure")
+        yield  # noqa: F841 — makes this an async generator
+
+    sync_gen = dspy.streaming.apply_sync_streaming(failing_generator())
+    with pytest.raises(RuntimeError, match="immediate failure"):
+        list(sync_gen)


### PR DESCRIPTION
## Problem

`apply_sync_streaming` silently swallows exceptions raised by the async generator. When an exception occurs during iteration, the `finally` block sends the stop sentinel to the queue, but the exception itself is never communicated to the consumer thread. The caller receives a truncated stream with no indication that an error occurred.

## Root Cause

The producer's `runner()` function wraps the async iteration in `try/finally`. When the generator raises, execution goes straight to `finally` which puts `stop_sentinel` on the queue. The consumer sees the sentinel and breaks out of the loop — the exception is silently discarded.

## Fix

- Add an `error_sentinel` alongside the existing `stop_sentinel`
- Catch `BaseException` in the producer and enqueue a `(error_sentinel, exc)` tuple
- On the consumer side, detect error tuples and re-raise the original exception
- The `finally` block still sends `stop_sentinel` to guarantee clean shutdown

This preserves all items yielded before the exception and re-raises the original exception with its full traceback on the consumer thread.

## Tests

- `test_apply_sync_streaming_propagates_exceptions`: verifies mid-stream `ValueError` propagation with correct partial results
- `test_apply_sync_streaming_propagates_runtime_error`: verifies immediate `RuntimeError` propagation

Fixes #9142