### PR TITLE
docs: add docstrings to Predict, ChainOfThought, and ReAct

### DIFF
--- a/dspy/predict/chain_of_thought.py
+++ b/dspy/predict/chain_of_thought.py
@@ -35,7 +35,35 @@ class ChainOfThought(Module):
         self.predict = dspy.Predict(extended_signature, **config)
 
     def forward(self, **kwargs):
+        """Execute chain-of-thought reasoning and return a prediction.
+
+        Delegates to the internal :class:`dspy.Predict` module whose signature
+        has been extended with a ``reasoning`` output field. The returned
+        :class:`dspy.Prediction` therefore contains both the reasoning trace
+        and the final output fields.
+
+        Keyword Args:
+            **kwargs: Input fields matching the module's signature.
+
+        Returns:
+            A :class:`dspy.Prediction` with ``reasoning`` and the signature's
+            output fields.
+
+        Example:
+
+            .. code-block:: python
+
+                cot = dspy.ChainOfThought("question -> answer")
+                pred = cot(question="What is the capital of France?")
+                print(pred.reasoning)
+                print(pred.answer)
+        """
         return self.predict(**kwargs)
 
     async def aforward(self, **kwargs):
+        """Asynchronous version of :meth:`forward`.
+
+        Accepts the same keyword arguments and returns the same
+        :class:`dspy.Prediction` type.
+        """
         return await self.predict.acall(**kwargs)

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -63,12 +63,32 @@ class Predict(Module, Parameter):
         self.reset()
 
     def reset(self):
+        """Reset the module's internal state.
+
+        Clears the language model, traces, training examples, and demonstrations,
+        returning the module to its initial state. This is called automatically during
+        ``__init__`` and can be called manually to reinitialize the module.
+        """
         self.lm = None
         self.traces = []
         self.train = []
         self.demos = []
 
     def dump_state(self, json_mode=True):
+        """Serialize the module's state to a dictionary.
+
+        Captures the current demos, traces, training data, signature, and
+        language model configuration so that the module can be saved and later
+        restored via :meth:`load_state`.
+
+        Args:
+            json_mode: When ``True`` (default), demo objects are converted to
+                plain dictionaries. Set to ``False`` to preserve the original
+                objects.
+
+        Returns:
+            A dictionary containing the serialized state.
+        """
         state_keys = ["traces", "train"]
         state = {k: getattr(self, k) for k in state_keys}
 
@@ -130,6 +150,11 @@ class Predict(Module, Parameter):
         return super().__call__(**kwargs)
 
     async def acall(self, *args, **kwargs):
+        """Asynchronous version of :meth:`__call__`.
+
+        Accepts the same keyword arguments as a synchronous call. Positional
+        arguments are not allowed and will raise a ``ValueError``.
+        """
         if args:
             raise ValueError(self._get_positional_args_error_message())
 
@@ -241,6 +266,23 @@ class Predict(Module, Parameter):
         return should_stream
 
     def forward(self, **kwargs):
+        """Execute the prediction by calling the language model.
+
+        Preprocesses the inputs, invokes the configured adapter and LM, and
+        returns a :class:`dspy.Prediction`. Supports streaming when a stream
+        listener is registered in the current settings.
+
+        Keyword Args:
+            **kwargs: Input fields matching the module's signature. Three
+                special keyword arguments are also accepted:
+
+                * ``signature`` – override the module's signature for this call.
+                * ``demos`` – override the demonstrations used.
+                * ``config`` – extra LM configuration merged with the defaults.
+
+        Returns:
+            A :class:`dspy.Prediction` containing the model's outputs.
+        """
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
 
         adapter = settings.adapter or ChatAdapter()
@@ -255,6 +297,12 @@ class Predict(Module, Parameter):
         return self._forward_postprocess(completions, signature, **kwargs)
 
     async def aforward(self, **kwargs):
+        """Asynchronous version of :meth:`forward`.
+
+        Accepts the same keyword arguments and returns the same
+        :class:`dspy.Prediction` type. Use this when running inside an async
+        event loop.
+        """
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
 
         adapter = settings.adapter or ChatAdapter()

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -94,6 +94,24 @@ class ReAct(Module):
         return adapter.format_user_message_content(trajectory_signature, trajectory)
 
     def forward(self, **input_args):
+        """Run the ReAct reasoning-and-acting loop.
+
+        Iteratively calls the language model to reason about the current
+        situation, select a tool, and execute it. The loop continues until
+        the model selects the ``finish`` tool or ``max_iters`` is reached.
+        After the loop, a final extraction step produces the output fields
+        defined in the module's signature.
+
+        Keyword Args:
+            **input_args: Input fields matching the module's signature. An
+                optional ``max_iters`` keyword can override the default
+                maximum number of iterations for this call.
+
+        Returns:
+            A :class:`dspy.Prediction` containing the signature's output
+            fields and a ``trajectory`` dict recording each thought, tool
+            call, and observation.
+        """
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         for idx in range(max_iters):
@@ -119,6 +137,11 @@ class ReAct(Module):
         return dspy.Prediction(trajectory=trajectory, **extract)
 
     async def aforward(self, **input_args):
+        """Asynchronous version of :meth:`forward`.
+
+        Behaves identically to the synchronous variant but awaits tool calls
+        via ``tool.acall()`` and can be used inside an async event loop.
+        """
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         for idx in range(max_iters):


### PR DESCRIPTION
## Summary

Adds Google-style docstrings to undocumented public methods in the core predict modules.

### Files claimed in #9481

**`dspy/predict/predict.py`**
- `reset()`, `dump_state()`, `acall()`, `forward()`, `aforward()`

**`dspy/predict/chain_of_thought.py`**
- `forward()` (with code example), `aforward()`

**`dspy/predict/react.py`**
- `forward()`, `aforward()`

All docstrings follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).

Resolves part of #8926
Related: #9481