### PR TITLE
feat: make optuna optional

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -25,6 +25,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+def _import_optuna():
+    try:
+        import optuna
+    except ModuleNotFoundError as exc:
+        if exc.name == "optuna":
+            raise ImportError(
+                "MIPROv2 requires optional dependency 'optuna'. "
+                "Install it with `pip install dspy[optuna]`."
+            ) from exc
+        raise
+    return optuna
+
+
 # Constants
 BOOTSTRAPPED_FEWSHOT_EXAMPLES_IN_CONTEXT = 3
 LABELED_FEWSHOT_EXAMPLES_IN_CONTEXT = 0
@@ -505,7 +519,7 @@ class MIPROv2(Teleprompter):
         minibatch_full_eval_steps: int,
         seed: int,
     ) -> Any | None:
-        import optuna
+        optuna = _import_optuna()
 
         # Run optimization
         optuna.logging.set_verbosity(optuna.logging.WARNING)
@@ -771,7 +785,8 @@ class MIPROv2(Teleprompter):
         return chosen_params, raw_chosen_params
 
     def _get_param_distributions(self, program, instruction_candidates, demo_candidates):
-        from optuna.distributions import CategoricalDistribution
+        optuna = _import_optuna()
+        CategoricalDistribution = optuna.distributions.CategoricalDistribution
 
         param_distributions = {}
 
@@ -801,7 +816,7 @@ class MIPROv2(Teleprompter):
         instruction_candidates: list,
         demo_candidates: list,
     ):
-        import optuna
+        optuna = _import_optuna()
 
         logger.info(f"===== Trial {trial_num + 1} / {adjusted_num_trials} - Full Evaluation =====")
 

--- a/dspy/teleprompt/teleprompt_optuna.py
+++ b/dspy/teleprompt/teleprompt_optuna.py
@@ -4,6 +4,19 @@ from dspy.teleprompt.teleprompt import Teleprompter
 from .bootstrap import BootstrapFewShot
 
 
+def _import_optuna():
+    try:
+        import optuna
+    except ModuleNotFoundError as exc:
+        if exc.name == "optuna":
+            raise ImportError(
+                "BootstrapFewShotWithOptuna requires optional dependency 'optuna'. "
+                "Install it with `pip install dspy[optuna]`."
+            ) from exc
+        raise
+    return optuna
+
+
 class BootstrapFewShotWithOptuna(Teleprompter):
     def __init__(
         self,
@@ -53,7 +66,7 @@ class BootstrapFewShotWithOptuna(Teleprompter):
         return result.score
 
     def compile(self, student, *, teacher=None, max_demos, trainset, valset=None):
-        import optuna
+        optuna = _import_optuna()
         self.trainset = trainset
         self.valset = valset or trainset
         self.student = student.reset_copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "orjson>=3.9.0",
     "tqdm>=4.66.1",
     "requests>=2.31.0",
-    "optuna>=3.4.0",
     "pydantic>=2.0",
     "litellm>=1.64.0",
     "diskcache>=5.6.0",
@@ -46,6 +45,7 @@ anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client~=4.5.4"]
 mcp = ["mcp; python_version >= '3.10'"]
 langchain = ["langchain_core"]
+optuna = ["optuna>=3.4.0"]
 dev = [
     "pytest>=6.2.5",
     "pytest-mock>=3.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -745,7 +745,6 @@ dependencies = [
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "openai", version = "1.75.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "openai", version = "1.88.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
-    { name = "optuna" },
     { name = "orjson" },
     { name = "pydantic" },
     { name = "regex" },
@@ -777,6 +776,9 @@ langchain = [
 mcp = [
     { name = "mcp", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "mcp", version = "1.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
+]
+optuna = [
+    { name = "optuna" },
 ]
 test-extras = [
     { name = "datasets" },
@@ -812,7 +814,7 @@ requires-dist = [
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'test-extras'" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "openai", specifier = ">=0.28.1" },
-    { name = "optuna", specifier = ">=3.4.0" },
+    { name = "optuna", marker = "extra == 'optuna'", specifier = ">=3.4.0" },
     { name = "optuna", marker = "extra == 'test-extras'", specifier = ">=3.4.0" },
     { name = "orjson", specifier = ">=3.9.0" },
     { name = "pandas", marker = "extra == 'test-extras'", specifier = ">=2.1.1" },
@@ -830,7 +832,7 @@ requires-dist = [
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = "~=4.5.4" },
     { name = "xxhash", specifier = ">=3.5.0" },
 ]
-provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "dev", "test-extras"]
+provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "dev", "test-extras"]
 
 [[package]]
 name = "email-validator"
@@ -1609,6 +1611,9 @@ name = "litellm-proxy-extras"
 version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/22/2d15f5c0198dee49f8296369486fa6319edca0c3af52e80ae2cdc1118b5a/litellm_proxy_extras-0.1.15.tar.gz", hash = "sha256:0e9b9074023eea8954183746f196d4a62f5d9fda2838fac3cb94d6ee1899a308", size = 11888, upload-time = "2025-05-03T16:29:02.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/eb/d85f375f12fa7cba9415d617d289ae969c461df918ce2c63fb22df5c77ef/litellm_proxy_extras-0.1.15-py3-none-any.whl", hash = "sha256:f0e96a2ff89e8ae67ec695db073958722a85dbea3f99a660ed16c47d585ae46e", size = 18941, upload-time = "2026-02-21T20:02:55.509Z" },
+]
 
 [[package]]
 name = "mako"


### PR DESCRIPTION
optuna (a Bayesian optimization library) was previously a required dependency for all dspy users, even though only two teleprompters use it: MIPROv2 and BootstrapFewShotWithOptuna.

This PR makes optuna optional: it is removed from core dependencies in pyproject.toml and moved to an extras group installable via pip install dspy[optuna]. Both files that use optuna add a _import_optuna() helper that attempts the import at call time and raises a friendly ImportError if the package is missing.

This change saves:
- 12.70 MB uncompressed
- 3.45 MB zipped