### PR TITLE
fix(docs): remove broken BetterTogether tutorial links

### DIFF
--- a/docs/docs/api/optimizers/BetterTogether.md
+++ b/docs/docs/api/optimizers/BetterTogether.md
@@ -19,10 +19,6 @@
         inherited_members: true
 <!-- END_API_REF -->
 
-## Usage Examples
-
-See BetterTogether usage tutorials in [BetterTogether Tutorials](../../../tutorials/bettertogether/index.md).
-
 ## How BetterTogether Works
 
 BetterTogether executes optimizers in a configurable sequence, evaluating each intermediate result and returning the best performing program. Here's how it works:

--- a/docs/docs/learn/optimization/optimizers.md
+++ b/docs/docs/learn/optimization/optimizers.md
@@ -75,7 +75,7 @@ This optimizer is used to fine-tune the underlying LLM(s).
 
 ### Meta-Optimizers
 
-11. [**`BetterTogether`**](../../api/optimizers/BetterTogether.md): A meta-optimizer that combines prompt optimization and weight optimization (fine-tuning) in configurable sequences. Prompt optimization can discover effective task decompositions and reasoning strategies, while weight optimization can specialize the model to execute these patterns more efficiently. Using these approaches together in sequences (e.g., prompt → weight → prompt) may allow each to build on the improvements made by the other. Empirically, this approach often outperforms either strategy alone. Detailed tutorial available at [BetterTogether AIME Tutorial](../../tutorials/bettertogether_aime/index.ipynb).
+11. [**`BetterTogether`**](../../api/optimizers/BetterTogether.md): A meta-optimizer that combines prompt optimization and weight optimization (fine-tuning) in configurable sequences. Prompt optimization can discover effective task decompositions and reasoning strategies, while weight optimization can specialize the model to execute these patterns more efficiently. Using these approaches together in sequences (e.g., prompt → weight → prompt) may allow each to build on the improvements made by the other. Empirically, this approach often outperforms either strategy alone. 
 
 
 ## Which optimizer should I use?


### PR DESCRIPTION
Remove broken links to non-existent BetterTogether tutorial pages. Fixes #9474.