### PR TITLE
docs: add docstrings to predict module public APIs

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -79,8 +79,9 @@ class Predict(Module, Parameter):
 
         Args:
             json_mode: If True, convert demonstration examples to plain
-                dictionaries for JSON serialization. If False, preserve
-                the original example objects.
+                dictionaries for JSON serialization. If False, keep the
+                original container types (e.g., ``Example``), though
+                individual field values are still serialized.
 
         Returns:
             A dictionary containing the serialized module state with keys


### PR DESCRIPTION
## Summary
- Adds Google-style docstrings to all public methods in `dspy/predict/predict.py` that were missing documentation
- Methods documented: `reset()`, `dump_state()`, `__call__()`, `acall()`, `forward()`, `aforward()`, `update_config()`, `get_config()`
- Follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) as specified in the issue

Resolves #8926 (partial — covers the `predict` module)

## Changes
- 8 public methods now have complete docstrings with Args, Returns, and Example sections
- Private methods (prefixed with `_`) intentionally skipped
- No functional code changes — docstrings only

## Test plan
- [x] Verify docstrings render correctly with `help(dspy.Predict)` in a Python REPL
- [x] Confirm no functional code changes were made