### PR TITLE
fix(copro): make eval_kwargs optional in compile() (fixes #9080)

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -120,7 +120,7 @@ class COPRO(Teleprompter):
         assert hasattr(predictor, "signature")
         predictor.signature = updated_signature
 
-    def compile(self, student, *, trainset, eval_kwargs):
+    def compile(self, student, *, trainset, eval_kwargs=None):
         """
         optimizes `signature` of `student` program - note that it may be zero-shot or already pre-optimized (demos already chosen - `demos != []`)
 
@@ -132,6 +132,7 @@ class COPRO(Teleprompter):
 
         Returns optimized version of `student`.
         """
+        eval_kwargs = eval_kwargs or {}
         module = student.deepcopy()
         evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
         total_calls = 0

--- a/tests/teleprompt/test_copro_optimizer.py
+++ b/tests/teleprompt/test_copro_optimizer.py
@@ -154,3 +154,18 @@ def test_statistics_tracking_during_optimization():
     ), "Optimizer did not properly populate the latest results statistics"
 
     # Additional detailed checks can be added here to verify the contents of the tracked statistics
+
+
+def test_compile_without_eval_kwargs():
+    """COPRO.compile should work without eval_kwargs (issue #9080)."""
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {"proposed_instruction": "Optimized Prompt", "proposed_prefix_for_output_field": "Optimized Prefix"},
+            ]
+        )
+    )
+    optimizer = COPRO(metric=simple_metric, breadth=2, depth=1, init_temperature=1.4)
+    student = SimpleModule("input -> output")
+    optimized_student = optimizer.compile(student, trainset=trainset)
+    assert optimized_student is not student


### PR DESCRIPTION
## Summary
Makes `eval_kwargs` truly optional in `COPRO.compile()` as documented. Previously callers had to pass `eval_kwargs={}` as a workaround.

## Root cause
`compile()` required `eval_kwargs` as a keyword-only argument with no default. The docstring stated it was optional, but the implementation did not support omitting it.

## Changes
- Add default `eval_kwargs=None` to `compile()` signature
- Use `eval_kwargs or {}` when passing to `Evaluate`
- Add test `test_compile_without_eval_kwargs` to verify the fix

Fixes #9080

Made with [Cursor](https://cursor.com)