### PR TITLE
fix: exclude Code docstring from JSON schema to prevent prompt bloat

### DIFF
--- a/dspy/adapters/types/code.py
+++ b/dspy/adapters/types/code.py
@@ -2,7 +2,8 @@ import re
 from typing import Any, ClassVar
 
 import pydantic
-from pydantic import create_model
+from pydantic import GetJsonSchemaHandler, create_model
+from pydantic.json_schema import JsonSchemaValue
 
 from dspy.adapters.types.base_type import Type
 
@@ -66,6 +67,22 @@ class Code(Type):
     code: str
 
     language: ClassVar[str] = "python"
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        source_type: Any,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        """Override to exclude the class docstring from the JSON schema.
+
+        Pydantic uses the class docstring as the schema ``description`` by default.
+        For ``Code``, the docstring contains lengthy usage examples that bloat LLM
+        prompts when the schema is injected (see stanfordnlp/dspy#9251).
+        """
+        schema = handler(source_type)
+        schema.pop("description", None)
+        return schema
 
     def format(self):
         return f"{self.code}"


### PR DESCRIPTION
## Summary

Fixes #9251.

`dspy.Code`'s class docstring (which contains lengthy usage examples) is included by Pydantic in the generated JSON schema's `description` field. When the adapter injects this schema into the LLM prompt, it produces bloated, confusing prompts with contradictory formatting instructions (markdown vs JSON).

**Root cause:** Pydantic v2 automatically uses the class docstring as the `description` in `json_schema()` output. Since `Code` has a long docstring with full code examples, all of that text ends up in the prompt.

**Fix:** Override `__get_pydantic_json_schema__` on the `Code` class to strip the `description` field from the generated schema. This is the standard Pydantic v2 hook for customizing JSON schema generation and ensures the docstring never leaks into prompts regardless of which code path generates the schema (`TypeAdapter.json_schema()`, `model_json_schema()`, nested types like `list[Code]`, etc.).

The existing guard in `translate_field_type` (which skips schema injection for direct `Code` output fields) is preserved as defense-in-depth, since `Code.description()` already provides concise, well-formatted type instructions.

## Test plan

- [ ] Existing `test_chat_adapter_with_code` should pass and the system prompt should no longer contain the JSON schema with docstring examples
- [ ] Verify `pydantic.TypeAdapter(dspy.Code).json_schema()` no longer includes a `description` field
- [ ] Verify `pydantic.TypeAdapter(dspy.Code["java"]).json_schema()` also excludes the description (subclass via `__class_getitem__`)
- [ ] Verify nested types like `list[dspy.Code]` also produce clean schemas

🤖 Generated with [Claude Code](https://claude.com/claude-code)