### PR TITLE
feat(module): add get_prompt_templates() for exporting prompts

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -176,6 +176,44 @@ class Module(BaseModule, metaclass=ProgramMeta):
         """
         return [param for _, param in self.named_predictors()]
 
+    def get_prompt_templates(self, adapter=None):
+        """Get the formatted prompt templates for all predictors in this module.
+
+        Returns the system and user message templates that each predictor would
+        send to the LM, with placeholder values (e.g. ``{question}``) in place
+        of actual inputs. Useful for exporting DSPy programs as standard prompts
+        that can be used without DSPy.
+
+        Args:
+            adapter: The adapter to use for formatting. If ``None``, uses the
+                adapter from ``dspy.settings`` or falls back to ``ChatAdapter()``.
+
+        Returns:
+            dict[str, list[dict[str, str]]]: A dict mapping predictor names to
+                their formatted message lists. Each message is a dict with
+                ``"role"`` and ``"content"`` keys.
+
+        Examples:
+            >>> import dspy
+            >>> program = dspy.Predict("question -> answer")
+            >>> templates = program.get_prompt_templates()
+            >>> templates["self"]  # doctest: +SKIP
+            [{"role": "system", "content": "..."}, {"role": "user", "content": "..."}]
+        """
+        from dspy.adapters.chat_adapter import ChatAdapter
+
+        if adapter is None:
+            adapter = settings.adapter or ChatAdapter()
+
+        return {
+            name: adapter.format(
+                p.signature,
+                demos=p.demos,
+                inputs={k: f"{{{k}}}" for k in p.signature.input_fields},
+            )
+            for name, p in self.named_predictors()
+        }
+
     def set_lm(self, lm):
         """Set the language model for all predictors in this module.
 
@@ -329,8 +367,9 @@ class Module(BaseModule, metaclass=ProgramMeta):
         if prediction_in_output:
             prediction_in_output.set_lm_usage(tokens)
         else:
-            logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking.")
-
+            logger.warning(
+                "Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking."
+            )
 
     def __getattribute__(self, name):
         attr = super().__getattribute__(name)

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -197,3 +197,64 @@ def test_load_dspy_program_cross_version():
 
     assert len(loaded_react.react.demos) == 2
     assert len(loaded_react.extract.predict.demos) == 2
+
+
+def test_get_prompt_templates_single_predictor():
+    program = dspy.Predict("question -> answer")
+    templates = program.get_prompt_templates()
+
+    assert "self" in templates
+    messages = templates["self"]
+    assert len(messages) >= 2
+    assert messages[0]["role"] == "system"
+    assert messages[-1]["role"] == "user"
+    # Placeholder should appear in the user message
+    assert "{question}" in messages[-1]["content"]
+
+
+def test_get_prompt_templates_multi_predictor():
+    module = HopModule()
+    templates = module.get_prompt_templates()
+
+    assert len(templates) == 2
+    assert "predict1" in templates
+    assert "predict2" in templates
+    # Each should have system + user messages at minimum
+    for _name, messages in templates.items():
+        assert len(messages) >= 2
+        assert messages[0]["role"] == "system"
+
+
+def test_get_prompt_templates_nested_module():
+    class Hop2Module(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.hop = HopModule()
+
+    module = Hop2Module()
+    templates = module.get_prompt_templates()
+
+    assert len(templates) == 2
+    assert "hop.predict1" in templates
+    assert "hop.predict2" in templates
+
+
+def test_get_prompt_templates_with_demos():
+    program = dspy.Predict("question -> answer")
+    program.demos = [
+        {"question": "Is the sky blue?", "answer": "Yes"},
+    ]
+    templates = program.get_prompt_templates()
+
+    messages = templates["self"]
+    # With one demo, expect: system, demo user, demo assistant, user
+    assert len(messages) >= 4
+    demo_content = " ".join(m["content"] for m in messages if m["role"] == "assistant")
+    assert "Yes" in demo_content
+
+
+def test_get_prompt_templates_empty_module():
+    module = Module()
+    templates = module.get_prompt_templates()
+
+    assert templates == {}


### PR DESCRIPTION
## Summary

Adds a `get_prompt_templates()` method to `Module` that returns the formatted system/user message templates for each predictor, with placeholder values (e.g. `{question}`) instead of actual inputs. This lets users export DSPy programs as standard prompts usable without DSPy.

Implements the syntactic sugar @okhat proposed in #7830:

```python
templates = program.get_prompt_templates()
# => {"self": [{"role": "system", "content": "..."}, {"role": "user", "content": "..."}]}
```

Under the hood, it calls `adapter.format(signature, demos, inputs={k: f"{{{k}}}" for k in signature.input_fields})` for each predictor. Accepts an optional `adapter` argument; defaults to `dspy.settings.adapter` or `ChatAdapter()`.

Fixes #7830

## Changes

- `dspy/primitives/module.py`: Add `get_prompt_templates(adapter=None)` method to `Module`
- `tests/primitives/test_module.py`: 5 test cases covering single predictor, multi-predictor, nested modules, demos, and empty module

## Testing

- All 20 tests pass (15 existing + 5 new)
- `ruff check` and `ruff format` clean on changed files