### PR TITLE
fix: ignore extra args passed to finish tool in ReAct

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -107,13 +107,14 @@ class ReAct(Module):
             trajectory[f"tool_name_{idx}"] = pred.next_tool_name
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
+            if pred.next_tool_name == "finish":
+                trajectory[f"observation_{idx}"] = self.tools["finish"]()
+                break
+
             try:
                 trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](**pred.next_tool_args)
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
-
-            if pred.next_tool_name == "finish":
-                break
 
         extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)
@@ -132,13 +133,14 @@ class ReAct(Module):
             trajectory[f"tool_name_{idx}"] = pred.next_tool_name
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
+            if pred.next_tool_name == "finish":
+                trajectory[f"observation_{idx}"] = self.tools["finish"]()
+                break
+
             try:
                 trajectory[f"observation_{idx}"] = await self.tools[pred.next_tool_name].acall(**pred.next_tool_args)
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
-
-            if pred.next_tool_name == "finish":
-                break
 
         extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)


### PR DESCRIPTION
## Summary

Fixes #9424.

When a model provides final output values in `next_tool_args` for the `finish` step (e.g. structured output fields like `type`, `confidence`, etc.), `ReAct` previously passed those args to the `finish` tool, which accepts no arguments. This caused a spurious `ValueError` that was logged as an execution error in the trajectory, even though the run could still succeed via the extraction step.

**Fix:** When `next_tool_name` is `"finish"`, call `finish()` with no arguments and break immediately, ignoring any extra args the model may have provided. This applies to both `forward()` and `aforward()`.

## Changes

- `dspy/predict/react.py`: In both `forward` and `aforward`, check for `finish` **before** calling the tool with `**pred.next_tool_args`. If finish, call with no args and break.

## Test plan

- [ ] Existing ReAct tests pass (no behavior change for normal tool calls)
- [ ] When a model emits `next_tool_args` with extra fields for `finish`, no `ValueError` is raised and no execution error appears in the trajectory
- [ ] The `observation` for `finish` is still recorded as `"Completed."`

🤖 Generated with [Claude Code](https://claude.com/claude-code)