### PR TITLE
fix: share usage_tracker across parallel workers for correct aggregation

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -326,6 +326,12 @@ class Module(BaseModule, metaclass=ProgramMeta):
             prediction_in_output = output
         elif isinstance(output, tuple) and len(output) > 0 and isinstance(output[0], Prediction):
             prediction_in_output = output[0]
+        elif isinstance(output, list) and len(output) > 0 and isinstance(output[0], Prediction):
+            # Parallel returns a list of Predictions — attach usage to each
+            for pred in output:
+                if isinstance(pred, Prediction):
+                    pred.set_lm_usage(tokens)
+            return
         if prediction_in_output:
             prediction_in_output.set_lm_usage(tokens)
         else:

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -1,5 +1,4 @@
 import contextlib
-import copy
 import logging
 import signal
 import sys
@@ -90,9 +89,9 @@ class ParallelExecutor:
 
             original = thread_local_overrides.get()
             new_overrides = {**original, **parent_overrides.copy()}
-            if new_overrides.get("usage_tracker"):
-                # Usage tracker needs to be deep copied across threads so that each thread tracks its own usage
-                new_overrides["usage_tracker"] = copy.deepcopy(new_overrides["usage_tracker"])
+            # Share the parent's usage_tracker across threads instead of deep-copying.
+            # UsageTracker.add_usage() is thread-safe, so parallel workers can safely
+            # aggregate usage data into the same tracker instance.
             token = thread_local_overrides.set(new_overrides)
 
             try:

--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -1,5 +1,6 @@
 """Usage tracking utilities for DSPy."""
 
+import threading
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Generator
@@ -10,7 +11,11 @@ from dspy.dsp.utils.settings import settings
 
 
 class UsageTracker:
-    """Tracks LM usage data within a context."""
+    """Tracks LM usage data within a context.
+
+    Thread-safe: multiple threads can call add_usage() concurrently,
+    allowing a single tracker to aggregate usage across parallel workers.
+    """
 
     def __init__(self):
         # Map of LM name to list of usage entries. For example:
@@ -21,6 +26,7 @@ class UsageTracker:
         #     ],
         # }
         self.usage_data = defaultdict(list)
+        self._lock = threading.Lock()
 
     def _flatten_usage_entry(self, usage_entry: dict[str, Any]) -> dict[str, Any]:
         result = {}
@@ -50,9 +56,11 @@ class UsageTracker:
         return result
 
     def add_usage(self, lm: str, usage_entry: dict[str, Any]) -> None:
-        """Add a usage entry to the tracker."""
+        """Add a usage entry to the tracker. Thread-safe."""
         if len(usage_entry) > 0:
-            self.usage_data[lm].append(self._flatten_usage_entry(usage_entry))
+            flattened = self._flatten_usage_entry(usage_entry)
+            with self._lock:
+                self.usage_data[lm].append(flattened)
 
     def get_total_tokens(self) -> dict[str, dict[str, Any]]:
         """Calculate total tokens from all tracked usage."""

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -340,7 +340,11 @@ def test_merge_usage_entries_with_pydantic_models():
 
 
 def test_parallel_executor_with_usage_tracker():
-    """Test that usage tracking works correctly with ParallelExecutor and mocked LM calls."""
+    """Test that usage tracking works correctly with ParallelExecutor.
+
+    The parent tracker should aggregate usage from all parallel workers,
+    enabling correct total usage reporting in dspy.Module.__call__.
+    """
 
     parent_tracker = UsageTracker()
 
@@ -362,7 +366,7 @@ def test_parallel_executor_with_usage_tracker():
                 "total_tokens": 60,
             },
         )
-        return dspy.settings.usage_tracker.get_total_tokens()
+        return "task1_done"
 
     def task2():
         # Simulate LM usage tracking for task 2 with different values
@@ -374,21 +378,19 @@ def test_parallel_executor_with_usage_tracker():
                 "total_tokens": 95,
             },
         )
-        return dspy.settings.usage_tracker.get_total_tokens()
+        return "task2_done"
 
     # Execute tasks in parallel
     with dspy.context(track_usage=True, usage_tracker=parent_tracker):
         executor = dspy.Parallel()
         results = executor([(task1, {}), (task2, {})])
-    # Verify that the two workers had different usage
-    usage1 = results[0]
-    usage2 = results[1]
 
-    # Task 1 should have 50 prompt tokens, task 2 should have 80
-    assert usage1["openai/gpt-4o-mini"]["prompt_tokens"] == 50
-    assert usage1["openai/gpt-4o-mini"]["completion_tokens"] == 10
-    assert usage2["openai/gpt-4o-mini"]["prompt_tokens"] == 80
-    assert usage2["openai/gpt-4o-mini"]["completion_tokens"] == 15
+    # All results should complete successfully
+    assert all(r is not None for r in results)
 
-    # Parent tracker should remain unchanged (workers have independent copies)
-    assert len(parent_tracker.usage_data) == 0
+    # Parent tracker should have aggregated usage from both workers
+    total = parent_tracker.get_total_tokens()
+    assert "openai/gpt-4o-mini" in total
+    assert total["openai/gpt-4o-mini"]["prompt_tokens"] == 130  # 50 + 80
+    assert total["openai/gpt-4o-mini"]["completion_tokens"] == 25  # 10 + 15
+    assert total["openai/gpt-4o-mini"]["total_tokens"] == 155  # 60 + 95


### PR DESCRIPTION
## Problem

When `dspy.Parallel` runs inside a `dspy.Module` with `track_usage=True`, calling the module via `__call__` returns broken results and usage data is lost. This is reported in #9201.

### Root Cause

`ParallelExecutor` deep-copies the `usage_tracker` for each worker thread (line 94-95 in `parallelizer.py`):

```python
if new_overrides.get("usage_tracker"):
    new_overrides["usage_tracker"] = copy.deepcopy(new_overrides["usage_tracker"])
```

This creates independent tracker instances per thread. When workers add usage data, it goes to the thread-local copy and never reaches the parent tracker. After `Parallel` completes, the parent's `usage_tracker.get_total_tokens()` returns empty data.

Additionally, `Module._set_lm_usage()` didn't handle `list` outputs (which is what `Parallel` returns), so even if usage was available, it would log a warning and fail to attach it.

## Solution

### 1. Thread-safe UsageTracker
Added `threading.Lock` to `UsageTracker.add_usage()` so the same tracker instance can safely be shared across worker threads:

```python
def add_usage(self, lm, usage_entry):
    if len(usage_entry) > 0:
        flattened = self._flatten_usage_entry(usage_entry)
        with self._lock:
            self.usage_data[lm].append(flattened)
```

### 2. Share tracker instead of deep-copying
Removed the `copy.deepcopy(usage_tracker)` in `ParallelExecutor` worker threads. All workers now share the parent's tracker, correctly aggregating usage data.

### 3. Handle list outputs in _set_lm_usage
When `Module.forward()` returns a list of Predictions (from `Parallel`), `_set_lm_usage` now iterates and attaches usage to each Prediction.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| `Mod()()` with track_usage | `[None, None]` or empty usage | Correct Predictions with usage |
| Parent tracker after Parallel | Empty | Aggregated from all workers |
| `_set_lm_usage` with list output | Warning, no usage attached | Usage attached to each Prediction |

Fixes #9201