### PR TITLE
docs: remove n=5 assumption from modules tutorial example

### DIFF
--- a/docs/docs/learn/programming/modules.md
+++ b/docs/docs/learn/programming/modules.md
@@ -54,7 +54,10 @@ response = classify(question=question)
 # 3) Access the output.
 response.answer
 ```
-
+**Possible Output:**
+```text
+'One great thing about the ColBERT retrieval model is its superior efficiency and effectiveness compared to other models.'
+```
 
 Let's discuss the output object here. The `dspy.ChainOfThought` module will generally inject a `reasoning` before the output field(s) of your signature.
 
@@ -69,19 +72,6 @@ print(f"Answer: {response.answer}")
 Reasoning: We can consider the fact that ColBERT has shown to outperform other state-of-the-art retrieval models in terms of efficiency and effectiveness. It uses contextualized embeddings and performs document retrieval in a way that is both accurate and scalable.
 Answer: One great thing about the ColBERT retrieval model is its superior efficiency and effectiveness compared to other models.
 ```
-
-This is accessible whether we request one or many completions.
-
-We can also access completions as a list of `Prediction`s or as several lists, one for each field.
-
-```python
-response.completions[0].reasoning == response.completions.reasoning[0]
-```
-**Output:**
-```text
-True
-```
-
 
 ## What other DSPy modules are there? How can I use them?
 


### PR DESCRIPTION
removes the default `n=5` assumption from the main `ChainOfThought` example.

 `n=5` to request multiple completions now fails for many provider/model combinations because multi-candidate generation is often, nowadays, restricted or unsupported.

I verified this behavior with current provider-backed models:

- `groq/moonshotai/kimi-k2-instruct-0905`  
  → `BadRequestError`: `'n' : number must be at most 1`
- `gemini/gemini-3.1-flash-lite-preview`  
  → `BadRequestError`: `Multiple candidates is not enabled for this model`
- `anthropic/claude-3-5-haiku-latest` via LiteLLM  
  → `UnsupportedParamsError`: provider does not support `n`