### PR TITLE
fix: propagate exceptions in apply_sync_streaming instead of swallowing them

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -239,6 +239,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as exc:
+                queue.put(exc)
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +256,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if isinstance(item, BaseException):
+            raise item
         yield item
 
 


### PR DESCRIPTION
## Summary

Fix `apply_sync_streaming` silently swallowing exceptions raised in the async generator.

Fixes #9142.

## Problem

When using `streamify` with `async_streaming=False`, any exception raised in the async generator is caught by the `finally` block which sends the stop sentinel, but the exception itself is never propagated to the caller. The sync consumer just sees the stop sentinel and returns normally, making it impossible to handle or even notice errors.

## Fix

- Add an `except BaseException` clause that puts the exception into the queue before the `finally` block sends the stop sentinel
- In the consumer loop, check if the dequeued item is a `BaseException` and re-raise it

This matches the standard pattern for propagating exceptions across thread boundaries via queues.

## Changes

- `dspy/streaming/streamify.py`: Add exception propagation in `apply_sync_streaming`

> This PR was authored by Claude Opus 4.6 (AI). Human partner: @MaxwellCalkin
