### PR TITLE
feat(deps): make diskcache an optional dependency

### DIFF
--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import litellm
 
 from dspy.clients.base_lm import BaseLM, inspect_history
-from dspy.clients.cache import Cache
+from dspy.clients.cache import DISKCACHE_AVAILABLE, Cache
 from dspy.clients.embedding import Embedder
 from dspy.clients.lm import LM
 from dspy.clients.provider import Provider, TrainingJob
@@ -17,7 +17,7 @@ DISK_CACHE_LIMIT = int(os.environ.get("DSPY_CACHE_LIMIT", 3e10))  # 30 GB defaul
 
 
 def configure_cache(
-    enable_disk_cache: bool | None = True,
+    enable_disk_cache: bool | None = None,
     enable_memory_cache: bool | None = True,
     disk_cache_dir: str | None = DISK_CACHE_DIR,
     disk_size_limit_bytes: int | None = DISK_CACHE_LIMIT,
@@ -26,13 +26,16 @@ def configure_cache(
     """Configure the cache for DSPy.
 
     Args:
-        enable_disk_cache: Whether to enable on-disk cache.
+        enable_disk_cache: Whether to enable on-disk cache. Defaults to True if diskcache is installed, False otherwise.
         enable_memory_cache: Whether to enable in-memory cache.
         disk_cache_dir: The directory to store the on-disk cache.
         disk_size_limit_bytes: The size limit of the on-disk cache.
         memory_max_entries: The maximum number of entries in the in-memory cache. To allow the cache to grow without
                             bounds, set this parameter to `math.inf` or a similar value.
     """
+
+    if enable_disk_cache is None:
+        enable_disk_cache = DISKCACHE_AVAILABLE
 
     DSPY_CACHE = Cache(
         enable_disk_cache,
@@ -58,7 +61,7 @@ def _get_dspy_cache():
 
     try:
         _dspy_cache = Cache(
-            enable_disk_cache=True,
+            enable_disk_cache=DISKCACHE_AVAILABLE,
             enable_memory_cache=True,
             disk_cache_dir=disk_cache_dir,
             disk_size_limit_bytes=disk_cache_limit,
@@ -119,4 +122,5 @@ __all__ = [
     "enable_litellm_logging",
     "disable_litellm_logging",
     "configure_cache",
+    "DISKCACHE_AVAILABLE",
 ]

--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -10,7 +10,13 @@ import cloudpickle
 import orjson
 import pydantic
 from cachetools import LRUCache
-from diskcache import FanoutCache
+
+try:
+    from diskcache import FanoutCache
+
+    DISKCACHE_AVAILABLE = True
+except ImportError:
+    DISKCACHE_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +26,7 @@ class Cache:
 
     `Cache` provides 2 levels of caching (in the given order):
         1. In-memory cache - implemented with cachetools.LRUCache
-        2. On-disk cache - implemented with diskcache.FanoutCache
+        2. On-disk cache - implemented with diskcache.FanoutCache (requires diskcache: pip install dspy[diskcache])
     """
 
     def __init__(
@@ -51,12 +57,18 @@ class Cache:
         else:
             self.memory_cache = {}
         if self.enable_disk_cache:
-            self.disk_cache = FanoutCache(
-                shards=16,
-                timeout=10,
-                directory=disk_cache_dir,
-                size_limit=disk_size_limit_bytes,
-            )
+            if not DISKCACHE_AVAILABLE:
+                raise ImportError(
+                    "Disk caching requires the 'diskcache' package. "
+                    "Install it with: pip install dspy[diskcache]"
+                )
+            else:
+                self.disk_cache = FanoutCache(
+                    shards=16,
+                    timeout=10,
+                    directory=disk_cache_dir,
+                    size_limit=disk_size_limit_bytes,
+                )
         else:
             self.disk_cache = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "optuna>=3.4.0",
     "pydantic>=2.0",
     "litellm>=1.64.0",
-    "diskcache>=5.6.0",
     "json-repair>=0.54.2",
     "tenacity>=8.2.3",
     "anyio",
@@ -46,7 +45,9 @@ anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client~=4.5.4"]
 mcp = ["mcp; python_version >= '3.10'"]
 langchain = ["langchain_core"]
+diskcache = ["diskcache>=5.6.0"]
 dev = [
+    "diskcache>=5.6.0",
     "pytest>=6.2.5",
     "pytest-mock>=3.12.0",
     "pytest-asyncio>=0.26.0",

--- a/tests/clients/test_cache.py
+++ b/tests/clients/test_cache.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 import pydantic
 import pytest
 from cachetools import LRUCache
-from diskcache import FanoutCache
 
-from dspy.clients.cache import Cache
+from dspy.clients.cache import DISKCACHE_AVAILABLE, Cache
+
+if DISKCACHE_AVAILABLE:
+    from diskcache import FanoutCache
 
 
 @dataclass
@@ -369,3 +371,38 @@ def test_cache_fallback_on_restricted_environment():
             os.environ.pop("DSPY_CACHEDIR", None)
         else:
             os.environ["DSPY_CACHEDIR"] = old_env
+
+
+def test_cache_raises_when_disk_requested_without_diskcache():
+    """Explicitly requesting disk cache without diskcache installed should raise ImportError."""
+    from unittest.mock import patch
+
+    with patch("dspy.clients.cache.DISKCACHE_AVAILABLE", False):
+        with pytest.raises(ImportError, match="pip install dspy\\[diskcache\\]"):
+            Cache(
+                enable_disk_cache=True,
+                enable_memory_cache=True,
+                disk_cache_dir="",
+                disk_size_limit_bytes=0,
+                memory_max_entries=100,
+            )
+
+
+def test_cache_memory_only_when_diskcache_unavailable():
+    """Cache works with memory-only when disk cache is not explicitly requested."""
+    from unittest.mock import patch
+
+    with patch("dspy.clients.cache.DISKCACHE_AVAILABLE", False):
+        cache = Cache(
+            enable_disk_cache=False,
+            enable_memory_cache=True,
+            disk_cache_dir="",
+            disk_size_limit_bytes=0,
+            memory_max_entries=100,
+        )
+        assert cache.enable_disk_cache is False
+        assert cache.disk_cache == {}
+
+        request = {"prompt": "Hello"}
+        cache.put(request, "result")
+        assert cache.get(request) == "result"

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,6 @@ dependencies = [
     { name = "asyncer" },
     { name = "cachetools" },
     { name = "cloudpickle" },
-    { name = "diskcache" },
     { name = "gepa" },
     { name = "json-repair" },
     { name = "litellm", version = "1.68.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
@@ -762,6 +761,7 @@ anthropic = [
 dev = [
     { name = "build" },
     { name = "datamodel-code-generator" },
+    { name = "diskcache" },
     { name = "litellm", version = "1.68.0", source = { registry = "https://pypi.org/simple" }, extra = ["proxy"], marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "litellm", version = "1.72.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
     { name = "pillow" },
@@ -770,6 +770,9 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
     { name = "ruff" },
+]
+diskcache = [
+    { name = "diskcache" },
 ]
 langchain = [
     { name = "langchain-core" },
@@ -800,7 +803,8 @@ requires-dist = [
     { name = "cloudpickle", specifier = ">=3.0.0" },
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
-    { name = "diskcache", specifier = ">=5.6.0" },
+    { name = "diskcache", marker = "extra == 'dev'", specifier = ">=5.6.0" },
+    { name = "diskcache", marker = "extra == 'diskcache'", specifier = ">=5.6.0" },
     { name = "gepa", extras = ["dspy"], specifier = "==0.0.26" },
     { name = "json-repair", specifier = ">=0.54.2" },
     { name = "langchain-core", marker = "extra == 'langchain'" },
@@ -830,7 +834,7 @@ requires-dist = [
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = "~=4.5.4" },
     { name = "xxhash", specifier = ">=3.5.0" },
 ]
-provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "dev", "test-extras"]
+provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "diskcache", "dev", "test-extras"]
 
 [[package]]
 name = "email-validator"
@@ -1609,6 +1613,9 @@ name = "litellm-proxy-extras"
 version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/22/2d15f5c0198dee49f8296369486fa6319edca0c3af52e80ae2cdc1118b5a/litellm_proxy_extras-0.1.15.tar.gz", hash = "sha256:0e9b9074023eea8954183746f196d4a62f5d9fda2838fac3cb94d6ee1899a308", size = 11888, upload-time = "2025-05-03T16:29:02.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/eb/d85f375f12fa7cba9415d617d289ae969c461df918ce2c63fb22df5c77ef/litellm_proxy_extras-0.1.15-py3-none-any.whl", hash = "sha256:f0e96a2ff89e8ae67ec695db073958722a85dbea3f99a660ed16c47d585ae46e", size = 18941, upload-time = "2026-02-21T20:02:55.509Z" },
+]
 
 [[package]]
 name = "mako"


### PR DESCRIPTION
[CVE-2025-69872](https://www.sentinelone.com/vulnerability-database/cve-2025-69872/) (CVSS 9.8) is a remote code execution vulnerability in diskcache via pickle deserialization, affecting all versions through 5.6.3. No patched version exists. Because DSPy declares diskcache as a required dependency, every DSPy installation inherits this critical finding, which blocks deployment in environments with mandatory security scanning.

This PR moves diskcache from required to optional `pip install dspy[diskcache]`. Users who have diskcache installed see no change. Users without it get memory-only caching automatically - a path DSPy already supported via `_get_dspy_cache()`'s existing try/except fallback.

**Changes** - 5 files:

**pyproject.toml** - moved diskcache to optional extra, added to dev extras for CI
**dspy/clients/cache.py** - conditional import with DISKCACHE_AVAILABLE flag (follows existing `SF_AVAILABLE` pattern in `adapters/types/audio.py`), guard in `Cache.__init__`
**dspy/clients/__init__.py** - `configure_cache()` and `_get_dspy_cache()` auto-detect diskcache availability; explicit enable_disk_cache=True without the package raises a clear `ImportError`
**tests/clients/test_cache.py** - conditional import, 2 new tests for the no-diskcache path. All tests pass!

**Precedent:** [FastMCP had the same issue](https://github.com/PrefectHQ/fastmcp/issues/3239) for this CVE and took the same approach. Google ADK avoids the problem entirely by using optional dependency groups for non-core features `pip install google-adk[extensions]`

Related: #8717 (disk caching unconditionally enabled at import time), #8799 (bus error on import from disk cache on network FS)