### PR TITLE
Fix PythonInterpreter failing with default setup due to symlinks in Deno cache path

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -193,7 +193,7 @@ class PythonInterpreter:
     @functools.lru_cache(maxsize=1)
     def _get_deno_dir() -> str | None:
         if "DENO_DIR" in os.environ:
-            return os.environ["DENO_DIR"]
+            return os.path.realpath(os.environ["DENO_DIR"])
 
         try:
             result = subprocess.run(
@@ -204,7 +204,9 @@ class PythonInterpreter:
             )
             if result.returncode == 0:
                 info = json.loads(result.stdout)
-                return info.get("denoDir")
+                deno_dir = info.get("denoDir")
+                if deno_dir:
+                    return os.path.realpath(deno_dir)
         except Exception:
             logger.warning("Unable to find the Deno cache dir.")
 


### PR DESCRIPTION
## Problem

PythonInterpreter fails with default setup due to symlinks in the Deno cache directory path.

When the Deno cache directory path (returned by `deno info --json` or the `DENO_DIR` environment variable) contains unresolved symbolic links, Deno's `--allow-read` permission fails silently because the symlink target paths are not directly readable. This manifests as Pyodide files not being accessible without explicit `enable_read_paths`.

## Root Cause

In `_get_deno_dir()`, the returned path is used directly in `--allow-read` without resolving symlinks. For example, if `$HOME/node_modules/pyodide` is a symlink to `$HOME/node_modules/.deno/pyodide@0.29.3/node_modules/pyodide`, the unresolved path causes Deno permission failures.

## Solution

Use `os.path.realpath()` to canonicalize the Deno cache directory path before returning it. This resolves all symlinks in the path, ensuring `--allow-read` gets paths that Deno can actually access.

```python
# Before
return os.environ["DENO_DIR"]
return info.get("denoDir")

# After
return os.path.realpath(os.environ["DENO_DIR"])
deno_dir = info.get("denoDir")
if deno_dir:
    return os.path.realpath(deno_dir)
```

The fix is minimal (4 lines changed) and targets the exact root cause identified in issue #9501.

Fixes #9501
