### PR TITLE
fix: propagate exceptions from async generator in apply_sync_streaming

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -228,6 +228,7 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
     """Convert the async streaming generator to a sync generator."""
     queue = Queue()  # Queue to hold items from the async generator
     stop_sentinel = object()  # Sentinel to signal the generator is complete
+    error_sentinel = object()  # Sentinel to signal an exception occurred
 
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
@@ -239,6 +240,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as e:
+                queue.put((error_sentinel, e))
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +257,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if isinstance(item, tuple) and len(item) == 2 and item[0] is error_sentinel:
+            raise item[1]
         yield item
 
 

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2062,3 +2062,20 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+def test_apply_sync_streaming_propagates_exceptions():
+    """Exceptions from the async generator should propagate to the sync consumer."""
+
+    async def failing_generator():
+        yield "first"
+        yield "second"
+        raise RuntimeError("async generator failed")
+
+    gen = dspy.streaming.apply_sync_streaming(failing_generator())
+    items = []
+    with pytest.raises(RuntimeError, match="async generator failed"):
+        for item in gen:
+            items.append(item)
+
+    assert items == ["first", "second"]


### PR DESCRIPTION
## Problem

`apply_sync_streaming()` converts an async generator to a sync generator using a background daemon thread. When the async generator raises an exception, the daemon thread silently swallows it — Python does not propagate exceptions from daemon threads to the main thread. The consumer loop receives the `stop_sentinel` and exits normally, with no indication that an error occurred.

## Root Cause

The async `runner()` function has a `try/finally` that always sends `stop_sentinel`, but exceptions raised during async iteration are not captured or forwarded. Since `producer()` runs in a daemon thread, unhandled exceptions are silently lost.

## Fix

- Added an `error_sentinel` alongside the existing `stop_sentinel`
- Exceptions caught in `runner()` are wrapped as `(error_sentinel, exception)` tuples and put on the queue before `stop_sentinel`
- Consumer loop checks for error tuples using identity comparison (`item[0] is error_sentinel`) and re-raises the original exception with its traceback preserved
- The `error_sentinel` is a closure-local `object()`, so user-yielded tuples cannot collide with the error pattern

## Testing

Added `test_apply_sync_streaming_propagates_exceptions` that verifies:
- Items yielded before the exception are delivered normally
- The exception is re-raised in the consumer thread
- The error message matches the original exception

Fixes #9142