### PR TITLE
fix(adapters): raise AdapterParseError on empty LM response instead of silent None

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -11,6 +11,7 @@ from dspy.adapters.types.tool import Tool, ToolCalls
 from dspy.experimental import Citations
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback, with_callbacks
+from dspy.utils.exceptions import AdapterParseError
 
 logger = logging.getLogger(__name__)
 
@@ -139,10 +140,17 @@ class Adapter:
                     if field_name not in value:
                         # We need to set the field not present in the processed signature to None for consistency.
                         value[field_name] = None
-            else:
+            elif tool_calls and tool_call_output_field_name:
                 value = {}
                 for field_name in original_signature.output_fields.keys():
                     value[field_name] = None
+            else:
+                raise AdapterParseError(
+                    adapter_name=type(self).__name__,
+                    signature=original_signature,
+                    lm_response=str(output),
+                    message="The LM returned an empty or null response.",
+                )
 
             if tool_calls and tool_call_output_field_name:
                 tool_calls = [

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -743,3 +743,53 @@ All interactions will be structured in the following way, with the appropriate v
 In adhering to this structure, your objective is: 
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+def test_null_content_raises_adapter_parse_error():
+    """When the LM returns content=None with no tool calls (e.g. content filter),
+    the adapter should raise AdapterParseError instead of silently returning None fields."""
+    from dspy.utils.exceptions import AdapterParseError
+
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+    response = ModelResponse(
+        choices=[Choices(message=Message(content=None))],
+        model="openai/gpt-4o-mini",
+    )
+
+    with dspy.context(lm=lm):
+        with mock.patch("litellm.completion", return_value=response):
+            cot = dspy.ChainOfThought("question -> answer")
+            with pytest.raises(AdapterParseError):
+                cot(question="test")
+
+
+def test_empty_string_content_raises_adapter_parse_error():
+    """Same as above but with empty string content."""
+    from dspy.utils.exceptions import AdapterParseError
+
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+    response = ModelResponse(
+        choices=[Choices(message=Message(content=""))],
+        model="openai/gpt-4o-mini",
+    )
+
+    with dspy.context(lm=lm):
+        with mock.patch("litellm.completion", return_value=response):
+            cot = dspy.ChainOfThought("question -> answer")
+            with pytest.raises(AdapterParseError):
+                cot(question="test")
+
+
+def test_tool_call_with_null_content_does_not_raise():
+    """Tool-call-only responses legitimately have content=None.
+    _call_postprocess must NOT raise when tool_calls are present."""
+    adapter = dspy.ChatAdapter(use_native_function_calling=True)
+    sig_cls = dspy.Signature("question, tools: list[dspy.Tool] -> answer, tool_calls: dspy.ToolCalls")
+
+    outputs = [{"text": None, "tool_calls": [
+        {"function": {"name": "search", "arguments": '{"query": "test"}'}, "id": "call_1", "type": "function"}
+    ]}]
+
+    result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
+    assert result is not None
+    assert len(result) == 1


### PR DESCRIPTION
## Summary

Fixes #9372 and #9378

When the LM returns `content=None` or an empty string with no usable output (e.g. content filter, rate-limit), DSPy was silently producing a `Prediction` with all-`None` fields.

## Before/After

**Before:** `Prediction(reasoning=None, mark=None, feedback=None)` returned silently
**After:** `AdapterParseError: The LM returned an empty or null response.`