### PR TITLE
docs: add docstrings to Predict and ReAct public methods

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -63,12 +63,23 @@ class Predict(Module, Parameter):
         self.reset()
 
     def reset(self):
+        """Reset the module state, clearing the language model, traces, training data, and demos."""
         self.lm = None
         self.traces = []
         self.train = []
         self.demos = []
 
     def dump_state(self, json_mode=True):
+        """Serialize the module state to a dictionary for saving.
+
+        Args:
+            json_mode: If True, convert demo examples to JSON-serializable dicts.
+                Defaults to True.
+
+        Returns:
+            A dictionary containing the serialized module state, including demos,
+            signature, traces, training data, and LM configuration.
+        """
         state_keys = ["traces", "train"]
         state = {k: getattr(self, k) for k in state_keys}
 
@@ -130,6 +141,11 @@ class Predict(Module, Parameter):
         return super().__call__(**kwargs)
 
     async def acall(self, *args, **kwargs):
+        """Asynchronous version of ``__call__``.
+
+        Accepts the same keyword arguments as ``__call__``. Positional arguments
+        are not allowed and will raise a ``ValueError``.
+        """
         if args:
             raise ValueError(self._get_positional_args_error_message())
 
@@ -241,6 +257,20 @@ class Predict(Module, Parameter):
         return should_stream
 
     def forward(self, **kwargs):
+        """Execute the prediction by calling the language model.
+
+        This is the core execution method that preprocesses inputs, invokes the
+        language model through the configured adapter, and postprocesses the
+        completions into a ``dspy.Prediction``.
+
+        Args:
+            **kwargs: Keyword arguments matching the signature's input fields.
+                Additionally accepts ``signature``, ``demos``, ``config``, and
+                ``lm`` as privileged overrides for this call.
+
+        Returns:
+            A ``dspy.Prediction`` containing the model's output fields.
+        """
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
 
         adapter = settings.adapter or ChatAdapter()
@@ -255,6 +285,13 @@ class Predict(Module, Parameter):
         return self._forward_postprocess(completions, signature, **kwargs)
 
     async def aforward(self, **kwargs):
+        """Asynchronous version of :meth:`forward`.
+
+        Accepts the same keyword arguments as ``forward``.
+
+        Returns:
+            A ``dspy.Prediction`` containing the model's output fields.
+        """
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
 
         adapter = settings.adapter or ChatAdapter()

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -94,6 +94,20 @@ class ReAct(Module):
         return adapter.format_user_message_content(trajectory_signature, trajectory)
 
     def forward(self, **input_args):
+        """Run the ReAct agent loop synchronously.
+
+        Iterates through reasoning steps, tool calls, and observations until the
+        agent calls the ``finish`` tool or reaches ``max_iters``. Falls back to a
+        ``ChainOfThought`` extraction if the context window is exceeded.
+
+        Args:
+            **input_args: Keyword arguments matching the signature's input fields.
+                Optionally pass ``max_iters`` to override the default for this call.
+
+        Returns:
+            A ``dspy.Prediction`` with the signature's output fields and the full
+            ``trajectory`` of thoughts, tool calls, and observations.
+        """
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         for idx in range(max_iters):
@@ -119,6 +133,14 @@ class ReAct(Module):
         return dspy.Prediction(trajectory=trajectory, **extract)
 
     async def aforward(self, **input_args):
+        """Asynchronous version of :meth:`forward`.
+
+        Accepts the same keyword arguments as ``forward``.
+
+        Returns:
+            A ``dspy.Prediction`` with the signature's output fields and the full
+            ``trajectory`` of thoughts, tool calls, and observations.
+        """
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         for idx in range(max_iters):


### PR DESCRIPTION
## Summary

Add Google-style docstrings to 7 public methods in `dspy.Predict` and `dspy.ReAct` that were missing documentation.

## Changes

**`dspy/predict/predict.py`** (5 methods):
- `Predict.reset()` — describes state clearing behavior
- `Predict.dump_state()` — documents args, return value, serialization
- `Predict.acall()` — documents async call behavior
- `Predict.forward()` — documents core execution, args, and return
- `Predict.aforward()` — documents async forward

**`dspy/predict/react.py`** (2 methods):
- `ReAct.forward()` — documents the agent loop, tool calling, and fallback
- `ReAct.aforward()` — documents async version

## Style

- Follows [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
- Matches existing docstring patterns in the codebase
- Describes Args, Returns, and behavior accurately

## Test plan

- [x] No code logic changed — docstrings only
- [x] All existing tests pass unchanged

Relates to #8926