### PR TITLE
ci: drop unused write permissions from ruff lint job

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,8 +12,7 @@ jobs:
     name: Check Ruff Fix
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
The **Check Ruff Fix** job in `run_tests.yml` only runs `ruff check --fix-only --diff` and never writes to the repo or posts PR comments.

**Changes:**
- `contents: write` → `contents: read`
- Removed `pull-requests: write` entirely

Follows least-privilege principle — no functional change to CI behavior.