### PR TITLE
feat: retry LM call on pydantic validation and adapter parse errors

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, get_origin
 
 import json_repair
 import litellm
+import pydantic
 
 from dspy.adapters.types import History, Type
 from dspy.adapters.types.base_type import split_message_content_for_custom_types
@@ -207,8 +208,20 @@ class Adapter:
         processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
         inputs = self.format(processed_signature, demos, inputs)
 
-        outputs = lm(messages=inputs, **lm_kwargs)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        max_retries = getattr(lm, 'num_retries', 3)
+        last_error = None
+        for attempt in range(max_retries + 1):
+            outputs = lm(messages=inputs, **lm_kwargs)
+            try:
+                return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+            except (AdapterParseError, pydantic.ValidationError) as e:
+                last_error = e
+                if attempt < max_retries:
+                    logger.warning(
+                        "Adapter parse error on attempt %d/%d, retrying: %s",
+                        attempt + 1, max_retries + 1, str(e)[:200],
+                    )
+        raise last_error
 
     async def acall(
         self,
@@ -221,8 +234,20 @@ class Adapter:
         processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
         inputs = self.format(processed_signature, demos, inputs)
 
-        outputs = await lm.acall(messages=inputs, **lm_kwargs)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        max_retries = getattr(lm, 'num_retries', 3)
+        last_error = None
+        for attempt in range(max_retries + 1):
+            outputs = await lm.acall(messages=inputs, **lm_kwargs)
+            try:
+                return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+            except (AdapterParseError, pydantic.ValidationError) as e:
+                last_error = e
+                if attempt < max_retries:
+                    logger.warning(
+                        "Adapter parse error on attempt %d/%d, retrying: %s",
+                        attempt + 1, max_retries + 1, str(e)[:200],
+                    )
+        raise last_error
 
     def format(
         self,


### PR DESCRIPTION
## Summary

Add retry logic to the base adapter's `__call__` and `acall` methods so that when parsing the LM output fails with `AdapterParseError` or `pydantic.ValidationError`, the LM call is retried instead of immediately failing.

## Problem

When a language model returns output that doesn't match the expected Pydantic schema (e.g., wrong field types, missing required fields), parsing raises `pydantic.ValidationError` wrapped in `AdapterParseError`. Currently this immediately propagates as an error, even though the LM might produce valid output on a subsequent call (especially with temperature > 0).

## Fix

- In `Adapter.__call__()` and `Adapter.acall()`, wrap the LM call + postprocess in a retry loop
- Catch `AdapterParseError` and `pydantic.ValidationError`
- Retry up to `lm.num_retries` times (defaults to 3)
- Log a warning on each retry attempt
- Raise the last error if all retries are exhausted

This is especially useful for structured output with strict Pydantic models where the LM occasionally produces slightly malformed output.

Relates to #7693