### PR TITLE
fix: accept extra args in ReAct finish tool without spurious error

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -61,7 +61,7 @@ class ReAct(Module):
         )
 
         tools["finish"] = Tool(
-            func=lambda: "Completed.",
+            func=lambda **kwargs: "Completed.",
             name="finish",
             desc=f"Marks the task as complete. That is, signals that all information for producing the outputs, i.e. {outputs}, are now available to be extracted.",
             args={},

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -423,3 +423,41 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_react_finish_with_extra_args_no_error():
+    """When the model provides structured output fields as finish args, no execution error should be logged.
+
+    Regression test for https://github.com/stanfordnlp/dspy/issues/9424
+    """
+    def dummy_tool(x: int) -> str:
+        """A dummy tool."""
+        return f"result_{x}"
+
+    react = dspy.ReAct("question -> answer: str, confidence: float", tools=[dummy_tool])
+
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I should call the tool first.",
+                "next_tool_name": "dummy_tool",
+                "next_tool_args": {"x": 42},
+            },
+            {
+                "next_thought": "I have the answer now.",
+                "next_tool_name": "finish",
+                "next_tool_args": {"answer": "result_42", "confidence": 0.95},
+            },
+            {"reasoning": "Based on the tool result.", "answer": "result_42", "confidence": 0.95},
+        ]
+    )
+
+    with dspy.context(lm=lm):
+        result = react(question="What is the answer?")
+
+    trajectory = result.trajectory
+    # The finish observation should NOT contain "Execution error"
+    finish_obs = trajectory.get("observation_1", "")
+    assert "Execution error" not in finish_obs, f"Unexpected execution error in finish: {finish_obs}"
+    assert finish_obs == "Completed."
+    assert result.answer == "result_42"


### PR DESCRIPTION
## Problem

When using `dspy.ReAct` with structured output signatures, models often place final output values into `next_tool_args` when calling `finish`. For example:

```json
{
  "next_tool_name": "finish",
  "next_tool_args": {"answer": "result", "confidence": 0.95}
}
```

Since `finish` is defined as `lambda: "Completed."` with `args={}`, this raises a `ValueError` that gets logged as an execution error in the trajectory — even though the final prediction is still correct.

Closes #9424

## Root Cause

`finish` is defined with no parameters:
```python
tools["finish"] = Tool(func=lambda: "Completed.", name="finish", ..., args={})
```

When the model passes extra args, `Tool._validate_and_parse_args()` raises `ValueError: Arg X is not in the tool's args`.

## Solution

Change finish to accept `**kwargs`:
```python
tools["finish"] = Tool(func=lambda **kwargs: "Completed.", name="finish", ..., args={})
```

This works because `Tool._validate_and_parse_args()` checks `self.has_kwargs` (line 117/123) and skips validation for unknown args when the function accepts `**kwargs`.

## Testing

- 1 new test: verifies finish with extra structured output args produces `"Completed."` observation (not an execution error)
- All 8 existing ReAct tests pass