### PR TITLE
fix: propagate exceptions from async generator in apply_sync_streaming

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -228,6 +228,7 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
     """Convert the async streaming generator to a sync generator."""
     queue = Queue()  # Queue to hold items from the async generator
     stop_sentinel = object()  # Sentinel to signal the generator is complete
+    error_sentinel = object()  # Sentinel to signal an exception occurred
 
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
@@ -239,6 +240,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as e:
+                queue.put((error_sentinel, e))
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +257,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if isinstance(item, tuple) and len(item) == 2 and item[0] is error_sentinel:
+            raise item[1]
         yield item
 
 


### PR DESCRIPTION
## Summary

Fix exception propagation in `apply_sync_streaming()` so that errors from the async generator are properly raised in the consumer thread.

## Problem

In `apply_sync_streaming()`, the producer thread runs an async generator and puts items on a queue. If the async generator raises an exception, the `try/finally` block only places the `stop_sentinel` on the queue. The exception is silently swallowed, and the consumer simply stops iterating — the caller never sees the error.

This makes debugging very difficult because errors like `AdapterParseError`, `ValueError`, or LM API errors are completely hidden when using sync streaming.

## Fix

- Add an `error_sentinel` alongside the existing `stop_sentinel`
- In the `runner()` async function, catch `BaseException` and put `(error_sentinel, exception)` on the queue before the finally block places the stop sentinel
- In the consumer loop, check for error sentinels and re-raise the original exception

This ensures that any exception from the async generator (LM errors, parse errors, etc.) is properly propagated to the caller of the sync streaming generator.