### PR TITLE
perf: use deque instead of list for LM history storage

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,5 +1,6 @@
 import datetime
 import uuid
+from collections import deque
 from typing import Any
 
 from dspy.dsp.utils import settings
@@ -7,7 +8,7 @@ from dspy.utils.callback import with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
 
 MAX_HISTORY_SIZE = 10_000
-GLOBAL_HISTORY = []
+GLOBAL_HISTORY: deque = deque(maxlen=MAX_HISTORY_SIZE)
 
 
 class BaseLM:
@@ -47,7 +48,7 @@ class BaseLM:
         self.model_type = model_type
         self.cache = cache
         self.kwargs = dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
-        self.history = []
+        self.history: deque = deque(maxlen=settings.max_history_size)
 
     def _process_lm_response(self, response, prompt, messages, **kwargs):
         merged_kwargs = {**self.kwargs, **kwargs}
@@ -168,18 +169,12 @@ class BaseLM:
             return
 
         # Global LM history
-        if len(GLOBAL_HISTORY) >= MAX_HISTORY_SIZE:
-            GLOBAL_HISTORY.pop(0)
-
         GLOBAL_HISTORY.append(entry)
 
         if settings.max_history_size == 0:
             return
 
         # dspy.LM.history
-        if len(self.history) >= settings.max_history_size:
-            self.history.pop(0)
-
         self.history.append(entry)
 
         # Per-module history


### PR DESCRIPTION
## Summary

Fixes #9347

Both `GLOBAL_HISTORY` and per-instance `self.history` in `BaseLM` use `list.pop(0)` to evict old entries when the history exceeds its size limit. This is O(n) for each eviction because Python lists are array-backed and must shift all remaining elements left.

### Changes

Replace `list` with `collections.deque(maxlen=...)`:

- `GLOBAL_HISTORY` becomes `deque(maxlen=MAX_HISTORY_SIZE)` — automatic O(1) eviction
- `self.history` becomes `deque(maxlen=settings.max_history_size)` — automatic O(1) eviction
- Remove manual `len() >= max` checks and `pop(0)` calls since `deque(maxlen=...)` handles eviction automatically

### Why deque

`deque` with `maxlen` is the idiomatic Python solution for bounded-size FIFO buffers:
- `append()` is O(1)
- Automatic eviction of the oldest element when `maxlen` is reached (also O(1))
- No need for manual size checking

### Backward compatibility

`deque` supports the same iteration, indexing, and `len()` operations as `list`. The `pretty_print_history` function iterates over the history, which works identically with `deque`.
