### PR TITLE
perf: use deque instead of list for LM history to avoid O(n) pop(0)

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils import settings
@@ -7,7 +8,7 @@ from dspy.utils.callback import with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
 
 MAX_HISTORY_SIZE = 10_000
-GLOBAL_HISTORY = []
+GLOBAL_HISTORY: deque = deque(maxlen=MAX_HISTORY_SIZE)
 
 
 class BaseLM:
@@ -47,7 +48,7 @@ class BaseLM:
         self.model_type = model_type
         self.cache = cache
         self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
-        self.history = []
+        self.history: deque = deque()
 
     def _process_lm_response(self, response, prompt, messages, **kwargs):
         merged_kwargs = {**self.kwargs, **kwargs}
@@ -145,7 +146,7 @@ class BaseLM:
         import copy
 
         new_instance = copy.deepcopy(self)
-        new_instance.history = []
+        new_instance.history = deque()
 
         for key, value in kwargs.items():
             if hasattr(self, key):
@@ -167,10 +168,7 @@ class BaseLM:
         if settings.disable_history:
             return
 
-        # Global LM history
-        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
-            GLOBAL_HISTORY.pop(0)
-
+        # Global LM history (deque auto-evicts oldest entries)
         GLOBAL_HISTORY.append(entry)
 
         if settings.max_history_size == 0:
@@ -178,7 +176,7 @@ class BaseLM:
 
         # dspy.LM.history
         if len(self.history) >= settings.max_history_size:
-            self.history.pop(0)
+            self.history.popleft() if isinstance(self.history, deque) else self.history.pop(0)
 
         self.history.append(entry)
 
@@ -186,7 +184,7 @@ class BaseLM:
         caller_modules = settings.caller_modules or []
         for module in caller_modules:
             if len(module.history) >= settings.max_history_size:
-                module.history.pop(0)
+                module.history.popleft() if isinstance(module.history, deque) else module.history.pop(0)
             module.history.append(entry)
 
     def _process_completion(self, response, merged_kwargs):

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -3,6 +3,7 @@ import os
 import re
 import threading
 import warnings
+from collections import deque
 from typing import Any, Literal, cast
 
 import litellm
@@ -74,7 +75,7 @@ class LM(BaseLM):
         self.cache = cache
         self.provider = provider or self.infer_provider()
         self.callbacks = callbacks or []
-        self.history = []
+        self.history: deque = deque()
         self.num_retries = num_retries
         self.finetuning_model = finetuning_model
         self.launch_kwargs = launch_kwargs or {}

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -13,7 +13,7 @@ def _blue(text: str, end: str = "\n"):
 def pretty_print_history(history, n: int = 1):
     """Prints the last n prompts and their completions."""
 
-    for item in history[-n:]:
+    for item in list(history)[-n:]:
         messages = item["messages"] or [{"role": "user", "content": item["prompt"]}]
         outputs = item["outputs"]
         timestamp = item.get("timestamp", "Unknown time")

--- a/tests/clients/test_inspect_global_history.py
+++ b/tests/clients/test_inspect_global_history.py
@@ -1,6 +1,7 @@
 import pytest
 
 import dspy
+from collections import deque
 from dspy.clients.base_lm import GLOBAL_HISTORY
 from dspy.utils.dummies import DummyLM
 
@@ -25,7 +26,7 @@ def test_inspect_history_basic(capsys):
     history = GLOBAL_HISTORY
     print(capsys)
     assert len(history) > 0
-    assert isinstance(history, list)
+    assert isinstance(history, deque)
     assert all(isinstance(entry, dict) for entry in history)
     assert all("messages" in entry for entry in history)
 
@@ -60,7 +61,7 @@ def test_inspect_empty_history(capsys):
     dspy.inspect_history()
     history = GLOBAL_HISTORY
     assert len(history) == 0
-    assert isinstance(history, list)
+    assert isinstance(history, deque)
 
 
 def test_inspect_history_n_larger_than_history(capsys):


### PR DESCRIPTION
## Summary

Fixes #9347

Replaces `list`-based history storage with `collections.deque` for both `GLOBAL_HISTORY` and per-LM/per-module history. This eliminates the O(n) cost of `list.pop(0)` when the history reaches its size limit.

## Problem

`GLOBAL_HISTORY`, `self.history`, and `module.history` all use `list.pop(0)` to evict the oldest entry when the history reaches its maximum size. On a Python `list`, `pop(0)` is O(n) because it shifts all remaining elements. With `MAX_HISTORY_SIZE = 10_000`, this means up to 10,000 element shifts on every LM call once the history is full.

## Solution

- **`GLOBAL_HISTORY`**: Changed to `deque(maxlen=MAX_HISTORY_SIZE)`. The `maxlen` parameter automatically evicts the oldest entry in O(1) when the limit is reached, eliminating the manual size check entirely.
- **`self.history`** (per-LM): Changed to `deque()`. Uses `popleft()` (O(1)) instead of `pop(0)` (O(n)).
- **`module.history`** (per-module): Uses `popleft()` when available, with a fallback to `pop(0)` for backward compatibility with any external code that initializes history as a plain list.
- **`pretty_print_history`**: Updated to materialize the deque to a list before slicing, since `deque` does not support slice notation.

## Testing

- All 4 global history tests pass (updated `isinstance` checks from `list` to `deque`)
- All module history and base module tests pass
- 2 consecutive clean test runs with 0 errors