### PR TITLE
fix(ci): correct setup-node SHA typo in docs-push workflow

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up Node.js
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e210 # v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: "18"
       - name: Install dependencies and build


### PR DESCRIPTION
## Summary
Fix a single-character typo in the `actions/setup-node` SHA pin in `docs-push.yml` introduced in #9509.

The hash ended in `e210` but the correct [`v3.9.1` release](https://github.com/actions/setup-node/releases/tag/v3.9.1) commit ends in `e610`: [`3235b876344d2a9aa001b8d1453c930bba69e610`](https://github.com/actions/setup-node/commit/3235b876344d2a9aa001b8d1453c930bba69e610).

Also updates the version comment from `# v3` to `# v3.9.1` to match the actual pinned release.

Ref: https://github.com/stanfordnlp/dspy/pull/9509#discussion_r2114858275