### PR TITLE
fix(streaming): propagate exceptions from async generator in apply_sync_streaming

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -224,10 +224,23 @@ def streamify(
         return sync_streamer
 
 
+class _QueueException:
+    """Wrapper to ferry an exception from the producer thread to the consumer."""
+
+    __slots__ = ("exc",)
+
+    def __init__(self, exc: BaseException) -> None:
+        self.exc = exc
+
+
 def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
-    """Convert the async streaming generator to a sync generator."""
-    queue = Queue()  # Queue to hold items from the async generator
-    stop_sentinel = object()  # Sentinel to signal the generator is complete
+    """Convert the async streaming generator to a sync generator.
+
+    Exceptions raised inside *async_generator* are propagated to the caller of
+    the returned sync generator instead of being silently swallowed.
+    """
+    queue: Queue = Queue()
+    stop_sentinel = object()
 
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
@@ -239,21 +252,22 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except Exception as exc:  # noqa: BLE001
+                queue.put(_QueueException(exc))
             finally:
-                # Signal completion
                 queue.put(stop_sentinel)
 
         context.run(asyncio.run, runner())
 
-    # Start the producer in a background thread
     thread = threading.Thread(target=producer, daemon=True)
     thread.start()
 
-    # Consume items from the queue
     while True:
-        item = queue.get()  # Block until an item is available
+        item = queue.get()
         if item is stop_sentinel:
             break
+        if isinstance(item, _QueueException):
+            raise item.exc
         yield item
 
 


### PR DESCRIPTION
## Problem

When using `streamify` with `async_streaming=False`, any exception raised inside the async generator is silently swallowed.

The root cause is that `apply_sync_streaming` only used a `finally` block (not an `except` block) in the `runner()` coroutine. As a result, the stop sentinel was queued and the consumer loop exited cleanly — losing the exception entirely.

Reported in #9142.

## Fix

Introduce a lightweight `_QueueException` wrapper. Any `Exception` caught inside `runner()` is placed in the queue. The consumer detects it and re-raises, giving callers full visibility into failures.

```python
# Before: exceptions silently dropped
async def runner():
    try:
        async for item in async_generator:
            queue.put(item)
    finally:
        queue.put(stop_sentinel)   # swallows any exception

# After: exceptions propagated
async def runner():
    try:
        async for item in async_generator:
            queue.put(item)
    except Exception as exc:
        queue.put(_QueueException(exc))   # ferry the error to consumer
    finally:
        queue.put(stop_sentinel)

# Consumer re-raises
if isinstance(item, _QueueException):
    raise item.exc
```

Fixes #9142