### PR TITLE
fix: use analyzePath for cross-platform Pyodide FS mkdir checks

### DIFF
--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -265,12 +265,7 @@ while (true) {
       let cur = '';
       for (const d of dirs) {
         cur += '/' + d;
-        // Check if directory exists before creating
-        try {
-          pyodide.FS.stat(cur);
-          // Directory exists, continue to next
-        } catch {
-          // Directory doesn't exist, create it
+        if (!pyodide.FS.analyzePath(cur).exists) {
           pyodide.FS.mkdir(cur);
         }
       }
@@ -314,8 +309,8 @@ while (true) {
   if (method === "inject_var") {
     const { name, value } = params;
     try {
-      try { pyodide.FS.mkdir('/tmp'); } catch (e) { /* exists */ }
-      try { pyodide.FS.mkdir('/tmp/dspy_vars'); } catch (e) { /* exists */ }
+      if (!pyodide.FS.analyzePath('/tmp').exists) { pyodide.FS.mkdir('/tmp'); }
+      if (!pyodide.FS.analyzePath('/tmp/dspy_vars').exists) { pyodide.FS.mkdir('/tmp/dspy_vars'); }
       pyodide.FS.writeFile(`/tmp/dspy_vars/${name}.json`, new TextEncoder().encode(value));
       console.log(jsonrpcResult({ injected: name }, requestId));
     } catch (e) {


### PR DESCRIPTION
## Summary

Fixes #9107

- Replace `try/catch` with `pyodide.FS.stat()` and blind `catch` blocks in `mount_file` with `pyodide.FS.analyzePath(path).exists` checks
- Replace `try { pyodide.FS.mkdir(...) } catch (e) { /* exists */ }` in `inject_var` with the same `analyzePath` approach

The previous approach in `mount_file` used `pyodide.FS.stat()` wrapped in try/catch to detect existing directories, and `inject_var` used blind catch blocks that swallowed all errors. Both patterns are fragile: the original code (before a prior partial fix) relied on `e.message.includes('File exists')` which is OS-specific and fails on Windows where Deno produces different error messages.

`pyodide.FS.analyzePath()` is the recommended Pyodide API for checking path existence and works consistently across all platforms.

## Test plan

- [x] Verified the fix compiles (no syntax errors in the JS)
- [ ] Test on Windows with Deno to confirm `mount_file` and `inject_var` work correctly
- [ ] Test on Linux/macOS to confirm no regression