### PR TITLE
fix(JSONAdapter): Ensure JSON serialization handles diacritics correctly for Pydantic BaseModel as a field datatype

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -207,7 +207,7 @@ class JSONAdapter(ChatAdapter):
         else:
             d = fields_with_values.items()
             d = {k.name: v for k, v in d}
-            return json.dumps(serialize_for_json(d), indent=2)
+            return json.dumps(serialize_for_json(d), indent=2, ensure_ascii=False)
 
     def format_finetune_data(
         self, signature: type[Signature], demos: list[dict[str, Any]], inputs: dict[str, Any], outputs: dict[str, Any]


### PR DESCRIPTION
## Issue
When `pydantic.BaseModel` is used as a datatype for field in `dspy.Signature`, the diacritics in descriptions of model fields are escaped. This increases prompt token usage and decreases readability during debugging.

## Test code
```Python
import dspy
import os
from pydantic import BaseModel, Field
import warnings


# Ignore Pydantic UserWarnings specifically
warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")

# Set up LM
lm = dspy.LM(
    "gemini/gemini-2.5-flash",
    api_key=os.environ["GEMINI_API_KEY"],
    cache=False,
    temperature=1,
)
dspy.configure(lm=lm, adapter=dspy.JSONAdapter())


class A(BaseModel):
    x: str = Field(description="Příliš žluťoučký kůň úpěl ďábelské ódy")  # <- diacritics here is a problem


class Sig(dspy.Signature):
    """Příliš žluťoučký kůň úpěl ďábelské ódy"""

    q: str = dspy.InputField(desc="Příliš žluťoučký kůň úpěl ďábelské ódy")
    a: A = dspy.OutputField(desc="Příliš žluťoučký kůň úpěl ďábelské ódy")


p = dspy.Predict(Sig)
p(q="Příliš žluťoučký kůň úpěl ďábelské ódy")

print(lm.history[-1])
```

## Result before fix
```Python
{
    "prompt": None,
    "messages": [
        {
            "role": "system",
            "content": 'Your input fields are:\n1. `q` (str): Příliš žluťoučký kůň úpěl ďábelské ódy\nYour output fields are:\n1. `a` (A): Příliš žluťoučký kůň úpěl ďábelské ódy\nAll interactions will be structured in the following way, with the appropriate values filled in.\n\nInputs will have the following structure:\n\n[[ ## q ## ]]\n{q}\n\nOutputs will be a JSON object with the following fields.\n\n{\n  "a": "{a}        # note: the value you produce must adhere to the JSON schema: {\\"type\\": \\"object\\", \\"properties\\": {\\"x\\": {\\"type\\": \\"string\\", \\"description\\": \\"P\\u0159\\u00edli\\u0161 \\u017elu\\u0165ou\\u010dk\\u00fd k\\u016f\\u0148 \\u00fap\\u011bl \\u010f\\u00e1belsk\\u00e9 \\u00f3dy\\", \\"title\\": \\"X\\"}}, \\"required\\": [\\"x\\"], \\"title\\": \\"A\\"}"\n}\nIn adhering to this structure, your objective is: \n        Příliš žluťoučký kůň úpěl ďábelské ódy',
        },
        {
            "role": "user",
            "content": "[[ ## q ## ]]\nPříliš žluťoučký kůň úpěl ďábelské ódy\n\nRespond with a JSON object in the following order of fields: `a` (must be formatted as a valid Python A).",
        },
    ],
    "kwargs": {"response_format": {"type": "json_object"}},
    "response": ...,
    "outputs": ['{\n  "a": {\n    "x": "Příliš žluťoučký kůň úpěl ďábelské ódy"\n  }\n}'],
    "usage": {
        "completion_tokens": 398,
        "prompt_tokens": 372,
        "total_tokens": 770,
        "completion_tokens_details": CompletionTokensDetailsWrapper(
            accepted_prediction_tokens=None,
            audio_tokens=None,
            reasoning_tokens=359,
            rejected_prediction_tokens=None,
            text_tokens=39,
        ),
        "prompt_tokens_details": PromptTokensDetailsWrapper(
            audio_tokens=None, cached_tokens=None, text_tokens=372, image_tokens=None
        ),
    },
    "cost": None,
    "timestamp": "2026-03-23T10:02:55.738589",
    "uuid": "1fc68ff3-857a-4d34-87df-140aa6601989",
    "model": "gemini/gemini-2.5-flash",
    "response_model": "gemini-2.5-flash",
    "model_type": "chat",
}
```
The issue is in `messages`: `...must adhere to the JSON schema: {\\"type\\": \\"object\\", \\"properties\\": {\\"x\\": {\\"type\\": \\"string\\", \\"description\\": \\"P\\u0159\\u00edli\\u0161 \\u017elu\\u0165ou\\u010dk\\u00fd k\\u016f\\u0148 \\u00fap\\u011bl \\u010f\\u00e1belsk\\u00e9 \\u00f3dy\\", \\"title\\": \\"X\\"}}, \\"required\\": [\\"x\\"], \\"title\\": \\"A\\"}"\n}\n...`.

Also note the prompt token usage `"prompt_tokens": 372`

## Result after fix
```Python
{
    "prompt": None,
    "messages": [
        {
            "role": "system",
            "content": 'Your input fields are:\n1. `q` (str): Příliš žluťoučký kůň úpěl ďábelské ódy\nYour output fields are:\n1. `a` (A): Příliš žluťoučký kůň úpěl ďábelské ódy\nAll interactions will be structured in the following way, with the appropriate values filled in.\n\nInputs will have the following structure:\n\n[[ ## q ## ]]\n{q}\n\nOutputs will be a JSON object with the following fields.\n\n{\n  "a": "{a}        # note: the value you produce must adhere to the JSON schema: {\\"type\\": \\"object\\", \\"properties\\": {\\"x\\": {\\"type\\": \\"string\\", \\"description\\": \\"Příliš žluťoučký kůň úpěl ďábelské ódy\\", \\"title\\": \\"X\\"}}, \\"required\\": [\\"x\\"], \\"title\\": \\"A\\"}"\n}\nIn adhering to this structure, your objective is: \n        Příliš žluťoučký kůň úpěl ďábelské ódy',
        },
        {
            "role": "user",
            "content": "[[ ## q ## ]]\nPříliš žluťoučký kůň úpěl ďábelské ódy\n\nRespond with a JSON object in the following order of fields: `a` (must be formatted as a valid Python A).",
        },
    ],
    "kwargs": {"response_format": {"type": "json_object"}},
    "response": ...,
    "outputs": ['{\n  "a": {\n    "x": "Příliš žluťoučký kůň úpěl ďábelské ódy"\n  }\n}'],
    "usage": {
        "completion_tokens": 478,
        "prompt_tokens": 297,
        "total_tokens": 775,
        "completion_tokens_details": CompletionTokensDetailsWrapper(
            accepted_prediction_tokens=None,
            audio_tokens=None,
            reasoning_tokens=439,
            rejected_prediction_tokens=None,
            text_tokens=39,
        ),
        "prompt_tokens_details": PromptTokensDetailsWrapper(
            audio_tokens=None, cached_tokens=None, text_tokens=297, image_tokens=None
        ),
    },
    "cost": None,
    "timestamp": "2026-03-23T10:06:46.660602",
    "uuid": "d7c25519-3f49-4b0f-9944-533bc82fdfac",
    "model": "gemini/gemini-2.5-flash",
    "response_model": "gemini-2.5-flash",
    "model_type": "chat",
}
```
It is no longer escaped and the prompt token usage is lower `"prompt_tokens": 297`.