### PR TITLE
Improve dspy.Example docstrings and examples

### DIFF
--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -2,11 +2,11 @@ from pydantic import BaseModel
 
 
 class Example:
-    """Store one DSPy data point with named fields.
+    """A flexible data container for DSPy examples and training data with named fields.
 
-    Think of an `Example` as one row from a HuggingFace dataset or pandas
-    DataFrame. Each field is a column value you can access by name, either with
-    `example.question` or `example["question"]`.
+    An `Example` is roughly one row from a HuggingFace dataset or pandas
+    `DataFrame`. It behaves a lot like a dictionary or dot-access record: you
+    can read fields with `example["question"]` or `example.question`.
 
     In DSPy, lists of `Example` objects are your trainset, devset, and testset.
     Most examples are built from keyword arguments or an existing record, then
@@ -25,18 +25,22 @@ class Example:
         >>> example = dspy.Example(
         ...     question="What is the capital of France?",
         ...     answer="Paris",
-        ... )
+        ... ).with_inputs("question")
         >>> example.question
         'What is the capital of France?'
         >>> example.answer
         'Paris'
+        >>> example.inputs().toDict()
+        {'question': 'What is the capital of France?'}
 
         Build one from an existing record:
 
         >>> record = {"question": "What is 2+2?", "answer": "4"}
-        >>> example = dspy.Example(**record)
+        >>> example = dspy.Example(**record).with_inputs("question")
         >>> example["question"]
         'What is 2+2?'
+        >>> example.labels().answer
+        '4'
 
         Mark which fields are inputs:
 
@@ -69,7 +73,7 @@ class Example:
 
         Use it like a dictionary:
 
-        >>> example = dspy.Example(name="Alice", age=30)
+        >>> example = dspy.Example(name="Alice", age=30).with_inputs("name")
         >>> "name" in example
         True
         >>> example.get("city", "Unknown")


### PR DESCRIPTION
## Summary

Improve the `dspy.Example` docs so they read better in both MkDocs and IDE help.

This PR:
- rewrites the class docstring around the mental model users actually need: an `Example` is one row of task data
- connects `Example` to familiar concepts like pandas rows and HuggingFace dataset records
- explains how `with_inputs()`, `inputs()`, and `labels()` are used in practice
- adds clearer doctest-style examples, including trainset and metric usage
- documents all public methods shown in the API reference with concrete Google-style docstrings
- keeps `__init__` focused on constructor help so signature help in IDEs is more useful

## Why

`dspy.Example` is one of the first APIs new users encounter, but the previous docs were vague and a bit awkward when rendered in MkDocs. In particular:
- the class overview did not clearly explain what an `Example` is in everyday terms
- the rendered "Key features" section felt odd
- `__init__` help was too abstract for users typing `dspy.Example(...)` in an IDE
- several public methods in the API reference were undocumented

This revision aims to make the docs more concrete, beginner-friendly, and easier to use from both the website and editor hovers.

# Before

<img width="1786" height="1355" alt="image" src="https://github.com/user-attachments/assets/3e90f1cf-060d-4eb1-a499-feb22176d06b" />

# After

<img width="1786" height="1355" alt="image" src="https://github.com/user-attachments/assets/379146ba-8c6c-41c6-92e6-b5fcac67357a" />

