### PR TITLE
[codex] add docstrings for logging_utils.py

### DIFF
--- a/dspy/utils/logging_utils.py
+++ b/dspy/utils/logging_utils.py
@@ -15,22 +15,35 @@ class DSPyLoggingStream:
     """
 
     def __init__(self):
+        """Initialize the stream in an enabled state."""
         self._enabled = True
 
     def write(self, text):
+        """Write text to the current ``sys.stderr`` stream when logging is enabled.
+
+        Args:
+            text: Text emitted by the logging subsystem.
+        """
         if self._enabled:
             sys.stderr.write(text)
 
     def flush(self):
+        """Flush the current ``sys.stderr`` stream when logging is enabled."""
         if self._enabled:
             sys.stderr.flush()
 
     @property
     def enabled(self):
+        """Whether writes and flushes should be forwarded to ``sys.stderr``."""
         return self._enabled
 
     @enabled.setter
     def enabled(self, value):
+        """Enable or disable forwarding to ``sys.stderr``.
+
+        Args:
+            value: ``True`` to emit log output, ``False`` to suppress it.
+        """
         self._enabled = value
 
 
@@ -55,6 +68,15 @@ def enable_logging():
 
 
 def configure_dspy_loggers(root_module_name):
+    """Configure DSPy's root logger to emit through ``DSPY_LOGGING_STREAM``.
+
+    This helper installs a single named stream handler, formats log lines using
+    DSPy's standard timestamped format, and prevents duplicate propagation to
+    ancestor loggers.
+
+    Args:
+        root_module_name: Root logger name to configure, for example ``"dspy"``.
+    """
     formatter = logging.Formatter(fmt=LOGGING_LINE_FORMAT, datefmt=LOGGING_DATETIME_FORMAT)
 
     dspy_handler_name = "dspy_handler"


### PR DESCRIPTION
Resolves #9428.

This PR fills in the remaining public docstrings in `dspy/utils/logging_utils.py`. The module already documented the high-level logging toggles, but the stream methods and the logger configuration entry point still required readers to infer their behavior from the implementation.

The change is intentionally documentation-only. It adds Google-style docstrings for the `DSPyLoggingStream` lifecycle and forwarding methods, the `enabled` property setter/getter, and `configure_dspy_loggers()`. The new text explains how the stream proxies to the current `sys.stderr`, how logging can be suppressed, and how DSPy installs its root stream handler.

Validation was limited to non-behavioral checks because the diff changes docstrings only: `python -m py_compile dspy/utils/logging_utils.py` and `uv run ruff check dspy/utils/logging_utils.py` both passed.

Ref: #8926