### PR TITLE
feat(pot): add AST validation for early syntax error detection in ProgramOfThought

### DIFF
--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -147,16 +147,20 @@ class ProgramOfThought(Module):
         if last_line_match and len(lines) > 1:
             code_block += "\n" + last_line_match.group(1)
         else:
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)(?=[a-zA-Z_]\w* *=)",
-                r"\1\n",
-                code_block,
-            )
-            code_block = re.sub(
-                r"([a-zA-Z_]\w* *=.*?)([a-zA-Z_]\w*)$",
-                r"\1\n\2",
-                code_block,
-            )
+            # Only attempt regex-based rewriting on single-line code that
+            # fails AST validation, to avoid corrupting valid Python
+            # (e.g., strings containing '=' characters).
+            if self._validate_syntax(code_block) is not None:
+                code_block = re.sub(
+                    r"([a-zA-Z_]\w* *=.*?)(?=[a-zA-Z_]\w* *=)",
+                    r"\1\n",
+                    code_block,
+                )
+                code_block = re.sub(
+                    r"([a-zA-Z_]\w* *=.*?)([a-zA-Z_]\w*)$",
+                    r"\1\n\2",
+                    code_block,
+                )
         syntax_error = self._validate_syntax(code_block)
         if syntax_error:
             return code_block, f"Error: {syntax_error}"
@@ -171,7 +175,7 @@ class ProgramOfThought(Module):
         except SyntaxError as e:
             parts = [f"SyntaxError: {e.msg}"]
             if e.lineno is not None:
-                parts.append(f"  Line {e.lineno}")
+                parts.append(f"\n  Line {e.lineno}")
                 if e.offset is not None:
                     parts.append(f", Column {e.offset}")
             if e.text is not None:

--- a/tests/predict/test_program_of_thought.py
+++ b/tests/predict/test_program_of_thought.py
@@ -136,11 +136,13 @@ def test_validate_syntax_valid():
     assert ProgramOfThought._validate_syntax("x = 1 + 1\nprint(x)") is None
 
 
-def test_validate_syntax_invalid():
+def test_validate_syntax_detailed_error():
     error = ProgramOfThought._validate_syntax("if True\n    pass")
     assert error is not None
     assert "SyntaxError" in error
     assert "Line 1" in error
+    assert "Column" in error
+    assert "if True" in error
 
 
 def test_parse_code_rejects_syntax_error():
@@ -153,6 +155,7 @@ def test_parse_code_rejects_syntax_error():
     assert error is not None
     assert "SyntaxError" in error
     assert "Line" in error
+    assert "Column" in error
 
 
 def test_parse_code_accepts_valid_code():


### PR DESCRIPTION
## Summary

Adds `ast.parse()` validation in `_parse_code()` to catch syntax errors before code execution, providing precise line/column information for the LLM's refinement loop.

Fixes #9236

## Problem

Currently, `_parse_code` extracts code from LLM outputs but doesn't validate syntax until execution. This misses an opportunity to provide precise error feedback (line numbers, error types) that would improve DSPy's multi-turn refinement loop.

## Solution

Add a `_validate_syntax()` static method that uses `ast.parse()` to validate Python syntax after code extraction. When syntax errors are detected:
- The error is caught **before** execution
- Precise line number and column offset are included
- The offending source line is shown
- This feedback is passed to the LLM in the regeneration loop

### Example error output:
```
Error: SyntaxError: expected ':'
  Line 1, Column 8
  if True
```

## Changes

### `dspy/predict/program_of_thought.py`
- Add `import ast`
- Add `_validate_syntax(code: str) -> str | None` static method
- Integrate validation at the end of `_parse_code()` — if syntax is invalid, return error immediately without executing

### `tests/predict/test_program_of_thought.py`
- `test_validate_syntax_valid`: Valid Python passes validation
- `test_validate_syntax_invalid`: SyntaxError caught with line info
- `test_parse_code_rejects_syntax_error`: Integration test — invalid code rejected before execution
- `test_parse_code_accepts_valid_code`: Valid code passes through

## Test Results

All 5 non-deno tests pass (existing + new).