### PR TITLE
fix: prevent spurious reasoning_content parsing when native reasoning is disabled

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -102,6 +102,7 @@ class Adapter:
                 return signature_for_native_function_calling
 
         # Handle custom types that use native LM features, e.g., reasoning, citations, etc.
+        deleted_field_names = set(signature.output_fields)
         for name, field in signature.output_fields.items():
             if (
                 isinstance(field.annotation, type)
@@ -110,7 +111,8 @@ class Adapter:
             ):
                 signature = field.annotation.adapt_to_native_lm_feature(signature, name, lm, lm_kwargs)
 
-        return signature
+        deleted_field_names -= set(signature.output_fields)
+        return signature, deleted_field_names
 
     def _call_postprocess(
         self,
@@ -119,6 +121,7 @@ class Adapter:
         outputs: list[dict[str, Any] | str],
         lm: "LM",
         lm_kwargs: dict[str, Any],
+        deleted_field_names: set[str] | None = None,
     ) -> list[dict[str, Any]]:
         values = []
 
@@ -162,8 +165,13 @@ class Adapter:
                 ]
                 value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
 
-            # Parse custom types that does not rely on the `Adapter.parse()` method
+            # Parse custom types that does not rely on the `Adapter.parse()` method.
+            # Only parse for fields that were actually deleted by adapt_to_native_lm_feature
+            # (i.e., fields handled by native LM features like vLLM reasoning_content).
+            # Fields not in deleted_field_names are handled by the adapter's parse() method.
             for name, field in original_signature.output_fields.items():
+                if deleted_field_names is not None and name not in deleted_field_names:
+                    continue
                 if (
                     isinstance(field.annotation, type)
                     and field.annotation in self.native_response_types
@@ -204,11 +212,13 @@ class Adapter:
             List of dictionaries representing parsed LM responses. Each dictionary contains keys matching the
             signature's output field names. For multiple generations (n > 1), returns multiple dictionaries.
         """
-        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+        processed_signature, deleted_field_names = self._call_preprocess(lm, lm_kwargs, signature, inputs)
         inputs = self.format(processed_signature, demos, inputs)
 
         outputs = lm(messages=inputs, **lm_kwargs)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        return self._call_postprocess(
+            processed_signature, signature, outputs, lm, lm_kwargs, deleted_field_names
+        )
 
     async def acall(
         self,
@@ -218,11 +228,13 @@ class Adapter:
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+        processed_signature, deleted_field_names = self._call_preprocess(lm, lm_kwargs, signature, inputs)
         inputs = self.format(processed_signature, demos, inputs)
 
         outputs = await lm.acall(messages=inputs, **lm_kwargs)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        return self._call_postprocess(
+            processed_signature, signature, outputs, lm, lm_kwargs, deleted_field_names
+        )
 
     def format(
         self,


### PR DESCRIPTION
## What
When `litellm.supports_reasoning()` returns False (e.g. vLLM models not in litellm's internal registry), `dspy.Reasoning.adapt_to_native_lm_feature()` returns early without deleting the reasoning field from the signature. The `_call_postprocess` method was then calling `parse_lm_response` for ALL native response type fields in the original signature — including reasoning — which caused it to spuriously populate `dspy.Reasoning` from any `reasoning_content` key in the LM response, even when the adapter's `parse()` method had already correctly handled the reasoning text.

## Root Cause
`adapt_to_native_lm_feature` is a no-op when the LM doesn't support reasoning, so the reasoning field stays in the signature. But `_call_postprocess` unconditionally called `parse_lm_response` for all native response type fields, creating a spurious second parsing path.

## Fix
Track which fields were actually deleted by `adapt_to_native_lm_feature` in `_call_preprocess`, and only call `parse_lm_response` for those deleted fields in `_call_postprocess\'. Fields not deleted are left to the adapter's `parse()` method (backward compatible).

## Testing
`tests/adapters/test_reasoning.py` and `tests/adapters/test_citation.py` all pass (13/13).

Fixes #9503.