### PR TITLE
fix: move callbacks list construction per-invocation in streamify

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -161,12 +161,12 @@ def streamify(
     elif not iscoroutinefunction(program):
         program = asyncify(program)
 
-    callbacks = list(settings.callbacks)
-    status_streaming_callback = StatusStreamingCallback(status_message_provider)
-    if not any(isinstance(c, StatusStreamingCallback) for c in callbacks):
-        callbacks.append(status_streaming_callback)
-
     async def generator(args, kwargs, stream: MemoryObjectSendStream):
+        callbacks = list(settings.callbacks)
+        status_streaming_callback = StatusStreamingCallback(status_message_provider)
+        if not any(isinstance(c, StatusStreamingCallback) for c in callbacks):
+            callbacks.append(status_streaming_callback)
+
         with settings.context(send_stream=stream, callbacks=callbacks, stream_listeners=stream_listeners):
             prediction = await program(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

Fixes #9074

`streamify` builds a `callbacks` list once at wrapper-creation time (line 164) and captures it in the closure shared by every subsequent call to the returned async streamer. Although #9073 replaced the direct `settings.callbacks.append()` with `list(settings.callbacks)`, the shallow copy is still made **once** — so:

- The same `callbacks` list object leaks across invocations of the streamer.
- `settings.callbacks` changes after `streamify()` is called are never picked up.

This PR moves the callbacks construction (`list(settings.callbacks)` + conditional `StatusStreamingCallback` append) **inside** the `generator` coroutine so that each invocation gets its own fresh copy from the current `settings.callbacks`.

## Test plan

- Existing tests in `tests/streaming/` continue to pass.
- The reproduction steps from #9074 / #9073 no longer exhibit callback leakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)