### PR TITLE
fix: ignore extra args passed to finish tool in ReAct (#9424)

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -107,13 +107,17 @@ class ReAct(Module):
             trajectory[f"tool_name_{idx}"] = pred.next_tool_name
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
+            if pred.next_tool_name == "finish":
+                # Models sometimes place final output values into next_tool_args for finish.
+                # Since finish accepts no arguments, call it without args to avoid a spurious
+                # execution error in the trajectory (see #9424).
+                trajectory[f"observation_{idx}"] = self.tools["finish"]()
+                break
+
             try:
                 trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](**pred.next_tool_args)
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
-
-            if pred.next_tool_name == "finish":
-                break
 
         extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)
@@ -132,13 +136,15 @@ class ReAct(Module):
             trajectory[f"tool_name_{idx}"] = pred.next_tool_name
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
+            if pred.next_tool_name == "finish":
+                # See sync forward() for rationale (issue #9424).
+                trajectory[f"observation_{idx}"] = self.tools["finish"]()
+                break
+
             try:
                 trajectory[f"observation_{idx}"] = await self.tools[pred.next_tool_name].acall(**pred.next_tool_args)
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
-
-            if pred.next_tool_name == "finish":
-                break
 
         extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)


### PR DESCRIPTION
## Summary

Fixes #9424

 defines  as a no-arg tool (), but models often place final structured output values into  when calling . This causes a misleading execution error like:



The trajectory records this as an "Execution error in finish" even though the run succeeds — the extract step still produces correct output.

## Changes

- Move the  check **before** the tool call in both  and 
- When , call the finish tool without passing 
- Extra args from the model are silently ignored instead of causing a spurious error

This is a minimal, non-breaking fix. The maintainers mentioned a larger ReAct overhaul with RLM-style submit (#9424 comment), and this change is compatible with that direction.

## Test plan

- Existing ReAct tests should continue to pass
- Models that put output fields in finish args will no longer see execution errors in trajectory
- The extract step continues to work as before since it reads from the full trajectory

Generated with [Claude Code](https://claude.com/claude-code)