### PR TITLE
add fixed_trainset, constraint and verbose parameters to GEPA optimizer for industrial stability

### DIFF
--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -208,6 +208,9 @@ class GEPA(Teleprompter):
         auto: The auto budget to use for the run. Options: "light", "medium", "heavy".
         max_full_evals: The maximum number of full evaluations to perform.
         max_metric_calls: The maximum number of metric calls to perform.
+        fixed_trainset: A small set of critical examples (e.g. edge cases, frequent errors) that will be
+            injected into every reflection minibatch. This ensures the optimizer does not "forget" how to
+            handle these examples.
         reflection_minibatch_size: The number of examples to use for reflection in a single GEPA step. Default is 3.
         candidate_selection_strategy: The strategy to use for candidate selection. Default is "pareto",
             which stochastically selects candidates from the Pareto frontier of all validation scores.
@@ -252,8 +255,11 @@ class GEPA(Teleprompter):
             'all' (selects all components for simultaneous optimization). Custom selectors can implement strategies
             using LLM-driven selection logic based on optimization state and trajectories.
             See [gepa component selectors](https://github.com/gepa-ai/gepa/blob/main/src/gepa/strategies/component_selector.py)
-            for available built-in selectors and the ReflectionComponentSelector protocol for implementing custom selectors.
-        add_format_failure_as_feedback: Whether to add format failures as feedback. Default is False.
+            for available built-in selectors and the ReflectionComponentSelector protocol for implementing custom selectors.        constraint: Specific rules or constraints that the generated instructions must strictly follow.
+            Can be a single string or a list of strings (e.g. `["Do not delete existing rules.", "Output must be JSON."]`).
+            This text is injected into the LLM prompt during the reflection phase to protect critical core rules.
+        verbose: If True, prints verbose details of the reflection process to stdout, including the exact prompt
+            sent to the `reflection_lm`, the raw output, and the newly parsed instruction.        add_format_failure_as_feedback: Whether to add format failures as feedback. Default is False.
         use_merge: Whether to use merge-based optimization. Default is True.
         max_merge_invocations: The maximum number of merge invocations to perform. Default is 5.
         num_threads: The number of threads to use for evaluation with `Evaluate`. Optional.
@@ -336,6 +342,7 @@ class GEPA(Teleprompter):
         max_full_evals: int | None = None,
         max_metric_calls: int | None = None,
         # Reflection configuration
+        fixed_trainset: list["Example"] | None = None,
         reflection_minibatch_size: int = 3,
         candidate_selection_strategy: Literal["pareto", "current_best"] = "pareto",
         reflection_lm: LM | None = None,
@@ -343,6 +350,10 @@ class GEPA(Teleprompter):
         add_format_failure_as_feedback: bool = False,
         instruction_proposer: "ProposalFn | None" = None,
         component_selector: "ReflectionComponentSelector | str" = "round_robin",
+        # Constraint configuration
+        constraint: str | list[str] | None = None,
+        # Verbose output
+        verbose: bool = False,
         # Merge-based configuration
         use_merge: bool = True,
         max_merge_invocations: int | None = 5,
@@ -386,6 +397,7 @@ class GEPA(Teleprompter):
         self.max_metric_calls = max_metric_calls
 
         # Reflection configuration
+        self.fixed_trainset = fixed_trainset
         self.reflection_minibatch_size = reflection_minibatch_size
         self.candidate_selection_strategy = candidate_selection_strategy
 
@@ -398,6 +410,12 @@ class GEPA(Teleprompter):
         self.reflection_lm = reflection_lm
         self.skip_perfect_score = skip_perfect_score
         self.add_format_failure_as_feedback = add_format_failure_as_feedback
+
+        # Constraint configuration
+        self.constraint = constraint
+
+        # Verbose output
+        self.verbose = verbose
 
         # Merge-based configuration
         self.use_merge = use_merge
@@ -552,42 +570,102 @@ class GEPA(Teleprompter):
             custom_instruction_proposer=self.custom_instruction_proposer,
             warn_on_score_mismatch=self.warn_on_score_mismatch,
             reflection_minibatch_size=self.reflection_minibatch_size,
+            constraint=self.constraint,
+            verbose=self.verbose,
         )
 
         # Build the seed candidate: map each predictor name to its current instruction
         seed_candidate = {name: pred.signature.instructions for name, pred in student.named_predictors()}
 
-        gepa_result: GEPAResult = optimize(
-            seed_candidate=seed_candidate,
-            trainset=trainset,
-            valset=valset,
-            adapter=adapter,
+        optimize_kwargs = {
+            "seed_candidate": seed_candidate,
+            "valset": valset,
+            "adapter": adapter,
             # Reflection-based configuration
-            reflection_lm=(lambda x: adapter.stripped_lm_call(x)[0]) if self.reflection_lm is not None else None,
-            candidate_selection_strategy=self.candidate_selection_strategy,
-            skip_perfect_score=self.skip_perfect_score,
-            reflection_minibatch_size=self.reflection_minibatch_size,
-            module_selector=self.component_selector,
-            perfect_score=self.perfect_score,
+            "reflection_lm": (lambda x: adapter.stripped_lm_call(x)[0]) if self.reflection_lm is not None else None,
+            "candidate_selection_strategy": self.candidate_selection_strategy,
+            "skip_perfect_score": self.skip_perfect_score,
+            "module_selector": self.component_selector,
+            "perfect_score": self.perfect_score,
             # Merge-based configuration
-            use_merge=self.use_merge,
-            max_merge_invocations=self.max_merge_invocations,
+            "use_merge": self.use_merge,
+            "max_merge_invocations": self.max_merge_invocations,
             # Budget
-            max_metric_calls=self.max_metric_calls,
+            "max_metric_calls": self.max_metric_calls,
             # Logging
-            logger=LoggerAdapter(logger),
-            run_dir=self.log_dir,
-            use_wandb=self.use_wandb,
-            wandb_api_key=self.wandb_api_key,
-            wandb_init_kwargs=self.wandb_init_kwargs,
-            use_mlflow=self.use_mlflow,
-            track_best_outputs=self.track_best_outputs,
-            display_progress_bar=True,
-            raise_on_exception=True,
+            "logger": LoggerAdapter(logger),
+            "run_dir": self.log_dir,
+            "use_wandb": self.use_wandb,
+            "wandb_api_key": self.wandb_api_key,
+            "wandb_init_kwargs": self.wandb_init_kwargs,
+            "use_mlflow": self.use_mlflow,
+            "track_best_outputs": self.track_best_outputs,
+            "display_progress_bar": True,
+            "raise_on_exception": True,
             # Reproducibility
-            seed=self.seed,
-            **self.gepa_kwargs,
-        )
+            "seed": self.seed,
+            **(self.gepa_kwargs or {}),
+        }
+
+        if getattr(self, "fixed_trainset", None):
+            if len(self.fixed_trainset) > self.reflection_minibatch_size:
+                raise ValueError(
+                    f"Number of fixed trainset samples ({len(self.fixed_trainset)}) cannot exceed reflection_minibatch_size ({self.reflection_minibatch_size})"
+                )
+
+            combined_trainset = list(self.fixed_trainset) + list(trainset)
+            optimize_kwargs["trainset"] = combined_trainset
+
+            class AnchorBatchSampler:
+                def __init__(self, num_fixed, total_len, minibatch_size, rng_sampler):
+                    self.num_fixed = num_fixed
+                    self.total_len = total_len
+                    self.minibatch_size = minibatch_size
+                    self.rng = rng_sampler
+                    self.epoch = -1
+                    self.shuffled_ids = []
+
+                def _update_shuffled(self):
+                    self.shuffled_ids = list(range(self.num_fixed, self.total_len))
+                    self.rng.shuffle(self.shuffled_ids)
+
+                    needed_random = self.minibatch_size - self.num_fixed
+                    if needed_random > 0 and len(self.shuffled_ids) > 0:
+                        mod = len(self.shuffled_ids) % needed_random
+                        pad_len = (needed_random - mod) if mod != 0 else 0
+                        if pad_len > 0:
+                            self.shuffled_ids.extend(self.shuffled_ids[:pad_len])
+
+                def next_minibatch_ids(self, loader, state) -> list[int]:
+                    needed_random = self.minibatch_size - self.num_fixed
+                    fixed_ids = list(range(self.num_fixed))
+
+                    if needed_random == 0 or self.total_len <= self.num_fixed:
+                        return fixed_ids
+
+                    base_idx = state.i * needed_random
+                    curr_epoch = 0 if self.epoch == -1 else base_idx // max(len(self.shuffled_ids), 1)
+
+                    if not self.shuffled_ids or curr_epoch > self.epoch:
+                        self.epoch = curr_epoch
+                        self._update_shuffled()
+
+                    b_idx = base_idx % len(self.shuffled_ids)
+                    e_idx = b_idx + needed_random
+                    batch_random = self.shuffled_ids[b_idx:e_idx]
+                    return fixed_ids + batch_random
+
+            optimize_kwargs["batch_sampler"] = AnchorBatchSampler(
+                num_fixed=len(self.fixed_trainset),
+                total_len=len(combined_trainset),
+                minibatch_size=self.reflection_minibatch_size,
+                rng_sampler=rng,
+            )
+        else:
+            optimize_kwargs["trainset"] = trainset
+            optimize_kwargs["reflection_minibatch_size"] = self.reflection_minibatch_size
+
+        gepa_result: GEPAResult = optimize(**optimize_kwargs)
 
         new_prog = adapter.build_program(gepa_result.best_candidate)
 

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -88,6 +88,8 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         custom_instruction_proposer: "ProposalFn | None" = None,
         warn_on_score_mismatch: bool = True,
         reflection_minibatch_size: int | None = None,
+        constraint: str | list[str] | None = None,
+        verbose: bool = False,
     ):
         self.student = student_module
         self.metric_fn = metric_fn
@@ -100,6 +102,41 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
         self.custom_instruction_proposer = custom_instruction_proposer
         self.warn_on_score_mismatch = warn_on_score_mismatch
         self.reflection_minibatch_size = reflection_minibatch_size
+        self.constraint = constraint
+        self.verbose = verbose
+        self._reflection_call_count = 0  # 追踪反思轮次
+
+    def _build_constraint_prompt_template(self) -> str | None:
+        """根据 self.constraint 构建注入了约束的自定义 prompt_template。
+        若未设置 constraint 则返回 None，使用 InstructionProposalSignature 的默认模板。
+        """
+        if self.constraint is None:
+            return None
+
+        # 将约束格式化为编号列表
+        if isinstance(self.constraint, list):
+            constraint_text = "\n".join(f"  {i + 1}. {c}" for i, c in enumerate(self.constraint))
+        else:
+            constraint_text = f"  1. {self.constraint}"
+
+        constraint_block = (
+            f"\n**重要约束（IMPORTANT CONSTRAINTS）**：生成的新指令必须严格遵守以下所有约束，"
+            f"\n{constraint_text}\n\n"
+            "在输出新指令之前，请逐条检查上述约束是否均已满足。"
+        )
+
+        from gepa.strategies.instruction_proposal import InstructionProposalSignature as _IPS
+
+        base_template = _IPS.default_prompt_template
+        # 在末尾 "Provide the new instructions" 之前插入约束块
+        anchor = "Provide the new instructions within ``` blocks."
+        if anchor in base_template:
+            return base_template.replace(
+                anchor,
+                constraint_block + f"\n{anchor} 请确保新指令满足以上全部约束。",
+            )
+        # 若锚点不存在（版本差异），直接追加到末尾
+        return base_template + "\n" + constraint_block + "\nProvide the new instructions within ``` blocks."
 
     def propose_new_texts(
         self,
@@ -119,17 +156,30 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
 
         results: dict[str, str] = {}
 
+        # 若设置了 constraint，构建注入约束的自定义 prompt_template
+        prompt_template = self._build_constraint_prompt_template()
+
         with dspy.context(lm=reflection_lm):
             for name in components_to_update:
                 base_instruction = candidate[name]
                 dataset_with_feedback = reflective_dataset[name]
-                results[name] = InstructionProposalSignature.run(
+                input_dict: dict[str, Any] = {
+                    "current_instruction_doc": base_instruction,
+                    "dataset_with_feedback": dataset_with_feedback,
+                }
+                if prompt_template is not None:
+                    input_dict["prompt_template"] = prompt_template
+                new_instruction = InstructionProposalSignature.run(
                     lm=(lambda x: self.stripped_lm_call(x)[0]),
-                    input_dict={
-                        "current_instruction_doc": base_instruction,
-                        "dataset_with_feedback": dataset_with_feedback,
-                    },
+                    input_dict=input_dict,
                 )["new_instruction"]
+                if self.verbose:
+                    print(f"\n{'─' * 70}")
+                    print(f"✏️  【第 {self._reflection_call_count} 次反思 · 组件: {name}】优化后新指令：")
+                    print(f"{'─' * 70}")
+                    print(new_instruction)
+                    print(f"{'─' * 70}\n")
+                results[name] = new_instruction
 
         return results
 
@@ -305,6 +355,14 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                             self.warn_on_score_mismatch = False
                         fb["score"] = module_score
 
+                # ── 只保留答错的样本进入 reflective dataset ──────────────────
+                # 正确样本（score >= perfect_score）的 feedback 对 reflection_lm
+                # 改进 prompt 没有帮助，只会稀释错误信号。
+                # GEPA 引擎层的 skip_perfect_score 仅在全部正确时跳过整轮，
+                # 但这里过滤确保传给 reflection_lm 的样本全部是错误案例。
+                # if module_score >= self.perfect_score:
+                #     continue
+
                 items.append(d)
 
             if len(items) == 0:
@@ -321,6 +379,15 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
     # Always return strings from the LM outputs
     # Even when it returns a dict with e.g., "text" and "reasoning" fields
     def stripped_lm_call(self, x: str) -> list[str]:
+        self._reflection_call_count += 1
+
+        if self.verbose:
+            print(f"\n{'=' * 70}")
+            print(f"🔄 第 {self._reflection_call_count} 次反思 · 发给 reflection_lm 的 Prompt")
+            print(f"{'=' * 70}")
+            print(x)
+            print(f"{'=' * 70}")
+
         raw_outputs = self.reflection_lm(x)
         outputs = []
         for raw_output in raw_outputs:
@@ -333,5 +400,14 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
             else:
                 raise TypeError("Unexpected output type from the base LM! Expected str or dict")
 
-        return outputs
+        if self.verbose:
+            print(f"\n{'─' * 70}")
+            print(f"💡 第 {self._reflection_call_count} 次反思 · reflection_lm 原始返回")
+            print(f"{'─' * 70}")
+            for i, o in enumerate(outputs):
+                if len(outputs) > 1:
+                    print(f"[输出 {i + 1}]:")
+                print(o)
+            print(f"{'─' * 70}\n")
 
+        return outputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ filterwarnings = [
     # For examples, see litellm PRs #6903, #7300, #8096, #9372, and #12528.
     "ignore:.+class-based `config` is deprecated, use ConfigDict:DeprecationWarning",
 ]
+markers = [
+    "real_lm: tests that make real LLM API calls (deselect with -k 'not real_lm')",
+]
 
 [tool.ruff]
 include = ["dspy/**/*.py", "tests/**/*.py"]

--- a/tests/teleprompt/test_bettertogether.py
+++ b/tests/teleprompt/test_bettertogether.py
@@ -3,6 +3,7 @@
 Most of the code in this test file was LLM-generated but has been verified
 to correctly test the BetterTogether optimizer functionality.
 """
+
 from unittest.mock import Mock, patch
 
 import pytest
@@ -21,9 +22,14 @@ def simple_metric(example, prediction, trace=None):
 
 
 examples = [
-    Example(input="What is the oldest known human-made monument?", output="Göbekli Tepe in southeastern Turkiye, dating back to around 9600 BCE").with_inputs("input"),
+    Example(
+        input="What is the oldest known human-made monument?",
+        output="Göbekli Tepe in southeastern Turkiye, dating back to around 9600 BCE",
+    ).with_inputs("input"),
     Example(input="Why can't fish fall in love?", output="Because love is in the air").with_inputs("input"),
-    Example(input="What would bring world peace?", output="8 billion people meeting for a tea party in my backyard").with_inputs("input"),
+    Example(
+        input="What would bring world peace?", output="8 billion people meeting for a tea party in my backyard"
+    ).with_inputs("input"),
 ]
 trainset = examples[:2]
 valset = [examples[2]]
@@ -42,14 +48,17 @@ class SimpleModule(dspy.Module):
 # Reusable Mock Optimizers
 # ============================================================================
 
+
 class SimpleOptimizer(Teleprompter):
     """A simple optimizer that returns the student unchanged."""
+
     def compile(self, student, **kwargs):
         return student
 
 
 class MarkedOptimizer(Teleprompter):
     """An optimizer that marks the program with a specific identifier."""
+
     def __init__(self, marker):
         self.marker = marker
 
@@ -61,18 +70,20 @@ class MarkedOptimizer(Teleprompter):
 
 class CapturingOptimizer(Teleprompter):
     """An optimizer that captures the kwargs it receives."""
+
     def __init__(self):
         self.received_kwargs = {}
 
-    def compile(self, student, trainset=None, valset=None, teacher=None,
-                num_trials=None, max_bootstrapped_demos=None, **kwargs):
+    def compile(
+        self, student, trainset=None, valset=None, teacher=None, num_trials=None, max_bootstrapped_demos=None, **kwargs
+    ):
         self.received_kwargs = {
             "trainset": trainset,
             "valset": valset,
             "teacher": teacher,
             "num_trials": num_trials,
             "max_bootstrapped_demos": max_bootstrapped_demos,
-            **kwargs
+            **kwargs,
         }
         return student
 
@@ -80,6 +91,7 @@ class CapturingOptimizer(Teleprompter):
 # ============================================================================
 # Pytest Fixtures
 # ============================================================================
+
 
 @pytest.fixture
 def student_with_lm():
@@ -93,9 +105,11 @@ def student_with_lm():
 @pytest.fixture
 def mock_bt_dependencies():
     """Mock the common BetterTogether dependencies."""
-    with patch("dspy.teleprompt.bettertogether.eval_candidate_program") as mock_eval, \
-         patch("dspy.teleprompt.bettertogether.launch_lms") as mock_launch, \
-         patch("dspy.teleprompt.bettertogether.kill_lms") as mock_kill:
+    with (
+        patch("dspy.teleprompt.bettertogether.eval_candidate_program") as mock_eval,
+        patch("dspy.teleprompt.bettertogether.launch_lms") as mock_launch,
+        patch("dspy.teleprompt.bettertogether.kill_lms") as mock_kill,
+    ):
         mock_eval.return_value = Mock(score=0.8)
         yield mock_eval, mock_launch, mock_kill
 
@@ -103,6 +117,7 @@ def mock_bt_dependencies():
 # ============================================================================
 # Tests
 # ============================================================================
+
 
 def test_bettertogether_import():
     """Sanity check: Test that BetterTogether can be imported."""
@@ -116,10 +131,10 @@ def test_bettertogether_initialization_default():
     assert optimizer.metric == simple_metric, "Metric not correctly initialized"
     assert "p" in optimizer.optimizers, "Default 'p' optimizer not created"
     assert "w" in optimizer.optimizers, "Default 'w' optimizer not created"
-    assert isinstance(optimizer.optimizers["p"], BootstrapFewShotWithRandomSearch), \
+    assert isinstance(optimizer.optimizers["p"], BootstrapFewShotWithRandomSearch), (
         "Default 'p' should be BootstrapFewShotWithRandomSearch"
-    assert isinstance(optimizer.optimizers["w"], BootstrapFinetune), \
-        "Default 'w' should be BootstrapFinetune"
+    )
+    assert isinstance(optimizer.optimizers["w"], BootstrapFinetune), "Default 'w' should be BootstrapFinetune"
 
 
 def test_bettertogether_initialization_custom():
@@ -127,11 +142,7 @@ def test_bettertogether_initialization_custom():
     custom_p = BootstrapFewShotWithRandomSearch(metric=simple_metric)
     custom_w = BootstrapFinetune(metric=simple_metric)
 
-    optimizer = BetterTogether(
-        metric=simple_metric,
-        p=custom_p,
-        w=custom_w
-    )
+    optimizer = BetterTogether(metric=simple_metric, p=custom_p, w=custom_w)
 
     assert optimizer.optimizers["p"] is custom_p, "Custom 'p' optimizer not set"
     assert optimizer.optimizers["w"] is custom_w, "Custom 'w' optimizer not set"
@@ -142,7 +153,7 @@ def test_bettertogether_initialization_invalid_optimizer():
     try:
         optimizer = BetterTogether(
             metric=simple_metric,
-            p="not_a_teleprompter"  # Invalid type
+            p="not_a_teleprompter",  # Invalid type
         )
         assert False, "Should have raised TypeError for invalid optimizer"
     except TypeError as e:
@@ -194,12 +205,7 @@ def test_compile_basic():
 
         with patch("dspy.teleprompt.bettertogether.launch_lms"):
             with patch("dspy.teleprompt.bettertogether.kill_lms"):
-                compiled = optimizer.compile(
-                    student,
-                    trainset=trainset,
-                    valset=valset,
-                    strategy="p"
-                )
+                compiled = optimizer.compile(student, trainset=trainset, valset=valset, strategy="p")
 
     assert compiled is not None, "Compilation returned None"
     assert hasattr(compiled, "candidate_programs"), "Missing candidate_programs attribute"
@@ -251,10 +257,7 @@ def test_optimizer_compile_args_validation():
 
     # Test invalid optimizer key
     try:
-        optimizer._prepare_optimizer_compile_args(
-            {"invalid_key": {"num_trials": 10}},
-            teacher=None
-        )
+        optimizer._prepare_optimizer_compile_args({"invalid_key": {"num_trials": 10}}, teacher=None)
         assert False, "Should have raised ValueError for invalid optimizer key"
     except ValueError as e:
         assert "invalid optimizer key" in str(e).lower()
@@ -265,11 +268,7 @@ def test_student_in_optimizer_compile_args():
     optimizer = BetterTogether(metric=simple_metric)
 
     try:
-        optimizer._validate_compile_args(
-            optimizer.optimizers["p"],
-            "p",
-            {"student": SimpleModule("input -> output")}
-        )
+        optimizer._validate_compile_args(optimizer.optimizers["p"], "p", {"student": SimpleModule("input -> output")})
         assert False, "Should have raised ValueError for 'student' in compile_args"
     except ValueError as e:
         assert "student" in str(e).lower()
@@ -288,11 +287,7 @@ def test_compile_args_passed_to_optimizer(student_with_lm, mock_bt_dependencies)
     custom_args = {"num_trials": 20, "max_bootstrapped_demos": 8}
 
     optimizer.compile(
-        student_with_lm,
-        trainset=trainset,
-        valset=valset,
-        strategy="p",
-        optimizer_compile_args={"p": custom_args}
+        student_with_lm, trainset=trainset, valset=valset, strategy="p", optimizer_compile_args={"p": custom_args}
     )
 
     # Verify the custom args were passed to the optimizer
@@ -317,11 +312,7 @@ def test_compile_args_multi_optimizer_strategy():
             self.received_kwargs = {}
 
         def compile(self, student, trainset=None, num_trials=None, **kwargs):
-            self.received_kwargs = {
-                "trainset": trainset,
-                "num_trials": num_trials,
-                **kwargs
-            }
+            self.received_kwargs = {"trainset": trainset, "num_trials": num_trials, **kwargs}
             return student
 
     class WeightOptimizer(Teleprompter):
@@ -329,11 +320,7 @@ def test_compile_args_multi_optimizer_strategy():
             self.received_kwargs = {}
 
         def compile(self, student, trainset=None, num_batches=None, **kwargs):
-            self.received_kwargs = {
-                "trainset": trainset,
-                "num_batches": num_batches,
-                **kwargs
-            }
+            self.received_kwargs = {"trainset": trainset, "num_batches": num_batches, **kwargs}
             return student
 
     mock_p = PromptOptimizer()
@@ -341,10 +328,7 @@ def test_compile_args_multi_optimizer_strategy():
     optimizer = BetterTogether(metric=simple_metric, p=mock_p, w=mock_w)
 
     # Define different compile args for each optimizer
-    compile_args = {
-        "p": {"num_trials": 10},
-        "w": {"num_batches": 5}
-    }
+    compile_args = {"p": {"num_trials": 10}, "w": {"num_batches": 5}}
 
     with patch("dspy.teleprompt.bettertogether.eval_candidate_program") as mock_eval:
         mock_eval.return_value = Mock(score=0.85)
@@ -356,7 +340,7 @@ def test_compile_args_multi_optimizer_strategy():
                         trainset=trainset,
                         valset=valset,
                         strategy="p -> w",
-                        optimizer_compile_args=compile_args
+                        optimizer_compile_args=compile_args,
                     )
 
     # Verify each optimizer received its specific args
@@ -385,12 +369,7 @@ def test_compile_args_override_global_params():
             self.received_kwargs = {}
 
         def compile(self, student, trainset=None, valset=None, teacher=None, **kwargs):
-            self.received_kwargs = {
-                "trainset": trainset,
-                "valset": valset,
-                "teacher": teacher,
-                **kwargs
-            }
+            self.received_kwargs = {"trainset": trainset, "valset": valset, "teacher": teacher, **kwargs}
             return student
 
     mock_p = CapturingTeleprompter()
@@ -398,7 +377,7 @@ def test_compile_args_override_global_params():
 
     # Create override values
     override_trainset = [examples[2]]  # Different from global trainset
-    override_valset = [examples[0]]    # Different from global valset
+    override_valset = [examples[0]]  # Different from global valset
     override_teacher = SimpleModule("input -> output")
 
     # Pass global values to compile, but override them in optimizer_compile_args
@@ -417,25 +396,26 @@ def test_compile_args_override_global_params():
                 optimizer.compile(
                     student,
                     trainset=trainset,  # Global trainset (examples[:2])
-                    valset=valset,      # Global valset (examples[2])
-                    teacher=None,       # Global teacher (None)
+                    valset=valset,  # Global valset (examples[2])
+                    teacher=None,  # Global teacher (None)
                     strategy="p",
-                    optimizer_compile_args=compile_args
+                    optimizer_compile_args=compile_args,
                 )
 
     # Verify the optimizer received the override values, not the global ones
-    assert mock_p.received_kwargs["trainset"] == override_trainset, \
+    assert mock_p.received_kwargs["trainset"] == override_trainset, (
         "Optimizer should receive override trainset from compile_args"
-    assert mock_p.received_kwargs["valset"] == override_valset, \
+    )
+    assert mock_p.received_kwargs["valset"] == override_valset, (
         "Optimizer should receive override valset from compile_args"
-    assert mock_p.received_kwargs["teacher"] is override_teacher, \
+    )
+    assert mock_p.received_kwargs["teacher"] is override_teacher, (
         "Optimizer should receive override teacher from compile_args"
+    )
 
     # Verify they're different from the global values
-    assert mock_p.received_kwargs["trainset"] != trainset, \
-        "Override trainset should differ from global trainset"
-    assert mock_p.received_kwargs["valset"] != valset, \
-        "Override valset should differ from global valset"
+    assert mock_p.received_kwargs["trainset"] != trainset, "Override trainset should differ from global trainset"
+    assert mock_p.received_kwargs["valset"] != valset, "Override valset should differ from global valset"
 
 
 def test_trainset_shuffling_between_steps():
@@ -468,7 +448,7 @@ def test_trainset_shuffling_between_steps():
                         trainset=trainset,
                         valset=valset,
                         strategy="p -> w",
-                        shuffle_trainset_between_steps=True
+                        shuffle_trainset_between_steps=True,
                     )
 
     # Verify trainset was shuffled between steps
@@ -480,8 +460,9 @@ def test_trainset_shuffling_between_steps():
     assert len(trainset_p) == len(trainset_w), "Trainsets should have same length"
     # With shuffling enabled and only 2 examples, there's a 50% chance they're in different order
     # We can't reliably test order difference with small dataset, but we can verify they contain same examples
-    assert set(id(ex) for ex in trainset_p) == set(id(ex) for ex in trainset_w), \
+    assert set(id(ex) for ex in trainset_p) == set(id(ex) for ex in trainset_w), (
         "Trainsets should contain the same example objects"
+    )
 
 
 def test_strategy_execution_order():
@@ -518,12 +499,7 @@ def test_strategy_execution_order():
         with patch("dspy.teleprompt.bettertogether.launch_lms"):
             with patch("dspy.teleprompt.bettertogether.kill_lms"):
                 with patch.object(optimizer, "_models_changed", return_value=False):
-                    result = optimizer.compile(
-                        student,
-                        trainset=trainset,
-                        valset=valset,
-                        strategy="p -> w -> p"
-                    )
+                    result = optimizer.compile(student, trainset=trainset, valset=valset, strategy="p -> w -> p")
 
     # Verify execution order
     assert len(execution_log) == 3, "Should have executed 3 optimization steps"
@@ -553,12 +529,7 @@ def test_lm_lifecycle_management():
         with patch("dspy.teleprompt.bettertogether.launch_lms") as mock_launch:
             with patch("dspy.teleprompt.bettertogether.kill_lms") as mock_kill:
                 with patch.object(optimizer, "_models_changed", return_value=True):
-                    optimizer.compile(
-                        student,
-                        trainset=trainset,
-                        valset=valset,
-                        strategy="p -> w"
-                    )
+                    optimizer.compile(student, trainset=trainset, valset=valset, strategy="p -> w")
 
     # Verify launch and kill were called
     # When models change (which we mocked to return True), launch should be called
@@ -598,12 +569,7 @@ def test_error_handling_returns_best_program():
         with patch("dspy.teleprompt.bettertogether.launch_lms"):
             with patch("dspy.teleprompt.bettertogether.kill_lms"):
                 with patch.object(optimizer, "_models_changed", return_value=False):
-                    result = optimizer.compile(
-                        student,
-                        trainset=trainset,
-                        valset=valset,
-                        strategy="p -> w"
-                    )
+                    result = optimizer.compile(student, trainset=trainset, valset=valset, strategy="p -> w")
 
     # Verify a program was returned despite the failure
     assert result is not None, "Should return a program even if a step fails"
@@ -613,10 +579,13 @@ def test_error_handling_returns_best_program():
     assert len(result.candidate_programs) > 0, "Should have at least one candidate program"
 
 
-@pytest.mark.parametrize("test_valset,expected_marker,test_description", [
-    (valset, "p_optimized", "With valset: returns best score (p), not latest (w)"),
-    (None, "w_optimized", "Without valset: returns latest program (w)"),
-])
+@pytest.mark.parametrize(
+    "test_valset,expected_marker,test_description",
+    [
+        (valset, "p_optimized", "With valset: returns best score (p), not latest (w)"),
+        (None, "w_optimized", "Without valset: returns latest program (w)"),
+    ],
+)
 def test_program_selection(student_with_lm, test_valset, expected_marker, test_description):
     """Test program selection logic with and without validation set."""
     mock_p = MarkedOptimizer("p_optimized")
@@ -636,10 +605,7 @@ def test_program_selection(student_with_lm, test_valset, expected_marker, test_d
             with patch("dspy.teleprompt.bettertogether.kill_lms"):
                 with patch.object(optimizer, "_models_changed", return_value=False):
                     result = optimizer.compile(
-                        student_with_lm,
-                        trainset=trainset,
-                        valset=test_valset,
-                        strategy="p -> w"
+                        student_with_lm, trainset=trainset, valset=test_valset, strategy="p -> w"
                     )
 
     # Verify the correct program was returned based on valset presence
@@ -663,12 +629,7 @@ def test_candidate_programs_structure(student_with_lm):
         with patch("dspy.teleprompt.bettertogether.launch_lms"):
             with patch("dspy.teleprompt.bettertogether.kill_lms"):
                 with patch.object(optimizer, "_models_changed", return_value=False):
-                    result = optimizer.compile(
-                        student_with_lm,
-                        trainset=trainset,
-                        valset=valset,
-                        strategy="p -> w"
-                    )
+                    result = optimizer.compile(student_with_lm, trainset=trainset, valset=valset, strategy="p -> w")
 
     # Verify candidate_programs exists and has correct structure
     assert hasattr(result, "candidate_programs"), "Result should have candidate_programs attribute"
@@ -713,7 +674,7 @@ def test_empty_valset_handling(student_with_lm):
                     student_with_lm,
                     trainset=trainset,
                     valset=[],  # Empty list (not None)
-                    strategy="p"
+                    strategy="p",
                 )
 
     # With empty valset, should return latest program (same behavior as valset=None)
@@ -736,7 +697,7 @@ def test_empty_valset_handling(student_with_lm):
                     student2,
                     trainset=trainset,
                     valset=None,  # Explicit None
-                    strategy="p"
+                    strategy="p",
                 )
 
     # Both should behave the same way

--- a/tests/teleprompt/test_copro_optimizer.py
+++ b/tests/teleprompt/test_copro_optimizer.py
@@ -149,8 +149,8 @@ def test_statistics_tracking_during_optimization():
     assert "results_best" in optimized_student.__dict__, "Optimizer did not track the best results"
     assert "results_latest" in optimized_student.__dict__, "Optimizer did not track the latest results"
     assert len(optimized_student.results_best) > 0, "Optimizer did not properly populate the best results statistics"
-    assert (
-        len(optimized_student.results_latest) > 0
-    ), "Optimizer did not properly populate the latest results statistics"
+    assert len(optimized_student.results_latest) > 0, (
+        "Optimizer did not properly populate the latest results statistics"
+    )
 
     # Additional detailed checks can be added here to verify the contents of the tracked statistics

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -43,16 +43,25 @@ def bad_metric(example, prediction):
     return 0.0
 
 
-@pytest.mark.parametrize("reflection_minibatch_size, batch, expected_callback_metadata", [
-    (None, [], {"metric_key": "eval_full"}),
-    (None, [Example(input="What is the color of the sky?", output="blue")], {"metric_key": "eval_full"}),
-    (1, [], {"disable_logging": True}),
-    (1, [
-        Example(input="What is the color of the sky?", output="blue"),
-        Example(input="What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!"),
-    ], {"metric_key": "eval_full"}),
-])
-def test_gepa_adapter_disables_logging_on_minibatch_eval(monkeypatch, reflection_minibatch_size, batch, expected_callback_metadata):
+@pytest.mark.parametrize(
+    "reflection_minibatch_size, batch, expected_callback_metadata",
+    [
+        (None, [], {"metric_key": "eval_full"}),
+        (None, [Example(input="What is the color of the sky?", output="blue")], {"metric_key": "eval_full"}),
+        (1, [], {"disable_logging": True}),
+        (
+            1,
+            [
+                Example(input="What is the color of the sky?", output="blue"),
+                Example(input="What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!"),
+            ],
+            {"metric_key": "eval_full"},
+        ),
+    ],
+)
+def test_gepa_adapter_disables_logging_on_minibatch_eval(
+    monkeypatch, reflection_minibatch_size, batch, expected_callback_metadata
+):
     from dspy.teleprompt import bootstrap_trace as bootstrap_trace_module
     from dspy.teleprompt.gepa import gepa_utils
 
@@ -109,13 +118,7 @@ def test_basic_workflow(use_mlflow, mock_mlflow):
     dspy.configure(lm=lm_main)
     reflection_lm = DictDummyLM(reflection_lm_history)
 
-    optimizer = dspy.GEPA(
-        metric=simple_metric,
-        reflection_lm=reflection_lm,
-        max_metric_calls=5,
-        use_mlflow=use_mlflow
-    )
-
+    optimizer = dspy.GEPA(metric=simple_metric, reflection_lm=reflection_lm, max_metric_calls=5, use_mlflow=use_mlflow)
 
     trainset = [
         Example(input="What is the color of the sky?", output="blue").with_inputs("input"),
@@ -123,11 +126,15 @@ def test_basic_workflow(use_mlflow, mock_mlflow):
     ]
 
     optimized_program = optimizer.compile(student, trainset=trainset, valset=trainset)
-    assert optimized_program.predictor.signature.instructions == 'Given the field `input` containing a question or phrase, produce the field `output` containing the exact, direct, and contextually appropriate answer or response that the user expects, without additional explanations, commentary, or general knowledge unless explicitly requested.\n\nKey details and guidelines:\n\n1. The `input` field contains a question or phrase that may be literal, factual, or culturally specific (e.g., references to popular culture or memes).\n\n2. The `output` must be the precise answer or response that directly addresses the `input` as intended by the user, not a general or encyclopedic explanation.\n\n3. If the `input` is a well-known phrase or question from popular culture (e.g., "What does the fox say?"), the `output` should reflect the expected or canonical answer associated with that phrase, rather than a factual or scientific explanation.\n\n4. Avoid providing additional background information, scientific explanations, or alternative interpretations unless explicitly requested.\n\n5. The goal is to produce the answer that the user expects or the "correct" answer in the context of the question, including culturally recognized or meme-based answers.\n\n6. If the `input` is a straightforward factual question (e.g., "What is the color of the sky?"), provide the commonly accepted direct answer (e.g., "Blue") rather than a detailed scientific explanation.\n\n7. The output should be concise, clear, and focused solely on answering the question or phrase in the `input`.\n\nExample:\n\n- Input: "What is the color of the sky?"\n- Output: "Blue."\n\n- Input: "What does the fox say?"\n- Output: "Ring-ding-ding-ding-dingeringeding!"\n\nThis approach ensures that the assistant provides the expected, contextually appropriate answers rather than general or overly detailed responses that may be considered incorrect by the user.'
+    assert (
+        optimized_program.predictor.signature.instructions
+        == 'Given the field `input` containing a question or phrase, produce the field `output` containing the exact, direct, and contextually appropriate answer or response that the user expects, without additional explanations, commentary, or general knowledge unless explicitly requested.\n\nKey details and guidelines:\n\n1. The `input` field contains a question or phrase that may be literal, factual, or culturally specific (e.g., references to popular culture or memes).\n\n2. The `output` must be the precise answer or response that directly addresses the `input` as intended by the user, not a general or encyclopedic explanation.\n\n3. If the `input` is a well-known phrase or question from popular culture (e.g., "What does the fox say?"), the `output` should reflect the expected or canonical answer associated with that phrase, rather than a factual or scientific explanation.\n\n4. Avoid providing additional background information, scientific explanations, or alternative interpretations unless explicitly requested.\n\n5. The goal is to produce the answer that the user expects or the "correct" answer in the context of the question, including culturally recognized or meme-based answers.\n\n6. If the `input` is a straightforward factual question (e.g., "What is the color of the sky?"), provide the commonly accepted direct answer (e.g., "Blue") rather than a detailed scientific explanation.\n\n7. The output should be concise, clear, and focused solely on answering the question or phrase in the `input`.\n\nExample:\n\n- Input: "What is the color of the sky?"\n- Output: "Blue."\n\n- Input: "What does the fox say?"\n- Output: "Ring-ding-ding-ding-dingeringeding!"\n\nThis approach ensures that the assistant provides the expected, contextually appropriate answers rather than general or overly detailed responses that may be considered incorrect by the user.'
+    )
     if use_mlflow:
         assert mock_mlflow.start_run.call_count == 1
     else:
         assert mock_mlflow.start_run.call_count == 0
+
 
 def test_workflow_with_custom_instruction_proposer_and_component_selector():
     """Test to ensure the basic compile flow runs without errors when using a custom instruction proposer and component selector."""
@@ -204,8 +211,14 @@ def test_workflow_with_custom_instruction_proposer_and_component_selector():
     ]
     o = optimizer.compile(student, trainset=trainset, valset=trainset)
 
-    assert o.hour_predictor.signature.instructions == "Task\n- Input: clock_photo (an image of an analog clock)\n- Output: hour (an integer 1\u201312). Output only the hour number with no extra text.\n\nGoal\n- Determine the correct hour by accurately identifying the hour hand and its position relative to the hour marks, taking into account the minute hand\u2019s position (since the hour hand moves continuously between numbers).\n\nStep-by-step procedure\n1) Find the dial and pivot\n- Locate the clock face and the central pivot where all hands originate.\n- Ignore decorative elements that do not originate at the central pivot (e.g., ornaments, shadows, reflections).\n\n2) Determine the 12 o\u2019clock direction\n- Prefer the numeral \u201c12\u201d if visible. Otherwise use the upright orientation of numerals or the topmost marker.\n- If the photo is rotated, mentally rotate so numerals read upright: 12 at top, 3 right, 6 bottom, 9 left.\n\n3) Identify the hands correctly (do not assume a default \u201c10:10\u201d)\n- Second hand: thinnest, often with a counterweight, may span very long; ignore for the hour.\n- Minute hand: longest, usually reaches or nearly reaches the outer minute tick marks.\n- Hour hand: shortest, usually thicker, typically ends well inside the numerals.\n- If ambiguous, classify by tip distance from center: minute \u2265 hour. Use the piece actually anchored at the pivot, not its shadow.\n\n4) Measure positions (angles)\n- Measure each hand\u2019s angle clockwise from 12 o\u2019clock.\n- Minute angle \u03b8m \u2248 position of the minute hand; hour angle \u03b8h \u2248 position of the hour hand.\n\n5) Use minute-hand position to validate the hour-hand location\n- The hour hand advances 0.5\u00b0 per minute (i.e., 1/12 of the distance between hour marks every 5 minutes).\n- Sanity check examples:\n  - ~15 minutes past: hour hand \u2248 1/4 of the way from the current hour toward the next.\n  - ~30 minutes: \u2248 halfway.\n  - ~45 minutes: \u2248 3/4 of the way.\n- If this relationship doesn\u2019t hold, you likely swapped hour and minute hands\u2014re-identify them.\n\n6) Determine the hour\n- Compute the \u201clast passed\u201d hour: H = floor((\u03b8h mod 360) / 30). Map 0 to 12 (i.e., if floor(...) = 0, H = 12).\n- Do not round up to the next hour. The correct hour is the number the hour hand has most recently passed, not the one it is approaching.\n- If the hour hand appears exactly on an hour mark but the minute hand is not at 12, treat it as still between hours and choose the lower (last passed) hour.\n\n7) Edge cases and robustness\n- Stylized or missing numerals: rely on the 12/3/6/9 axes and tick marks rather than numeral shapes.\n- Roman numerals: \u201c4\u201d may be IIII; positions are unchanged.\n- Ignore mirrored effects, reflections, and shadows; only consider hands anchored at the pivot.\n- Overlap times: if hands nearly overlap, use \u03b8m to ensure the hour hand offset matches 0.5\u00b0 per minute.\n- Return 12, not 0, when appropriate (e.g., just after 12:00).\n\nOutput format\n- Provide only: hour as an integer in [1,12], with no additional text.\n\nCommon error prevention (from prior mistakes)\n- Do not confuse the minute hand for the hour hand; verify by length and reach to the outer tick marks.\n- Do not infer times like \u201c10:10\u201d by default; always read from the actual hand angles.\n- Ensure the hour chosen matches the \u201clast passed\u201d number given the minute hand\u2019s position (e.g., at ~:16, the hour hand must be just past the hour, not near 1 when the minute hand is at 3)."
-    assert o.minute_predictor.signature.instructions == "Task: From the image field clock_photo (an analog clock), output the minute value as an integer from 0\u201359 in the field minute. Output only the minute number\u2014no text or other fields.\n\nWhat to analyze\n- Clock face orientation: Identify where \u201c12\u201d is on the dial. Use the numerals (Arabic or Roman, stylized fonts) or the positions of 3, 6, 9, 12 to set the reference. If the photo is tilted, measure angles relative to the clock face, not the image frame.\n- Hands identification (do not confuse them):\n  - Minute hand: typically the longest solid hand reaching near the minute ticks/outer ring; thicker than the second hand; often has a pronounced pointer tip.\n  - Hour hand: shorter and thicker, typically ends near the numerals.\n  - Second hand (if present): the thinnest, often the longest, usually with a counterweight; ignore it for minute reading.\n  - If two non-second hands look similar, the one whose tip reaches closer to the minute tick ring is the minute hand.\n- Ticks and numerals: Each numeral-to-numeral segment equals 5 minutes. If minute tick marks exist, use them. If not, divide each numeral interval evenly into five.\n\nHow to compute the minute\n1. Locate the clock center and the minute hand\u2019s tip.\n2. Determine the angle of the minute hand from the 12 o\u2019clock direction, increasing clockwise.\n3. Convert angle to minutes: minute_estimate = (angle_from_12 / 6). Round to the nearest whole minute.\n   - Mapping: 12 \u2192 0, 1 \u2192 5, 2 \u2192 10, 3 \u2192 15, 4 \u2192 20, 5 \u2192 25, 6 \u2192 30, 7 \u2192 35, 8 \u2192 40, 9 \u2192 45, 10 \u2192 50, 11 \u2192 55.\n   - If the tip is slightly past a numeral (e.g., just past 3), do not snap to the numeral; round to the nearest minute (e.g., 16 instead of 15).\n4. Consistency check with the hour hand (useful to avoid off-by-one and hand mix-ups):\n   - The hour hand moves continuously: it advances 0.5 degrees per minute (i.e., 1/12 of the way to the next numeral every 5 minutes).\n   - If your minute_estimate is an exact multiple of 5 but the hour hand is clearly between hour markers (not aligned with an hour), re-examine: the minute hand is likely slightly past the numeral; adjust to the nearest minute accordingly.\n   - If the minute hand choice is ambiguous, infer the minute from the hour hand\u2019s fraction toward the next hour: minute \u2248 fraction_between_hour_markers \u00d7 60, then choose the hand assignment that matches this.\n5. Edge cases:\n   - Overlapping hands: Look at which tip extends farther toward the tick ring to identify the minute hand.\n   - Strong perspective or glare: Use the line from center to the visible tip; ignore reflections.\n   - No minute ticks: Evenly interpolate between numerals.\n   - Subdials or decorative elements (e.g., pendulum windows) are not the minute indicator; use the main dial only.\n\nOutput format\n- Return only the integer minute value (0\u201359) in the minute field.\n- If the angle computes to 60, output 0.\n\nError prevention reminders\n- Do not treat the hour hand as the minute hand.\n- Do not use the second hand to compute minutes.\n- Do not assume the minute hand is exactly on a numeral\u2014check for slight offsets and round to the nearest minute.\n- Ensure the final minute agrees with the hour hand\u2019s position trend (hour hand slightly past an hour implies minutes > 0)."
+    assert (
+        o.hour_predictor.signature.instructions
+        == "Task\n- Input: clock_photo (an image of an analog clock)\n- Output: hour (an integer 1\u201312). Output only the hour number with no extra text.\n\nGoal\n- Determine the correct hour by accurately identifying the hour hand and its position relative to the hour marks, taking into account the minute hand\u2019s position (since the hour hand moves continuously between numbers).\n\nStep-by-step procedure\n1) Find the dial and pivot\n- Locate the clock face and the central pivot where all hands originate.\n- Ignore decorative elements that do not originate at the central pivot (e.g., ornaments, shadows, reflections).\n\n2) Determine the 12 o\u2019clock direction\n- Prefer the numeral \u201c12\u201d if visible. Otherwise use the upright orientation of numerals or the topmost marker.\n- If the photo is rotated, mentally rotate so numerals read upright: 12 at top, 3 right, 6 bottom, 9 left.\n\n3) Identify the hands correctly (do not assume a default \u201c10:10\u201d)\n- Second hand: thinnest, often with a counterweight, may span very long; ignore for the hour.\n- Minute hand: longest, usually reaches or nearly reaches the outer minute tick marks.\n- Hour hand: shortest, usually thicker, typically ends well inside the numerals.\n- If ambiguous, classify by tip distance from center: minute \u2265 hour. Use the piece actually anchored at the pivot, not its shadow.\n\n4) Measure positions (angles)\n- Measure each hand\u2019s angle clockwise from 12 o\u2019clock.\n- Minute angle \u03b8m \u2248 position of the minute hand; hour angle \u03b8h \u2248 position of the hour hand.\n\n5) Use minute-hand position to validate the hour-hand location\n- The hour hand advances 0.5\u00b0 per minute (i.e., 1/12 of the distance between hour marks every 5 minutes).\n- Sanity check examples:\n  - ~15 minutes past: hour hand \u2248 1/4 of the way from the current hour toward the next.\n  - ~30 minutes: \u2248 halfway.\n  - ~45 minutes: \u2248 3/4 of the way.\n- If this relationship doesn\u2019t hold, you likely swapped hour and minute hands\u2014re-identify them.\n\n6) Determine the hour\n- Compute the \u201clast passed\u201d hour: H = floor((\u03b8h mod 360) / 30). Map 0 to 12 (i.e., if floor(...) = 0, H = 12).\n- Do not round up to the next hour. The correct hour is the number the hour hand has most recently passed, not the one it is approaching.\n- If the hour hand appears exactly on an hour mark but the minute hand is not at 12, treat it as still between hours and choose the lower (last passed) hour.\n\n7) Edge cases and robustness\n- Stylized or missing numerals: rely on the 12/3/6/9 axes and tick marks rather than numeral shapes.\n- Roman numerals: \u201c4\u201d may be IIII; positions are unchanged.\n- Ignore mirrored effects, reflections, and shadows; only consider hands anchored at the pivot.\n- Overlap times: if hands nearly overlap, use \u03b8m to ensure the hour hand offset matches 0.5\u00b0 per minute.\n- Return 12, not 0, when appropriate (e.g., just after 12:00).\n\nOutput format\n- Provide only: hour as an integer in [1,12], with no additional text.\n\nCommon error prevention (from prior mistakes)\n- Do not confuse the minute hand for the hour hand; verify by length and reach to the outer tick marks.\n- Do not infer times like \u201c10:10\u201d by default; always read from the actual hand angles.\n- Ensure the hour chosen matches the \u201clast passed\u201d number given the minute hand\u2019s position (e.g., at ~:16, the hour hand must be just past the hour, not near 1 when the minute hand is at 3)."
+    )
+    assert (
+        o.minute_predictor.signature.instructions
+        == "Task: From the image field clock_photo (an analog clock), output the minute value as an integer from 0\u201359 in the field minute. Output only the minute number\u2014no text or other fields.\n\nWhat to analyze\n- Clock face orientation: Identify where \u201c12\u201d is on the dial. Use the numerals (Arabic or Roman, stylized fonts) or the positions of 3, 6, 9, 12 to set the reference. If the photo is tilted, measure angles relative to the clock face, not the image frame.\n- Hands identification (do not confuse them):\n  - Minute hand: typically the longest solid hand reaching near the minute ticks/outer ring; thicker than the second hand; often has a pronounced pointer tip.\n  - Hour hand: shorter and thicker, typically ends near the numerals.\n  - Second hand (if present): the thinnest, often the longest, usually with a counterweight; ignore it for minute reading.\n  - If two non-second hands look similar, the one whose tip reaches closer to the minute tick ring is the minute hand.\n- Ticks and numerals: Each numeral-to-numeral segment equals 5 minutes. If minute tick marks exist, use them. If not, divide each numeral interval evenly into five.\n\nHow to compute the minute\n1. Locate the clock center and the minute hand\u2019s tip.\n2. Determine the angle of the minute hand from the 12 o\u2019clock direction, increasing clockwise.\n3. Convert angle to minutes: minute_estimate = (angle_from_12 / 6). Round to the nearest whole minute.\n   - Mapping: 12 \u2192 0, 1 \u2192 5, 2 \u2192 10, 3 \u2192 15, 4 \u2192 20, 5 \u2192 25, 6 \u2192 30, 7 \u2192 35, 8 \u2192 40, 9 \u2192 45, 10 \u2192 50, 11 \u2192 55.\n   - If the tip is slightly past a numeral (e.g., just past 3), do not snap to the numeral; round to the nearest minute (e.g., 16 instead of 15).\n4. Consistency check with the hour hand (useful to avoid off-by-one and hand mix-ups):\n   - The hour hand moves continuously: it advances 0.5 degrees per minute (i.e., 1/12 of the way to the next numeral every 5 minutes).\n   - If your minute_estimate is an exact multiple of 5 but the hour hand is clearly between hour markers (not aligned with an hour), re-examine: the minute hand is likely slightly past the numeral; adjust to the nearest minute accordingly.\n   - If the minute hand choice is ambiguous, infer the minute from the hour hand\u2019s fraction toward the next hour: minute \u2248 fraction_between_hour_markers \u00d7 60, then choose the hand assignment that matches this.\n5. Edge cases:\n   - Overlapping hands: Look at which tip extends farther toward the tick ring to identify the minute hand.\n   - Strong perspective or glare: Use the line from center to the visible tip; ignore reflections.\n   - No minute ticks: Evenly interpolate between numerals.\n   - Subdials or decorative elements (e.g., pendulum windows) are not the minute indicator; use the main dial only.\n\nOutput format\n- Return only the integer minute value (0\u201359) in the minute field.\n- If the angle computes to 60, output 0.\n\nError prevention reminders\n- Do not treat the hour hand as the minute hand.\n- Do not use the second hand to compute minutes.\n- Do not assume the minute hand is exactly on a numeral\u2014check for slight offsets and round to the nearest minute.\n- Ensure the final minute agrees with the hour hand\u2019s position trend (hour hand slightly past an hour implies minutes > 0)."
+    )
 
 
 def test_metric_requires_feedback_signature():
@@ -485,11 +498,9 @@ def test_alternating_half_component_selector():
                 selected = components[mid_point:]
 
         # Track selections for verification
-        selection_history.append({
-            "iteration": state.i,
-            "selected": selected.copy(),
-            "all_components": components.copy()
-        })
+        selection_history.append(
+            {"iteration": state.i, "selected": selected.copy(), "all_components": components.copy()}
+        )
 
         return selected
 
@@ -515,9 +526,17 @@ def test_alternating_half_component_selector():
     for i, selection in enumerate(selection_history):
         if selection["iteration"] % 2 == 0:
             # Even iteration should select first half: ["classifier"]
-            assert "classifier" in selection["selected"], f"Even iteration {selection['iteration']} should include classifier"
-            assert "generator" not in selection["selected"], f"Even iteration {selection['iteration']} should not include generator"
+            assert "classifier" in selection["selected"], (
+                f"Even iteration {selection['iteration']} should include classifier"
+            )
+            assert "generator" not in selection["selected"], (
+                f"Even iteration {selection['iteration']} should not include generator"
+            )
         else:
             # Odd iteration should select second half: ["generator"]
-            assert "generator" in selection["selected"], f"Odd iteration {selection['iteration']} should include generator"
-            assert "classifier" not in selection["selected"], f"Odd iteration {selection['iteration']} should not include classifier"
+            assert "generator" in selection["selected"], (
+                f"Odd iteration {selection['iteration']} should include generator"
+            )
+            assert "classifier" not in selection["selected"], (
+                f"Odd iteration {selection['iteration']} should not include classifier"
+            )

--- a/tests/teleprompt/test_gepa_constraint.py
+++ b/tests/teleprompt/test_gepa_constraint.py
@@ -1,0 +1,418 @@
+"""
+tests/teleprompt/test_gepa_constraint.py
+
+测试目标：验证 GEPA 的 constraint 参数能正确地：
+  1. [单元] _build_constraint_prompt_template 将约束注入到 prompt_template
+  2. [集成-mock] propose_new_texts 调用 reflection_lm 时，实际发送的 prompt 包含约束文本
+  3. [集成-真实LLM] 完整跑一轮 GEPA，reflection_lm 生成的新 prompt 中能体现约束要求
+
+运行方式（需提前配置好相应的 conda 环境或 pip 环境）：
+  # 仅跑单元 + mock 测试（无需联网）
+  pytest tests/teleprompt/test_gepa_constraint.py -v -k "not real_lm"
+
+  # 跑全部（包含真实 LLM 调用，需配置好 API key）
+  pytest tests/teleprompt/test_gepa_constraint.py -v
+"""
+
+import os
+import sys
+
+# 确保使用本地 dspy 源码
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+import pytest
+
+import dspy
+from dspy import Example
+from dspy.predict import Predict
+from dspy.utils.dummies import DummyLM
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 公共 fixture / helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class SimpleQAModule(dspy.Module):
+    """用于测试的最小 DSPy 模块：question -> answer"""
+
+    def __init__(self):
+        super().__init__()
+        self.predictor = Predict("question -> answer")
+
+    def forward(self, question):
+        return self.predictor(question=question)
+
+
+def simple_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
+    """永远返回 0 分 + 固定 feedback，使 GEPA 一直有错误样本可反思"""
+    return dspy.Prediction(score=0, feedback="The answer was wrong. Please try harder.")
+
+
+def _make_adapter(constraint):
+    """构造一个带指定 constraint 的 DspyAdapter，reflection_lm 使用 DummyLM"""
+    from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+
+    student = SimpleQAModule()
+    dummy_reflection_lm = DummyLM([{"answer": "dummy"}])
+
+    adapter = DspyAdapter(
+        student_module=student,
+        metric_fn=simple_metric,
+        feedback_map={},
+        reflection_lm=dummy_reflection_lm,
+        constraint=constraint,
+    )
+    return adapter
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 1 组：单元测试 _build_constraint_prompt_template
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildConstraintPromptTemplate:
+    """直接测试 DspyAdapter._build_constraint_prompt_template 的输出"""
+
+    def test_none_constraint_returns_none(self):
+        """未设置 constraint 时返回 None，不影响默认行为"""
+        adapter = _make_adapter(constraint=None)
+        assert adapter._build_constraint_prompt_template() is None
+
+    def test_single_string_constraint_is_injected(self):
+        """单条字符串约束被注入到模板中"""
+        constraint = "输出的 prompt 必须只包含 JSON 格式"
+        adapter = _make_adapter(constraint=constraint)
+        template = adapter._build_constraint_prompt_template()
+
+        assert template is not None
+        assert constraint in template, "约束文本未出现在模板中"
+
+    def test_list_constraint_all_items_injected(self):
+        """列表形式的多条约束，每条都必须出现在模板中"""
+        constraints = [
+            "不得删除任何意图类别",
+            "必须保留中文描述",
+            "输出必须是合法 JSON",
+        ]
+        adapter = _make_adapter(constraint=constraints)
+        template = adapter._build_constraint_prompt_template()
+
+        assert template is not None
+        for i, c in enumerate(constraints, start=1):
+            assert c in template, f"第 {i} 条约束未出现在模板中：{c}"
+
+    def test_list_constraint_numbered_correctly(self):
+        """列表约束按 1/2/3 编号出现"""
+        constraints = ["约束A", "约束B", "约束C"]
+        adapter = _make_adapter(constraint=constraints)
+        template = adapter._build_constraint_prompt_template()
+
+        assert "1. 约束A" in template
+        assert "2. 约束B" in template
+        assert "3. 约束C" in template
+
+    def test_constraint_injected_before_final_anchor(self):
+        """约束块插在 'Provide the new instructions within ``` blocks.' 之前"""
+
+        anchor = "Provide the new instructions within ``` blocks."
+        constraint = "必须遵守此约束"
+        adapter = _make_adapter(constraint=constraint)
+        template = adapter._build_constraint_prompt_template()
+
+        assert template is not None
+        anchor_pos = template.find(anchor)
+        constraint_pos = template.find(constraint)
+
+        assert anchor_pos != -1, "锚点文本不存在于模板中"
+        assert constraint_pos != -1, "约束文本不存在于模板中"
+        assert constraint_pos < anchor_pos, "约束块应在锚点之前出现"
+
+    def test_template_still_contains_original_placeholders(self):
+        """注入约束后，原始模板的两个占位符依然保留"""
+        adapter = _make_adapter(constraint="某约束")
+        template = adapter._build_constraint_prompt_template()
+
+        assert "<curr_instructions>" in template, "原始占位符 <curr_instructions> 丢失"
+        assert "<inputs_outputs_feedback>" in template, "原始占位符 <inputs_outputs_feedback> 丢失"
+
+    def test_no_constraint_adapter_uses_default_template(self):
+        """无约束时 propose_new_texts 使用 InstructionProposalSignature 默认模板（不传 prompt_template）"""
+
+        adapter = _make_adapter(constraint=None)
+        # None 表示不会向 InstructionProposalSignature.run 传 prompt_template 参数
+        assert adapter._build_constraint_prompt_template() is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 2 组：集成测试（mock reflection_lm）—— 验证 propose_new_texts 发送的 prompt
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class CapturingLM:
+    """
+    一个伪造的 LM 对象：
+      - 记录所有被调用时收到的 prompt 字符串（捕获）
+      - 返回固定的 mock 新指令
+    """
+
+    def __init__(self, return_instruction="Improved instruction from mock LM."):
+        self.captured_prompts: list[str] = []
+        self._return_instruction = return_instruction
+
+    def __call__(self, prompt_or_messages, **kwargs):
+        # InstructionProposalSignature.run 通过 stripped_lm_call 调用，
+        # stripped_lm_call 将收到的字符串直接传给 self.reflection_lm(x)
+        self.captured_prompts.append(str(prompt_or_messages))
+        # 返回格式：stripped_lm_call 期望 list[str] 或 list[dict]
+        return [f"```\n{self._return_instruction}\n```"]
+
+    @property
+    def last_prompt(self) -> str | None:
+        return self.captured_prompts[-1] if self.captured_prompts else None
+
+
+class TestProposeNewTextsWithConstraint:
+    """
+    通过替换 reflection_lm 为 CapturingLM，
+    直接断言 propose_new_texts 发出的 prompt 包含约束文本。
+    """
+
+    def _run_propose(self, constraint):
+        """
+        构造 DspyAdapter，调用 propose_new_texts，
+        返回 (capturing_lm, results)。
+        """
+        from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+
+        student = SimpleQAModule()
+        capturing_lm = CapturingLM()
+
+        adapter = DspyAdapter(
+            student_module=student,
+            metric_fn=simple_metric,
+            feedback_map={},
+            reflection_lm=capturing_lm,
+            constraint=constraint,
+        )
+
+        candidate = {"predictor": "Answer the question directly."}
+        reflective_dataset = {
+            "predictor": [
+                {
+                    "Inputs": {"question": "What is 2+2?"},
+                    "Generated Outputs": {"answer": "5"},
+                    "Feedback": "The answer was wrong. The correct answer is 4.",
+                }
+            ]
+        }
+
+        with dspy.context(lm=DummyLM([{"answer": "dummy"}])):
+            results = adapter.propose_new_texts(
+                candidate=candidate,
+                reflective_dataset=reflective_dataset,
+                components_to_update=["predictor"],
+            )
+
+        return capturing_lm, results
+
+    def test_without_constraint_prompt_has_no_constraint_marker(self):
+        """不设置 constraint 时，发出的 prompt 不含约束标记"""
+        capturing_lm, _ = self._run_propose(constraint=None)
+        assert capturing_lm.last_prompt is not None, "reflection_lm 未被调用"
+        assert "IMPORTANT CONSTRAINTS" not in capturing_lm.last_prompt
+        assert "重要约束" not in capturing_lm.last_prompt
+
+    def test_single_string_constraint_in_sent_prompt(self):
+        """单条字符串约束出现在发给 reflection_lm 的 prompt 中"""
+        constraint = "输出必须是合法 JSON 格式"
+        capturing_lm, _ = self._run_propose(constraint=constraint)
+
+        assert capturing_lm.last_prompt is not None, "reflection_lm 未被调用"
+        assert constraint in capturing_lm.last_prompt, (
+            f"约束文本未出现在发送给 reflection_lm 的 prompt 中。\n"
+            f"约束：{constraint}\n"
+            f"实际 prompt 前 500 字符：{capturing_lm.last_prompt[:500]}"
+        )
+
+    def test_list_constraints_all_in_sent_prompt(self):
+        """列表形式的多条约束都出现在发给 reflection_lm 的 prompt 中"""
+        constraints = ["不得删除任何类别", "必须保留中文说明", "不能超过500字"]
+        capturing_lm, _ = self._run_propose(constraint=constraints)
+
+        assert capturing_lm.last_prompt is not None, "reflection_lm 未被调用"
+        for c in constraints:
+            assert c in capturing_lm.last_prompt, f"约束 '{c}' 未出现在发送给 reflection_lm 的 prompt 中"
+
+    def test_constraint_before_anchor_in_sent_prompt(self):
+        """约束块在锚点之前出现（在实际发送的 prompt 中验证顺序）"""
+        anchor = "Provide the new instructions within ``` blocks."
+        constraint = "必须遵守此重要约束"
+        capturing_lm, _ = self._run_propose(constraint=constraint)
+
+        prompt = capturing_lm.last_prompt
+        assert prompt is not None
+
+        constraint_pos = prompt.find(constraint)
+        anchor_pos = prompt.find(anchor)
+
+        assert constraint_pos != -1, "约束文本不在发送的 prompt 中"
+        assert anchor_pos != -1, "锚点文本不在发送的 prompt 中"
+        assert constraint_pos < anchor_pos, "约束块应在锚点之前"
+
+    def test_propose_returns_string_instruction(self):
+        """propose_new_texts 返回的新指令是字符串（而非 None 或异常）"""
+        constraint = "约束：必须返回有效指令"
+        _, results = self._run_propose(constraint=constraint)
+
+        assert "predictor" in results
+        assert isinstance(results["predictor"], str)
+        assert len(results["predictor"]) > 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 3 组：端到端测试（真实 LLM 调用）
+# ─────────────────────────────────────────────────────────────────────────────
+
+# 真实 LM 配置（与 notebook 保持一致）
+_REAL_LM_CONFIG = dict(
+    model="openai/Doubao-pro-128k",
+    api_base="https://aigc.sankuai.com/v1/openai/native",
+    api_key="2015679947834241043",
+    temperature=0,
+)
+_REAL_REFLECTION_LM_CONFIG = dict(
+    model="openai/Doubao-pro-128k",
+    api_base="https://aigc.sankuai.com/v1/openai/native",
+    api_key="2015679947834241043",
+    temperature=1.0,
+    max_tokens=4096,
+)
+
+
+@pytest.mark.real_lm
+class TestConstraintWithRealLLM:
+    """
+    使用真实 LLM 的端到端测试。
+
+    跳过方式：pytest -k "not real_lm"
+    运行方式：pytest tests/teleprompt/test_gepa_constraint.py -v -m real_lm
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_lm(self):
+        """初始化真实 LM 并配置到 dspy"""
+        try:
+            lm = dspy.LM(**_REAL_LM_CONFIG)
+            dspy.configure(lm=lm)
+        except Exception as e:
+            pytest.skip(f"无法初始化真实 LM，跳过测试：{e}")
+
+    def _make_real_reflection_lm(self):
+        try:
+            return dspy.LM(**_REAL_REFLECTION_LM_CONFIG)
+        except Exception as e:
+            pytest.skip(f"无法初始化 reflection_lm，跳过测试：{e}")
+
+    def test_constraint_appears_in_reflection_lm_prompt_with_real_lm(self):
+        """
+        验证：真实 LM 调用时，constraint 文本确实出现在发给 reflection_lm 的 prompt 里。
+
+        策略：用 CapturingLM 替换 reflection_lm，主力 LM 使用真实模型。
+        这样只消耗一次主力 LM 推理，就能验证 prompt 注入是否生效。
+        """
+        import sys
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+        from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+
+        constraint = "【测试约束-请勿删除】输出的 prompt 必须要求模型以 JSON 格式回复"
+
+        student = SimpleQAModule()
+        capturing_lm = CapturingLM(return_instruction="Improved instruction that follows the constraint.")
+
+        adapter = DspyAdapter(
+            student_module=student,
+            metric_fn=simple_metric,
+            feedback_map={},
+            reflection_lm=capturing_lm,
+            constraint=constraint,
+        )
+
+        candidate = {"predictor": "请回答用户的问题。"}
+        reflective_dataset = {
+            "predictor": [
+                {
+                    "Inputs": {"question": "今天天气怎么样？"},
+                    "Generated Outputs": {"answer": "不知道"},
+                    "Feedback": "回答太模糊，应该给出具体信息。",
+                }
+            ]
+        }
+
+        results = adapter.propose_new_texts(
+            candidate=candidate,
+            reflective_dataset=reflective_dataset,
+            components_to_update=["predictor"],
+        )
+
+        assert capturing_lm.last_prompt is not None, "reflection_lm 未被调用"
+        assert constraint in capturing_lm.last_prompt, (
+            f"约束文本未出现在发给 reflection_lm 的 prompt 中。\n"
+            f"约束：{constraint}\n"
+            f"prompt 前 800 字符：\n{capturing_lm.last_prompt[:800]}"
+        )
+        assert isinstance(results.get("predictor"), str)
+        print("\n✅ reflection_lm 收到的 prompt 包含约束文本")
+        print(f"   约束：{constraint}")
+
+    def test_gepa_full_run_with_constraint_real_lm(self):
+        """
+        完整跑一轮 GEPA（max_metric_calls=15），验证：
+          1. 优化正常完成，返回 optimized_program
+          2. 最终生成的新 prompt（instructions）中能体现约束关键词
+
+        注意：该测试会消耗真实 API token，约需 1-3 分钟。
+        """
+        reflection_lm = self._make_real_reflection_lm()
+
+        # 约束：要求生成的 prompt 必须包含 JSON 输出要求
+        constraint = "生成的指令必须明确要求模型以 JSON 格式输出结果，字段名为 answer"
+
+        trainset = [
+            Example(question="What is 2+2?", answer="4").with_inputs("question"),
+            Example(question="What color is the sky?", answer="blue").with_inputs("question"),
+            Example(question="How many days in a week?", answer="7").with_inputs("question"),
+        ]
+
+        student = SimpleQAModule()
+        original_instruction = student.predictor.signature.instructions
+
+        optimizer = dspy.GEPA(
+            metric=simple_metric,
+            auto="light",
+            reflection_lm=reflection_lm,
+            reflection_minibatch_size=3,
+            num_threads=1,
+            constraint=constraint,
+            track_stats=True,
+        )
+
+        print("\n🚀 开始 GEPA 优化（含 constraint）...")
+        optimized_program = optimizer.compile(student, trainset=trainset, valset=trainset)
+
+        new_instruction = optimized_program.predictor.signature.instructions
+        print(f"\n📝 原始 prompt：\n{original_instruction}")
+        print(f"\n📝 优化后 prompt：\n{new_instruction}")
+
+        # 断言 1：程序确实被更新了（instruction 有改动）
+        assert new_instruction != original_instruction, "优化后的 instruction 与原始相同，GEPA 可能未生效"
+
+        # 断言 2：新 prompt 中包含约束的核心关键词（JSON / answer）
+        # 因为 reflection_lm 被要求在生成 prompt 时遵守约束，所以生成的 prompt 应体现 JSON 要求
+        new_instruction_lower = new_instruction.lower()
+        assert "json" in new_instruction_lower or "answer" in new_instruction_lower, (
+            f"新 prompt 中未体现约束关键词 'json' 或 'answer'。\n新 prompt：{new_instruction}"
+        )
+
+        print("\n✅ GEPA 优化完成，新 prompt 体现了约束要求")

--- a/tests/teleprompt/test_gepa_fixed_trainset.py
+++ b/tests/teleprompt/test_gepa_fixed_trainset.py
@@ -1,0 +1,96 @@
+from unittest import mock
+
+import pytest
+
+import dspy
+from dspy.teleprompt.gepa.gepa import GEPA
+
+
+class SimpleModule(dspy.Module):
+    def __init__(self, signature):
+        super().__init__()
+        self.predictor = dspy.Predict(signature)
+
+    def forward(self, **kwargs):
+        return self.predictor(**kwargs)
+
+
+class DummyLM(dspy.clients.lm.LM):
+    def __init__(self, history):
+        super().__init__("dummy")
+        self.history = history
+        self.provider = "dummy"
+
+    def __call__(self, prompt=None, messages=None, **kwargs):
+        return ["dummy output"]
+
+
+def simple_metric(gold, pred, trace=None, pred_name=None, pred_trace=None):
+    return True
+
+
+def test_gepa_fixed_trainset_too_large():
+    fixed = [dspy.Example(input="f1").with_inputs("input"), dspy.Example(input="f2").with_inputs("input")]
+
+    optimizer = GEPA(
+        metric=simple_metric,
+        fixed_trainset=fixed,
+        reflection_minibatch_size=1,
+        max_metric_calls=10,
+        reflection_lm=DummyLM([]),
+    )
+    student = SimpleModule("input -> output")
+    trainset = [dspy.Example(input="t1").with_inputs("input")]
+
+    with pytest.raises(ValueError, match="cannot exceed reflection_minibatch_size"):
+        optimizer.compile(student, trainset=trainset)
+
+
+@mock.patch("gepa.optimize")
+def test_gepa_fixed_trainset_sampler(mock_optimize):
+    mock_gepa_result = mock.MagicMock()
+    mock_gepa_result.best_candidate = {}
+    mock_optimize.return_value = mock_gepa_result
+
+    fixed = [dspy.Example(input="f1").with_inputs("input"), dspy.Example(input="f2").with_inputs("input")]
+    trainset = [dspy.Example(input=f"t{i}").with_inputs("input") for i in range(10)]
+
+    optimizer = GEPA(
+        metric=simple_metric,
+        fixed_trainset=fixed,
+        reflection_minibatch_size=5,
+        max_metric_calls=10,
+        reflection_lm=DummyLM([]),
+    )
+    student = SimpleModule("input -> output")
+
+    dspy.settings.configure(lm=DummyLM([]))
+
+    optimizer.compile(student, trainset=trainset)
+
+    mock_optimize.assert_called_once()
+    kwargs = mock_optimize.call_args[1]
+
+    assert "batch_sampler" in kwargs
+    sampler = kwargs["batch_sampler"]
+    assert sampler.num_fixed == 2
+    assert sampler.minibatch_size == 5
+    assert sampler.total_len == 12
+
+    state = mock.MagicMock()
+    state.total_metric_calls = 0
+    state.i = 0
+
+    # next_minibatch_ids twice
+    batch1 = sampler.next_minibatch_ids(None, state)
+    assert len(batch1) == 5
+    assert batch1[0] == 0
+    assert batch1[1] == 1
+    assert 0 not in batch1[2:]
+    assert 1 not in batch1[2:]
+
+    state.i = 1
+    batch2 = sampler.next_minibatch_ids(None, state)
+    assert len(batch2) == 5
+    assert batch2[0] == 0
+    assert batch2[1] == 1

--- a/tests/teleprompt/test_gepa_verbose.py
+++ b/tests/teleprompt/test_gepa_verbose.py
@@ -1,0 +1,366 @@
+"""
+tests/teleprompt/test_gepa_verbose.py
+
+测试目标：验证 GEPA verbose=True 参数能正确向 stdout 输出：
+  1. 反思的 Prompt（发给 reflection_lm 的完整 prompt）
+  2. 反思的结果（reflection_lm 的原始返回）
+  3. 优化后的新指令
+
+测试策略：
+  - 用 capsys 捕获 stdout（pytest 内置 fixture，无需联网）
+  - 用 CapturingLM 作为 reflection_lm，固定返回内容，验证输出内容可预期
+  - 验证 verbose=False（默认）时不打印任何内容（不影响原有行为）
+
+运行方式：
+  pytest tests/teleprompt/test_gepa_verbose.py -v
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+import dspy
+from dspy.predict import Predict
+from dspy.utils.dummies import DummyLM
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 公共工具
+# ─────────────────────────────────────────────────────────────────────────────
+
+MOCK_NEW_INSTRUCTION = "This is the improved instruction returned by reflection LM."
+
+
+class CapturingLM:
+    """
+    伪造的 reflection_lm：
+    - 返回固定的 MOCK_NEW_INSTRUCTION（wrapped 在 ``` 代码块里，符合解析规范）
+    - 同时记录收到的 prompt 用于额外断言
+    """
+
+    def __init__(self):
+        self.received_prompts: list[str] = []
+
+    def __call__(self, prompt, **kwargs):
+        self.received_prompts.append(str(prompt))
+        return [f"```\n{MOCK_NEW_INSTRUCTION}\n```"]
+
+
+class SimpleQAModule(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.predictor = Predict("question -> answer")
+
+    def forward(self, question):
+        return self.predictor(question=question)
+
+
+def always_wrong_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
+    """永远返回 0 分，确保 GEPA 触发反思流程"""
+    return dspy.Prediction(score=0, feedback="Wrong. Please improve the instruction.")
+
+
+def _run_propose(verbose: bool, capsys):
+    """
+    直接调用 DspyAdapter.propose_new_texts，
+    返回 (capturing_lm, results, stdout_text)
+    """
+    from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+
+    student = SimpleQAModule()
+    capturing_lm = CapturingLM()
+
+    adapter = DspyAdapter(
+        student_module=student,
+        metric_fn=always_wrong_metric,
+        feedback_map={},
+        reflection_lm=capturing_lm,
+        verbose=verbose,
+    )
+
+    candidate = {"predictor": "Answer the question."}
+    reflective_dataset = {
+        "predictor": [
+            {
+                "Inputs": {"question": "What is 2+2?"},
+                "Generated Outputs": {"answer": "5"},
+                "Feedback": "Wrong. The correct answer is 4.",
+            }
+        ]
+    }
+
+    with dspy.context(lm=DummyLM([{"answer": "dummy"}])):
+        results = adapter.propose_new_texts(
+            candidate=candidate,
+            reflective_dataset=reflective_dataset,
+            components_to_update=["predictor"],
+        )
+
+    captured = capsys.readouterr()
+    return capturing_lm, results, captured.out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 1 组：verbose=False（默认）时没有任何 stdout 输出
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVerboseFalse:
+    """verbose=False 时不打印任何内容，保持原有行为"""
+
+    def test_no_stdout_when_verbose_false(self, capsys):
+        """verbose=False 时 stdout 为空"""
+        _, _, stdout = _run_propose(verbose=False, capsys=capsys)
+        assert stdout == "", f"verbose=False 时不应有任何 stdout 输出，但实际输出：\n{stdout}"
+
+    def test_result_still_correct_when_verbose_false(self, capsys):
+        """verbose=False 时结果仍然正确返回"""
+        _, results, _ = _run_propose(verbose=False, capsys=capsys)
+        assert "predictor" in results
+        assert results["predictor"] == MOCK_NEW_INSTRUCTION
+
+    def test_reflection_counter_increments_when_verbose_false(self, capsys):
+        """verbose=False 时计数器仍正常递增"""
+        from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+
+        student = SimpleQAModule()
+        adapter = DspyAdapter(
+            student_module=student,
+            metric_fn=always_wrong_metric,
+            feedback_map={},
+            reflection_lm=CapturingLM(),
+            verbose=False,
+        )
+        assert adapter._reflection_call_count == 0
+
+        with dspy.context(lm=DummyLM([{"answer": "dummy"}])):
+            adapter.propose_new_texts(
+                candidate={"predictor": "instruction"},
+                reflective_dataset={
+                    "predictor": [
+                        {
+                            "Inputs": {"question": "q"},
+                            "Generated Outputs": {"answer": "a"},
+                            "Feedback": "feedback",
+                        }
+                    ]
+                },
+                components_to_update=["predictor"],
+            )
+
+        assert adapter._reflection_call_count == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 2 组：verbose=True 时 stdout 包含反思 Prompt
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVerboseTruePromptOutput:
+    """验证 verbose=True 时，反思 Prompt 被正确打印"""
+
+    def test_prompt_header_printed(self, capsys):
+        """stdout 包含反思 Prompt 的标题行"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "发给 reflection_lm 的 Prompt" in stdout, f"stdout 中未找到 Prompt 标题。\nstdout:\n{stdout}"
+
+    def test_prompt_separator_printed(self, capsys):
+        """stdout 包含用于分隔的 === 分隔线"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "=" * 70 in stdout, f"stdout 中未找到 === 分隔线。\nstdout:\n{stdout}"
+
+    def test_prompt_contains_current_instruction(self, capsys):
+        """stdout 中的 Prompt 包含当前 instruction 原文"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "Answer the question." in stdout, f"stdout 中未找到当前 instruction。\nstdout:\n{stdout}"
+
+    def test_prompt_contains_feedback(self, capsys):
+        """stdout 中的 Prompt 包含 feedback 内容"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "Wrong. The correct answer is 4." in stdout, f"stdout 中未找到 feedback 内容。\nstdout:\n{stdout}"
+
+    def test_prompt_contains_reflection_call_count(self, capsys):
+        """stdout 中包含反思次数计数（第 1 次）"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "第 1 次反思" in stdout, f"stdout 中未找到反思次数计数。\nstdout:\n{stdout}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 3 组：verbose=True 时 stdout 包含反思结果（reflection_lm 的返回）
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVerboseTrueResultOutput:
+    """验证 verbose=True 时，reflection_lm 的返回被正确打印"""
+
+    def test_result_header_printed(self, capsys):
+        """stdout 包含反思结果的标题行"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "reflection_lm 原始返回" in stdout, f"stdout 中未找到结果标题。\nstdout:\n{stdout}"
+
+    def test_result_separator_printed(self, capsys):
+        """stdout 包含 --- 分隔线"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "─" * 70 in stdout, f"stdout 中未找到 --- 分隔线。\nstdout:\n{stdout}"
+
+    def test_raw_lm_output_in_stdout(self, capsys):
+        """reflection_lm 返回的原始内容（含 ``` 代码块）出现在 stdout 中"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert MOCK_NEW_INSTRUCTION in stdout, (
+            f"stdout 中未找到 reflection_lm 返回的原始内容。\n期望包含：{MOCK_NEW_INSTRUCTION}\n实际 stdout：\n{stdout}"
+        )
+
+    def test_new_instruction_header_printed(self, capsys):
+        """stdout 包含优化后新指令的标题行"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "优化后新指令" in stdout, f"stdout 中未找到优化后新指令标题。\nstdout:\n{stdout}"
+
+    def test_new_instruction_content_in_stdout(self, capsys):
+        """解析后的新指令内容出现在 stdout 中"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert MOCK_NEW_INSTRUCTION in stdout, (
+            f"stdout 中未找到新指令内容。\n期望包含：{MOCK_NEW_INSTRUCTION}\n实际 stdout：\n{stdout}"
+        )
+
+    def test_component_name_in_stdout(self, capsys):
+        """stdout 中包含组件名称（predictor）"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        assert "predictor" in stdout, f"stdout 中未找到组件名称。\nstdout:\n{stdout}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 4 组：输出顺序验证
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVerboseOutputOrder:
+    """验证输出顺序正确：先 Prompt，后结果，最后新指令"""
+
+    def test_prompt_before_result(self, capsys):
+        """'发给 reflection_lm 的 Prompt' 出现在 'reflection_lm 原始返回' 之前"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        pos_prompt = stdout.find("发给 reflection_lm 的 Prompt")
+        pos_result = stdout.find("reflection_lm 原始返回")
+        assert pos_prompt != -1 and pos_result != -1
+        assert pos_prompt < pos_result, "Prompt 标题应该出现在结果标题之前"
+
+    def test_result_before_new_instruction(self, capsys):
+        """'reflection_lm 原始返回' 出现在 '优化后新指令' 之前"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        pos_result = stdout.find("reflection_lm 原始返回")
+        pos_new = stdout.find("优化后新指令")
+        assert pos_result != -1 and pos_new != -1
+        assert pos_result < pos_new, "结果标题应该出现在新指令标题之前"
+
+    def test_full_output_order(self, capsys):
+        """完整顺序：Prompt 标题 → Prompt 内容 → 结果标题 → 新指令标题"""
+        _, _, stdout = _run_propose(verbose=True, capsys=capsys)
+        markers = [
+            "发给 reflection_lm 的 Prompt",
+            "Answer the question.",  # Prompt 内容
+            "reflection_lm 原始返回",
+            MOCK_NEW_INSTRUCTION,  # 结果内容
+            "优化后新指令",
+        ]
+        positions = []
+        for m in markers:
+            pos = stdout.find(m)
+            assert pos != -1, f"stdout 中未找到：{m}"
+            positions.append(pos)
+
+        assert positions == sorted(positions), f"输出顺序不符合预期。各标记位置：{list(zip(markers, positions))}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 第 5 组：多次反思时计数器递增
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVerboseMultipleReflections:
+    """验证多次调用时，反思计数器正确递增，每次都有对应输出"""
+
+    def test_counter_increments_across_calls(self, capsys):
+        """两次调用 propose_new_texts，计数器从 1 递增到 2"""
+        from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+
+        student = SimpleQAModule()
+        capturing_lm = CapturingLM()
+
+        adapter = DspyAdapter(
+            student_module=student,
+            metric_fn=always_wrong_metric,
+            feedback_map={},
+            reflection_lm=capturing_lm,
+            verbose=True,
+        )
+
+        candidate = {"predictor": "Initial instruction."}
+        reflective_dataset = {
+            "predictor": [
+                {
+                    "Inputs": {"question": "q"},
+                    "Generated Outputs": {"answer": "wrong"},
+                    "Feedback": "feedback text",
+                }
+            ]
+        }
+
+        with dspy.context(lm=DummyLM([{"answer": "dummy"}])):
+            adapter.propose_new_texts(
+                candidate=candidate,
+                reflective_dataset=reflective_dataset,
+                components_to_update=["predictor"],
+            )
+            adapter.propose_new_texts(
+                candidate=candidate,
+                reflective_dataset=reflective_dataset,
+                components_to_update=["predictor"],
+            )
+
+        stdout = capsys.readouterr().out
+        assert "第 1 次反思" in stdout, "未找到第 1 次反思"
+        assert "第 2 次反思" in stdout, "未找到第 2 次反思"
+        assert adapter._reflection_call_count == 2
+
+    def test_both_prompts_appear_for_two_calls(self, capsys):
+        """两次调用，两个 Prompt 都出现在 stdout 中"""
+        from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+
+        student = SimpleQAModule()
+
+        adapter = DspyAdapter(
+            student_module=student,
+            metric_fn=always_wrong_metric,
+            feedback_map={},
+            reflection_lm=CapturingLM(),
+            verbose=True,
+        )
+
+        candidate = {"predictor": "instruction v1"}
+        reflective_dataset = {
+            "predictor": [
+                {
+                    "Inputs": {"question": "q"},
+                    "Generated Outputs": {"answer": "a"},
+                    "Feedback": "feedback",
+                }
+            ]
+        }
+
+        with dspy.context(lm=DummyLM([{"answer": "dummy"}])):
+            adapter.propose_new_texts(
+                candidate=candidate,
+                reflective_dataset=reflective_dataset,
+                components_to_update=["predictor"],
+            )
+            adapter.propose_new_texts(
+                candidate={"predictor": "instruction v2"},
+                reflective_dataset=reflective_dataset,
+                components_to_update=["predictor"],
+            )
+
+        stdout = capsys.readouterr().out
+        # 两次 Prompt 都应出现
+        assert stdout.count("发给 reflection_lm 的 Prompt") == 2
+        assert stdout.count("reflection_lm 原始返回") == 2
+        assert stdout.count("优化后新指令") == 2

--- a/tests/teleprompt/test_utils.py
+++ b/tests/teleprompt/test_utils.py
@@ -42,6 +42,7 @@ def test_eval_candidate_program_minibatch():
     assert called_kwargs["callback_metadata"] == {"metric_key": "eval_minibatch"}
     assert result == 0
 
+
 def test_eval_candidate_program_failure():
     trainset = [1, 2, 3, 4, 5]
     candidate_program = DummyModule()
@@ -89,9 +90,5 @@ def test_create_n_fewshot_demo_sets_passes_metric_threshold_for_unshuffled():
         # Every BootstrapFewShot call should include metric_threshold
         for call in calls:
             _, kwargs = call
-            assert "metric_threshold" in kwargs, (
-                f"metric_threshold missing from BootstrapFewShot call: {kwargs}"
-            )
-            assert kwargs["metric_threshold"] == 0.9, (
-                f"metric_threshold={kwargs['metric_threshold']}, expected 0.9"
-            )
+            assert "metric_threshold" in kwargs, f"metric_threshold missing from BootstrapFewShot call: {kwargs}"
+            assert kwargs["metric_threshold"] == 0.9, f"metric_threshold={kwargs['metric_threshold']}, expected 0.9"


### PR DESCRIPTION
### Description
This PR introduces three practical usability and stability enhancements to the `GEPA` optimizer, specifically aimed at addressing common pitfalls in industrial, real-world deployment (e.g., intent classification with sensitive edge cases).

**1. `fixed_trainset` (Surgical Anchor Batching)**
- **Motivation:** In production, there are often critical edge cases or historical errors that a model *must not regress* on. Standard randomized batching might skip these, leading to "forgetful" optimizations.
- **Change:** Implemented a new `AnchorBatchSampler`. When `fixed_trainset` is provided, these critical examples are persistently injected into every reflection minibatch, while the remaining slots are filled from the standard `trainset`. 

**2. `constraint` (Core Rule Preservation)**
- **Motivation:** During Reflection Mutation, LLMs occasionally over-optimize for a specific mini-batch at the expense of deleting the core backbone definitions or mandatory output formats (e.g., forcing JSON).
- **Change:** Added a `constraint` parameter (accepts `str` or `list[str]`). This dynamically injects a strict `IMPORTANT CONSTRAINTS` block right before the anchor text in the `InstructionProposalSignature`, preventing the LLM from deleting essential structural rules.

**3. `verbose` (Transparent Reflection Trajectory Logging)**
- **Motivation:** Debugging why GEPA produced a certain prompt is often a "black box" experience. 
- **Change:** Added a `verbose=True` toggle inside `DspyAdapter` that prints a detailed, step-by-step reflection trajectory: the exact prompt sent to `reflection_lm`, the raw LLM output, and the newly parsed instruction.

### Testing
Added comprehensive unit and integration tests under `tests/teleprompt/`:
- `test_gepa_constraint.py` (including deep mocked tests and `real_lm` end-to-end tests)
- `test_gepa_fixed_trainset.py`
- `test_gepa_verbose.py`
- *Note:* Also introduced a `real_lm` marker in `pyproject.toml` to protect CI environments from accidental API token consumption.

I have run `ruff check` and `ruff format`, and all tests pass successfully.