### PR TITLE
fix: support both isError and is_error in MCP CallToolResult

### DIFF
--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -21,7 +21,11 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if len(text_contents) == 1:
         tool_content = tool_content[0]
 
-    if call_tool_result.isError:
+    # Support both official MCP SDK (isError) and FastMCP (is_error) attribute names
+    is_error = getattr(call_tool_result, "isError", None)
+    if is_error is None:
+        is_error = getattr(call_tool_result, "is_error", False)
+    if is_error:
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
 
     return tool_content or non_text_contents


### PR DESCRIPTION
## Summary
- Fix `_convert_mcp_tool_result` to handle both `isError` (official MCP SDK) and `is_error` (FastMCP) attribute names using `getattr` with fallback
- Prevents `AttributeError: 'CallToolResult' object has no attribute 'isError'` when using FastMCP

## Details
The official MCP Python SDK defines `CallToolResult.isError` as a camelCase Pydantic field, but FastMCP's `CallToolResult` uses `is_error` (snake_case). The current code hardcodes `call_tool_result.isError`, which crashes when the result object comes from FastMCP.

The fix uses `getattr` to check `isError` first (official SDK), then falls back to `is_error` (FastMCP), defaulting to `False` if neither exists.

Fixes #8760

## Test plan
- [ ] Verify MCP tool calls work with the official `mcp` Python SDK (`CallToolResult.isError`)
- [ ] Verify MCP tool calls work with FastMCP (`CallToolResult.is_error`)
- [ ] Verify error case: when `isError`/`is_error` is `True`, `RuntimeError` is raised
- [ ] Verify success case: when `isError`/`is_error` is `False`, tool content is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)