### PR TITLE
[docs] Remove misleading confidence field from Classification example

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -199,7 +199,7 @@ DSPy shifts your focus from tinkering with prompt strings to **programming with 
         ```text
         Prediction(
             sentiment='positive',
-            toxicity=0.75
+            toxicity=0.15
         )
         ```
 


### PR DESCRIPTION
The `confidence: float` output field in the Classification example is not a calibrated probability — the LLM simply generates a plausible number. Remove it to avoid misleading newcomers into thinking DSPy produces reliable confidence scores out of the box.

The motivation is that we recently apply DSPy in building sentiment judges in production, and stakeholders want out of the box confidence scores generated from LLM. We need to explain to them that the confidence score obtained directly from LLM is no better than hallucitaion. 

Follow-up: I plan a separate PR to add a principled confidence measure based on consistency across repeated runs.