### PR TITLE
perf: replace list with deque for O(1) history eviction (fixes #9347)

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils import settings
@@ -7,7 +8,7 @@ from dspy.utils.callback import with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
 
 MAX_HISTORY_SIZE = 10_000
-GLOBAL_HISTORY = []
+GLOBAL_HISTORY: deque = deque(maxlen=MAX_HISTORY_SIZE)
 
 
 class BaseLM:
@@ -47,7 +48,7 @@ class BaseLM:
         self.model_type = model_type
         self.cache = cache
         self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
-        self.history = []
+        self.history: deque = deque()
 
     def _process_lm_response(self, response, prompt, messages, **kwargs):
         merged_kwargs = {**self.kwargs, **kwargs}
@@ -145,7 +146,7 @@ class BaseLM:
         import copy
 
         new_instance = copy.deepcopy(self)
-        new_instance.history = []
+        new_instance.history = deque()
 
         for key, value in kwargs.items():
             if hasattr(self, key):
@@ -167,10 +168,7 @@ class BaseLM:
         if settings.disable_history:
             return
 
-        # Global LM history
-        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
-            GLOBAL_HISTORY.pop(0)
-
+        # Global LM history (deque with maxlen auto-evicts oldest entries)
         GLOBAL_HISTORY.append(entry)
 
         if settings.max_history_size == 0:
@@ -178,7 +176,7 @@ class BaseLM:
 
         # dspy.LM.history
         if len(self.history) >= settings.max_history_size:
-            self.history.pop(0)
+            self.history.popleft()
 
         self.history.append(entry)
 
@@ -186,7 +184,7 @@ class BaseLM:
         caller_modules = settings.caller_modules or []
         for module in caller_modules:
             if len(module.history) >= settings.max_history_size:
-                module.history.pop(0)
+                module.history.popleft()
             module.history.append(entry)
 
     def _process_completion(self, response, merged_kwargs):

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -3,6 +3,7 @@ import os
 import re
 import threading
 import warnings
+from collections import deque
 from typing import Any, Literal, cast
 
 import litellm
@@ -74,7 +75,7 @@ class LM(BaseLM):
         self.cache = cache
         self.provider = provider or self.infer_provider()
         self.callbacks = callbacks or []
-        self.history = []
+        self.history = deque()
         self.num_retries = num_retries
         self.finetuning_model = finetuning_model
         self.launch_kwargs = launch_kwargs or {}

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from collections import deque
 from typing import Callable
 
 import dspy
@@ -39,7 +40,7 @@ class CodeAct(ReAct, ProgramOfThought):
         """
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
-        self.history = []
+        self.history = deque()
 
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
         if any(

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils.settings import settings
@@ -69,13 +70,13 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def _base_init(self):
         self._compiled = False
         self.callbacks = []
-        self.history = []
+        self.history = deque()
 
     def __init__(self, callbacks=None):
         self.callbacks = callbacks or []
         self._compiled = False
         # LM calling history of the module.
-        self.history = []
+        self.history = deque()
 
     def __getstate__(self):
         state = self.__dict__.copy()
@@ -86,7 +87,7 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def __setstate__(self, state):
         self.__dict__.update(state)
         if not hasattr(self, "history"):
-            self.history = []
+            self.history = deque()
         if not hasattr(self, "callbacks"):
             self.callbacks = []
 

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -13,7 +13,7 @@ def _blue(text: str, end: str = "\n"):
 def pretty_print_history(history, n: int = 1):
     """Prints the last n prompts and their completions."""
 
-    for item in history[-n:]:
+    for item in list(history)[-n:]:
         messages = item["messages"] or [{"role": "user", "content": item["prompt"]}]
         outputs = item["outputs"]
         timestamp = item.get("timestamp", "Unknown time")


### PR DESCRIPTION
## Problem

Both `GLOBAL_HISTORY` and per-LM `self.history` use Python lists with `pop(0)` for eviction, which is O(n) — it shifts all remaining elements on every call. With `MAX_HISTORY_SIZE = 10_000`, this becomes a noticeable overhead on high-throughput workloads.

Reported in #9347.

## Fix

Replace `list` with `collections.deque`:

| Container | `GLOBAL_HISTORY` | `self.history` / module history |
|---|---|---|
| **Before** | `list` + manual `pop(0)` (O(n)) | `list` + manual `pop(0)` (O(n)) |
| **After** | `deque(maxlen=MAX_HISTORY_SIZE)` (auto-evict, O(1)) | `deque()` + `popleft()` (O(1)) |

### Why not `maxlen` everywhere?

`GLOBAL_HISTORY` uses a compile-time constant (`MAX_HISTORY_SIZE = 10_000`), so `maxlen` is ideal.

Per-LM / per-module history uses `settings.max_history_size`, which can change at runtime — so we keep the manual length check but use `popleft()` for O(1) removal.

### Inspection compatibility

`deque` doesn't support slicing (`history[-n:]`), so `pretty_print_history` converts to list before slicing. This is fine since inspection is a rare user-initiated action, not a hot path.

Fixes #9347