### PR TITLE
fix(adapters): raise AdapterParseError when LM returns empty text for regular output fields

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -140,9 +140,30 @@ class Adapter:
                         # We need to set the field not present in the processed signature to None for consistency.
                         value[field_name] = None
             else:
+                # Text is empty — parse an empty string so that required output fields
+                # that can only come from text trigger an AdapterParseError rather than
+                # silently returning None.  Custom-type fields (e.g. Reasoning, parsed
+                # from reasoning_content) are handled in the loop below and will override
+                # any values set here.  We only suppress the error if the signature has
+                # NO text-parseable output fields (i.e. all fields are handled by native
+                # response type parsers).
                 value = {}
                 for field_name in original_signature.output_fields.keys():
                     value[field_name] = None
+                # Check whether any output field requires text-based parsing.
+                native_response_types = getattr(self, 'native_response_types', set())
+                has_text_only_field = any(
+                    not (
+                        isinstance(field.annotation, type)
+                        and issubclass(field.annotation, Type)
+                        and field.annotation in native_response_types
+                    )
+                    for field in original_signature.output_fields.values()
+                )
+                if has_text_only_field:
+                    # Re-use parse() to emit the proper AdapterParseError for the
+                    # missing fields rather than propagating None silently.
+                    self.parse(processed_signature, "")
 
             if tool_calls and tool_call_output_field_name:
                 tool_calls = [

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -743,3 +743,33 @@ All interactions will be structured in the following way, with the appropriate v
 In adhering to this structure, your objective is: 
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+def test_empty_text_raises_adapter_parse_error_for_regular_fields():
+    """When the LM returns empty text, AdapterParseError should be raised for regular output
+    fields rather than silently returning None values.
+
+    Regression test for https://github.com/stanfordnlp/dspy/issues/9378.
+    """
+    import dspy
+    from dspy.utils.exceptions import AdapterParseError
+
+    class Translate(dspy.Signature):
+        """Translate a word from English to Spanish."""
+
+        english: str = dspy.InputField()
+        spanish: str = dspy.OutputField()
+
+    class FakeLM(dspy.BaseLM):
+        def __init__(self):
+            super().__init__(model="fake")
+
+        def __call__(self, prompt=None, messages=None, **kwargs):
+            # Return a response with empty text and some content only in reasoning_content
+            return [{"text": "", "reasoning_content": "the answer is hola"}]
+
+    lm = FakeLM()
+    adapter = dspy.ChatAdapter()
+    with dspy.context(lm=lm, adapter=adapter):
+        with pytest.raises(AdapterParseError):
+            dspy.Predict(Translate)(english="hello")


### PR DESCRIPTION
## Problem

Fixes #9378.

When an LM returns an empty `text` response (e.g., when a model's response body is `""`), `BaseAdapter._call_postprocess` silently set **all output fields to `None`** without raising any error:

```python
# Before
else:  # text == ""
    value = {}
    for field_name in original_signature.output_fields.keys():
        value[field_name] = None  # ← silently returns None, no validation
```

This bypassed Pydantic type validation entirely. A signature like:

```python
class Translate(dspy.Signature):
    english: str = dspy.InputField()
    spanish: str = dspy.OutputField()   # expects str, gets None
```

would return `None` for `spanish` with no exception, even though `str` is a required typed field.

## Fix

When `text` is empty, check if any output field requires text-based parsing (i.e. is NOT a custom type satisfied by non-text response data like `reasoning_content`). If such a field exists, call `self.parse(processed_signature, "")` to trigger the normal `AdapterParseError` path:

```python
has_text_only_field = any(
    not (isinstance(f.annotation, type) and issubclass(f.annotation, Type) and f.annotation in native_response_types)
    for f in original_signature.output_fields.values()
)
if has_text_only_field:
    self.parse(processed_signature, "")   # raises AdapterParseError
```

**Custom-type fields** (e.g. `Reasoning`, parsed from `reasoning_content`) are handled in the existing native-response-type loop and are NOT affected — they do not trigger the empty-text error path.

## Test

Added `test_empty_text_raises_adapter_parse_error_for_regular_fields` that:
1. Creates a `FakeLM` returning `text=""` with `reasoning_content`
2. Expects `AdapterParseError` to be raised for the `spanish: str` output field