### PR TITLE
Restrict litellm version to <=1.82.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "tqdm>=4.66.1",
     "requests>=2.31.0",
     "pydantic>=2.0",
-    "litellm>=1.64.0,<1.82.7",
+    "litellm>=1.64.0,<=1.82.6",
     "diskcache>=5.6.0",
     "json-repair>=0.54.2",
     "tenacity>=8.2.3",


### PR DESCRIPTION
See https://github.com/BerriAI/litellm/issues/24512

litellm 1.82.7 and 1.82.8 contain a malicious .pth file that automatically executes a credential-stealing script when Python starts. This PR pins litellm<=1.82.6 (last known safe version)

LiteLLM is quarantined on PyPi currently, so builds will fail.

We should merge this, wait for it to be unquarantined, so we can update uv.lock, then cut a patch version.

Thankfully the versions in our uv.lock are 1.68.0 or 1.72.6.

Closes #9497