### PR TITLE
Add XMLAdapter to dspy.ai

### DIFF
--- a/docs/docs/api/adapters/XMLAdapter.md
+++ b/docs/docs/api/adapters/XMLAdapter.md
@@ -1,0 +1,31 @@
+# dspy.XMLAdapter
+
+<!-- START_API_REF -->
+::: dspy.XMLAdapter
+    handler: python
+    options:
+        members:
+            - __call__
+            - acall
+            - format
+            - format_assistant_message_content
+            - format_conversation_history
+            - format_demos
+            - format_field_description
+            - format_field_structure
+            - format_field_with_value
+            - format_finetune_data
+            - format_system_message
+            - format_task_description
+            - format_user_message_content
+            - parse
+            - user_message_output_requirements
+        show_source: true
+        show_root_heading: true
+        heading_level: 2
+        docstring_style: google
+        show_root_full_path: true
+        show_object_full_path: false
+        separate_signature: false
+        inherited_members: true
+<!-- END_API_REF -->

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
         - Adapters:
             - Adapter: api/adapters/Adapter.md
             - ChatAdapter: api/adapters/ChatAdapter.md
+            - XMLAdapter: api/adapters/XMLAdapter.md
             - JSONAdapter: api/adapters/JSONAdapter.md
             - TwoStepAdapter: api/adapters/TwoStepAdapter.md
         - Evaluation:


### PR DESCRIPTION
XMLAdapter were not listed to be on dspy.ai, this fixes that.

<img width="1381" height="1366" alt="image" src="https://github.com/user-attachments/assets/5dc3e73e-3883-49ea-85d2-0b21cb2da926" />
