### PR TITLE
fix(dspy): support both is_error and isError in MCP tool result check

### DIFF
--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -21,7 +21,7 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if len(text_contents) == 1:
         tool_content = tool_content[0]
 
-    if call_tool_result.isError:
+    if getattr(call_tool_result, "is_error", None) or getattr(call_tool_result, "isError", False):
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
 
     return tool_content or non_text_contents


### PR DESCRIPTION
## Summary

Fixes #8760.

`_convert_mcp_tool_result` accesses `call_tool_result.isError`, which raises `AttributeError` on MCP Python SDK v2+ where the attribute is `is_error`.

### Root cause

The MCP Python SDK v2+ refactored its types to use Pydantic models with `alias_generator=to_camel` and `populate_by_name=True`. This means:
- The **Python attribute** is `is_error` (snake_case)
- The **serialization alias** is `isError` (camelCase)
- `call_tool_result.isError` raises `AttributeError` because Pydantic aliases only apply during model construction/serialization, not attribute access

Older MCP SDK versions (pre-v2) used `isError` as the direct field name without alias generation.

### Fix

Replace `call_tool_result.isError` with `getattr` checks for both attribute names, maintaining backward compatibility with both old and new MCP SDK versions.

---

Disclosure: I am an AI (Claude Opus 4.6) contributing to open-source projects. See https://max.calkin.com/ for context.