### PR TITLE
fix(streaming): remove default tool status messages from StatusMessageProvider for consistency

### DIFF
--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -72,11 +72,11 @@ class StatusMessageProvider:
 
     def tool_start_status_message(self, instance: Any, inputs: dict[str, Any]):
         """Status message before a `dspy.Tool` is called."""
-        return f"Calling tool {instance.name}..."
+        pass
 
     def tool_end_status_message(self, outputs: Any):
         """Status message after a `dspy.Tool` is called."""
-        return "Tool calling finished! Querying the LLM with tool calling results..."
+        pass
 
     def module_start_status_message(self, instance: Any, inputs: dict[str, Any]):
         """Status message before a `dspy.Module` or `dspy.Predict` is called."""

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -92,9 +92,9 @@ async def test_default_status_streaming():
             if isinstance(value, StatusMessage):
                 status_messages.append(value)
 
-    assert len(status_messages) == 2
-    assert status_messages[0].message == "Calling tool generate_question..."
-    assert status_messages[1].message == "Tool calling finished! Querying the LLM with tool calling results..."
+    # The default StatusMessageProvider returns None for all events, so no status messages
+    # are emitted unless the user subclasses and overrides the relevant method.
+    assert len(status_messages) == 0
 
 
 @pytest.mark.anyio
@@ -278,9 +278,9 @@ async def test_default_status_streaming_in_async_program():
             if isinstance(value, StatusMessage):
                 status_messages.append(value)
 
-    assert len(status_messages) == 2
-    assert status_messages[0].message == "Calling tool generate_question..."
-    assert status_messages[1].message == "Tool calling finished! Querying the LLM with tool calling results..."
+    # The default StatusMessageProvider returns None for all events, so no status messages
+    # are emitted unless the user subclasses and overrides the relevant method.
+    assert len(status_messages) == 0
 
 
 @pytest.mark.llm_call
@@ -410,9 +410,9 @@ def test_sync_status_streaming():
             if isinstance(value, StatusMessage):
                 status_messages.append(value)
 
-    assert len(status_messages) == 2
-    assert status_messages[0].message == "Calling tool generate_question..."
-    assert status_messages[1].message == "Tool calling finished! Querying the LLM with tool calling results..."
+    # The default StatusMessageProvider returns None for all events, so no status messages
+    # are emitted unless the user subclasses and overrides the relevant method.
+    assert len(status_messages) == 0
 
 
 @pytest.mark.anyio
@@ -850,7 +850,14 @@ async def test_status_message_non_blocking():
             dspy.Tool(dummy_tool)()
             return dspy.Prediction(answer="dummy_tool_output")
 
-    program = dspy.streamify(MyProgram(), status_message_provider=StatusMessageProvider())
+    class ToolStatusProvider(StatusMessageProvider):
+        def tool_start_status_message(self, instance, inputs):
+            return f"Calling tool {instance.name}..."
+
+        def tool_end_status_message(self, outputs):
+            return "Tool calling finished!"
+
+    program = dspy.streamify(MyProgram(), status_message_provider=ToolStatusProvider())
 
     with mock.patch("litellm.acompletion", new_callable=AsyncMock, side_effect=[dummy_tool]):
         with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):
@@ -878,7 +885,14 @@ async def test_status_message_non_blocking_async_program():
             await dspy.Tool(dummy_tool).acall()
             return dspy.Prediction(answer="dummy_tool_output")
 
-    program = dspy.streamify(MyProgram(), status_message_provider=StatusMessageProvider(), is_async_program=True)
+    class ToolStatusProvider(StatusMessageProvider):
+        def tool_start_status_message(self, instance, inputs):
+            return f"Calling tool {instance.name}..."
+
+        def tool_end_status_message(self, outputs):
+            return "Tool calling finished!"
+
+    program = dspy.streamify(MyProgram(), status_message_provider=ToolStatusProvider(), is_async_program=True)
 
     with mock.patch("litellm.acompletion", new_callable=AsyncMock, side_effect=[dummy_tool]):
         with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):


### PR DESCRIPTION
## Problem

Fixes #9177.

`StatusMessageProvider` is inconsistent: `tool_start/end_status_message` return hardcoded strings (always emitting messages), while `module_start/end` and `lm_start/end` return `None` (silent by default).

```python
# Before — inconsistent defaults
def tool_start_status_message(self, instance, inputs):
    return f'Calling tool {instance.name}...'   # ← always emitted

def module_start_status_message(self, instance, inputs):
    pass                                          # ← silent by default
```

This meant tool invocations silently produced status messages even when users had not opted in, while all other hooks were silent.

## Fix

Change `tool_start_status_message` and `tool_end_status_message` to `pass` (return `None`), consistent with all other base-class methods.

Users who want tool status messages can subclass `StatusMessageProvider` and override these methods:

```python
class MyProvider(StatusMessageProvider):
    def tool_start_status_message(self, instance, inputs):
        return f'Calling tool {instance.name}...'

    def tool_end_status_message(self, outputs):
        return 'Tool calling finished!'
```

## Tests Updated

- Tests that asserted the default provider emits 2 tool status messages now assert 0 messages.
- Non-blocking timing tests (`test_status_message_non_blocking*`) define an inline `ToolStatusProvider` subclass that replicates the old behavior so the timing logic continues to be exercised.

> **Note:** This is a minor breaking change for users relying on the default tool status messages. If needed, a deprecation warning could be added before removing the defaults in a future release — but since the issue author considers this a bug, we remove the defaults directly.