### PR TITLE
docs: add Google-style docstrings to dspy/datasets/dataloader.py

### DIFF
--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -10,6 +10,18 @@ if TYPE_CHECKING:
 
 
 class DataLoader(Dataset):
+    """Utility for loading datasets from various sources into DSPy Examples.
+
+    DataLoader provides methods to load data from Hugging Face Hub, CSV, JSON,
+    Parquet files, Pandas DataFrames, and retrieval modules, converting each row
+    into a ``dspy.Example`` with the specified input keys.
+
+    Example:
+        >>> dl = dspy.DataLoader()
+        >>> dataset = dl.from_csv("data.csv", input_keys=("question",))
+        >>> trainset, testset = dl.train_test_split(dataset, train_size=0.8).values()
+    """
+
     def __init__(self):
         pass
 
@@ -21,6 +33,41 @@ class DataLoader(Dataset):
         fields: tuple[str] | None = None,
         **kwargs,
     ) -> Mapping[str, list[dspy.Example]] | list[dspy.Example]:
+        """Load a dataset from Hugging Face Hub.
+
+        Wraps ``datasets.load_dataset`` and converts each row into a
+        ``dspy.Example``. When the dataset has multiple splits the return value
+        is a dict mapping split names to lists of examples; when a single split
+        is requested a flat list is returned.
+
+        Args:
+            dataset_name: Name or path of the Hugging Face dataset
+                (e.g. ``"squad"``).
+            *args: Positional arguments forwarded to ``datasets.load_dataset``.
+            input_keys: Fields to mark as inputs via
+                ``Example.with_inputs()``.
+            fields: Subset of columns to keep. If ``None``, all columns are
+                included.
+            **kwargs: Keyword arguments forwarded to ``datasets.load_dataset``
+                (e.g. ``split="train"``).
+
+        Returns:
+            A dict of ``{split_name: [dspy.Example, ...]}`` when multiple
+            splits are loaded, or a flat ``[dspy.Example, ...]`` for a single
+            split.
+
+        Raises:
+            ValueError: If ``fields`` is not a tuple or ``input_keys`` is not
+                a tuple.
+
+        Example:
+            >>> dl = dspy.DataLoader()
+            >>> dataset = dl.from_huggingface(
+            ...     "squad",
+            ...     split="train[:100]",
+            ...     input_keys=("question", "context"),
+            ... )
+        """
         if fields and not isinstance(fields, tuple):
             raise ValueError("Invalid fields provided. Please provide a tuple of fields.")
 
@@ -66,6 +113,21 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load a dataset from a CSV file.
+
+        Args:
+            file_path: Path to the CSV file.
+            fields: Columns to include. If ``None``, all columns are included.
+            input_keys: Fields to mark as inputs via
+                ``Example.with_inputs()``.
+
+        Returns:
+            A list of ``dspy.Example`` instances.
+
+        Example:
+            >>> dl = dspy.DataLoader()
+            >>> dataset = dl.from_csv("data.csv", input_keys=("question",))
+        """
         from datasets import load_dataset
 
         dataset = load_dataset("csv", data_files=file_path)["train"]
@@ -81,6 +143,23 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load a dataset from a Pandas DataFrame.
+
+        Args:
+            df: The source DataFrame.
+            fields: Columns to include. If ``None``, all columns are included.
+            input_keys: Fields to mark as inputs via
+                ``Example.with_inputs()``.
+
+        Returns:
+            A list of ``dspy.Example`` instances.
+
+        Example:
+            >>> import pandas as pd
+            >>> dl = dspy.DataLoader()
+            >>> df = pd.DataFrame({"question": ["What is AI?"], "answer": ["..."]})
+            >>> dataset = dl.from_pandas(df, input_keys=("question",))
+        """
         if fields is None:
             fields = list(df.columns)
 
@@ -94,6 +173,21 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load a dataset from a JSON or JSONL file.
+
+        Args:
+            file_path: Path to the JSON or JSONL file.
+            fields: Columns to include. If ``None``, all columns are included.
+            input_keys: Fields to mark as inputs via
+                ``Example.with_inputs()``.
+
+        Returns:
+            A list of ``dspy.Example`` instances.
+
+        Example:
+            >>> dl = dspy.DataLoader()
+            >>> dataset = dl.from_json("data.jsonl", input_keys=("question",))
+        """
         from datasets import load_dataset
 
         dataset = load_dataset("json", data_files=file_path)["train"]
@@ -109,6 +203,21 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load a dataset from a Parquet file.
+
+        Args:
+            file_path: Path to the Parquet file.
+            fields: Columns to include. If ``None``, all columns are included.
+            input_keys: Fields to mark as inputs via
+                ``Example.with_inputs()``.
+
+        Returns:
+            A list of ``dspy.Example`` instances.
+
+        Example:
+            >>> dl = dspy.DataLoader()
+            >>> dataset = dl.from_parquet("data.parquet", input_keys=("question",))
+        """
         from datasets import load_dataset
 
         dataset = load_dataset("parquet", data_files=file_path)["train"]
@@ -119,6 +228,24 @@ class DataLoader(Dataset):
         return [dspy.Example({field: row[field] for field in fields}).with_inputs(*input_keys) for row in dataset]
 
     def from_rm(self, num_samples: int, fields: list[str], input_keys: list[str]) -> list[dspy.Example]:
+        """Load examples from the configured retrieval module.
+
+        Fetches objects from the retrieval module set via ``dspy.configure``
+        and converts them into ``dspy.Example`` instances.
+
+        Args:
+            num_samples: Number of samples to retrieve.
+            fields: Fields to include from each retrieved object.
+            input_keys: Fields to mark as inputs via
+                ``Example.with_inputs()``.
+
+        Returns:
+            A list of ``dspy.Example`` instances.
+
+        Raises:
+            ValueError: If no retrieval module is configured or it does not
+                support ``get_objects``.
+        """
         try:
             rm = dspy.settings.rm
             try:
@@ -131,9 +258,7 @@ class DataLoader(Dataset):
                     "Retrieval module does not support `get_objects`. Please use a different retrieval module."
                 )
         except AttributeError:
-            raise ValueError(
-                "Retrieval module not found. Please set a retrieval module using `dspy.configure`."
-            )
+            raise ValueError("Retrieval module not found. Please set a retrieval module using `dspy.configure`.")
 
     def sample(
         self,
@@ -142,6 +267,25 @@ class DataLoader(Dataset):
         *args,
         **kwargs,
     ) -> list[dspy.Example]:
+        """Return a random sample of examples from a dataset.
+
+        Args:
+            dataset: A list of ``dspy.Example`` instances to sample from.
+            n: Number of examples to sample.
+            *args: Additional arguments forwarded to ``random.sample``.
+            **kwargs: Additional keyword arguments forwarded to
+                ``random.sample``.
+
+        Returns:
+            A list of ``n`` randomly selected ``dspy.Example`` instances.
+
+        Raises:
+            ValueError: If ``dataset`` is not a list.
+
+        Example:
+            >>> dl = dspy.DataLoader()
+            >>> subset = dl.sample(dataset, n=10)
+        """
         if not isinstance(dataset, list):
             raise ValueError(
                 f"Invalid dataset provided of type {type(dataset)}. Please provide a list of `dspy.Example`s."
@@ -156,6 +300,35 @@ class DataLoader(Dataset):
         test_size: int | float | None = None,
         random_state: int | None = None,
     ) -> Mapping[str, list[dspy.Example]]:
+        """Split a dataset into train and test sets.
+
+        The dataset is shuffled before splitting. Sizes can be specified as
+        floats (proportions) or ints (absolute counts).
+
+        Args:
+            dataset: A list of ``dspy.Example`` instances to split.
+            train_size: If float, the proportion of the dataset for the train
+                split (between 0 and 1). If int, the absolute number of train
+                samples.
+            test_size: If float, the proportion for the test split. If int,
+                the absolute number of test samples. If ``None``, defaults to
+                the remainder after the train split.
+            random_state: Seed for the random number generator used for
+                shuffling. If ``None``, results are non-deterministic.
+
+        Returns:
+            A dict with ``"train"`` and ``"test"`` keys mapping to lists of
+            ``dspy.Example`` instances.
+
+        Raises:
+            ValueError: If ``train_size`` or ``test_size`` are invalid, or if
+                their sum exceeds the dataset size.
+
+        Example:
+            >>> dl = dspy.DataLoader()
+            >>> splits = dl.train_test_split(dataset, train_size=0.8, random_state=42)
+            >>> trainset, testset = splits["train"], splits["test"]
+        """
         if random_state is not None:
             random.seed(random_state)
 

--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -16,10 +16,12 @@ class DataLoader(Dataset):
     Parquet files, Pandas DataFrames, and retrieval modules, converting each row
     into a `dspy.Example` with the specified input keys.
 
-    Example:
-        >>> dl = dspy.DataLoader()
-        >>> dataset = dl.from_csv("data.csv", input_keys=("question",))
-        >>> trainset, testset = dl.train_test_split(dataset, train_size=0.8).values()
+    Examples:
+        ```python
+        dl = dspy.DataLoader()
+        dataset = dl.from_csv("data.csv", input_keys=("question",))
+        trainset, testset = dl.train_test_split(dataset, train_size=0.8).values()
+        ```
     """
 
     def __init__(self):
@@ -60,13 +62,15 @@ class DataLoader(Dataset):
             ValueError: If `fields` is not a tuple or `input_keys` is not
                 a tuple.
 
-        Example:
-            >>> dl = dspy.DataLoader()
-            >>> dataset = dl.from_huggingface(
-            ...     "squad",
-            ...     split="train[:100]",
-            ...     input_keys=("question", "context"),
-            ... )
+        Examples:
+            ```python
+            dl = dspy.DataLoader()
+            dataset = dl.from_huggingface(
+                "squad",
+                split="train[:100]",
+                input_keys=("question", "context"),
+            )
+            ```
         """
         if fields and not isinstance(fields, tuple):
             raise ValueError("Invalid fields provided. Please provide a tuple of fields.")
@@ -124,9 +128,11 @@ class DataLoader(Dataset):
         Returns:
             A list of `dspy.Example` instances.
 
-        Example:
-            >>> dl = dspy.DataLoader()
-            >>> dataset = dl.from_csv("data.csv", input_keys=("question",))
+        Examples:
+            ```python
+            dl = dspy.DataLoader()
+            dataset = dl.from_csv("data.csv", input_keys=("question",))
+            ```
         """
         from datasets import load_dataset
 
@@ -154,11 +160,13 @@ class DataLoader(Dataset):
         Returns:
             A list of `dspy.Example` instances.
 
-        Example:
-            >>> import pandas as pd
-            >>> dl = dspy.DataLoader()
-            >>> df = pd.DataFrame({"question": ["What is AI?"], "answer": ["..."]})
-            >>> dataset = dl.from_pandas(df, input_keys=("question",))
+        Examples:
+            ```python
+            import pandas as pd
+            dl = dspy.DataLoader()
+            df = pd.DataFrame({"question": ["What is AI?"], "answer": ["..."]})
+            dataset = dl.from_pandas(df, input_keys=("question",))
+            ```
         """
         if fields is None:
             fields = list(df.columns)
@@ -184,9 +192,11 @@ class DataLoader(Dataset):
         Returns:
             A list of `dspy.Example` instances.
 
-        Example:
-            >>> dl = dspy.DataLoader()
-            >>> dataset = dl.from_json("data.jsonl", input_keys=("question",))
+        Examples:
+            ```python
+            dl = dspy.DataLoader()
+            dataset = dl.from_json("data.jsonl", input_keys=("question",))
+            ```
         """
         from datasets import load_dataset
 
@@ -214,9 +224,11 @@ class DataLoader(Dataset):
         Returns:
             A list of `dspy.Example` instances.
 
-        Example:
-            >>> dl = dspy.DataLoader()
-            >>> dataset = dl.from_parquet("data.parquet", input_keys=("question",))
+        Examples:
+            ```python
+            dl = dspy.DataLoader()
+            dataset = dl.from_parquet("data.parquet", input_keys=("question",))
+            ```
         """
         from datasets import load_dataset
 
@@ -282,9 +294,11 @@ class DataLoader(Dataset):
         Raises:
             ValueError: If `dataset` is not a list.
 
-        Example:
-            >>> dl = dspy.DataLoader()
-            >>> subset = dl.sample(dataset, n=10)
+        Examples:
+            ```python
+            dl = dspy.DataLoader()
+            subset = dl.sample(dataset, n=10)
+            ```
         """
         if not isinstance(dataset, list):
             raise ValueError(
@@ -324,10 +338,12 @@ class DataLoader(Dataset):
             ValueError: If `train_size` or `test_size` are invalid, or if
                 their sum exceeds the dataset size.
 
-        Example:
-            >>> dl = dspy.DataLoader()
-            >>> splits = dl.train_test_split(dataset, train_size=0.8, random_state=42)
-            >>> trainset, testset = splits["train"], splits["test"]
+        Examples:
+            ```python
+            dl = dspy.DataLoader()
+            splits = dl.train_test_split(dataset, train_size=0.8, random_state=42)
+            trainset, testset = splits["train"], splits["test"]
+            ```
         """
         if random_state is not None:
             random.seed(random_state)

--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -14,7 +14,7 @@ class DataLoader(Dataset):
 
     DataLoader provides methods to load data from Hugging Face Hub, CSV, JSON,
     Parquet files, Pandas DataFrames, and retrieval modules, converting each row
-    into a ``dspy.Example`` with the specified input keys.
+    into a `dspy.Example` with the specified input keys.
 
     Example:
         >>> dl = dspy.DataLoader()
@@ -35,29 +35,29 @@ class DataLoader(Dataset):
     ) -> Mapping[str, list[dspy.Example]] | list[dspy.Example]:
         """Load a dataset from Hugging Face Hub.
 
-        Wraps ``datasets.load_dataset`` and converts each row into a
-        ``dspy.Example``. When the dataset has multiple splits the return value
+        Wraps `datasets.load_dataset` and converts each row into a
+        `dspy.Example`. When the dataset has multiple splits the return value
         is a dict mapping split names to lists of examples; when a single split
         is requested a flat list is returned.
 
         Args:
             dataset_name: Name or path of the Hugging Face dataset
-                (e.g. ``"squad"``).
-            *args: Positional arguments forwarded to ``datasets.load_dataset``.
+                (e.g. `"squad"`).
+            *args: Positional arguments forwarded to `datasets.load_dataset`.
             input_keys: Fields to mark as inputs via
-                ``Example.with_inputs()``.
-            fields: Subset of columns to keep. If ``None``, all columns are
+                `Example.with_inputs()`.
+            fields: Subset of columns to keep. If `None`, all columns are
                 included.
-            **kwargs: Keyword arguments forwarded to ``datasets.load_dataset``
-                (e.g. ``split="train"``).
+            **kwargs: Keyword arguments forwarded to `datasets.load_dataset`
+                (e.g. `split="train"`).
 
         Returns:
-            A dict of ``{split_name: [dspy.Example, ...]}`` when multiple
-            splits are loaded, or a flat ``[dspy.Example, ...]`` for a single
+            A dict of `{split_name: [dspy.Example, ...]}` when multiple
+            splits are loaded, or a flat `[dspy.Example, ...]` for a single
             split.
 
         Raises:
-            ValueError: If ``fields`` is not a tuple or ``input_keys`` is not
+            ValueError: If `fields` is not a tuple or `input_keys` is not
                 a tuple.
 
         Example:
@@ -117,12 +117,12 @@ class DataLoader(Dataset):
 
         Args:
             file_path: Path to the CSV file.
-            fields: Columns to include. If ``None``, all columns are included.
+            fields: Columns to include. If `None`, all columns are included.
             input_keys: Fields to mark as inputs via
-                ``Example.with_inputs()``.
+                `Example.with_inputs()`.
 
         Returns:
-            A list of ``dspy.Example`` instances.
+            A list of `dspy.Example` instances.
 
         Example:
             >>> dl = dspy.DataLoader()
@@ -147,12 +147,12 @@ class DataLoader(Dataset):
 
         Args:
             df: The source DataFrame.
-            fields: Columns to include. If ``None``, all columns are included.
+            fields: Columns to include. If `None`, all columns are included.
             input_keys: Fields to mark as inputs via
-                ``Example.with_inputs()``.
+                `Example.with_inputs()`.
 
         Returns:
-            A list of ``dspy.Example`` instances.
+            A list of `dspy.Example` instances.
 
         Example:
             >>> import pandas as pd
@@ -177,12 +177,12 @@ class DataLoader(Dataset):
 
         Args:
             file_path: Path to the JSON or JSONL file.
-            fields: Columns to include. If ``None``, all columns are included.
+            fields: Columns to include. If `None`, all columns are included.
             input_keys: Fields to mark as inputs via
-                ``Example.with_inputs()``.
+                `Example.with_inputs()`.
 
         Returns:
-            A list of ``dspy.Example`` instances.
+            A list of `dspy.Example` instances.
 
         Example:
             >>> dl = dspy.DataLoader()
@@ -207,12 +207,12 @@ class DataLoader(Dataset):
 
         Args:
             file_path: Path to the Parquet file.
-            fields: Columns to include. If ``None``, all columns are included.
+            fields: Columns to include. If `None`, all columns are included.
             input_keys: Fields to mark as inputs via
-                ``Example.with_inputs()``.
+                `Example.with_inputs()`.
 
         Returns:
-            A list of ``dspy.Example`` instances.
+            A list of `dspy.Example` instances.
 
         Example:
             >>> dl = dspy.DataLoader()
@@ -230,21 +230,21 @@ class DataLoader(Dataset):
     def from_rm(self, num_samples: int, fields: list[str], input_keys: list[str]) -> list[dspy.Example]:
         """Load examples from the configured retrieval module.
 
-        Fetches objects from the retrieval module set via ``dspy.configure``
-        and converts them into ``dspy.Example`` instances.
+        Fetches objects from the retrieval module set via `dspy.configure`
+        and converts them into `dspy.Example` instances.
 
         Args:
             num_samples: Number of samples to retrieve.
             fields: Fields to include from each retrieved object.
             input_keys: Fields to mark as inputs via
-                ``Example.with_inputs()``.
+                `Example.with_inputs()`.
 
         Returns:
-            A list of ``dspy.Example`` instances.
+            A list of `dspy.Example` instances.
 
         Raises:
             ValueError: If no retrieval module is configured or it does not
-                support ``get_objects``.
+                support `get_objects`.
         """
         try:
             rm = dspy.settings.rm
@@ -270,17 +270,17 @@ class DataLoader(Dataset):
         """Return a random sample of examples from a dataset.
 
         Args:
-            dataset: A list of ``dspy.Example`` instances to sample from.
+            dataset: A list of `dspy.Example` instances to sample from.
             n: Number of examples to sample.
-            *args: Additional arguments forwarded to ``random.sample``.
+            *args: Additional arguments forwarded to `random.sample`.
             **kwargs: Additional keyword arguments forwarded to
-                ``random.sample``.
+                `random.sample`.
 
         Returns:
-            A list of ``n`` randomly selected ``dspy.Example`` instances.
+            A list of `n` randomly selected `dspy.Example` instances.
 
         Raises:
-            ValueError: If ``dataset`` is not a list.
+            ValueError: If `dataset` is not a list.
 
         Example:
             >>> dl = dspy.DataLoader()
@@ -306,22 +306,22 @@ class DataLoader(Dataset):
         floats (proportions) or ints (absolute counts).
 
         Args:
-            dataset: A list of ``dspy.Example`` instances to split.
+            dataset: A list of `dspy.Example` instances to split.
             train_size: If float, the proportion of the dataset for the train
                 split (between 0 and 1). If int, the absolute number of train
                 samples.
             test_size: If float, the proportion for the test split. If int,
-                the absolute number of test samples. If ``None``, defaults to
+                the absolute number of test samples. If `None`, defaults to
                 the remainder after the train split.
             random_state: Seed for the random number generator used for
-                shuffling. If ``None``, results are non-deterministic.
+                shuffling. If `None`, results are non-deterministic.
 
         Returns:
-            A dict with ``"train"`` and ``"test"`` keys mapping to lists of
-            ``dspy.Example`` instances.
+            A dict with `"train"` and `"test"` keys mapping to lists of
+            `dspy.Example` instances.
 
         Raises:
-            ValueError: If ``train_size`` or ``test_size`` are invalid, or if
+            ValueError: If `train_size` or `test_size` are invalid, or if
                 their sum exceeds the dataset size.
 
         Example:


### PR DESCRIPTION
Resolves #9457
Part of #8926

## Description

Adds comprehensive Google-style docstrings with `Args`, `Returns`, `Raises`, and `Example` sections to all 9 public APIs in `DataLoader`:

- `DataLoader` class docstring
- `from_huggingface()` — includes split behavior (dict vs flat list)
- `from_csv()`
- `from_pandas()`
- `from_json()`
- `from_parquet()`
- `from_rm()`
- `sample()`
- `train_test_split()` — documents float vs int size semantics

Each docstring includes a runnable code example showing typical usage.

`ruff check` and `ruff format` pass clean.