### PR TITLE
fix: replace list.pop(0) with deque.popleft() for O(1) history eviction

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils import settings
@@ -7,7 +8,7 @@ from dspy.utils.callback import with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
 
 MAX_HISTORY_SIZE = 10_000
-GLOBAL_HISTORY = []
+GLOBAL_HISTORY: deque[dict[str, Any]] = deque(maxlen=MAX_HISTORY_SIZE)
 
 
 class BaseLM:
@@ -47,7 +48,7 @@ class BaseLM:
         self.model_type = model_type
         self.cache = cache
         self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
-        self.history = []
+        self.history: deque[dict[str, Any]] = deque()
 
     def _process_lm_response(self, response, prompt, messages, **kwargs):
         merged_kwargs = {**self.kwargs, **kwargs}
@@ -145,7 +146,7 @@ class BaseLM:
         import copy
 
         new_instance = copy.deepcopy(self)
-        new_instance.history = []
+        new_instance.history = deque()
 
         for key, value in kwargs.items():
             if hasattr(self, key):
@@ -167,26 +168,22 @@ class BaseLM:
         if settings.disable_history:
             return
 
-        # Global LM history
-        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
-            GLOBAL_HISTORY.pop(0)
-
+        # Global LM history (deque with maxlen handles eviction automatically)
         GLOBAL_HISTORY.append(entry)
 
         if settings.max_history_size == 0:
             return
 
-        # dspy.LM.history
+        # dspy.LM.history — use popleft() for O(1) eviction instead of list.pop(0) O(n)
         if len(self.history) >= settings.max_history_size:
-            self.history.pop(0)
-
+            self.history.popleft()
         self.history.append(entry)
 
-        # Per-module history
+        # Per-module history — use popleft() for O(1) eviction
         caller_modules = settings.caller_modules or []
         for module in caller_modules:
             if len(module.history) >= settings.max_history_size:
-                module.history.pop(0)
+                module.history.popleft()
             module.history.append(entry)
 
     def _process_completion(self, response, merged_kwargs):

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -3,6 +3,7 @@ import os
 import re
 import threading
 import warnings
+from collections import deque
 from typing import Any, Literal, cast
 
 import litellm
@@ -74,7 +75,7 @@ class LM(BaseLM):
         self.cache = cache
         self.provider = provider or self.infer_provider()
         self.callbacks = callbacks or []
-        self.history = []
+        self.history: deque[dict[str, Any]] = deque()
         self.num_retries = num_retries
         self.finetuning_model = finetuning_model
         self.launch_kwargs = launch_kwargs or {}

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils.settings import settings
@@ -33,7 +34,7 @@ class ProgramMeta(type):
             if not hasattr(obj, "callbacks"):
                 obj.callbacks = []
             if not hasattr(obj, "history"):
-                obj.history = []
+                obj.history = deque()
         return obj
 
 
@@ -69,13 +70,13 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def _base_init(self):
         self._compiled = False
         self.callbacks = []
-        self.history = []
+        self.history: deque[dict[str, Any]] = deque()
 
     def __init__(self, callbacks=None):
         self.callbacks = callbacks or []
         self._compiled = False
         # LM calling history of the module.
-        self.history = []
+        self.history: deque[dict[str, Any]] = deque()
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -86,7 +87,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def __setstate__(self, state):
         self.__dict__.update(state)
         if not hasattr(self, "history"):
-            self.history = []
+            self.history = deque()
         if not hasattr(self, "callbacks"):
             self.callbacks = []
 

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -13,7 +13,7 @@ def _blue(text: str, end: str = "\n"):
 def pretty_print_history(history, n: int = 1):
     """Prints the last n prompts and their completions."""
 
-    for item in history[-n:]:
+    for item in list(history)[-n:]:
         messages = item["messages"] or [{"role": "user", "content": item["prompt"]}]
         outputs = item["outputs"]
         timestamp = item.get("timestamp", "Unknown time")

--- a/tests/clients/test_inspect_global_history.py
+++ b/tests/clients/test_inspect_global_history.py
@@ -1,5 +1,7 @@
 import pytest
 
+from collections import deque
+
 import dspy
 from dspy.clients.base_lm import GLOBAL_HISTORY
 from dspy.utils.dummies import DummyLM
@@ -25,7 +27,7 @@ def test_inspect_history_basic(capsys):
     history = GLOBAL_HISTORY
     print(capsys)
     assert len(history) > 0
-    assert isinstance(history, list)
+    assert isinstance(history, (list, deque))
     assert all(isinstance(entry, dict) for entry in history)
     assert all("messages" in entry for entry in history)
 
@@ -60,7 +62,7 @@ def test_inspect_empty_history(capsys):
     dspy.inspect_history()
     history = GLOBAL_HISTORY
     assert len(history) == 0
-    assert isinstance(history, list)
+    assert isinstance(history, (list, deque))
 
 
 def test_inspect_history_n_larger_than_history(capsys):


### PR DESCRIPTION
## Problem

`GLOBAL_HISTORY`, `BaseLM.history`, `LM.history`, and `Module.history` all use Python lists with `list.pop(0)` for eviction when the history buffer exceeds its size limit. `list.pop(0)` is an **O(n)** operation because it requires shifting all remaining elements left by one position. With `MAX_HISTORY_SIZE = 10_000`, this means up to 10,000 element shifts on every LM call once the buffer is full.

## Solution

Replace `list` with `collections.deque`, which provides **O(1)** `popleft()` operations via a doubly-linked list implementation.

### Key design decisions:

1. **`GLOBAL_HISTORY`**: Uses `deque(maxlen=MAX_HISTORY_SIZE)` — the maxlen is fixed at 10,000 and doesn't change at runtime, so deque's automatic eviction is ideal.

2. **`LM.history` and `Module.history`**: Use `deque()` **without** `maxlen`, because `settings.max_history_size` can change dynamically via `dspy.context(max_history_size=N)`. Instead, explicit `popleft()` calls in `update_history()` enforce the dynamic limit — still O(1) but respecting runtime configuration.

3. **`pretty_print_history()`**: Converts to `list()` for the final slice since `deque` doesn't support slicing. This is a display-only path called infrequently, so the conversion has negligible impact.

## Performance Impact

| Operation | Before (list) | After (deque) |
|-----------|--------------|---------------|
| Eviction (`pop(0)` vs `popleft()`) | O(n) | **O(1)** |
| Append | O(1) amortized | O(1) |
| Index access (`history[i]`) | O(1) | O(1) |
| Iteration | O(n) | O(n) |

For a full 10,000-entry buffer, each eviction goes from ~10,000 element shifts to a single pointer update.

## Changes

- `dspy/clients/base_lm.py`: `GLOBAL_HISTORY` → `deque(maxlen=...)`, `self.history` → `deque()`, `pop(0)` → `popleft()`
- `dspy/clients/lm.py`: `self.history` → `deque()`
- `dspy/primitives/module.py`: All `self.history` → `deque()`
- `dspy/utils/inspect_history.py`: `list(history)[-n:]` for slice compatibility
- `tests/clients/test_inspect_global_history.py`: Accept `deque` type

Fixes #9347