### PR TITLE
fix(signature): reject duplicate input and output field names

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -610,10 +610,21 @@ def _parse_signature(signature: str, names=None) -> dict[str, tuple[type, Any]]:
 
     inputs_str, outputs_str = signature.split("->")
 
+    input_fields = list(_parse_field_string(inputs_str, names))
+    output_fields = list(_parse_field_string(outputs_str, names))
+    duplicate_field_names = sorted({field_name for field_name, *_ in input_fields}.intersection(
+        field_name for field_name, *_ in output_fields
+    ))
+    if duplicate_field_names:
+        raise ValueError(
+            "Input and output fields must have distinct names, but found duplicates: "
+            f"'{', '.join(duplicate_field_names)}'."
+        )
+
     fields = {}
-    for field_name, field_type, is_type_undefined in _parse_field_string(inputs_str, names):
+    for field_name, field_type, is_type_undefined in input_fields:
         fields[field_name] = (field_type, InputField(IS_TYPE_UNDEFINED= is_type_undefined))
-    for field_name, field_type, _ in _parse_field_string(outputs_str, names):
+    for field_name, field_type, _ in output_fields:
         fields[field_name] = (field_type, OutputField())
 
     return fields

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -55,6 +55,11 @@ def test_signature_parsing():
     assert "output" in signature.output_fields
 
 
+def test_duplicate_input_output_field_names_raise():
+    with pytest.raises(ValueError, match="distinct names"):
+        Signature("value -> value")
+
+
 def test_with_signature():
     signature1 = Signature("input1, input2 -> output")
     signature2 = signature1.with_instructions("This is a test")


### PR DESCRIPTION
This fixes a bug where input field did not 'register' when input and output fields had the same name. Now we throw a ValueError.