### PR TITLE
fix: support both isError and is_error in MCP tool results

### DIFF
--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -21,7 +21,11 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if len(text_contents) == 1:
         tool_content = tool_content[0]
 
-    if call_tool_result.isError:
+    if hasattr(call_tool_result, "isError"):
+        is_error = call_tool_result.isError
+    else:
+        is_error = getattr(call_tool_result, "is_error", False)
+    if is_error:
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
 
     return tool_content or non_text_contents

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -3,10 +3,33 @@ import importlib
 
 import pytest
 
-from dspy.utils.mcp import convert_mcp_tool
+from dspy.utils.mcp import convert_mcp_tool, _convert_mcp_tool_result
 
 if importlib.util.find_spec("mcp") is None:
     pytest.skip(reason="mcp is not installed", allow_module_level=True)
+
+
+class _FakeMCPResult:
+    """Minimal stand-in for a CallToolResult that uses ``is_error`` (FastMCP convention)."""
+
+    def __init__(self, text: str, is_error: bool = False):
+        from mcp.types import TextContent
+
+        self.content = [TextContent(type="text", text=text)]
+        self.is_error = is_error
+
+
+def test_convert_mcp_tool_result_with_is_error_attribute():
+    """Ensure _convert_mcp_tool_result raises on ``is_error=True`` (FastMCP)."""
+    result = _FakeMCPResult("some error", is_error=True)
+    with pytest.raises(RuntimeError, match="Failed to call a MCP tool"):
+        _convert_mcp_tool_result(result)
+
+
+def test_convert_mcp_tool_result_success_with_is_error_attribute():
+    """Ensure _convert_mcp_tool_result returns content when ``is_error=False``."""
+    result = _FakeMCPResult("hello world", is_error=False)
+    assert _convert_mcp_tool_result(result) == "hello world"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #8760

The MCP Python SDK (`mcp`) uses `isError` on `CallToolResult`, while FastMCP uses `is_error`. When DSPy calls a tool on a FastMCP-based server, `_convert_mcp_tool_result()` raises an `AttributeError` because it accesses `call_tool_result.isError` directly.

## Changes

### `dspy/utils/mcp.py`
- Changed `call_tool_result.isError` to `getattr(call_tool_result, 'isError', None) or getattr(call_tool_result, 'is_error', False)`
- This supports both attribute names: `isError` (official SDK) first, then `is_error` (FastMCP) as fallback

### `tests/utils/test_mcp.py`
- Added unit tests with a mock `CallToolResult` that only has `is_error` (no `isError`)
- Tests both the error path (`is_error=True` → `RuntimeError`) and success path (`is_error=False` → content returned)

## Root Cause

The official MCP SDK uses camelCase (`isError`) while FastMCP uses snake_case (`is_error`). Direct attribute access breaks when the result object uses the other convention.