### PR TITLE
feat: add dspy.Video type adapter

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -6,7 +6,7 @@ from dspy.teleprompt import *
 
 from dspy.evaluate import Evaluate  # isort: skip
 from dspy.clients import *  # isort: skip
-from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, File, History, Type, Tool, ToolCalls, Code, Reasoning  # isort: skip
+from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, Video, File, History, Type, Tool, ToolCalls, Code, Reasoning  # isort: skip
 from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, enable_logging
 from dspy.utils.asyncify import asyncify
 from dspy.utils.syncify import syncify

--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -2,7 +2,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.two_step_adapter import TwoStepAdapter
-from dspy.adapters.types import Audio, Code, File, History, Image, Reasoning, Tool, ToolCalls, Type
+from dspy.adapters.types import Audio, Code, File, History, Image, Reasoning, Tool, ToolCalls, Type, Video
 from dspy.adapters.xml_adapter import XMLAdapter
 
 __all__ = [
@@ -12,6 +12,7 @@ __all__ = [
     "History",
     "Image",
     "Audio",
+    "Video",
     "File",
     "Code",
     "JSONAdapter",

--- a/dspy/adapters/types/__init__.py
+++ b/dspy/adapters/types/__init__.py
@@ -6,5 +6,6 @@ from dspy.adapters.types.history import History
 from dspy.adapters.types.image import Image
 from dspy.adapters.types.reasoning import Reasoning
 from dspy.adapters.types.tool import Tool, ToolCalls
+from dspy.adapters.types.video import Video
 
-__all__ = ["History", "Image", "Audio", "File", "Type", "Tool", "ToolCalls", "Code", "Reasoning"]
+__all__ = ["History", "Image", "Audio", "Video", "File", "Type", "Tool", "ToolCalls", "Code", "Reasoning"]

--- a/dspy/adapters/types/video.py
+++ b/dspy/adapters/types/video.py
@@ -7,6 +7,8 @@ import pydantic
 
 from dspy.adapters.types.base_type import Type
 
+MAX_INLINE_SIZE = 20 * 1024 * 1024  # 20 MB
+
 
 class Video(Type):
     """A video input type for DSPy.
@@ -52,6 +54,8 @@ class Video(Type):
             return {"url": values.url, "inline_data": values.inline_data, "mime_type": values.mime_type}
 
         if isinstance(values, str):
+            if values.startswith(("http://", "https://", "gs://")):
+                return {"url": values}
             if os.path.isfile(values):
                 return _encode_video_from_file(values)
             return {"url": values}
@@ -75,25 +79,17 @@ class Video(Type):
         has_url = self.url is not None
         has_inline_data = self.inline_data is not None
         if has_url == has_inline_data:
-            raise ValueError("Exactly one of 'url' or 'inline_data' must be provided.")
+            raise ValueError("You must provide either 'url' or 'inline_data'.")
         return self
 
     def format(self) -> list[dict[str, Any]]:
+        file_dict = {}
         if self.inline_data is not None:
-            return [{
-                "type": "file",
-                "file": {
-                    "format": self.mime_type,
-                    "file_data": f"data:{self.mime_type};base64,{self.inline_data}",
-                },
-            }]
-        return [{
-            "type": "file",
-            "file": {
-                "format": self.mime_type,
-                "file_id": self.url,
-            },
-        }]
+            file_dict["file_data"] = f"data:{self.mime_type};base64,{self.inline_data}"
+        else:
+            file_dict["file_id"] = self.url
+            file_dict["format"] = self.mime_type
+        return [{"type": "file", "file": file_dict}]
 
     @classmethod
     def from_url(cls, url: str, mime_type: str = "video/mp4") -> "Video":
@@ -133,6 +129,14 @@ def _encode_video_from_file(file_path: str, mime_type: str | None = None) -> dic
         mime_type, _ = mimetypes.guess_type(file_path)
         if mime_type is None:
             mime_type = "video/mp4"
+
+    file_size = os.path.getsize(file_path)
+    if file_size > MAX_INLINE_SIZE:
+        raise ValueError(
+            f"File '{file_path}' is {file_size / (1024 * 1024):.1f} MB, which exceeds the "
+            f"{MAX_INLINE_SIZE / (1024 * 1024):.0f} MB limit for inline video data. "
+            "Consider uploading via Google's Files API and using Video.from_url() instead."
+        )
 
     with open(file_path, "rb") as f:
         file_bytes = f.read()

--- a/dspy/adapters/types/video.py
+++ b/dspy/adapters/types/video.py
@@ -1,0 +1,141 @@
+import base64
+import mimetypes
+import os
+from typing import Any
+
+import pydantic
+
+from dspy.adapters.types.base_type import Type
+
+
+class Video(Type):
+    """A video input type for DSPy.
+
+    Currently only supported by Gemini models via litellm. Supports two modes:
+
+    1. **Inline**: Pass video bytes directly (suitable for videos under 20 MB).
+    2. **File reference**: Reference a video already uploaded via Google's Files API (Google's preferred method)
+
+    Example:
+        ```python
+        import dspy
+
+        class Describe(dspy.Signature):
+            video: dspy.Video = dspy.InputField()
+            description: str = dspy.OutputField()
+
+        program = dspy.Predict(Describe)
+
+        # Inline from a local file (< 20 MB)
+        result = program(video=dspy.Video.from_file("video.mp4"))
+
+        # Reference a file uploaded via Google's Files API
+        result = program(video=dspy.Video.from_url("https://generativelanguage.googleapis.com/..."))
+        ```
+    """
+
+    url: str | None = None
+    inline_data: str | None = None
+    mime_type: str = "video/mp4"
+
+    model_config = pydantic.ConfigDict(
+        frozen=True,
+        str_strip_whitespace=True,
+        validate_assignment=True,
+        extra="forbid",
+    )
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def validate_input(cls, values: Any) -> Any:
+        if isinstance(values, cls):
+            return {"url": values.url, "inline_data": values.inline_data, "mime_type": values.mime_type}
+
+        if isinstance(values, str):
+            if os.path.isfile(values):
+                return _encode_video_from_file(values)
+            return {"url": values}
+
+        if isinstance(values, dict):
+            if "url" in values or "inline_data" in values:
+                return values
+            raise ValueError("Dict must contain 'url' or 'inline_data'.")
+
+        if isinstance(values, bytes):
+            encoded = base64.b64encode(values).decode("utf-8")
+            return {"inline_data": encoded}
+
+        raise TypeError(
+            f"Unsupported input type {type(values).__name__}. "
+            "Expected a URL string, file path, bytes, or dict with 'url'/'inline_data'."
+        )
+
+    @pydantic.model_validator(mode="after")
+    def validate_source(self):
+        has_url = self.url is not None
+        has_inline_data = self.inline_data is not None
+        if has_url == has_inline_data:
+            raise ValueError("Exactly one of 'url' or 'inline_data' must be provided.")
+        return self
+
+    def format(self) -> list[dict[str, Any]]:
+        if self.inline_data is not None:
+            return [{
+                "type": "file",
+                "file": {
+                    "format": self.mime_type,
+                    "file_data": f"data:{self.mime_type};base64,{self.inline_data}",
+                },
+            }]
+        return [{
+            "type": "file",
+            "file": {
+                "format": self.mime_type,
+                "file_id": self.url,
+            },
+        }]
+
+    @classmethod
+    def from_url(cls, url: str, mime_type: str = "video/mp4") -> "Video":
+        """Create a Video from a Google Files API reference or other URL.
+
+        The URL is passed directly to the model provider without downloading.
+        """
+        return cls(url=url, mime_type=mime_type)
+
+    @classmethod
+    def from_file(cls, file_path: str, mime_type: str | None = None) -> "Video":
+        """Create a Video from a local file, encoding it as inline base64 data."""
+        result = _encode_video_from_file(file_path, mime_type=mime_type)
+        return cls(**result)
+
+    @classmethod
+    def from_bytes(cls, data: bytes, mime_type: str = "video/mp4") -> "Video":
+        """Create a Video from raw bytes."""
+        encoded = base64.b64encode(data).decode("utf-8")
+        return cls(inline_data=encoded, mime_type=mime_type)
+
+    def __str__(self):
+        return self.serialize_model()
+
+    def __repr__(self):
+        if self.url is not None:
+            return f"Video(url='{self.url}')"
+        return f"Video(inline_data=<base64:{len(self.inline_data or '')} chars>)"
+
+
+def _encode_video_from_file(file_path: str, mime_type: str | None = None) -> dict:
+    """Encode a local video file as base64."""
+    if not os.path.isfile(file_path):
+        raise ValueError(f"File not found: {file_path}")
+
+    if mime_type is None:
+        mime_type, _ = mimetypes.guess_type(file_path)
+        if mime_type is None:
+            mime_type = "video/mp4"
+
+    with open(file_path, "rb") as f:
+        file_bytes = f.read()
+
+    encoded = base64.b64encode(file_bytes).decode("utf-8")
+    return {"inline_data": encoded, "mime_type": mime_type}

--- a/dspy/adapters/types/video.py
+++ b/dspy/adapters/types/video.py
@@ -58,7 +58,7 @@ class Video(Type):
                 return {"url": values}
             if os.path.isfile(values):
                 return _encode_video_from_file(values)
-            return {"url": values}
+            raise ValueError(f"'{values}' is not a valid URL or existing file path.")
 
         if isinstance(values, dict):
             if "url" in values or "inline_data" in values:
@@ -79,7 +79,7 @@ class Video(Type):
         has_url = self.url is not None
         has_inline_data = self.inline_data is not None
         if has_url == has_inline_data:
-            raise ValueError("You must provide either 'url' or 'inline_data'.")
+            raise ValueError("Exactly one of 'url' or 'inline_data' must be provided")
         return self
 
     def format(self) -> list[dict[str, Any]]:

--- a/dspy/adapters/types/video.py
+++ b/dspy/adapters/types/video.py
@@ -7,7 +7,7 @@ import pydantic
 
 from dspy.adapters.types.base_type import Type
 
-MAX_INLINE_SIZE = 20 * 1024 * 1024  # 20 MB
+MAX_INLINE_SIZE = 20 * 1024 * 1024  # 20 MB (raw file size; prevents loading very large files into memory)
 
 
 class Video(Type):

--- a/tests/signatures/test_adapter_file.py
+++ b/tests/signatures/test_adapter_file.py
@@ -7,6 +7,7 @@ import pytest
 import dspy
 from dspy.adapters.types.file import encode_file_to_dict
 from dspy.utils.dummies import DummyLM
+from tests.test_utils.messages import count_messages_with_file_pattern
 
 
 @pytest.fixture
@@ -19,31 +20,6 @@ def sample_text_file():
         os.unlink(tmp_file_path)
     except Exception:
         pass
-
-
-def count_messages_with_file_pattern(messages):
-    pattern = {"type": "file", "file": lambda x: isinstance(x, dict)}
-
-    def check_pattern(obj, pattern):
-        if isinstance(pattern, dict):
-            if not isinstance(obj, dict):
-                return False
-            return all(k in obj and check_pattern(obj[k], v) for k, v in pattern.items())
-        if callable(pattern):
-            return pattern(obj)
-        return obj == pattern
-
-    def count_patterns(obj, pattern):
-        count = 0
-        if check_pattern(obj, pattern):
-            count += 1
-        if isinstance(obj, dict):
-            count += sum(count_patterns(v, pattern) for v in obj.values())
-        if isinstance(obj, list | tuple):
-            count += sum(count_patterns(v, pattern) for v in obj)
-        return count
-
-    return count_patterns(messages, pattern)
 
 
 def setup_predictor(signature, expected_output):

--- a/tests/signatures/test_adapter_video.py
+++ b/tests/signatures/test_adapter_video.py
@@ -8,8 +8,7 @@ import pytest
 import dspy
 from dspy.adapters.types.video import _encode_video_from_file
 from dspy.utils.dummies import DummyLM
-from tests.signatures.test_adapter_file import count_messages_with_file_pattern
-
+from tests.test_utils.messages import count_messages_with_file_pattern
 
 SAMPLE_VIDEO_BYTES = b"\x00\x00\x00\x1cftypisom" + b"\x00" * 50
 SAMPLE_VIDEO_B64 = base64.b64encode(SAMPLE_VIDEO_BYTES).decode("utf-8")
@@ -105,7 +104,7 @@ def test_dict_with_inline_data():
 
 
 def test_both_url_and_inline_data_raises():
-    with pytest.raises(pydantic.ValidationError, match="Exactly one"):
+    with pytest.raises(pydantic.ValidationError, match="url.*inline_data"):
         dspy.Video(url="https://example.com/video.mp4", inline_data=SAMPLE_VIDEO_B64)
 
 

--- a/tests/signatures/test_adapter_video.py
+++ b/tests/signatures/test_adapter_video.py
@@ -1,0 +1,221 @@
+import base64
+import os
+import tempfile
+
+import pydantic
+import pytest
+
+import dspy
+from dspy.adapters.types.video import _encode_video_from_file
+from dspy.utils.dummies import DummyLM
+from tests.signatures.test_adapter_file import count_messages_with_file_pattern
+
+
+SAMPLE_VIDEO_BYTES = b"\x00\x00\x00\x1cftypisom" + b"\x00" * 50
+SAMPLE_VIDEO_B64 = base64.b64encode(SAMPLE_VIDEO_BYTES).decode("utf-8")
+
+
+@pytest.fixture
+def sample_video_file():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as tmp:
+        tmp.write(SAMPLE_VIDEO_BYTES)
+        tmp_path = tmp.name
+    yield tmp_path
+    try:
+        os.unlink(tmp_path)
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def sample_webm_file():
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".webm") as tmp:
+        tmp.write(SAMPLE_VIDEO_BYTES)
+        tmp_path = tmp.name
+    yield tmp_path
+    try:
+        os.unlink(tmp_path)
+    except Exception:
+        pass
+
+
+def setup_predictor(signature, expected_output):
+    lm = DummyLM([expected_output])
+    dspy.settings.configure(lm=lm)
+    return dspy.Predict(signature), lm
+
+
+def test_from_url():
+    url = "https://generativelanguage.googleapis.com/v1beta/files/abc123"
+    v = dspy.Video.from_url(url)
+    assert v.url == url
+    assert v.inline_data is None
+    assert v.mime_type == "video/mp4"
+
+
+def test_from_url_custom_mime():
+    v = dspy.Video.from_url("https://example.com/video", mime_type="video/webm")
+    assert v.mime_type == "video/webm"
+
+
+def test_from_file(sample_video_file):
+    v = dspy.Video.from_file(sample_video_file)
+    assert v.inline_data is not None
+    assert v.url is None
+    assert v.mime_type == "video/mp4"
+    assert base64.b64decode(v.inline_data) == SAMPLE_VIDEO_BYTES
+
+
+def test_from_file_mime_detection(sample_webm_file):
+    v = dspy.Video.from_file(sample_webm_file)
+    assert v.mime_type == "video/webm"
+
+
+def test_from_file_custom_mime(sample_video_file):
+    v = dspy.Video.from_file(sample_video_file, mime_type="video/webm")
+    assert v.mime_type == "video/webm"
+
+
+def test_from_file_not_found():
+    with pytest.raises(ValueError, match="File not found"):
+        dspy.Video.from_file("/nonexistent/path/video.mp4")
+
+
+def test_from_bytes():
+    v = dspy.Video.from_bytes(SAMPLE_VIDEO_BYTES)
+    assert v.inline_data == SAMPLE_VIDEO_B64
+    assert v.mime_type == "video/mp4"
+
+
+def test_from_bytes_custom_mime():
+    v = dspy.Video.from_bytes(SAMPLE_VIDEO_BYTES, mime_type="video/webm")
+    assert v.mime_type == "video/webm"
+
+
+def test_dict_with_url():
+    v = dspy.Video(url="https://example.com/video.mp4")
+    assert v.url == "https://example.com/video.mp4"
+    assert v.inline_data is None
+
+
+def test_dict_with_inline_data():
+    v = dspy.Video(inline_data=SAMPLE_VIDEO_B64, mime_type="video/webm")
+    assert v.inline_data == SAMPLE_VIDEO_B64
+    assert v.mime_type == "video/webm"
+
+
+def test_both_url_and_inline_data_raises():
+    with pytest.raises(pydantic.ValidationError, match="Exactly one"):
+        dspy.Video(url="https://example.com/video.mp4", inline_data=SAMPLE_VIDEO_B64)
+
+
+def test_neither_url_nor_inline_data_raises():
+    with pytest.raises(pydantic.ValidationError, match="url.*inline_data"):
+        dspy.Video(mime_type="video/mp4")
+
+
+def test_invalid_dict_raises():
+    with pytest.raises(pydantic.ValidationError):
+        dspy.Video(**{"bad_key": "value"})
+
+
+def test_frozen():
+    v = dspy.Video(url="https://example.com/video.mp4")
+    with pytest.raises((TypeError, ValueError, pydantic.ValidationError)):
+        v.url = "https://other.com/video.mp4"
+
+
+def test_repr_url():
+    v = dspy.Video(url="https://example.com/video.mp4")
+    assert repr(v) == "Video(url='https://example.com/video.mp4')"
+
+
+def test_repr_inline():
+    v = dspy.Video(inline_data=SAMPLE_VIDEO_B64)
+    assert f"base64:{len(SAMPLE_VIDEO_B64)}" in repr(v)
+
+
+def test_str_contains_custom_type_markers():
+    v = dspy.Video(url="https://example.com/video.mp4")
+    s = str(v)
+    assert "<<CUSTOM-TYPE-START-IDENTIFIER>>" in s
+    assert "<<CUSTOM-TYPE-END-IDENTIFIER>>" in s
+
+
+# --- Integration with DSPy signature ---
+
+
+def test_video_in_signature():
+    predictor, lm = setup_predictor(
+        "video: dspy.Video -> description: str",
+        {"description": "A video about dogs"},
+    )
+    result = predictor(video=dspy.Video(url="https://example.com/video.mp4"))
+    assert result.description == "A video about dogs"
+    assert count_messages_with_file_pattern(lm.history[-1]["messages"]) == 1
+
+
+def test_video_inline_in_signature():
+    predictor, lm = setup_predictor(
+        "video: dspy.Video -> description: str",
+        {"description": "A test video"},
+    )
+    result = predictor(video=dspy.Video.from_bytes(SAMPLE_VIDEO_BYTES))
+    assert result.description == "A test video"
+    assert count_messages_with_file_pattern(lm.history[-1]["messages"]) == 1
+
+
+def test_video_list_in_signature():
+    class VideoListSignature(dspy.Signature):
+        videos: list[dspy.Video] = dspy.InputField()
+        summary: str = dspy.OutputField()
+
+    predictor, lm = setup_predictor(VideoListSignature, {"summary": "Multiple videos"})
+    videos = [
+        dspy.Video(url="https://example.com/video1.mp4"),
+        dspy.Video.from_bytes(SAMPLE_VIDEO_BYTES),
+    ]
+    result = predictor(videos=videos)
+    assert result.summary == "Multiple videos"
+    assert count_messages_with_file_pattern(lm.history[-1]["messages"]) == 2
+
+
+def test_optional_video_field():
+    class OptionalVideoSignature(dspy.Signature):
+        video: dspy.Video | None = dspy.InputField()
+        output: str = dspy.OutputField()
+
+    predictor, lm = setup_predictor(OptionalVideoSignature, {"output": "No video"})
+    result = predictor(video=None)
+    assert result.output == "No video"
+    assert count_messages_with_file_pattern(lm.history[-1]["messages"]) == 0
+
+
+def test_save_load_video_signature():
+    signature = "video: dspy.Video -> description: str"
+    video = dspy.Video(url="https://example.com/video.mp4")
+    examples = [dspy.Example(video=video, description="A dog video")]
+
+    predictor, lm = setup_predictor(signature, {"description": "A video"})
+    optimizer = dspy.teleprompt.LabeledFewShot(k=1)
+    compiled = optimizer.compile(student=predictor, trainset=examples, sample=False)
+
+    with tempfile.NamedTemporaryFile(mode="w+", delete=True, suffix=".json") as tmp:
+        compiled.save(tmp.name)
+        loaded = dspy.Predict(signature)
+        loaded.load(tmp.name)
+
+    loaded(video=dspy.Video(url="https://example.com/new.mp4"))
+    # 2 = one from the few-shot demo + one from the new input
+    assert count_messages_with_file_pattern(lm.history[-1]["messages"]) == 2
+
+
+def test_encode_video_from_file(sample_video_file):
+    result = _encode_video_from_file(sample_video_file)
+    assert result["inline_data"] == SAMPLE_VIDEO_B64
+    assert result["mime_type"] == "video/mp4"
+
+
+def test_encode_video_from_file_not_found():
+    with pytest.raises(ValueError, match="File not found"):
+        _encode_video_from_file("/nonexistent/video.mp4")

--- a/tests/test_utils/messages.py
+++ b/tests/test_utils/messages.py
@@ -1,0 +1,24 @@
+def count_messages_with_file_pattern(messages):
+    """Count content parts matching {"type": "file", "file": <dict>} in messages."""
+    pattern = {"type": "file", "file": lambda x: isinstance(x, dict)}
+
+    def check_pattern(obj, pattern):
+        if isinstance(pattern, dict):
+            if not isinstance(obj, dict):
+                return False
+            return all(k in obj and check_pattern(obj[k], v) for k, v in pattern.items())
+        if callable(pattern):
+            return pattern(obj)
+        return obj == pattern
+
+    def count_patterns(obj, pattern):
+        count = 0
+        if check_pattern(obj, pattern):
+            count += 1
+        if isinstance(obj, dict):
+            count += sum(count_patterns(v, pattern) for v in obj.values())
+        if isinstance(obj, list | tuple):
+            count += sum(count_patterns(v, pattern) for v in obj)
+        return count
+
+    return count_patterns(messages, pattern)


### PR DESCRIPTION
### Summary
Adds a Video type to DSPy's adapter system, following the same pattern as the existing types.

Relevant issues #8507 #7847

Currently only Gemini works with video, so the PR is google-specific. Video adapter can be extended in the future when more providers allow for video.

I've been using similar adapter for video analysis for the past few months.

Supports passing video inline or referencing an already uploaded video to Google's Files API (their recommended approach)


Example:

       
```
import dspy
dspy.configure(lm=dspy.LM("gemini/gemini-3-flash-preview"))

class Describe(dspy.Signature):
    video: dspy.Video = dspy.InputField()
    description: str = dspy.OutputField()

program = dspy.Predict(Describe)
result = program(video=dspy.Video.from_file("video.mp4"))
```