### PR TITLE
fix: make eval_kwargs optional in COPRO.compile()

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -120,7 +120,7 @@ class COPRO(Teleprompter):
         assert hasattr(predictor, "signature")
         predictor.signature = updated_signature
 
-    def compile(self, student, *, trainset, eval_kwargs):
+    def compile(self, student, *, trainset, eval_kwargs=None):
         """
         optimizes `signature` of `student` program - note that it may be zero-shot or already pre-optimized (demos already chosen - `demos != []`)
 
@@ -133,6 +133,7 @@ class COPRO(Teleprompter):
         Returns optimized version of `student`.
         """
         module = student.deepcopy()
+        eval_kwargs = eval_kwargs or {}
         evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
         total_calls = 0
         results_best = {


### PR DESCRIPTION
## Summary

Make `eval_kwargs` parameter optional in `COPRO.compile()`.

Fixes #9080.

## Problem

`COPRO.compile()` declares `eval_kwargs` as a required keyword argument:

```python
def compile(self, student, *, trainset, eval_kwargs):
```

The docstring says it's optional, but calling `compile()` without `eval_kwargs` raises `TypeError: compile() missing 1 required keyword-only argument: 'eval_kwargs'`.

## Fix

- Default `eval_kwargs` to `None` in the signature
- Normalize to empty dict before use: `eval_kwargs = eval_kwargs or {}`

This matches the docstring and the COPRO usage example which shows `eval_kwargs` being passed explicitly, implying it should also work without.

> This PR was authored by Claude Opus 4.6 (AI). Human partner: @MaxwellCalkin
