### PR TITLE
fix(Code): remove default language and strip docstring from JSON schema

### DIFF
--- a/dspy/adapters/types/code.py
+++ b/dspy/adapters/types/code.py
@@ -8,64 +8,19 @@ from dspy.adapters.types.base_type import Type
 
 
 class Code(Type):
-    """Code type in DSPy.
+    """Code type for code generation and analysis in DSPy.
 
-    This type is useful for code generation and code analysis.
-
-    Example 1: dspy.Code as output type in code generation:
-
-    ```python
-    import dspy
-
-    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
-
-
-    class CodeGeneration(dspy.Signature):
-        '''Generate python code to answer the question.'''
-
-        question: str = dspy.InputField(description="The question to answer")
-        code: dspy.Code["java"] = dspy.OutputField(description="The code to execute")
-
-
-    predict = dspy.Predict(CodeGeneration)
-
-    result = predict(question="Given an array, find if any of the two numbers sum up to 10")
-    print(result.code)
-    ```
-
-    Example 2: dspy.Code as input type in code analysis:
-
-    ```python
-    import dspy
-    import inspect
-
-    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
-
-    class CodeAnalysis(dspy.Signature):
-        '''Analyze the time complexity of the function.'''
-
-        code: dspy.Code["python"] = dspy.InputField(description="The function to analyze")
-        result: str = dspy.OutputField(description="The time complexity of the function")
-
-
-    predict = dspy.Predict(CodeAnalysis)
-
-
-    def sleepsort(x):
-        import time
-
-        for i in x:
-            time.sleep(i)
-            print(i)
-
-    result = predict(code=inspect.getsource(sleepsort))
-    print(result.result)
-    ```
+    Supports optional language specification via ``dspy.Code["python"]`` syntax.
+    When no language is specified, the model chooses the appropriate language.
     """
+
+    model_config = pydantic.ConfigDict(
+        json_schema_extra={"description": "Code object with a single `code` string field."},
+    )
 
     code: str
 
-    language: ClassVar[str] = "python"
+    language: ClassVar[str] = ""
 
     def format(self):
         return f"{self.code}"
@@ -77,11 +32,16 @@ class Code(Type):
 
     @classmethod
     def description(cls) -> str:
-        return (
+        base = (
             "Code represented in a string, specified in the `code` field. If this is an output field, the code "
-            f"field should follow the markdown code block format, e.g. \n```{cls.language.lower()}\n{{code}}\n```"
-            f"\nProgramming language: {cls.language}"
+            "field should follow the markdown code block format, e.g. "
         )
+        if cls.language:
+            base += f"\n```{cls.language.lower()}\n{{code}}\n```"
+            base += f"\nProgramming language: {cls.language}"
+        else:
+            base += "\n```\n{code}\n```"
+        return base
 
     @pydantic.model_validator(mode="before")
     @classmethod

--- a/tests/adapters/test_code.py
+++ b/tests/adapters/test_code.py
@@ -45,6 +45,26 @@ def test_code_with_language():
     assert "Programming language: cpp" in cpp_code.description()
 
 
+def test_code_no_default_language():
+    """Bare dspy.Code should not default to any language (#9251)."""
+    assert dspy.Code.language == ""
+    desc = dspy.Code.description()
+    assert "Programming language" not in desc
+    assert "```\n{code}\n```" in desc
+
+
+def test_code_json_schema_excludes_docstring():
+    """JSON schema should not contain the full class docstring (#9251)."""
+    schema = pydantic.TypeAdapter(dspy.Code).json_schema()
+    assert "Example 1" not in schema.get("description", "")
+    assert "Example 2" not in schema.get("description", "")
+    assert "code generation and code analysis" not in schema.get("description", "")
+
+    # Parameterized Code should also have a clean schema
+    schema_py = pydantic.TypeAdapter(dspy.Code["python"]).json_schema()
+    assert "Example 1" not in schema_py.get("description", "")
+
+
 def test_code_parses_from_dirty_code():
     dirty_code = "```python\nprint('Hello, world!')```"
     code = dspy.Code(code=dirty_code)


### PR DESCRIPTION
## Summary

Fixes #9251 — `dspy.Code` type JSON schema includes full docstring in prompt, causing contradictory instructions (markdown vs JSON format directives).

## Changes

### 1. Remove default `language="python"` (addresses @arjunguha's feedback)

Bare `dspy.Code` no longer defaults to Python. This allows:
- Signatures where a separate input field specifies the programming language
- Tasks where the appropriate language is clearly not Python (e.g., "write a web page")
- The model to choose the most appropriate language naturally

`dspy.Code["python"]` still works exactly as before — the language is only set when explicitly requested.

### 2. Strip docstring from JSON schema (defense-in-depth)

The 54-line docstring with usage examples was leaking into Pydantic's JSON schema `description` field. While the existing `translate_field_type` guard in `utils.py` (line 104) prevents this from reaching prompts, the fix was downstream — the schema itself still contained the full docstring.

Now:
- Class docstring is shortened to a concise summary (no usage examples)
- `model_config = ConfigDict(json_schema_extra={"description": ...})` provides a minimal schema description
- Even if `_get_json_schema(Code)` is called elsewhere, it produces clean output

### 3. Update `description()` for language-awareness

When no language is specified:
```
Code represented in a string, specified in the `code` field. If this is an output field, the code field should follow the markdown code block format, e.g.
` ` `
{code}
` ` `
```

When language is specified (e.g., `dspy.Code["java"]`):
```
Code represented in a string, specified in the `code` field. If this is an output field, the code field should follow the markdown code block format, e.g.
` ` `java
{code}
` ` `
Programming language: java
```

### 4. Tests added

- `test_code_no_default_language`: Verifies bare `dspy.Code` has no language and description omits "Programming language"
- `test_code_json_schema_excludes_docstring`: Verifies JSON schema doesn't contain usage examples from the old docstring (both base `Code` and parameterized `Code["python"]`)

## Backward Compatibility

- `dspy.Code["python"]`, `dspy.Code["java"]`, etc. — **no change**, work exactly as before
- `dspy.Code` (bare) — language changes from `"python"` to `""`. This is the **intended fix** per the issue reporter's feedback. Users who relied on the implicit Python default should switch to `dspy.Code["python"]` for explicit behavior.
- All existing tests pass (the `test_code_with_language` test only asserts on parameterized Code types)
