### PR TITLE
fix: [Bug] Streaming completion path skips num_retries / retry_strategy

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -307,6 +307,7 @@ def _get_stream_completion_fn(
     cache_kwargs: dict[str, Any],
     sync=True,
     headers: dict[str, Any] | None = None,
+    num_retries: int = 0,
 ):
     stream = dspy.settings.send_stream
     caller_predict = dspy.settings.caller_predict
@@ -325,6 +326,8 @@ def _get_stream_completion_fn(
         response = await litellm.acompletion(
             cache=cache_kwargs,
             stream=True,
+            num_retries=num_retries,
+            retry_strategy="exponential_backoff_retry",
             headers=headers,
             **request,
         )
@@ -355,7 +358,7 @@ def litellm_completion(request: dict[str, Any], num_retries: int, cache: dict[st
     request = dict(request)
     request.pop("rollout_id", None)
     headers = _add_dspy_identifier_to_headers(request.pop("headers", None))
-    stream_completion = _get_stream_completion_fn(request, cache, sync=True, headers=headers)
+    stream_completion = _get_stream_completion_fn(request, cache, sync=True, headers=headers, num_retries=num_retries)
     if stream_completion is None:
         return litellm.completion(
             cache=cache,
@@ -403,7 +406,7 @@ async def alitellm_completion(request: dict[str, Any], num_retries: int, cache: 
     request = dict(request)
     request.pop("rollout_id", None)
     headers = request.pop("headers", None)
-    stream_completion = _get_stream_completion_fn(request, cache, sync=False)
+    stream_completion = _get_stream_completion_fn(request, cache, sync=False, headers=_add_dspy_identifier_to_headers(headers), num_retries=num_retries)
     if stream_completion is None:
         return await litellm.acompletion(
             cache=cache,


### PR DESCRIPTION
Fixes #9459

The streaming completion path in `_get_stream_completion_fn` silently dropped `num_retries`, causing rate limit errors to go unretried when streaming was enabled. Both `litellm_completion` and `alitellm_completion` accepted `num_retries` but never forwarded it to `_get_stream_completion_fn`, leaving the parameter unused on the streaming code path. The fix adds `num_retries` as a parameter to `_get_stream_completion_fn` in `dspy/clients/lm.py` and passes it through to `litellm.acompletion` alongside a hardcoded `retry_strategy="exponential_backoff_retry"`, matching the behavior of the non-streaming path. Also fixes `alitellm_completion` to correctly apply `_add_dspy_identifier_to_headers` before passing headers to the stream function, consistent with how `litellm_completion` handles it. Verified by confirming retries occur on rate limit errors with streaming enabled.