### PR TITLE
fix(react): allow finish tool to accept extra args from LLM

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -61,7 +61,7 @@ class ReAct(Module):
         )
 
         tools["finish"] = Tool(
-            func=lambda: "Completed.",
+            func=lambda **kwargs: "Completed.",
             name="finish",
             desc=f"Marks the task as complete. That is, signals that all information for producing the outputs, i.e. {outputs}, are now available to be extracted.",
             args={},


### PR DESCRIPTION
## Summary
- Changes the `finish` tool's lambda from `lambda: "Completed."` to `lambda **kwargs: "Completed."` so `Tool.has_kwargs=True`
- Models with structured output signatures often place final output values into `next_tool_args` when calling `finish`, causing a spurious `ValueError("Arg X is not in the tool's args")` even though the run succeeds via the extraction step
- With `**kwargs`, the `_validate_and_parse_args` method skips unknown arguments via the `has_kwargs` path instead of raising

Fixes #9424

## Test plan
- [ ] Run ReAct with a multi-output signature and verify no spurious execution errors in the trajectory for the `finish` tool call
- [ ] Verify `finish` with no args still works as before
- [ ] Run existing tests

https://claude.ai/code/session_011TWMvnjeLgAJg9XtxoLfZT