### PR TITLE
fix(clients): pass num_retries and retry_strategy to streaming LLM calls

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -305,6 +305,7 @@ class LM(BaseLM):
 def _get_stream_completion_fn(
     request: dict[str, Any],
     cache_kwargs: dict[str, Any],
+    num_retries: int = 0,
     sync=True,
     headers: dict[str, Any] | None = None,
 ):
@@ -326,6 +327,8 @@ def _get_stream_completion_fn(
             cache=cache_kwargs,
             stream=True,
             headers=headers,
+            num_retries=num_retries,
+            retry_strategy="exponential_backoff_retry" if num_retries > 0 else None,
             **request,
         )
         chunks = []
@@ -355,7 +358,7 @@ def litellm_completion(request: dict[str, Any], num_retries: int, cache: dict[st
     request = dict(request)
     request.pop("rollout_id", None)
     headers = _add_dspy_identifier_to_headers(request.pop("headers", None))
-    stream_completion = _get_stream_completion_fn(request, cache, sync=True, headers=headers)
+    stream_completion = _get_stream_completion_fn(request, cache, num_retries=num_retries, sync=True, headers=headers)
     if stream_completion is None:
         return litellm.completion(
             cache=cache,
@@ -403,7 +406,7 @@ async def alitellm_completion(request: dict[str, Any], num_retries: int, cache: 
     request = dict(request)
     request.pop("rollout_id", None)
     headers = request.pop("headers", None)
-    stream_completion = _get_stream_completion_fn(request, cache, sync=False)
+    stream_completion = _get_stream_completion_fn(request, cache, num_retries=num_retries, sync=False, headers=_add_dspy_identifier_to_headers(headers))
     if stream_completion is None:
         return await litellm.acompletion(
             cache=cache,


### PR DESCRIPTION
## Summary

Fix streaming LLM calls to respect `num_retries` and `retry_strategy` parameters.

**Problem**: `dspy.streamify()` uses `_get_stream_completion_fn()` which calls `litellm.acompletion(stream=True)` **without** `num_retries` or `retry_strategy`. Rate limit errors (429) crash immediately instead of retrying with exponential backoff.

**Fix**:
1. Add `num_retries` parameter to `_get_stream_completion_fn()`
2. Forward `num_retries` and `retry_strategy="exponential_backoff_retry"` to `litellm.acompletion(stream=True)`
3. Update both `litellm_completion()` and `alitellm_completion()` to pass `num_retries`
4. Bonus fix: `alitellm_completion()` was also missing `headers` — now added

## Changes

- `dspy/clients/lm.py`:
  - `_get_stream_completion_fn`: added `num_retries=0` parameter
  - `stream_completion()` closure: pass `num_retries` and `retry_strategy` to `litellm.acompletion(stream=True)`
  - `litellm_completion`: pass `num_retries` to `_get_stream_completion_fn`
  - `alitellm_completion`: pass `num_retries` and `headers` to `_get_stream_completion_fn`

## Reproduction (from issue)

```python
import dspy
lm = dspy.LM("anthropic/claude-opus-4-6", num_retries=5)
dspy.configure(lm=lm)

# Without streamify — retries work ✅
result = module(question="What is 2+2?")

# With streamify — now retries work too ✅
streamed = dspy.streamify(module)
result = streamed(question="What is 2+2?")
```

## Security/Reliability

- [x] No new dependencies
- [x] Graceful degradation: `retry_strategy=None` when `num_retries=0` preserves existing behavior
- [x] Matches pattern used in non-streaming code path

---

*Contribution by abdelhadisalmaoui0909@outlook.fr*