### PR TITLE
refactor: type-hint adapters with BaseLM instead of LM

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING, Any, get_origin
+from typing import Any, get_origin
 
 import json_repair
 
@@ -7,15 +7,13 @@ from dspy.adapters.types import History, Type
 from dspy.adapters.types.base_type import split_message_content_for_custom_types
 from dspy.adapters.types.reasoning import Reasoning
 from dspy.adapters.types.tool import Tool, ToolCalls
+from dspy.clients.base_lm import BaseLM
 from dspy.experimental import Citations
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback, with_callbacks
 from dspy.utils.exceptions import AdapterParseError
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from dspy.clients.lm import LM
 
 _DEFAULT_NATIVE_RESPONSE_TYPES = [Citations, Reasoning]
 
@@ -67,7 +65,7 @@ class Adapter:
 
     def _call_preprocess(
         self,
-        lm: "LM",
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         inputs: dict[str, Any],
@@ -114,7 +112,7 @@ class Adapter:
         processed_signature: type[Signature],
         original_signature: type[Signature],
         outputs: list[dict[str, Any] | str],
-        lm: "LM",
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         values = []
@@ -179,7 +177,7 @@ class Adapter:
 
     def __call__(
         self,
-        lm: "LM",
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         demos: list[dict[str, Any]],
@@ -209,7 +207,7 @@ class Adapter:
 
     async def acall(
         self,
-        lm: "LM",
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         demos: list[dict[str, Any]],

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -12,7 +12,7 @@ from dspy.adapters.utils import (
     parse_value,
     translate_field_type,
 )
-from dspy.clients.lm import LM
+from dspy.clients.base_lm import BaseLM
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import AdapterParseError, ContextWindowExceededError
@@ -62,7 +62,7 @@ class ChatAdapter(Adapter):
 
     def __call__(
         self,
-        lm: LM,
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         demos: list[dict[str, Any]],
@@ -86,7 +86,7 @@ class ChatAdapter(Adapter):
 
     async def acall(
         self,
-        lm: LM,
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         demos: list[dict[str, Any]],

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -16,7 +16,7 @@ from dspy.adapters.utils import (
     serialize_for_json,
     translate_field_type,
 )
-from dspy.clients.lm import LM
+from dspy.clients.base_lm import BaseLM
 from dspy.signatures.signature import Signature, SignatureMeta
 from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import AdapterParseError
@@ -57,7 +57,7 @@ class JSONAdapter(ChatAdapter):
 
     def __call__(
         self,
-        lm: LM,
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         demos: list[dict[str, Any]],
@@ -80,7 +80,7 @@ class JSONAdapter(ChatAdapter):
 
     async def acall(
         self,
-        lm: LM,
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         demos: list[dict[str, Any]],

--- a/dspy/adapters/two_step_adapter.py
+++ b/dspy/adapters/two_step_adapter.py
@@ -6,7 +6,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.types import ToolCalls
 from dspy.adapters.utils import get_field_description_string
-from dspy.clients import LM
+from dspy.clients.base_lm import BaseLM
 from dspy.signatures.field import InputField
 from dspy.signatures.signature import Signature, make_signature
 
@@ -39,10 +39,10 @@ class TwoStepAdapter(Adapter):
     ```
     """
 
-    def __init__(self, extraction_model: LM, **kwargs):
+    def __init__(self, extraction_model: BaseLM, **kwargs):
         super().__init__(**kwargs)
-        if not isinstance(extraction_model, LM):
-            raise ValueError("extraction_model must be an instance of LM")
+        if not isinstance(extraction_model, BaseLM):
+            raise ValueError("extraction_model must be an instance of dspy.BaseLM")
         self.extraction_model = extraction_model
 
     def format(
@@ -105,7 +105,7 @@ class TwoStepAdapter(Adapter):
 
     async def acall(
         self,
-        lm: "LM",
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
         signature: type[Signature],
         demos: list[dict[str, Any]],

--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING, Any, Optional, get_args, get_origin
 import json_repair
 import pydantic
 
+from dspy.clients.base_lm import BaseLM
+
 if TYPE_CHECKING:
     from litellm import ModelResponseStream
 
-    from dspy.clients.lm import LM
     from dspy.signatures.signature import Signature
 
 CUSTOM_TYPE_START_IDENTIFIER = "<<CUSTOM-TYPE-START-IDENTIFIER>>"
@@ -80,7 +81,7 @@ class Type(pydantic.BaseModel):
         cls,
         signature: type["Signature"],
         field_name: str,
-        lm: "LM",
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
     ) -> type["Signature"]:
         """Adapt the custom type to the native LM feature if possible.

--- a/dspy/adapters/types/reasoning.py
+++ b/dspy/adapters/types/reasoning.py
@@ -3,9 +3,9 @@ from typing import TYPE_CHECKING, Any, Optional
 import pydantic
 
 from dspy.adapters.types.base_type import Type
+from dspy.clients.base_lm import BaseLM
 
 if TYPE_CHECKING:
-    from dspy.clients.lm import LM
     from dspy.signatures.signature import Signature
 
 
@@ -47,7 +47,7 @@ class Reasoning(Type):
         cls,
         signature: type["Signature"],
         field_name: str,
-        lm: "LM",
+        lm: BaseLM,
         lm_kwargs: dict[str, Any],
     ) -> type["Signature"]:
         if "reasoning_effort" in lm_kwargs:

--- a/dspy/clients/utils_finetune.py
+++ b/dspy/clients/utils_finetune.py
@@ -1,12 +1,14 @@
 import os
 from enum import Enum
-from typing import Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 import orjson
 
 import dspy
-from dspy.adapters.base import Adapter
 from dspy.utils.caching import DSPY_CACHEDIR
+
+if TYPE_CHECKING:
+    from dspy.adapters.base import Adapter
 
 
 class TrainingStatus(str, Enum):
@@ -53,7 +55,7 @@ class GRPOStatus(TypedDict):
     pending_batch_ids: list[int] = []
 
 
-def infer_data_format(adapter: Adapter) -> str:
+def infer_data_format(adapter: "Adapter") -> str:
     if isinstance(adapter, dspy.ChatAdapter):
         return TrainDataFormat.CHAT
     raise ValueError(f"Could not infer the data format for: {adapter}")


### PR DESCRIPTION
**Related Epic:** Relates to #9514

This PR is made 'easier' by #9516 which abstract the capability checks properly into `BaseLM`.

**What this PR does**
Continues decoupling effort by changing types hints from `LM` to `BaseLM`:
* **Type Hints:** Updates method signatures (`_call_`, `acall`, `_call_preprocess`, etc.) for `BaseAdapter`, `ChatAdapter`, `JSONAdapter`, and custom `Type` handlers to expect `BaseLM` instead of `LM`.
* **Runtime Validation:** Fixes `TwoStepAdapter.__init__`, which was explicitly enforcing `isinstance(..., LM)`. It now correctly validates against `BaseLM` and raises an accurate `ValueError`. Now any custom backend can use `TwoStepAdapter`.
* **Clean Imports:** Removes legacy `TYPE_CHECKING` blocks that imported `LM` and fixes a potential circular import in `utils_finetune.py`. I felt base lm should have precedence of that util.

**Why this is needed**
Adapters handle the translation between DSPy signatures and model-specific formats. They do not require any of the `litellm`-specific logic found in `dspy.LM`; they only need the contract guaranteed by `BaseLM`. Previously, if a user passed a custom backend subclassing `BaseLM` to `TwoStepAdapter`, the hardcoded `isinstance` check would immediately crash. This PR fixes that bug and aligns static type checking across the entire adapter layer to fully support modular custom backends.
