### PR TITLE
ci: pin ollama Docker image to digest

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -122,7 +122,7 @@ jobs:
           docker run -d --name ollama \
             -p 11434:11434 \
             -v ${{ github.workspace }}/ollama-data:/root/.ollama \
-            ollama/ollama:latest
+            ollama/ollama@sha256:5a5d014aa774f78ebe1340c0d4afc2e35afc12a2c3b34c84e71f78ea20af4ba3 # latest as of 2026-03-25
           timeout 60 bash -c 'until curl -f http://localhost:11434/api/version; do sleep 2; done'
       - name: Pull LLM
         if: steps.cache-ollama.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What

Pin `ollama/ollama:latest` to its SHA256 digest to prevent mutable tag attacks on CI.

## Why

The `:latest` Docker tag is mutable — the image it points to can change at any time. If the upstream image were compromised (or a registry credential leaked), a poisoned image would be pulled silently by CI. Pinning to a digest ensures we always pull the exact image we verified.

This is part of broader CI hardening in response to the [litellm supply-chain compromise](https://snyk.io/articles/poisoned-security-scanner-backdooring-litellm/) where mutable upstream references were exploited.

## Verification

Digest `sha256:5a5d014aa774f78ebe1340c0d4afc2e35afc12a2c3b34c84e71f78ea20af4ba3` corresponds to `ollama/ollama:latest` as of 2026-03-25.

- **Docker Hub image page:** https://hub.docker.com/r/ollama/ollama/tags
- **Verify locally:**
  ```bash
  docker pull ollama/ollama:latest
  docker inspect --format='{{index .RepoDigests 0}}' ollama/ollama:latest
  ```
- **Image layer details:** https://hub.docker.com/layers/ollama/ollama/latest/images/sha256-5a5d014aa774f78ebe1340c0d4afc2e35afc12a2c3b34c84e71f78ea20af4ba3
