### PR TITLE
docs: add docstrings to Predict, ReAct, and BaseLM public methods

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -100,6 +100,23 @@ class BaseLM:
         messages: list[dict[str, Any]] | None = None,
         **kwargs
     ) -> list[dict[str, Any] | str]:
+        """Async version of ``__call__``.
+
+        Sends the request through ``aforward`` and processes the response
+        identically to the synchronous path.  Use this when calling the
+        language model inside an ``asyncio`` event loop.
+
+        Args:
+            prompt: A plain-text prompt.  Ignored when *messages* is given.
+            messages: A list of chat messages in OpenAI format.  Takes
+                precedence over *prompt*.
+            **kwargs: Extra keyword arguments forwarded to the underlying
+                provider (e.g. ``temperature``, ``max_tokens``).
+
+        Returns:
+            A list of output strings or dictionaries, one per completion
+            choice.
+        """
         response = await self.aforward(prompt=prompt, messages=messages, **kwargs)
         outputs = self._process_lm_response(response, prompt, messages, **kwargs)
         return outputs
@@ -161,9 +178,49 @@ class BaseLM:
         return new_instance
 
     def inspect_history(self, n: int = 1, file: "TextIO | None" = None) -> None:
+        """Print the last *n* LM interactions for this instance.
+
+        Each entry shows the prompt or messages sent to the model, the raw
+        response, token usage, and cost.  This is the per-instance history;
+        use the module-level ``dspy.inspect_history`` for the global log
+        shared across all LMs.
+
+        Args:
+            n: Number of recent entries to display.  Defaults to 1.
+            file: An optional file-like object to write output to.  When
+                provided, ANSI color codes are automatically disabled.
+                Defaults to ``None`` (prints to stdout).
+
+        Examples:
+            >>> lm = dspy.LM("openai/gpt-4o-mini")
+            >>> lm("What is DSPy?")
+            >>> lm.inspect_history(n=1)
+        """
         pretty_print_history(self.history, n, file=file)
 
     def update_history(self, entry):
+        """Append a completed LM interaction to the history logs.
+
+        Called automatically after every ``__call__`` / ``acall``.  The
+        entry is recorded in three places:
+
+        1. The **global** history (``dspy.inspect_history``).
+        2. This LM instance's ``self.history``.
+        3. The ``history`` list of every DSPy module currently on the call
+           stack, so that ``module.history`` reflects only the calls that
+           module triggered.
+
+        History recording is skipped entirely when
+        ``dspy.configure(disable_history=True)`` is set.  Both the global
+        and per-instance logs are capped by ``settings.max_history_size``
+        (default 10 000); when the cap is reached the oldest entry is
+        evicted.
+
+        Args:
+            entry: A dictionary describing the interaction.  Expected keys
+                include ``prompt``, ``messages``, ``response``, ``outputs``,
+                ``usage``, ``cost``, ``timestamp``, and ``model``.
+        """
         if settings.disable_history:
             return
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -63,12 +63,40 @@ class Predict(Module, Parameter):
         self.reset()
 
     def reset(self):
+        """Reset the module to its initial state.
+
+        Clears the language model override, accumulated traces, training
+        examples, and demos so the module behaves like a freshly created
+        instance.
+        """
         self.lm = None
         self.traces = []
         self.train = []
         self.demos = []
 
     def dump_state(self, json_mode=True):
+        """Serialize the module state to a plain dictionary.
+
+        The returned dictionary captures everything needed to recreate the
+        module later with ``load_state``: the signature, demos, traces,
+        training examples, and—when present—the language model configuration.
+
+        Args:
+            json_mode: When ``True`` (the default), ``Example`` demos are
+                converted to plain dicts so the result is JSON-serializable.
+
+        Returns:
+            A dictionary that can be passed to ``load_state`` to restore
+            this module.
+
+        Examples:
+            Save and reload a module:
+
+            >>> predict = dspy.Predict("question -> answer")
+            >>> state = predict.dump_state()
+            >>> restored = dspy.Predict("question -> answer")
+            >>> restored.load_state(state)
+        """
         state_keys = ["traces", "train"]
         state = {k: getattr(self, k) for k in state_keys}
 
@@ -241,6 +269,31 @@ class Predict(Module, Parameter):
         return should_stream
 
     def forward(self, **kwargs):
+        """Run the language model on the given inputs and return a prediction.
+
+        This is the synchronous entry point used internally by ``__call__``.
+        In most cases you call the module directly instead of calling
+        ``forward`` yourself:
+
+        >>> predict = dspy.Predict("question -> answer")
+        >>> result = predict(question="What is 2 + 2?")
+        >>> result.answer  # the model's answer
+        '4'
+
+        Args:
+            **kwargs: Input field values matching the module's signature.
+                Three special keys are also accepted:
+
+                * ``signature`` – override the module's signature for this
+                  call.
+                * ``demos`` – override the few-shot demos.
+                * ``config`` – extra keyword arguments forwarded to the
+                  language model (e.g. ``temperature``).
+
+        Returns:
+            A ``dspy.Prediction`` whose attributes correspond to the
+            signature's output fields.
+        """
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
 
         adapter = settings.adapter or ChatAdapter()
@@ -255,6 +308,13 @@ class Predict(Module, Parameter):
         return self._forward_postprocess(completions, signature, **kwargs)
 
     async def aforward(self, **kwargs):
+        """Async version of ``forward``.
+
+        Accepts the same arguments and returns the same ``dspy.Prediction``.
+        Use this when running inside an ``asyncio`` event loop:
+
+        >>> result = await predict.acall(question="What is 2 + 2?")
+        """
         lm, config, signature, demos, kwargs = self._forward_preprocess(**kwargs)
 
         adapter = settings.adapter or ChatAdapter()
@@ -268,9 +328,19 @@ class Predict(Module, Parameter):
         return self._forward_postprocess(completions, signature, **kwargs)
 
     def update_config(self, **kwargs):
+        """Merge extra keyword arguments into the module's default LM config.
+
+        Values set here apply to every future call unless overridden by a
+        per-call ``config`` dict.
+
+        Args:
+            **kwargs: Keyword arguments forwarded to the language model,
+                e.g. ``temperature=0.9``.
+        """
         self.config = {**self.config, **kwargs}
 
     def get_config(self):
+        """Return the module's current default LM keyword arguments."""
         return self.config
 
     def __repr__(self):

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -94,6 +94,31 @@ class ReAct(Module):
         return adapter.format_user_message_content(trajectory_signature, trajectory)
 
     def forward(self, **input_args):
+        """Execute the ReAct loop: reason, pick a tool, observe, repeat.
+
+        The agent iterates up to ``max_iters`` times.  In each iteration it
+        produces a thought, selects a tool, calls it, and records the
+        observation.  When it selects the ``finish`` tool the loop ends and
+        a ``ChainOfThought`` extractor produces the final output fields.
+
+        Args:
+            **input_args: Values for every input field in the module's
+                signature.  An optional ``max_iters`` key overrides the
+                default set in the constructor.
+
+        Returns:
+            A ``dspy.Prediction`` with the signature's output fields plus
+            a ``trajectory`` dict containing each step's thought, tool
+            name, tool args, and observation.
+
+        Examples:
+            >>> def add(a: int, b: int) -> int:
+            ...     return a + b
+            >>> react = dspy.ReAct("question -> answer", tools=[add])
+            >>> pred = react(question="What is 3 + 4?")
+            >>> pred.answer
+            '7'
+        """
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         for idx in range(max_iters):
@@ -119,6 +144,12 @@ class ReAct(Module):
         return dspy.Prediction(trajectory=trajectory, **extract)
 
     async def aforward(self, **input_args):
+        """Async version of ``forward``.
+
+        Identical behaviour to the synchronous loop but awaits both the
+        LM calls and any async-capable tools.  Use this when your tools
+        perform I/O that benefits from ``asyncio``.
+        """
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         for idx in range(max_iters):


### PR DESCRIPTION
## Summary

Add Google-style docstrings with code examples to public methods across three core files. All follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) and match the conventions established in #9444.

### Files changed

| File | Methods documented |
|------|--------------------|
| `dspy/predict/predict.py` | `reset`, `dump_state`, `forward`, `aforward`, `update_config`, `get_config` |
| `dspy/predict/react.py` | `forward`, `aforward` |
| `dspy/clients/base_lm.py` | `acall`, `inspect_history`, `update_history` |

### What each docstring includes

- One-line summary describing what the method does
- Explanation of behavior in context (when to use sync vs async, where history is recorded, etc.)
- `Args` section for every parameter
- `Returns` section where applicable
- Code examples using `>>>` doctest format where helpful

Resolves #9485, ref #8926