### PR TITLE
fix: propagate exceptions from apply_sync_streaming

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -228,6 +228,7 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
     """Convert the async streaming generator to a sync generator."""
     queue = Queue()  # Queue to hold items from the async generator
     stop_sentinel = object()  # Sentinel to signal the generator is complete
+    error_sentinel = object()  # Sentinel to signal an exception occurred
 
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
@@ -239,6 +240,9 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as e:
+                queue.put(error_sentinel)
+                queue.put(e)
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +258,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if item is error_sentinel:
+            raise queue.get()
         yield item
 
 

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2062,3 +2062,44 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+def test_apply_sync_streaming_propagates_exception():
+    """Exceptions raised in the async generator should propagate to the sync consumer."""
+
+    async def failing_generator():
+        yield "first"
+        yield "second"
+        raise ValueError("something went wrong")
+
+    sync_output = dspy.streaming.apply_sync_streaming(failing_generator())
+    items = []
+    with pytest.raises(ValueError, match="something went wrong"):
+        for item in sync_output:
+            items.append(item)
+
+    assert items == ["first", "second"]
+
+
+def test_apply_sync_streaming_propagates_runtime_error():
+    """RuntimeError raised in the async generator should propagate to the sync consumer."""
+
+    async def failing_generator():
+        raise RuntimeError("runtime failure")
+        yield  # make it a generator  # noqa: E501
+
+    sync_output = dspy.streaming.apply_sync_streaming(failing_generator())
+    with pytest.raises(RuntimeError, match="runtime failure"):
+        list(sync_output)
+
+
+def test_apply_sync_streaming_normal_completion():
+    """Normal async generator completion should still work correctly."""
+
+    async def normal_generator():
+        yield "a"
+        yield "b"
+        yield "c"
+
+    sync_output = dspy.streaming.apply_sync_streaming(normal_generator())
+    assert list(sync_output) == ["a", "b", "c"]


### PR DESCRIPTION
## Problem

When using `streamify` with `async_streaming=False`, exceptions raised in the async generator are silently swallowed. The `try/finally` block in the producer thread sends the stop sentinel regardless of whether an exception occurred, causing the consumer to stop iterating without ever seeing the error.

This makes debugging very difficult — the caller gets no items and no exception, as if the generator simply produced nothing.

Closes #9142

## Root Cause

In `apply_sync_streaming()`, the producer's `runner()` uses:

```python
try:
    async for item in async_generator:
        queue.put(item)
finally:
    queue.put(stop_sentinel)
```

When an exception occurs, it's caught by `finally`, the stop sentinel is enqueued, and the exception is lost.

## Solution

Add explicit exception handling that puts the exception into the queue via a dedicated `error_sentinel`, then let `finally` still send the stop sentinel. The consumer checks for the error sentinel and re-raises the exception:

```python
try:
    async for item in async_generator:
        queue.put(item)
except BaseException as e:
    queue.put(error_sentinel)
    queue.put(e)
finally:
    queue.put(stop_sentinel)
```

## Testing

- 3 new tests added covering: `ValueError` propagation after partial items, `RuntimeError` propagation on first item, and normal completion
- All 37 existing streaming tests pass + 3 new = 40 total