### PR TITLE
fix(adapters): pass use_native_function_calling in JSONAdapter.acall

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -98,7 +98,9 @@ class JSONAdapter(ChatAdapter):
             return await result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(signature)
+            structured_output_model = _get_structured_outputs_response_format(
+                signature, self.use_native_function_calling
+            )
             lm_kwargs["response_format"] = structured_output_model
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
         except Exception:


### PR DESCRIPTION
The async acall method was missing the use_native_function_calling argument when calling _get_structured_outputs_response_format, causing it to always default to True. This meant ToolCalls fields were incorrectly skipped in the structured output schema when using JSONAdapter(use_native_function_calling=False) via the async path.