### PR TITLE
fix(adapters): empty LM text response silently returns None instead of raising parse error

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -133,7 +133,7 @@ class Adapter:
                 output_logprobs = output.get("logprobs")
                 tool_calls = output.get("tool_calls")
 
-            if text:
+            if text is not None:
                 value = self.parse(processed_signature, text)
                 for field_name in original_signature.output_fields.keys():
                     if field_name not in value:

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -743,3 +743,27 @@ All interactions will be structured in the following way, with the appropriate v
 In adhering to this structure, your objective is: 
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+def test_empty_string_response_raises_parse_error_instead_of_returning_none():
+    """Regression test for #9378: empty LM text response should raise AdapterParseError,
+    not silently set all output fields to None."""
+
+    class Translate(dspy.Signature):
+        """Translate a word from English to Spanish."""
+
+        english: str = dspy.InputField()
+        spanish: str = dspy.OutputField()
+
+    adapter = dspy.ChatAdapter()
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content=""))],
+            model="openai/gpt-4o-mini",
+        )
+
+        lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+        with pytest.raises(dspy.utils.exceptions.AdapterParseError):
+            adapter(lm, {}, Translate, [], {"english": "hello"})


### PR DESCRIPTION
## Summary

Fixes #9378. When an LM returns an empty string as `text`, `_call_postprocess` in `base.py` checks `if text:`, which is `False` for `""`. This skips `self.parse()` entirely and silently sets all output fields to `None`, breaking typed response contracts.

The fix changes `if text:` to `if text is not None:` so empty strings are passed to `parse()`, which then raises `AdapterParseError` (the expected behavior for unparseable responses).

## Changes

- `dspy/adapters/base.py`: Replace truthiness check with explicit `None` check on line 136
- `tests/adapters/test_chat_adapter.py`: Add regression test confirming empty-string responses raise `AdapterParseError`

## Testing

- New test `test_empty_string_response_raises_parse_error_instead_of_returning_none` passes
- All 28 existing `test_chat_adapter.py` tests pass