### PR TITLE
feat(evaluate): add computed mode to SemanticF1 for programmatic P/R

### DIFF
--- a/dspy/evaluate/auto_evaluation.py
+++ b/dspy/evaluate/auto_evaluation.py
@@ -1,5 +1,3 @@
-import re
-
 from dspy.predict.chain_of_thought import ChainOfThought
 from dspy.primitives import Module
 from dspy.primitives.prediction import Prediction
@@ -37,37 +35,22 @@ class DecompositionalSemanticRecallPrecision(Signature):
 
 class ComputedSemanticRecallPrecision(Signature):
     """
-    Compare a system's response to the ground truth by enumerating key ideas and identifying which are covered.
-    List each key idea on its own numbered line (1. idea, 2. idea, ...).
-    For covered ideas, list ONLY the numbers of ideas that are present in the other response, e.g. "1, 3, 4".
-    If no ideas are covered, write "None".
+    Semantic recall and precision via programmatic computation over LLM-enumerated key ideas.
+    The LLM enumerates key ideas in each response and identifies which are covered by index.
+    Precision and recall are then computed from the coverage counts rather than LLM-estimated floats.
     """
 
     question: str = InputField()
     ground_truth: str = InputField()
     system_response: str = InputField()
-    ground_truth_key_ideas: str = OutputField(desc="numbered list (1. 2. 3. ...) of key ideas in the ground truth")
-    system_response_key_ideas: str = OutputField(
-        desc="numbered list (1. 2. 3. ...) of key ideas in the system response"
+    ground_truth_key_ideas: list[str] = OutputField(desc="key ideas in the ground truth")
+    system_response_key_ideas: list[str] = OutputField(desc="key ideas in the system response")
+    ground_truth_ideas_covered_by_system: list[int] = OutputField(
+        desc="indices of ground truth ideas that are covered by the system response"
     )
-    ground_truth_ideas_covered_by_system: str = OutputField(
-        desc="numbers of ground truth ideas covered by the system response, e.g. 1, 3, 4"
+    system_response_ideas_grounded_in_truth: list[int] = OutputField(
+        desc="indices of system response ideas that are supported by the ground truth"
     )
-    system_response_ideas_grounded_in_truth: str = OutputField(
-        desc="numbers of system response ideas supported by the ground truth, e.g. 1, 2"
-    )
-
-
-def _count_numbered_items(text: str) -> int:
-    """Count items in a numbered list like '1. foo\\n2. bar'."""
-    return len(re.findall(r"^\s*\d+[.\)]\s", text, re.MULTILINE))
-
-
-def _count_mentioned_numbers(text: str) -> int:
-    """Count distinct numbers mentioned in text like '1, 3, 4'. Returns 0 for 'None' or empty."""
-    if not text or text.strip().lower() == "none":
-        return 0
-    return len(set(re.findall(r"\d+", text)))
 
 
 def f1_score(precision, recall):
@@ -77,25 +60,16 @@ def f1_score(precision, recall):
 
 
 class SemanticF1(Module):
-    """Computes semantic F1 between a prediction and ground truth via LLM-based precision/recall.
+    """Computes semantic F1 between a prediction and ground truth via LLM-based precision/recall."""
 
-    Args:
-        threshold: Minimum F1 score to accept during optimization. Defaults to 0.66.
-        decompositional: Controls how precision and recall are obtained.
+    def __init__(self, threshold=0.66, decompositional=False, computed=False):
+        if decompositional and computed:
+            raise ValueError("decompositional and computed are mutually exclusive")
 
-            - ``False`` (default): the LLM directly outputs precision and recall floats.
-            - ``True``: the LLM enumerates key ideas and discusses overlap, then outputs
-              precision and recall floats.
-            - ``"computed"``: the LLM enumerates key ideas and identifies which are covered;
-              precision and recall are computed programmatically from the counts, avoiding
-              LLM float-calibration issues.
-    """
-
-    def __init__(self, threshold=0.66, decompositional=False):
         self.threshold = threshold
-        self._computed = decompositional == "computed"
+        self._computed = computed
 
-        if self._computed:
+        if computed:
             self.module = ChainOfThought(ComputedSemanticRecallPrecision)
         elif decompositional:
             self.module = ChainOfThought(DecompositionalSemanticRecallPrecision)
@@ -106,10 +80,10 @@ class SemanticF1(Module):
         scores = self.module(question=example.question, ground_truth=example.response, system_response=pred.response)
 
         if self._computed:
-            gt_count = _count_numbered_items(scores.ground_truth_key_ideas)
-            sr_count = _count_numbered_items(scores.system_response_key_ideas)
-            gt_covered = _count_mentioned_numbers(scores.ground_truth_ideas_covered_by_system)
-            sr_grounded = _count_mentioned_numbers(scores.system_response_ideas_grounded_in_truth)
+            gt_count = len(scores.ground_truth_key_ideas)
+            sr_count = len(scores.system_response_key_ideas)
+            gt_covered = len(set(scores.ground_truth_ideas_covered_by_system))
+            sr_grounded = len(set(scores.system_response_ideas_grounded_in_truth))
 
             recall = gt_covered / gt_count if gt_count > 0 else 0.0
             precision = sr_grounded / sr_count if sr_count > 0 else 0.0

--- a/dspy/evaluate/auto_evaluation.py
+++ b/dspy/evaluate/auto_evaluation.py
@@ -1,3 +1,5 @@
+import re
+
 from dspy.predict.chain_of_thought import ChainOfThought
 from dspy.primitives import Module
 from dspy.primitives.prediction import Prediction
@@ -33,6 +35,41 @@ class DecompositionalSemanticRecallPrecision(Signature):
     precision: float = OutputField(desc="fraction (out of 1.0) of system response covered by the ground truth")
 
 
+class ComputedSemanticRecallPrecision(Signature):
+    """
+    Compare a system's response to the ground truth by enumerating key ideas and identifying which are covered.
+    List each key idea on its own numbered line (1. idea, 2. idea, ...).
+    For covered ideas, list ONLY the numbers of ideas that are present in the other response, e.g. "1, 3, 4".
+    If no ideas are covered, write "None".
+    """
+
+    question: str = InputField()
+    ground_truth: str = InputField()
+    system_response: str = InputField()
+    ground_truth_key_ideas: str = OutputField(desc="numbered list (1. 2. 3. ...) of key ideas in the ground truth")
+    system_response_key_ideas: str = OutputField(
+        desc="numbered list (1. 2. 3. ...) of key ideas in the system response"
+    )
+    ground_truth_ideas_covered_by_system: str = OutputField(
+        desc="numbers of ground truth ideas covered by the system response, e.g. 1, 3, 4"
+    )
+    system_response_ideas_grounded_in_truth: str = OutputField(
+        desc="numbers of system response ideas supported by the ground truth, e.g. 1, 2"
+    )
+
+
+def _count_numbered_items(text: str) -> int:
+    """Count items in a numbered list like '1. foo\\n2. bar'."""
+    return len(re.findall(r"^\s*\d+[.\)]\s", text, re.MULTILINE))
+
+
+def _count_mentioned_numbers(text: str) -> int:
+    """Count distinct numbers mentioned in text like '1, 3, 4'. Returns 0 for 'None' or empty."""
+    if not text or text.strip().lower() == "none":
+        return 0
+    return len(set(re.findall(r"\d+", text)))
+
+
 def f1_score(precision, recall):
     """Compute the F1 score from precision and recall, clamping both to [0, 1]."""
     precision, recall = max(0.0, min(1.0, precision)), max(0.0, min(1.0, recall))
@@ -44,20 +81,41 @@ class SemanticF1(Module):
 
     Args:
         threshold: Minimum F1 score to accept during optimization. Defaults to 0.66.
-        decompositional: If True, uses DecompositionalSemanticRecallPrecision. Defaults to False.
+        decompositional: Controls how precision and recall are obtained.
+
+            - ``False`` (default): the LLM directly outputs precision and recall floats.
+            - ``True``: the LLM enumerates key ideas and discusses overlap, then outputs
+              precision and recall floats.
+            - ``"computed"``: the LLM enumerates key ideas and identifies which are covered;
+              precision and recall are computed programmatically from the counts, avoiding
+              LLM float-calibration issues.
     """
 
     def __init__(self, threshold=0.66, decompositional=False):
         self.threshold = threshold
+        self._computed = decompositional == "computed"
 
-        if decompositional:
+        if self._computed:
+            self.module = ChainOfThought(ComputedSemanticRecallPrecision)
+        elif decompositional:
             self.module = ChainOfThought(DecompositionalSemanticRecallPrecision)
         else:
             self.module = ChainOfThought(SemanticRecallPrecision)
 
     def forward(self, example, pred, trace=None):
         scores = self.module(question=example.question, ground_truth=example.response, system_response=pred.response)
-        score = f1_score(scores.precision, scores.recall)
+
+        if self._computed:
+            gt_count = _count_numbered_items(scores.ground_truth_key_ideas)
+            sr_count = _count_numbered_items(scores.system_response_key_ideas)
+            gt_covered = _count_mentioned_numbers(scores.ground_truth_ideas_covered_by_system)
+            sr_grounded = _count_mentioned_numbers(scores.system_response_ideas_grounded_in_truth)
+
+            recall = gt_covered / gt_count if gt_count > 0 else 0.0
+            precision = sr_grounded / sr_count if sr_count > 0 else 0.0
+            score = f1_score(precision, recall)
+        else:
+            score = f1_score(scores.precision, scores.recall)
 
         return Prediction(score=score if trace is None else score >= self.threshold)
 

--- a/tests/evaluate/test_auto_evaluation.py
+++ b/tests/evaluate/test_auto_evaluation.py
@@ -1,5 +1,10 @@
 import dspy
-from dspy.evaluate.auto_evaluation import CompleteAndGrounded, SemanticF1
+from dspy.evaluate.auto_evaluation import (
+    CompleteAndGrounded,
+    SemanticF1,
+    _count_mentioned_numbers,
+    _count_numbered_items,
+)
 from dspy.primitives.prediction import Prediction
 from dspy.utils.dummies import DummyLM
 
@@ -189,3 +194,149 @@ def test_semantic_f1_prediction_can_be_compared():
     assert isinstance(result1, Prediction)
     assert isinstance(result2, Prediction)
     assert result2.score > result1.score
+
+
+# --- Tests for computed SemanticF1 mode ---
+
+
+def test_count_numbered_items():
+    assert _count_numbered_items("1. first idea\n2. second idea\n3. third idea") == 3
+    assert _count_numbered_items("1) first\n2) second") == 2
+    assert _count_numbered_items("no numbered items here") == 0
+    assert _count_numbered_items("") == 0
+
+
+def test_count_mentioned_numbers():
+    assert _count_mentioned_numbers("1, 3, 4") == 3
+    assert _count_mentioned_numbers("1, 2") == 2
+    assert _count_mentioned_numbers("None") == 0
+    assert _count_mentioned_numbers("") == 0
+    # Duplicate numbers should be counted once
+    assert _count_mentioned_numbers("1, 1, 2") == 2
+
+
+def test_semantic_f1_computed_mode():
+    # 3 ground truth ideas, 2 covered -> recall = 2/3
+    # 2 system response ideas, 2 grounded -> precision = 2/2 = 1.0
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "Enumerating and matching ideas",
+                    "ground_truth_key_ideas": "1. Earth orbits the Sun\n2. Earth has one moon\n3. Earth has water",
+                    "system_response_key_ideas": "1. Earth orbits the Sun\n2. Earth has oceans",
+                    "ground_truth_ideas_covered_by_system": "1, 3",
+                    "system_response_ideas_grounded_in_truth": "1, 2",
+                }
+            ]
+        )
+    )
+
+    example = dspy.Example(question="Tell me about Earth", response="ground truth")
+    pred = dspy.Prediction(response="system response")
+
+    metric = SemanticF1(decompositional="computed")
+    result = metric(example, pred)
+
+    assert isinstance(result, Prediction)
+    # recall = 2/3, precision = 2/2 = 1.0
+    expected_recall = 2 / 3
+    expected_precision = 1.0
+    expected_f1 = 2 * (expected_precision * expected_recall) / (expected_precision + expected_recall)
+    assert abs(result.score - expected_f1) < 0.001
+
+
+def test_semantic_f1_computed_mode_with_trace():
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "Enumerating and matching ideas",
+                    "ground_truth_key_ideas": "1. idea A\n2. idea B",
+                    "system_response_key_ideas": "1. idea A\n2. idea B",
+                    "ground_truth_ideas_covered_by_system": "1, 2",
+                    "system_response_ideas_grounded_in_truth": "1, 2",
+                }
+            ]
+        )
+    )
+
+    example = dspy.Example(question="test", response="answer")
+    pred = dspy.Prediction(response="response")
+
+    metric = SemanticF1(threshold=0.5, decompositional="computed")
+    result = metric(example, pred, trace=True)
+
+    assert isinstance(result, Prediction)
+    assert isinstance(result.score, bool)
+    assert result.score is True  # F1 = 1.0 > 0.5 threshold
+
+
+def test_semantic_f1_computed_mode_no_matches():
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "No overlap found",
+                    "ground_truth_key_ideas": "1. idea A\n2. idea B",
+                    "system_response_key_ideas": "1. idea C",
+                    "ground_truth_ideas_covered_by_system": "None",
+                    "system_response_ideas_grounded_in_truth": "None",
+                }
+            ]
+        )
+    )
+
+    example = dspy.Example(question="test", response="answer")
+    pred = dspy.Prediction(response="response")
+
+    metric = SemanticF1(decompositional="computed")
+    result = metric(example, pred)
+
+    assert isinstance(result, Prediction)
+    assert result.score == 0.0
+
+
+def test_semantic_f1_computed_mode_backward_compat():
+    """Verify that existing decompositional=False and decompositional=True modes still work."""
+    # Test decompositional=False (default)
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "Comparing responses",
+                    "precision": 0.9,
+                    "recall": 0.8,
+                }
+            ]
+        )
+    )
+
+    example = dspy.Example(question="test", response="answer")
+    pred = dspy.Prediction(response="response")
+
+    metric = SemanticF1(decompositional=False)
+    result = metric(example, pred)
+    expected_f1 = 2 * (0.9 * 0.8) / (0.9 + 0.8)
+    assert abs(result.score - expected_f1) < 0.001
+
+    # Test decompositional=True
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "Detailed comparison",
+                    "ground_truth_key_ideas": "key ideas",
+                    "system_response_key_ideas": "key ideas",
+                    "discussion": "they overlap",
+                    "precision": 0.7,
+                    "recall": 0.6,
+                }
+            ]
+        )
+    )
+
+    metric = SemanticF1(decompositional=True)
+    result = metric(example, pred)
+    expected_f1 = 2 * (0.7 * 0.6) / (0.7 + 0.6)
+    assert abs(result.score - expected_f1) < 0.001

--- a/tests/evaluate/test_auto_evaluation.py
+++ b/tests/evaluate/test_auto_evaluation.py
@@ -1,9 +1,9 @@
+import pytest
+
 import dspy
 from dspy.evaluate.auto_evaluation import (
     CompleteAndGrounded,
     SemanticF1,
-    _count_mentioned_numbers,
-    _count_numbered_items,
 )
 from dspy.primitives.prediction import Prediction
 from dspy.utils.dummies import DummyLM
@@ -199,22 +199,6 @@ def test_semantic_f1_prediction_can_be_compared():
 # --- Tests for computed SemanticF1 mode ---
 
 
-def test_count_numbered_items():
-    assert _count_numbered_items("1. first idea\n2. second idea\n3. third idea") == 3
-    assert _count_numbered_items("1) first\n2) second") == 2
-    assert _count_numbered_items("no numbered items here") == 0
-    assert _count_numbered_items("") == 0
-
-
-def test_count_mentioned_numbers():
-    assert _count_mentioned_numbers("1, 3, 4") == 3
-    assert _count_mentioned_numbers("1, 2") == 2
-    assert _count_mentioned_numbers("None") == 0
-    assert _count_mentioned_numbers("") == 0
-    # Duplicate numbers should be counted once
-    assert _count_mentioned_numbers("1, 1, 2") == 2
-
-
 def test_semantic_f1_computed_mode():
     # 3 ground truth ideas, 2 covered -> recall = 2/3
     # 2 system response ideas, 2 grounded -> precision = 2/2 = 1.0
@@ -223,10 +207,10 @@ def test_semantic_f1_computed_mode():
             [
                 {
                     "reasoning": "Enumerating and matching ideas",
-                    "ground_truth_key_ideas": "1. Earth orbits the Sun\n2. Earth has one moon\n3. Earth has water",
-                    "system_response_key_ideas": "1. Earth orbits the Sun\n2. Earth has oceans",
-                    "ground_truth_ideas_covered_by_system": "1, 3",
-                    "system_response_ideas_grounded_in_truth": "1, 2",
+                    "ground_truth_key_ideas": ["Earth orbits the Sun", "Earth has one moon", "Earth has water"],
+                    "system_response_key_ideas": ["Earth orbits the Sun", "Earth has oceans"],
+                    "ground_truth_ideas_covered_by_system": [0, 2],
+                    "system_response_ideas_grounded_in_truth": [0, 1],
                 }
             ]
         )
@@ -235,7 +219,7 @@ def test_semantic_f1_computed_mode():
     example = dspy.Example(question="Tell me about Earth", response="ground truth")
     pred = dspy.Prediction(response="system response")
 
-    metric = SemanticF1(decompositional="computed")
+    metric = SemanticF1(computed=True)
     result = metric(example, pred)
 
     assert isinstance(result, Prediction)
@@ -252,10 +236,10 @@ def test_semantic_f1_computed_mode_with_trace():
             [
                 {
                     "reasoning": "Enumerating and matching ideas",
-                    "ground_truth_key_ideas": "1. idea A\n2. idea B",
-                    "system_response_key_ideas": "1. idea A\n2. idea B",
-                    "ground_truth_ideas_covered_by_system": "1, 2",
-                    "system_response_ideas_grounded_in_truth": "1, 2",
+                    "ground_truth_key_ideas": ["idea A", "idea B"],
+                    "system_response_key_ideas": ["idea A", "idea B"],
+                    "ground_truth_ideas_covered_by_system": [0, 1],
+                    "system_response_ideas_grounded_in_truth": [0, 1],
                 }
             ]
         )
@@ -264,7 +248,7 @@ def test_semantic_f1_computed_mode_with_trace():
     example = dspy.Example(question="test", response="answer")
     pred = dspy.Prediction(response="response")
 
-    metric = SemanticF1(threshold=0.5, decompositional="computed")
+    metric = SemanticF1(threshold=0.5, computed=True)
     result = metric(example, pred, trace=True)
 
     assert isinstance(result, Prediction)
@@ -278,10 +262,10 @@ def test_semantic_f1_computed_mode_no_matches():
             [
                 {
                     "reasoning": "No overlap found",
-                    "ground_truth_key_ideas": "1. idea A\n2. idea B",
-                    "system_response_key_ideas": "1. idea C",
-                    "ground_truth_ideas_covered_by_system": "None",
-                    "system_response_ideas_grounded_in_truth": "None",
+                    "ground_truth_key_ideas": ["idea A", "idea B"],
+                    "system_response_key_ideas": ["idea C"],
+                    "ground_truth_ideas_covered_by_system": [],
+                    "system_response_ideas_grounded_in_truth": [],
                 }
             ]
         )
@@ -290,11 +274,46 @@ def test_semantic_f1_computed_mode_no_matches():
     example = dspy.Example(question="test", response="answer")
     pred = dspy.Prediction(response="response")
 
-    metric = SemanticF1(decompositional="computed")
+    metric = SemanticF1(computed=True)
     result = metric(example, pred)
 
     assert isinstance(result, Prediction)
     assert result.score == 0.0
+
+
+def test_semantic_f1_computed_mode_duplicate_indices():
+    # LLM returns duplicate indices — should be deduplicated
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "Matching ideas",
+                    "ground_truth_key_ideas": ["idea A", "idea B", "idea C"],
+                    "system_response_key_ideas": ["idea A", "idea B"],
+                    "ground_truth_ideas_covered_by_system": [0, 0, 1],  # duplicate 0
+                    "system_response_ideas_grounded_in_truth": [0, 1, 1],  # duplicate 1
+                }
+            ]
+        )
+    )
+
+    example = dspy.Example(question="test", response="answer")
+    pred = dspy.Prediction(response="response")
+
+    metric = SemanticF1(computed=True)
+    result = metric(example, pred)
+
+    # After dedup: gt_covered = {0, 1} = 2, sr_grounded = {0, 1} = 2
+    # recall = 2/3, precision = 2/2 = 1.0
+    expected_recall = 2 / 3
+    expected_precision = 1.0
+    expected_f1 = 2 * (expected_precision * expected_recall) / (expected_precision + expected_recall)
+    assert abs(result.score - expected_f1) < 0.001
+
+
+def test_semantic_f1_computed_and_decompositional_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        SemanticF1(decompositional=True, computed=True)
 
 
 def test_semantic_f1_computed_mode_backward_compat():


### PR DESCRIPTION
## Summary

Adds a `decompositional="computed"` option to `SemanticF1` that **separates LLM semantic judgment from numerical score computation**, addressing the concern raised in #8283 (approved by @okhat).

### Problem

Current `SemanticF1` asks the LLM to directly output `precision: float` and `recall: float`. LLMs are unreliable at generating calibrated numerical scores — they excel at semantic understanding but not at precise float estimation.

### Solution

New `"computed"` mode that:
1. **LLM does what it's good at** — enumerates key ideas in both responses, then identifies which ideas are covered
2. **Code does what it's good at** — computes P/R programmatically: `recall = covered_gt_ideas / total_gt_ideas`, `precision = grounded_sr_ideas / total_sr_ideas`

### Usage

```python
# New computed mode — programmatic P/R from LLM idea matching
metric = SemanticF1(decompositional="computed")

# Existing modes — fully backward compatible
metric = SemanticF1()                        # LLM outputs P/R directly
metric = SemanticF1(decompositional=True)    # LLM enumerates ideas, then outputs P/R
```

### Changes

- **`dspy/evaluate/auto_evaluation.py`**:
  - New `ComputedSemanticRecallPrecision` signature — LLM enumerates numbered key ideas and lists which are covered
  - `_count_numbered_items()` — counts items in a numbered list
  - `_count_mentioned_numbers()` — counts distinct numbers in a comma-separated string
  - `SemanticF1` updated to accept `decompositional="computed"` with programmatic P/R computation

- **`tests/evaluate/test_auto_evaluation.py`**:
  - Tests for parsing utilities (`_count_numbered_items`, `_count_mentioned_numbers`)
  - Computed mode: correct F1 calculation, trace/threshold behavior, zero-match edge case
  - Backward compatibility: existing `False` and `True` modes unchanged

### Design Decisions

- **Additive, not breaking** — new mode is opt-in via `decompositional="computed"`, existing behavior unchanged
- **Single LLM call** — follows the existing decompositional pattern (enumerate + match in one call)
- **Numbered lists + comma-separated numbers** — simple, robust parsing; matches how LLMs naturally enumerate
- **`set()` for dedup** — if LLM repeats a number, it's counted once

Ref #8283

## Test plan

- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — already formatted
- [x] Python syntax validation — both files pass `ast.parse()`
- [x] Unit tests for parsing utilities (numbered lists, comma-separated numbers, edge cases)
- [x] Unit tests for computed mode (correct F1, trace mode, no-match case)
- [x] Backward compatibility tests (decompositional=False and True unchanged)