### PR TITLE
Deprecation warning that prefix, format, and parser kwargs in InputField/OutputField are not rendered by adapters.

### DIFF
--- a/dspy/predict/avatar/avatar.py
+++ b/dspy/predict/avatar/avatar.py
@@ -56,15 +56,11 @@ class Avatar(dspy.Module):
     def _get_field(self, field_info: FieldInfo):
         if field_info.json_schema_extra["__dspy_field_type"] == "input":
             return dspy.InputField(
-                prefix=field_info.json_schema_extra["prefix"],
                 desc=field_info.json_schema_extra["desc"],
-                format=field_info.json_schema_extra["format"] if "format" in field_info.json_schema_extra else None,
             )
         elif field_info.json_schema_extra["__dspy_field_type"] == "output":
             return dspy.OutputField(
-                prefix=field_info.json_schema_extra["prefix"],
                 desc=field_info.json_schema_extra["desc"],
-                format=field_info.json_schema_extra["format"] if "format" in field_info.json_schema_extra else None,
             )
         else:
             raise ValueError(f"Unknown field type: {field_info.json_schema_extra['__dspy_field_type']}")

--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -28,10 +28,9 @@ class ChainOfThought(Module):
         """
         super().__init__()
         signature = ensure_signature(signature)
-        prefix = "Reasoning: Let's think step by step in order to"
         desc = "${reasoning}"
         rationale_field_type = rationale_field.annotation if rationale_field else rationale_field_type
-        rationale_field = rationale_field if rationale_field else dspy.OutputField(prefix=prefix, desc=desc)
+        rationale_field = rationale_field if rationale_field else dspy.OutputField(desc=desc)
         extended_signature = signature.prepend(name="reasoning", field=rationale_field, type_=rationale_field_type)
         self.predict = dspy.Predict(extended_signature, **config)
 

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -67,35 +67,25 @@ class ProgramOfThought(Module):
         fields_for_mode = {
             "generate": {
                 "generated_code": dspy.OutputField(
-                    prefix="Code:",
                     desc="python code that answers the question",
-                    format=str,
                 ),
             },
             "regenerate": {
                 "previous_code": dspy.InputField(
-                    prefix="Previous Code:",
                     desc="previously-generated python code that errored",
-                    format=str,
                 ),
                 "error": dspy.InputField(
-                    prefix="Error:",
                     desc="error message from previously-generated python code",
                 ),
                 "generated_code": dspy.OutputField(
-                    prefix="Code:",
                     desc="python code that answers the question",
-                    format=str,
                 ),
             },
             "answer": {
                 "final_generated_code": dspy.InputField(
-                    prefix="Code:",
                     desc="python code that answers the question",
-                    format=str,
                 ),
                 "code_output": dspy.InputField(
-                    prefix="Code Output:",
                     desc="output of previously-generated python code",
                 ),
             }

--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -30,18 +30,13 @@ class DescribeProgram(dspy.Signature):
         """Below is some pseudo-code for a pipeline that solves tasks with calls to language models. Please describe what type of task this program appears to be designed to solve, and how it appears to work."""
     )
     program_code = dspy.InputField(
-        format=str,
         desc="Pseudocode for a language model program designed to solve a particular task.",
-        prefix="PROGRAM CODE:",
     )
     program_example = dspy.InputField(
-        format=str,
         desc="An example of the program in use.",
-        prefix="EXAMPLE OF PROGRAM IN USE:",
     )
     program_description = dspy.OutputField(
         desc="Describe what task the program is designed to solve, and how it goes about solving this task.",
-        prefix="SUMMARY OF PROGRAM ABOVE:",
     )
 
 
@@ -50,25 +45,19 @@ class DescribeModule(dspy.Signature):
         """Below is some pseudo-code for a pipeline that solves tasks with calls to language models. Please describe the purpose of one of the specified module in this pipeline."""
     )
     program_code = dspy.InputField(
-        format=str,
         desc="Pseudocode for a language model program designed to solve a particular task.",
-        prefix="PROGRAM CODE:",
     )
     program_example = dspy.InputField(
-        format=str,
         desc="An example of the program in use.",
-        prefix="EXAMPLE OF PROGRAM IN USE:",
     )
     program_description = dspy.InputField(
         desc="Summary of the task the program is designed to solve, and how it goes about solving it.",
-        prefix="SUMMARY OF PROGRAM ABOVE:",
     )
     module = dspy.InputField(
-        desc="The module in the program that we want to describe.", prefix="MODULE:",
+        desc="The module in the program that we want to describe.",
     )
     module_description = dspy.OutputField(
         desc="Description of the module's role in the broader program.",
-        prefix="MODULE DESCRIPTION:",
     )
 
 
@@ -86,47 +75,36 @@ def generate_instruction_class(
         if use_dataset_summary:
             dataset_description = dspy.InputField(
                 desc="A description of the dataset that we are using.",
-                prefix="DATASET SUMMARY:",
             )
         if program_aware:
             program_code = dspy.InputField(
-                format=str,
                 desc="Language model program designed to solve a particular task.",
-                prefix="PROGRAM CODE:",
             )
             program_description = dspy.InputField(
                 desc="Summary of the task the program is designed to solve, and how it goes about solving it.",
-                prefix="PROGRAM DESCRIPTION:",
             )
             module = dspy.InputField(
-                desc="The module to create an instruction for.", prefix="MODULE:",
+                desc="The module to create an instruction for.",
             )
             module_description = dspy.InputField(
-                desc="Description of the module to create an instruction for.", prefix="MODULE DESCRIPTION:",
+                desc="Description of the module to create an instruction for.",
             )
         task_demos = dspy.InputField(
-            format=str,
             desc="Example inputs/outputs of our module.",
-            prefix="TASK DEMO(S):",
         )
         if use_instruct_history:
             previous_instructions = dspy.InputField(
-                format=str,
                 desc="Previous instructions we've attempted, along with their associated scores.",
-                prefix="PREVIOUS INSTRUCTIONS:",
             )
         basic_instruction = dspy.InputField(
-            format=str, desc="Basic instruction.", prefix="BASIC INSTRUCTION:",
+            desc="Basic instruction.",
         )
         if use_tip:
             tip = dspy.InputField(
-                format=str,
                 desc="A suggestion for how to go about generating the new instruction.",
-                prefix="TIP:",
             )
         proposed_instruction = dspy.OutputField(
             desc="Propose an instruction that will be used to prompt a Language Model to perform this task.",
-            prefix="PROPOSED INSTRUCTION:",
         )
 
     return dspy.Predict(GenerateSingleModuleInstruction)

--- a/dspy/signatures/field.py
+++ b/dspy/signatures/field.py
@@ -1,9 +1,26 @@
+import warnings
+
 import pydantic
 
 # The following arguments can be used in DSPy InputField and OutputField in addition
 # to the standard pydantic.Field arguments. We just hope pydanitc doesn't add these,
 # as it would give a name clash.
 DSPY_FIELD_ARG_NAMES = ["desc", "prefix", "format", "parser", "__dspy_field_type"]
+
+_DEPRECATED_FIELD_ARGS = {
+    "prefix": (
+        "The 'prefix' argument in InputField/OutputField is deprecated and has no effect in DSPy. "
+        "It will be removed in a future version."
+    ),
+    "format": (
+        "The 'format' argument in InputField/OutputField is deprecated and has no effect in DSPy. "
+        "It will be removed in a future version."
+    ),
+    "parser": (
+        "The 'parser' argument in InputField/OutputField is deprecated and has no effect in DSPy. "
+        "It will be removed in a future version."
+    ),
+}
 
 PYDANTIC_CONSTRAINT_MAP = {
     "gt": "greater than: ",
@@ -51,11 +68,19 @@ def _translate_pydantic_field_constraints(**kwargs):
     return ", ".join(constraints)
 
 
+def _warn_deprecated_field_args(**kwargs):
+    for arg, message in _DEPRECATED_FIELD_ARGS.items():
+        if arg in kwargs:
+            warnings.warn(message, DeprecationWarning, stacklevel=3)
+
+
 def InputField(**kwargs): # noqa: N802
+    _warn_deprecated_field_args(**kwargs)
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="input"))
 
 
 def OutputField(**kwargs): # noqa: N802
+    _warn_deprecated_field_args(**kwargs)
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="output"))
 
 


### PR DESCRIPTION
These arguments are accepted but have no effect in DSPy's current adapter-based architecture. This change:

- Adds DeprecationWarning when users pass prefix, format, or parser to InputField or OutputField
- Removes internal usage of these args from chain_of_thought, program_of_thought, avatar, and grounded_proposer
- Does not break existing user code (args are still accepted, just warned)

# This convinced me they were not applied


## Proofs That Prefix Don't Do Anything


```python
import dspy
from difflib import unified_diff
from dspy.teleprompt.avatar_optimizer import Comparator

def as_text(messages):
    return "\n\n".join(f"{m['role'].upper()}:\n{m['content']}" for m in messages)

def diff(a, b, a_name="A", b_name="B"):
    return "\n".join(unified_diff(a.splitlines(), b.splitlines(), fromfile=a_name, tofile=b_name, lineterm=""))

sample_inputs = {
    "instruction": "Use tools carefully.",
    "actions": ["search", "lookup"],
    "pos_input_with_metrics": [{"example": {"q": "x"}, "score": 1.0, "actions": None}],
    "neg_input_with_metrics": [{"example": {"q": "y"}, "score": 0.0, "actions": None}],
}

```

```output:exec-1772724098203-132op
```

```python
# 1) Change ONLY prefixes
SigBase = Comparator
SigPrefix = (
    Comparator
    .with_updated_fields("instruction", prefix="!!! INSTR !!!")
    .with_updated_fields("actions", prefix="!!! ACT !!!")
    .with_updated_fields("pos_input_with_metrics", prefix="!!! POS !!!")
    .with_updated_fields("neg_input_with_metrics", prefix="!!! NEG !!!")
    .with_updated_fields("feedback", prefix="!!! FB !!!")
)

chat = dspy.ChatAdapter()
m_base = chat.format(signature=SigBase, demos=[], inputs=sample_inputs)
m_pref = chat.format(signature=SigPrefix, demos=[], inputs=sample_inputs)

print("ChatAdapter: prompts identical after prefix-only changes?", m_base == m_pref)
print(diff(as_text(m_base), as_text(m_pref), "base", "prefix"))  # should be empty

```

```output:exec-1772724136847-fjumj
ChatAdapter: prompts identical after prefix-only changes? True
```

```python
# 2) Change description instead (desc is used)
SigDesc = Comparator.with_updated_fields("instruction", desc="THIS DESC SHOULD APPEAR IN PROMPT")

m_desc = chat.format(signature=SigDesc, demos=[], inputs=sample_inputs)
print("ChatAdapter: prompts identical after desc change?", m_base == m_desc)
print(diff(as_text(m_base), as_text(m_desc), "base", "desc"))  # should show differences

```

```output:exec-1772724174458-tahni
ChatAdapter: prompts identical after desc change? False
--- base
+++ desc
@@ -1,6 +1,6 @@
 SYSTEM:
 Your input fields are:
-1. `instruction` (str): Instruction for the actor to execute the task
+1. `instruction` (str): THIS DESC SHOULD APPEAR IN PROMPT
 2. `actions` (list[str]): Actions actor can take to complete the task
 3. `pos_input_with_metrics` (list[EvalResult]): Positive inputs along with their score on a evaluation metric and actions taken
 4. `neg_input_with_metrics` (list[EvalResult]): Negative inputs along with their score on a evaluation metric and actions taken
```

```python
# 3) Repeat across adapters
adapters = {
    "chat": dspy.ChatAdapter(),
    "json": dspy.JSONAdapter(),
    "xml": dspy.XMLAdapter(),
}

for name, adapter in adapters.items():
    a = adapter.format(signature=SigBase, demos=[], inputs=sample_inputs)
    b = adapter.format(signature=SigPrefix, demos=[], inputs=sample_inputs)
    print(f"{name}: prefix-only identical? {a == b}")

```

```output:exec-1772724181386-g9grw
chat: prefix-only identical? True
json: prefix-only identical? True
xml: prefix-only identical? True
```

## Proving format and parser don't do anything


```python
import dspy

def bomb(*args, **kwargs):
    raise RuntimeError("field format/parser metadata was invoked")

class BaseSig(dspy.Signature):
    inp: str = dspy.InputField(desc="input text")
    out: int = dspy.OutputField(desc="output number")

# Only change DSPy metadata: format/parser
MutSig = BaseSig.with_updated_fields("inp", format=bomb)
MutSig = MutSig.with_updated_fields("out", format=bomb, parser=bomb)

inputs = {"inp": "hello"}

# 1) Prompt formatting should be identical
for name, ad in [("chat", dspy.ChatAdapter()), ("json", dspy.JSONAdapter()), ("xml", dspy.XMLAdapter())]:
    m_base = ad.format(signature=BaseSig, demos=[], inputs=inputs)
    m_mut = ad.format(signature=MutSig, demos=[], inputs=inputs)
    assert m_base == m_mut, f"{name} format changed when only format/parser metadata changed"

print("OK: format() identical across adapters when only format/parser changed")

# 2) Parsing should be identical
chat_completion = "[[ ## out ## ]]\n123\n\n[[ ## completed ## ]]\n"
json_completion = '{"out": 123}'
xml_completion = "<out>123</out>"

assert dspy.ChatAdapter().parse(BaseSig, chat_completion) == {"out": 123}
assert dspy.ChatAdapter().parse(MutSig, chat_completion) == {"out": 123}
assert dspy.JSONAdapter().parse(BaseSig, json_completion) == {"out": 123}
assert dspy.JSONAdapter().parse(MutSig, json_completion) == {"out": 123}
assert dspy.XMLAdapter().parse(BaseSig, xml_completion) == {"out": 123}
assert dspy.XMLAdapter().parse(MutSig, xml_completion) == {"out": 123}

print("OK: parse() identical across adapters when only format/parser changed")
print("If bomb() were used anywhere, this would have raised RuntimeError.")

```

```output:exec-1772724290038-nngmf
OK: format() identical across adapters when only format/parser changed
OK: parse() identical across adapters when only format/parser changed
If bomb() were used anywhere, this would have raised RuntimeError.
```

## Proof format used in pot does nothing


```python
import dspy
from dspy.utils.dummies import DummyLM

# Avoid deno dependency
class FakeInterpreter:
    def execute(self, code):
        return {"answer": "2"}
    def shutdown(self):
        pass

def make_pot():
    return dspy.ProgramOfThought("question -> answer", interpreter=FakeInterpreter(), max_iters=2)

def bomb(*args, **kwargs):
    raise RuntimeError("format metadata was invoked")

pot_a = make_pot()
pot_b = make_pot()

# Overwrite every existing field-format in PoT sub-signatures with bomb()
for chain in [pot_b.code_generate, pot_b.code_regenerate, pot_b.generate_output]:
    sig = chain.predict.signature
    for fname, finfo in list(sig.fields.items()):
        if finfo.json_schema_extra and ("format" in finfo.json_schema_extra):
            sig = sig.with_updated_fields(fname, format=bomb)
    chain.predict.signature = sig

# 1) Prompt proof: same messages
adapter = dspy.ChatAdapter()
msgs_a = adapter.format(signature=pot_a.code_generate.predict.signature, demos=[], inputs={"question": "what is 1+1?"})
msgs_b = adapter.format(signature=pot_b.code_generate.predict.signature, demos=[], inputs={"question": "what is 1+1?"})
assert msgs_a == msgs_b

# 2) Runtime proof: if format were used, this would raise RuntimeError
answers = [
    {"reasoning": "compute", "generated_code": "answer = 2"},
    {"reasoning": "finalize", "answer": "2"},
]
dspy.configure(lm=DummyLM(answers))
out_a = pot_a(question="what is 1+1?")

answers = [
    {"reasoning": "compute", "generated_code": "answer = 2"},
    {"reasoning": "finalize", "answer": "2"},
]
dspy.configure(lm=DummyLM(answers))
out_b = pot_b(question="what is 1+1?")

assert out_a.answer == out_b.answer == "2"
print("Proved: PoT field `format` metadata is not executed in this path.")

```

```output:exec-1772724902037-c4g4k
Proved: PoT field `format` metadata is not executed in this path.
```

```python
pot_a.code_regenerate
```

```output:exec-1772724967308-6hj3v
Out[47]: 
predict = Predict(StringSignature(question, previous_code, error -> reasoning, generated_code
    instructions='You are given `question`, `previous_code`, `error` due to an error in previous code.\nYour task is to correct the error and provide the new `generated_code`.'
    question = Field(annotation=str required=True json_schema_extra={'__dspy_field_type': 'input', 'prefix': 'Question:', 'desc': '${question}'})
    previous_code = Field(annotation=str required=True json_schema_extra={'prefix': 'Previous Code:', 'desc': 'previously-generated python code that errored', 'format': <class 'str'>, '__dspy_field_type': 'input'})
    error = Field(annotation=str required=True json_schema_extra={'prefix': 'Error:', 'desc': 'error message from previously-generated python code', '__dspy_field_type': 'input'})
    reasoning = Field(annotation=str required=True json_schema_extra={'prefix': "Reasoning: Let's think step by step in order to", 'desc': '${reasoning}', '__dspy_field_type': 'output'})
    generated_code = Field(annotation=str required=True json_schema_extra={'prefix': 'Code:', 'desc': 'python code that answers the question', 'format': <class 'str'>, '__dspy_field_type': 'output'})
))
```


```python
pot_b.code_regenerate
```

```output:exec-1772724980467-athui
Out[48]: 
predict = Predict(StringSignature(question, previous_code, error -> reasoning, generated_code
    instructions='You are given `question`, `previous_code`, `error` due to an error in previous code.\nYour task is to correct the error and provide the new `generated_code`.'
    question = Field(annotation=str required=True json_schema_extra={'__dspy_field_type': 'input', 'prefix': 'Question:', 'desc': '${question}'})
    previous_code = Field(annotation=str required=True json_schema_extra={'prefix': 'Previous Code:', 'desc': 'previously-generated python code that errored', 'format': <function bomb at 0x75a3d8ac2ac0>, '__dspy_field_type': 'input'})
    error = Field(annotation=str required=True json_schema_extra={'prefix': 'Error:', 'desc': 'error message from previously-generated python code', '__dspy_field_type': 'input'})
    reasoning = Field(annotation=str required=True json_schema_extra={'prefix': "Reasoning: Let's think step by step in order to", 'desc': '${reasoning}', '__dspy_field_type': 'output'})
    generated_code = Field(annotation=str required=True json_schema_extra={'prefix': 'Code:', 'desc': 'python code that answers the question', 'format': <function bomb at 0x75a3d8ac2ac0>, '__dspy_field_type': 'output'})
))
```

## Proof CoT does not apply its prefix


```python
import dspy
from dspy.utils.dummies import DummyLM

# 1) Build two CoTs: default prefix vs custom prefix
cot_default = dspy.ChainOfThought("question -> answer")
custom_prefix = "MY CUSTOM REASONING PREFIX:"
cot_custom = dspy.ChainOfThought(
    "question -> answer",
    rationale_field=dspy.OutputField(prefix=custom_prefix, desc="${reasoning}")
)

sig_default = cot_default.predict.signature
sig_custom = cot_custom.predict.signature

print("Default rationale prefix (metadata):", sig_default.output_fields["reasoning"].json_schema_extra["prefix"])
print("Custom rationale prefix  (metadata):", sig_custom.output_fields["reasoning"].json_schema_extra["prefix"])
```

```output:exec-1772727190152-51d1n
Default rationale prefix (metadata): Reasoning: Let's think step by step in order to
Custom rationale prefix  (metadata): MY CUSTOM REASONING PREFIX:
```



```python
# 2) Compare prompts generated by adapter
adapter = dspy.ChatAdapter()
inputs = {"question": "What is 2+2?"}

msgs_default = adapter.format(signature=sig_default, demos=[], inputs=inputs)
msgs_custom = adapter.format(signature=sig_custom, demos=[], inputs=inputs)

txt_default = "\n\n".join(m["content"] for m in msgs_default)
txt_custom = "\n\n".join(m["content"] for m in msgs_custom)

print("Default prefix appears in prompt?", "Reasoning: Let's think step by step in order to" in txt_default)
print("Custom prefix appears in prompt?", custom_prefix in txt_custom)
print("Prompt changes when only rationale prefix changes?", txt_default != txt_custom)

```

```output:exec-1772727208681-qwwvm
Default prefix appears in prompt? False
Custom prefix appears in prompt? False
Prompt changes when only rationale prefix changes? False
```

```python
# 3) Verify real LM call payload too (using DummyLM)
lm = DummyLM([{"reasoning": "quick calc", "answer": "4"}])
dspy.configure(lm=lm)

_ = cot_custom(question="What is 2+2?")
wire_prompt = "\n\n".join(m["content"] for m in lm.history[-1]["messages"])

print("Custom prefix appears in actual LM call?", custom_prefix in wire_prompt)
print("Last LM call messages:")
for m in lm.history[-1]["messages"]:
    print(f"\n[{m['role']}]\n{m['content']}")

```

```output:exec-1772727221000-ra0ea
Custom prefix appears in actual LM call? False
Last LM call messages:

[system]
Your input fields are:
1. `question` (str):
Your output fields are:
1. `reasoning` (str): 
2. `answer` (str):
All interactions will be structured in the following way, with the appropriate values filled in.

[[ ## question ## ]]
{question}

[[ ## reasoning ## ]]
{reasoning}

[[ ## answer ## ]]
{answer}

[[ ## completed ## ]]
In adhering to this structure, your objective is: 
        Given the fields `question`, produce the fields `answer`.

[user]
[[ ## question ## ]]
What is 2+2?

Respond with the corresponding output fields, starting with the field `[[ ## reasoning ## ]]`, then `[[ ## answer ## ]]`, and then ending with the marker for `[[ ## completed ## ]]`.
```

