### PR TITLE
fix: propagate exceptions from apply_sync_streaming instead of swallowing

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -228,6 +228,7 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
     """Convert the async streaming generator to a sync generator."""
     queue = Queue()  # Queue to hold items from the async generator
     stop_sentinel = object()  # Sentinel to signal the generator is complete
+    error_sentinel = object()  # Sentinel to signal an error occurred
 
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
@@ -239,6 +240,9 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as exc:
+                queue.put(error_sentinel)
+                queue.put(exc)
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +258,9 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if item is error_sentinel:
+            exc = queue.get()
+            raise exc
         yield item
 
 

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -415,6 +415,26 @@ def test_sync_status_streaming():
     assert status_messages[1].message == "Tool calling finished! Querying the LLM with tool calling results..."
 
 
+def test_sync_streaming_propagates_exceptions():
+    """Regression test: apply_sync_streaming must propagate exceptions from the
+    async generator instead of silently swallowing them.
+    See https://github.com/stanfordnlp/dspy/issues/9142"""
+    from dspy.streaming.streamify import apply_sync_streaming
+
+    async def failing_generator():
+        yield "first"
+        yield "second"
+        raise ValueError("intentional error from async generator")
+
+    gen = apply_sync_streaming(failing_generator())
+    items = []
+    with pytest.raises(ValueError, match="intentional error from async generator"):
+        for item in gen:
+            items.append(item)
+
+    assert items == ["first", "second"]
+
+
 @pytest.mark.anyio
 async def test_stream_listener_returns_correct_chunk_chat_adapter():
     class MyProgram(dspy.Module):


### PR DESCRIPTION
## Summary

Fixes #9142

When using `streamify` with `async_streaming=False`, exceptions raised in the async generator are silently swallowed. The producer thread's `runner()` catches exceptions only in a `finally` block, sending the stop sentinel without propagating the error to the consumer.

### Root Cause

```python
async def runner():
    try:
        async for item in async_generator:
            queue.put(item)
    finally:
        queue.put(stop_sentinel)  # ← exception lost here
```

When the async generator raises, the `finally` block sends the stop sentinel and the consumer exits normally — the exception is lost.

### Fix

Add an explicit `except BaseException` clause that puts an error sentinel followed by the exception into the queue before the stop sentinel. The consumer checks for the error sentinel and re-raises the exception.

## Tests

Added `test_sync_streaming_propagates_exceptions` that verifies exceptions are properly propagated through the queue mechanism.