### PR TITLE
fix(code): replace long docstring with concise description in JSON schema

### DIFF
--- a/dspy/adapters/types/code.py
+++ b/dspy/adapters/types/code.py
@@ -2,7 +2,7 @@ import re
 from typing import Any, ClassVar
 
 import pydantic
-from pydantic import create_model
+from pydantic import ConfigDict, create_model
 
 from dspy.adapters.types.base_type import Type
 
@@ -62,6 +62,11 @@ class Code(Type):
     print(result.result)
     ```
     """
+
+    # Use a concise JSON schema description to prevent the full class docstring (which contains
+    # lengthy Python examples) from leaking into the LM prompt via the JSON schema `# note:` hint.
+    # The class docstring is preserved for IDE/docs tooling; this override controls what the model sees.
+    model_config = ConfigDict(json_schema_extra={"description": "A code snippet."})
 
     code: str
 


### PR DESCRIPTION
## Problem

Fixes #9251.

`dspy.Code`'s class docstring contains extensive Python examples (two complete code snippets, ~50 lines). Pydantic uses the class docstring as the JSON schema `description` field, which `ChatAdapter` then injects into the LM prompt as a schema hint:

```
[[ ## code ## ]]
{code}        # note: the value you produce must adhere to the JSON schema: {
#   "description": "Code type in DSPy.\n\nThis type is useful for code generation...\n\nExample 1: ...\n\nExample 2: ...",
#   ...
# }
```

This creates two problems:
1. **Contradictory instructions**: The `Code.description()` method already tells the model to use Markdown code blocks (```python`), while the JSON schema note says the value must be a JSON object — confusing the model.
2. **Token waste**: The full docstring (~50 lines) is injected on every call.

## Fix

Add `model_config = ConfigDict(json_schema_extra={"description": "A code snippet."})` to override the JSON schema description without touching the class docstring. Pydantic merges `json_schema_extra` into the generated schema, replacing the auto-generated `description` key.

The class docstring is preserved for IDE autocompletion and documentation tooling. Only the LM-visible JSON schema description changes.

## Before / After

**Before:**
```
# note: the value you produce must adhere to the JSON schema: {"description": "Code type in DSPy.\n\nThis type is useful for code generation and code analysis.\n\nExample 1: ...", ...}
```

**After:**
```
# note: the value you produce must adhere to the JSON schema: {"description": "A code snippet.", ...}
```