### PR TITLE
docs: add docstrings to predict/refine.py and predict/best_of_n.py

### DIFF
--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -69,11 +69,13 @@ class BestOfN(Module):
 
         Returns:
             Prediction: The best prediction found across all attempts, determined by the highest
-                reward score. Returns ``None`` if all attempts fail with exceptions.
+                reward score. Returns ``None`` if no attempt succeeded and the ``fail_count``
+                re-raise threshold was not reached (possible when ``N <= 2`` or
+                ``fail_count >= N``).
 
         Raises:
-            Exception: Re-raises the last encountered exception if the number of consecutive
-                failures exceeds ``fail_count``.
+            Exception: Re-raises the last encountered exception when the current attempt
+                index exceeds the remaining ``fail_count`` (decremented after each failure).
         """
         lm = self.module.get_lm() or dspy.settings.lm
         start = lm.kwargs.get("rollout_id", 0)

--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -53,6 +53,28 @@ class BestOfN(Module):
         self.fail_count = fail_count or N  # default to N if fail_count is not provided
 
     def forward(self, **kwargs):
+        """Execute the best-of-N selection loop, running the module up to ``N`` times.
+
+        Each iteration runs the module with a unique rollout ID at ``temperature=1.0`` and scores
+        the result using the reward function. If a prediction meets or exceeds the threshold, it is
+        returned immediately. Otherwise, the prediction with the highest reward across all attempts
+        is returned.
+
+        Unlike :class:`~dspy.Refine`, this method does not generate feedback between attempts —
+        each attempt is independent.
+
+        Args:
+            **kwargs: Keyword arguments passed directly to the underlying module's forward method.
+                These should match the input fields defined in the module's signature.
+
+        Returns:
+            Prediction: The best prediction found across all attempts, determined by the highest
+                reward score. Returns ``None`` if all attempts fail with exceptions.
+
+        Raises:
+            Exception: Re-raises the last encountered exception if the number of consecutive
+                failures exceeds ``fail_count``.
+        """
         lm = self.module.get_lm() or dspy.settings.lm
         start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]

--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -110,11 +110,13 @@ class Refine(Module):
 
         Returns:
             Prediction: The best prediction found across all attempts, determined by the highest
-                reward score. Returns ``None`` if all attempts fail with exceptions.
+                reward score. Returns ``None`` if no attempt succeeded and the ``fail_count``
+                re-raise threshold was not reached (possible when ``N <= 2`` or
+                ``fail_count >= N``).
 
         Raises:
-            Exception: Re-raises the last encountered exception if the number of consecutive
-                failures exceeds ``fail_count``.
+            Exception: Re-raises the last encountered exception when the current attempt
+                index exceeds the remaining ``fail_count`` (decremented after each failure).
         """
         lm = self.module.get_lm() or dspy.settings.lm
         start = lm.kwargs.get("rollout_id", 0)

--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -96,6 +96,26 @@ class Refine(Module):
             self.reward_fn_code = inspect.getsource(reward_fn.__class__)
 
     def forward(self, **kwargs):
+        """Execute the refinement loop, running the module up to ``N`` times and selecting the best prediction.
+
+        Each iteration runs the module with a unique rollout ID at ``temperature=1.0``. If a
+        prediction's reward meets or exceeds the threshold, it is returned immediately. Otherwise,
+        an :class:`OfferFeedback` call generates per-module advice that is injected as a hint into
+        the next iteration via a wrapper adapter, enabling the module to improve on subsequent
+        attempts.
+
+        Args:
+            **kwargs: Keyword arguments passed directly to the underlying module's forward method.
+                These should match the input fields defined in the module's signature.
+
+        Returns:
+            Prediction: The best prediction found across all attempts, determined by the highest
+                reward score. Returns ``None`` if all attempts fail with exceptions.
+
+        Raises:
+            Exception: Re-raises the last encountered exception if the number of consecutive
+                failures exceeds ``fail_count``.
+        """
         lm = self.module.get_lm() or dspy.settings.lm
         start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]
@@ -178,6 +198,19 @@ class Refine(Module):
 
 
 def inspect_modules(program):
+    """Generate a human-readable summary of all predictor modules in a program.
+
+    Iterates over the program's named predictors and formats each module's input fields,
+    output fields, and original instructions into a structured text block separated by
+    horizontal rules.
+
+    Args:
+        program (Module): A DSPy module whose named predictors will be inspected.
+
+    Returns:
+        str: A formatted string describing each module's name, input/output field definitions,
+            and instructions, separated by dashed lines.
+    """
     separator = "-" * 80
     output = [separator]
 
@@ -198,6 +231,19 @@ def inspect_modules(program):
 
 
 def recursive_mask(o):
+    """Recursively replace non-JSON-serializable objects with placeholder strings.
+
+    Traverses a nested data structure (dicts, lists, tuples) and replaces any values that
+    cannot be serialized by ``orjson`` with a descriptive placeholder string of the form
+    ``<non-serializable: TypeName>``.
+
+    Args:
+        o: Any Python object to make JSON-serializable.
+
+    Returns:
+        The input object with all non-serializable leaf values replaced by placeholder strings.
+        Dicts, lists, and tuples are preserved structurally.
+    """
     # If the object is already serializable, return it.
     try:
         orjson.dumps(o)


### PR DESCRIPTION
Adds Google-style docstrings to public APIs in `dspy/predict/refine.py` and `dspy/predict/best_of_n.py` that were missing documentation.

Resolves #9462, ref #8926.

## Changes

### `dspy/predict/refine.py`
- **`Refine.forward()`** — Documents the refinement loop: how rollout IDs work, the feedback mechanism via `OfferFeedback`, early stopping on threshold, and exception behavior.
- **`inspect_modules()`** — Documents this utility that generates human-readable summaries of a program's predictor modules.
- **`recursive_mask()`** — Documents this helper that replaces non-JSON-serializable objects with placeholder strings.

### `dspy/predict/best_of_n.py`
- **`BestOfN.forward()`** — Documents the best-of-N selection loop, its independence from feedback (unlike `Refine`), and exception behavior.

## Style

All docstrings follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) with:
- Summary line
- Detailed description where appropriate
- `Args`, `Returns`, and `Raises` sections
- Cross-references between `Refine` and `BestOfN` for discoverability

Pre-commit checks (ruff lint, merge conflicts, debug statements) all pass.
