### PR TITLE
fix: guard issubclass() TypeError on generic field annotations

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -103,11 +103,18 @@ class Adapter:
 
         # Handle custom types that use native LM features, e.g., reasoning, citations, etc.
         for name, field in signature.output_fields.items():
-            if (
-                isinstance(field.annotation, type)
-                and issubclass(field.annotation, Type)
-                and field.annotation in self.native_response_types
-            ):
+            try:
+                is_native_type = (
+                    isinstance(field.annotation, type)
+                    and issubclass(field.annotation, Type)
+                    and field.annotation in self.native_response_types
+                )
+            except TypeError:
+                # Nested generics (e.g. list[dict[str, X]]) may pass isinstance(…, type)
+                # on some Python/Pydantic versions but still cause issubclass() to raise
+                # TypeError inside ABCMeta.__subclasscheck__.  See #9425.
+                is_native_type = False
+            if is_native_type:
                 signature = field.annotation.adapt_to_native_lm_feature(signature, name, lm, lm_kwargs)
 
         return signature
@@ -164,11 +171,15 @@ class Adapter:
 
             # Parse custom types that does not rely on the `Adapter.parse()` method
             for name, field in original_signature.output_fields.items():
-                if (
-                    isinstance(field.annotation, type)
-                    and issubclass(field.annotation, Type)
-                    and field.annotation in self.native_response_types
-                ):
+                try:
+                    is_native_type = (
+                        isinstance(field.annotation, type)
+                        and issubclass(field.annotation, Type)
+                        and field.annotation in self.native_response_types
+                    )
+                except TypeError:
+                    is_native_type = False
+                if is_native_type:
                     parsed_value = field.annotation.parse_lm_response(output)
                     if parsed_value is not None:
                         value[name] = parsed_value

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -793,3 +793,30 @@ def test_tool_call_with_null_content_does_not_raise():
     result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
     assert result is not None
     assert len(result) == 1
+
+
+def test_preprocess_does_not_crash_on_generic_annotations():
+    """Regression test for #9425: issubclass() TypeError on generic annotations.
+
+    When a signature has output fields annotated with generics like dict[str, Any],
+    the isinstance(annotation, type) guard may pass on some Python/Pydantic versions
+    while issubclass() still raises TypeError inside ABCMeta.__subclasscheck__.
+    _call_preprocess must handle this gracefully.
+    """
+    from typing import Any
+    from unittest.mock import MagicMock
+
+    sig = dspy.Signature(
+        "user_request -> process_result, tool_args",
+    )
+    # Manually add a generic-typed output field (dict[str, Any]) that can
+    # trigger the issubclass TypeError on certain Python/Pydantic combos.
+    sig = sig.append("tool_args_extra", dspy.OutputField(), type_=dict[str, Any])
+
+    adapter = dspy.ChatAdapter()
+    mock_lm = MagicMock()
+    mock_lm.model = "openai/gpt-4"
+
+    # This should not raise TypeError
+    processed = adapter._call_preprocess(mock_lm, {}, sig, {})
+    assert processed is not None


### PR DESCRIPTION
## Problem

Fixes #9425

`_call_preprocess` and `_call_postprocess` in `dspy/adapters/base.py` use this pattern:

```python
if isinstance(field.annotation, type) and issubclass(field.annotation, Type):
```

On certain Python/Pydantic version combinations (e.g. Pydantic 2.10.x), generic annotations like `dict[str, Any]` can pass `isinstance(annotation, type)` but still cause `issubclass()` to raise `TypeError` inside `ABCMeta.__subclasscheck__`. This crashes ReAct workflows that use tools, since the signature includes a `dict[str, Any]` output field for tool arguments.

## Root Cause

The exact same issue was **already identified and fixed** in `Type.extract_custom_type_from_annotation` (line 51-55 of `base_type.py`):

```python
# Nested type like `list[dict[str, Event]]` passes `isinstance(annotation, type)` in python 3.10
# while fails in python 3.11. To accommodate users using python 3.10, we need to capture the error and ignore it.
try:
    if isinstance(annotation, type) and issubclass(annotation, cls):
        return [annotation]
except TypeError:
    pass
```

But the same defensive pattern was **not applied** to the two equivalent call sites in `base.py`.

## Fix

Wrap both `issubclass()` calls in `_call_preprocess` (line 108) and `_call_postprocess` (line 169) with `try/except TypeError`, matching the existing pattern in `extract_custom_type_from_annotation`.

## Tests

Added `test_preprocess_does_not_crash_on_generic_annotations` regression test that creates a signature with `dict[str, Any]` output fields and verifies `_call_preprocess` completes without raising `TypeError`.

All existing adapter tests pass (no regressions).