### PR TITLE
docs: add docstrings for LiteLLM logging APIs

### DIFF
--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -92,11 +92,29 @@ def configure_litellm_logging(level: str = "ERROR"):
 
 
 def enable_litellm_logging():
+    """Enable verbose LiteLLM logs for DSPy client calls.
+
+    This function disables LiteLLM's debug-info suppression and sets the
+    LiteLLM verbose logger level to ``DEBUG``.
+
+    Example:
+        >>> import dspy
+        >>> dspy.enable_litellm_logging()
+    """
     litellm.suppress_debug_info = False
     configure_litellm_logging("DEBUG")
 
 
 def disable_litellm_logging():
+    """Disable verbose LiteLLM logs for quieter DSPy output.
+
+    This function enables LiteLLM's debug-info suppression and sets the
+    LiteLLM verbose logger level to ``ERROR``.
+
+    Example:
+        >>> import dspy
+        >>> dspy.disable_litellm_logging()
+    """
     litellm.suppress_debug_info = True
     configure_litellm_logging("ERROR")
 


### PR DESCRIPTION
## Summary
This PR adds missing Google-style docstrings to the public LiteLLM logging helpers in `dspy/clients/__init__.py`.

### Updated APIs
- `enable_litellm_logging`
- `disable_litellm_logging`

### Notes
- Added concise usage examples in each docstring.
- No runtime behavior changes.

### Validation
- `python3 -m py_compile dspy/clients/__init__.py`

Resolves #9453
Related to #8926