### PR TITLE
fix: propagate exceptions in apply_sync_streaming

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -239,6 +239,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as e:
+                queue.put(e)
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +256,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if isinstance(item, BaseException):
+            raise item
         yield item
 
 


### PR DESCRIPTION
## Summary

Fixes #9142.

`apply_sync_streaming` silently swallows exceptions raised in the async generator. The `try/finally` block in `runner()` sends the stop sentinel on exception, but the exception itself is never surfaced to the caller — it simply appears as if the stream ended normally.

This PR fixes the issue by:
- Adding an `except BaseException` clause in `runner()` that puts the exception object into the queue before the `finally` block sends the stop sentinel
- Adding an `isinstance(item, BaseException)` check in the consumer loop that re-raises the exception when it is dequeued

This ensures exceptions propagate correctly to the caller of the sync generator.

## Test plan

- Verify that exceptions raised inside the async generator are now raised in the consumer (caller) of `apply_sync_streaming`
- Verify that normal (non-error) streaming still works as before — items flow through the queue and the stop sentinel terminates the loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)