### PR TITLE
Add `Classifier` module with principled consistency-based confidence scoring

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       version: ${{ steps.extract_tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - id: extract_tag
         name: Extract tag name
         run: echo "tag=$(echo $GITHUB_REF | cut -d / -f 3)" >> "$GITHUB_OUTPUT"
@@ -24,19 +24,17 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.11"
       - name: Install dependencies
         run: python3 -m pip install --upgrade setuptools wheel twine build semver packaging
       - name: Install Deno
-        run: |
-          curl -fsSL https://deno.land/install.sh | sh
-          echo "${HOME}/.deno/bin" >> $GITHUB_PATH
-      - name: Verify Deno installation
-        run: deno --version
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: v2.7.7
       - name: Get correct version for TestPyPI release
         id: check_version
         run: |
@@ -64,7 +62,7 @@ jobs:
           deactivate
       # Publish to test-PyPI
       - name: Publish distribution 📦 to test-PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1 # This requires a trusted publisher to be setup in pypi/testpypi
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1 # This requires a trusted publisher to be setup in pypi/testpypi
         with:
           repository-url: https://test.pypi.org/legacy/
 
@@ -81,19 +79,17 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.11"
       - name: Install dependencies
         run: python3 -m pip install --upgrade setuptools wheel twine build
       - name: Install Deno
-        run: |
-          curl -fsSL https://deno.land/install.sh | sh
-          echo "${HOME}/.deno/bin" >> $GITHUB_PATH
-      - name: Verify Deno installation
-        run: deno --version
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: v2.7.7
       - name: Update version in pyproject.toml
         run: sed -i '/#replace_package_version_marker/{n;s/version *= *"[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
       - name: Update version in __metadata__.py
@@ -117,7 +113,7 @@ jobs:
           deactivate
           rm -r test_before_pypi
       - name: Publish distribution 📦 to PyPI (dspy)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           attestations: false
       # Publish to dspy-ai
@@ -131,11 +127,11 @@ jobs:
       - name: Build a binary wheel (dspy-ai)
         run: python3 -m build .github/.internal_dspyai/
       - name: Publish distribution 📦 to PyPI (dspy-ai)
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
         with:
           attestations: false
           packages-dir: .github/.internal_dspyai/dist/
-      - uses: stefanzweifel/git-auto-commit-action@v5 # auto commit changes to main
+      - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5 # auto commit changes to main
         with:
           commit_message: Update versions
           create_branch: true

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e210 # v3
         with:
           node-version: "18"
       - name: Install dependencies and build
@@ -31,11 +31,11 @@ jobs:
     if: github.event_name == 'push' && github.repository == 'stanfordnlp/dspy'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
       - name: Push docs to separate repo
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@55306faa4ed53b815ae49e564af8cfb359d32ae2 # main
         env:
           API_TOKEN_GITHUB: ${{ secrets.GH_PAT }}
         with:

--- a/.github/workflows/precommits_check.yml
+++ b/.github/workflows/precommits_check.yml
@@ -6,19 +6,19 @@ jobs:
   pre-commit-checks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
           cache: "pip"
       - name: Check Pull Request Title
-        uses: Slashgear/action-check-pr-title@main
+        uses: Slashgear/action-check-pr-title@76166c63ec0b25cdbe693e5e972e83ca186313fb # main
         with:
           regexp: '(break|build|ci|docs|feat|fix|perf|refactor|style|test|ops|hotfix|release|maint|init|enh|revert)\([a-z,A-Z,0-9,\-,\_,\/,:]+\)(:)\s{1}([\w\s]+)' # Regex the title should match.
       - name: Getting changed files list
         id: files
-        uses: jitterbit/get-changed-files@master
+        uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
       - name: Checking changed files
         shell: bash
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -12,15 +12,14 @@ jobs:
     name: Check Ruff Fix
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.11"
       - name: Install uv with caching
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -52,18 +51,18 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Deno
-        run: |
-          curl -fsSL https://deno.land/install.sh | sh
-          echo "${HOME}/.deno/bin" >> $GITHUB_PATH
+        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb # v2.0.3
+        with:
+          deno-version: v2.7.7
       - name: Verify Deno installation
         run: deno --version
       - name: Install uv with caching
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -78,7 +77,7 @@ jobs:
           uv sync --dev -p .venv --extra dev
           uv pip list
       - name: Run lint with tests
-        uses: chartboost/ruff-action@v1
+        uses: chartboost/ruff-action@e18ae971ccee1b2d7bbef113930f00c670b78da4 # v1
         with:
           args: check --fix-only
       - name: Run tests with pytest
@@ -92,12 +91,12 @@ jobs:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: 3.11
       - name: Install uv with caching
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           cache-dependency-glob: |
@@ -113,7 +112,7 @@ jobs:
           uv pip list
       - name: Cache Ollama models
         id: cache-ollama
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ollama-data
           key: ollama-llama3.2-3b-${{ runner.os }}-v1
@@ -146,12 +145,12 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv with caching
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
         with:
           enable-cache: true
           cache-dependency-glob: |

--- a/docs/docs/api/adapters/XMLAdapter.md
+++ b/docs/docs/api/adapters/XMLAdapter.md
@@ -1,0 +1,31 @@
+# dspy.XMLAdapter
+
+<!-- START_API_REF -->
+::: dspy.XMLAdapter
+    handler: python
+    options:
+        members:
+            - __call__
+            - acall
+            - format
+            - format_assistant_message_content
+            - format_conversation_history
+            - format_demos
+            - format_field_description
+            - format_field_structure
+            - format_field_with_value
+            - format_finetune_data
+            - format_system_message
+            - format_task_description
+            - format_user_message_content
+            - parse
+            - user_message_output_requirements
+        show_source: true
+        show_root_heading: true
+        heading_level: 2
+        docstring_style: google
+        show_root_full_path: true
+        show_object_full_path: false
+        separate_signature: false
+        inherited_members: true
+<!-- END_API_REF -->

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -188,7 +188,7 @@ DSPy shifts your focus from tinkering with prompt strings to **programming with 
             
             sentence: str = dspy.InputField()
             sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
-            confidence: float = dspy.OutputField()
+            toxicity: float = dspy.OutputField()
 
         classify = dspy.Predict(Classify)
         classify(sentence="This book was super fun to read, though not the last chapter.")
@@ -199,7 +199,7 @@ DSPy shifts your focus from tinkering with prompt strings to **programming with 
         ```text
         Prediction(
             sentiment='positive',
-            confidence=0.75
+            toxicity=0.15
         )
         ```
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
         - Adapters:
             - Adapter: api/adapters/Adapter.md
             - ChatAdapter: api/adapters/ChatAdapter.md
+            - XMLAdapter: api/adapters/XMLAdapter.md
             - JSONAdapter: api/adapters/JSONAdapter.md
             - TwoStepAdapter: api/adapters/TwoStepAdapter.md
         - Evaluation:

--- a/dspy/predict/__init__.py
+++ b/dspy/predict/__init__.py
@@ -1,6 +1,7 @@
 from dspy.predict.aggregation import majority
 from dspy.predict.best_of_n import BestOfN
 from dspy.predict.chain_of_thought import ChainOfThought
+from dspy.predict.classifier import Classifier
 from dspy.predict.code_act import CodeAct
 from dspy.predict.knn import KNN
 from dspy.predict.multi_chain_comparison import MultiChainComparison
@@ -15,6 +16,7 @@ __all__ = [
     "majority",
     "BestOfN",
     "ChainOfThought",
+    "Classifier",
     "CodeAct",
     "KNN",
     "MultiChainComparison",

--- a/dspy/predict/classifier.py
+++ b/dspy/predict/classifier.py
@@ -1,0 +1,135 @@
+import asyncio
+import math
+from collections import Counter
+from typing import Literal, get_origin
+
+import dspy
+from dspy.primitives.module import Module
+from dspy.signatures.signature import ensure_signature
+
+
+class Classifier(Module):
+    def __init__(self, signature, need_confidence=False, num_samples=10, classification_field=None, **config):
+        """A module that classifies inputs, optionally computing statistical confidence from multiple samples.
+
+        By default, runs a single prediction and returns the result directly. When
+        need_confidence=True, runs the prediction num_samples times and computes
+        confidence from the distribution of answers instead of asking the LM to
+        hallucinate a confidence score.
+
+        Args:
+            signature: The signature of the module.
+            need_confidence: If True, run num_samples predictions and return confidence
+                metrics (agreement_rate, entropy, prediction_counts). Default False.
+            num_samples: Number of times to run the prediction when need_confidence=True
+                (default 10).
+            classification_field: The output field to aggregate on. Auto-detected from
+                Literal-typed fields if not specified.
+            **config: Additional configuration passed to the underlying Predict module.
+        """
+        super().__init__()
+        self.signature = ensure_signature(signature)
+        self.need_confidence = need_confidence
+        self.num_samples = num_samples
+        self.classification_field = self._detect_classification_field(classification_field)
+        self.predict = dspy.Predict(self.signature, **config)
+
+    def _detect_classification_field(self, classification_field = None):
+        """Resolve the classification field from Literal-typed output fields."""
+        literal_fields = [
+            name for name, field_info in self.signature.output_fields.items()
+            if get_origin(field_info.annotation) is Literal
+        ]
+        if len(literal_fields) == 0:
+            raise ValueError(
+                "Classifier requires at least one Literal-typed output field. "
+                "Example: `label: Literal['positive', 'negative'] = dspy.OutputField()`"
+            )
+        if len(literal_fields) == 1:
+            if classification_field is None or classification_field == literal_fields[0]:
+                return literal_fields[0]
+            raise ValueError(
+                f"classification_field='{classification_field}' does not match the only "
+                f"Literal-typed output field '{literal_fields[0]}'."
+            )
+        # len(literal_fields) > 1
+        if classification_field in literal_fields:
+            return classification_field
+        raise ValueError(
+            f"Signature has multiple Literal-typed output fields: {literal_fields}. "
+            + (
+                f"classification_field='{classification_field}' is not among them. "
+                if classification_field is not None
+                else ""
+            )
+            + "Please specify which to use via `classification_field`."
+        )
+
+    def _aggregate_and_score(self, predictions):
+        """Compute majority vote and confidence metrics from independent predictions."""
+        field = self.classification_field
+        values = [pred[field] for pred in predictions]
+
+        # Majority vote
+        counts = Counter(values)
+        majority_value, majority_count = counts.most_common(1)[0]
+
+        # Agreement rate: fraction of predictions matching the most common class
+        agreement_rate = majority_count / len(values)
+
+        # Normalized Shannon entropy (0 = perfect agreement, 1 = max disagreement)
+        num_unique = len(counts)
+        if num_unique <= 1:
+            entropy = 0.0
+        else:
+            n = len(values)
+            raw_entropy = -sum((c / n) * math.log2(c / n) for c in counts.values())
+            entropy = raw_entropy / math.log2(num_unique)
+
+        # Build result from first prediction matching majority
+        for pred in predictions:
+            if pred[field] == majority_value:
+                result = pred
+                break
+
+        result.agreement_rate = agreement_rate
+        result.entropy = entropy
+        result.prediction_counts = dict(counts)
+        return result
+
+    def _ensure_config(self, kwargs):
+        """Extract config and set minimum temperature for diverse sampling.
+        
+        Explicitly sets n=1 to ensure compatibility with models that don't support
+        n > 1, since Classifier achieves multiple samples via separate calls.
+        """
+        config = {**kwargs.pop("config", {})}
+        # Explicitly set n=1 to override any LM-level n setting.
+        # Classifier makes num_samples separate calls instead of using batch n.
+        config["n"] = 1
+        temperature = config.get("temperature")
+        if temperature is not None and temperature < 0.15:
+            config["temperature"] = 0.5
+        return config, kwargs
+
+    def forward(self, **kwargs):
+        if not self.need_confidence:
+            return self.predict(**kwargs)
+        config, kwargs = self._ensure_config(kwargs)
+        predictions = [
+            self.predict(**kwargs, config={**config, "rollout_id": i})
+            for i in range(self.num_samples)
+        ]
+        return self._aggregate_and_score(predictions)
+
+    async def aforward(self, **kwargs):
+        if not self.need_confidence:
+            return await self.predict.acall(**kwargs)
+        config, kwargs = self._ensure_config(kwargs)
+        predictions = await asyncio.gather(
+            *[
+                self.predict.acall(**kwargs, config={**config, "rollout_id": i})
+                for i in range(self.num_samples)
+            ]
+        )
+        return self._aggregate_and_score(predictions)

--- a/dspy/retrievers/__init__.py
+++ b/dspy/retrievers/__init__.py
@@ -1,4 +1,4 @@
-from dspy.retrievers.embeddings import Embeddings
+from dspy.retrievers.embeddings import Embeddings, EmbeddingsWithScores
 from dspy.retrievers.retrieve import Retrieve
 
-__all__ = ["Embeddings", "Retrieve"]
+__all__ = ["Embeddings", "EmbeddingsWithScores", "Retrieve"]

--- a/dspy/retrievers/embeddings.py
+++ b/dspy/retrievers/embeddings.py
@@ -8,6 +8,13 @@ from dspy.utils.unbatchify import Unbatchify
 
 
 class Embeddings:
+    """DSPy Embeddings retriever.
+
+    This class retrieves the top-k most similar passages from a corpus using embedding-based similarity search.
+    For large corpora, a FAISS index is built for fast approximate candidate retrieval, followed by exact
+    re-ranking. For small corpora, brute-force search is used.
+    """
+
     def __init__(
         self,
         corpus: list[str],
@@ -35,9 +42,17 @@ class Embeddings:
         return self.forward(query)
 
     def forward(self, query: str):
+        """Search for the top-k passages most similar to the query.
+
+        Args:
+            query (str): The search query string
+
+        Returns:
+            dspy.Prediction: A prediction containing passages and their corpus indices.
+        """
         import dspy
 
-        passages, indices = self.search_fn(query)
+        passages, indices, _scores = self.search_fn(query)
         return dspy.Prediction(passages=passages, indices=indices)
 
     def _batch_forward(self, queries: list[str]):
@@ -81,8 +96,13 @@ class Embeddings:
 
         top_k_indices = np.argsort(-scores, axis=1)[:, : self.k]
         top_indices = candidate_indices[np.arange(len(q_embeds))[:, None], top_k_indices]
+        top_scores = scores[np.arange(len(q_embeds))[:, None], top_k_indices]
 
-        return [([self.corpus[idx] for idx in indices], [idx for idx in indices]) for indices in top_indices]  # noqa: C416
+        results = []
+        for indices, query_scores in zip(top_indices, top_scores, strict=True):
+            passages = [self.corpus[idx] for idx in indices]
+            results.append((passages, indices.tolist(), query_scores.tolist()))
+        return results
 
     def _normalize(self, embeddings: np.ndarray):
         norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
@@ -214,3 +234,25 @@ class Embeddings:
         instance.search_fn = Unbatchify(instance._batch_forward)
         instance.load(path, embedder)
         return instance
+
+
+class EmbeddingsWithScores(Embeddings):
+    """DSPy EmbeddingsWithScores retriever.
+
+    This class extends the Embeddings retriever to also return similarity scores alongside passages and indices.
+    Similarity scores enable downstream such as thresholding and re-ranking.
+    """
+
+    def forward(self, query: str):
+        """Search for the top-k passages most similar to the query.
+
+        Args:
+            query (str): The search query string.
+
+        Returns:
+            dspy.Prediction: A prediction containing passages, indices, and similarity scores.
+        """
+        import dspy
+
+        passages, indices, scores = self.search_fn(query)
+        return dspy.Prediction(passages=passages, indices=indices, scores=scores)

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -350,7 +350,7 @@ def with_callbacks(fn):
 
 def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -> Callable:
     """Selects the appropriate on_start handler of the callback based on the instance and function name."""
-    if isinstance(instance, dspy.LM):
+    if isinstance(instance, dspy.BaseLM):
         return callback.on_lm_start
     elif isinstance(instance, dspy.Evaluate):
         return callback.on_evaluate_start
@@ -372,7 +372,7 @@ def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -
 
 def _get_on_end_handler(callback: BaseCallback, instance: Any, fn: Callable) -> Callable:
     """Selects the appropriate on_end handler of the callback based on the instance and function name."""
-    if isinstance(instance, (dspy.LM)):
+    if isinstance(instance, dspy.BaseLM):
         return callback.on_lm_end
     elif isinstance(instance, dspy.Evaluate):
         return callback.on_evaluate_end

--- a/dspy/utils/dummies.py
+++ b/dspy/utils/dummies.py
@@ -5,12 +5,12 @@ from typing import Any
 import numpy as np
 
 from dspy.adapters.chat_adapter import FieldInfoWithName, field_header_pattern
-from dspy.clients.lm import LM
+from dspy.clients.base_lm import BaseLM
 from dspy.dsp.utils.utils import dotdict
 from dspy.signatures.field import OutputField
 
 
-class DummyLM(LM):
+class DummyLM(BaseLM):
     """Dummy language model for unit testing purposes.
 
     Three modes of operation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "tqdm>=4.66.1",
     "requests>=2.31.0",
     "pydantic>=2.0",
-    "litellm>=1.64.0",
+    "litellm>=1.64.0,<=1.82.6",
     "diskcache>=5.6.0",
     "json-repair>=0.54.2",
     "tenacity>=8.2.3",

--- a/tests/predict/test_classifier.py
+++ b/tests/predict/test_classifier.py
@@ -1,0 +1,267 @@
+import math
+from typing import Literal
+
+import pytest
+
+import dspy
+from dspy import Classifier
+from dspy.utils import DummyLM
+
+
+class SentimentSignature(dspy.Signature):
+    """Classify sentiment of a given sentence."""
+    sentence: str = dspy.InputField()
+    sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
+
+
+class PlainSignature(dspy.Signature):
+    """Answer a question."""
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField()
+
+
+class MultiOutputSignature(dspy.Signature):
+    """Classify a sentence with a topic and sentiment."""
+    sentence: str = dspy.InputField()
+    topic: str = dspy.OutputField()
+    sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
+
+
+def test_single_prediction_default():
+    """Default (need_confidence=False) runs a single prediction with no confidence fields."""
+    lm = DummyLM([{"sentiment": "positive"}])
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature)
+    result = classifier(sentence="Great movie!")
+
+    assert result.sentiment == "positive"
+    assert not hasattr(result, "agreement_rate")
+    assert not hasattr(result, "entropy")
+    assert not hasattr(result, "prediction_counts")
+
+
+def test_unanimous_agreement():
+    """All N samples return the same class → agreement_rate=1.0, entropy=0.0."""
+    answers = [{"sentiment": "positive"}] * 10
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Great movie!")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == 1.0
+    assert result.entropy == 0.0
+    assert result.prediction_counts == {"positive": 10}
+
+
+def test_mixed_responses():
+    """7/10 positive, 3/10 negative → majority positive, agreement_rate=0.7."""
+    answers = [{"sentiment": "positive"}] * 7 + [{"sentiment": "negative"}] * 3
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Mostly good but some issues.")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(0.7)
+    assert 0.0 < result.entropy < 1.0
+    assert result.prediction_counts == {"positive": 7, "negative": 3}
+
+
+def test_entropy_max_disagreement():
+    """5/10 positive, 5/10 negative → entropy == 1.0 (max for 2 classes)."""
+    answers = [{"sentiment": "positive"}] * 5 + [{"sentiment": "negative"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Mixed feelings.")
+
+    assert result.agreement_rate == pytest.approx(0.5)
+    assert result.entropy == pytest.approx(1.0)
+
+
+def test_auto_detect_literal_field():
+    """Signature with Literal field is auto-detected as the classification field."""
+    lm = DummyLM([{"sentiment": "neutral"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, num_samples=5)
+    assert classifier.classification_field == "sentiment"
+
+
+def test_single_literal_explicit_matching_field():
+    """Explicit classification_field matching the only Literal field is accepted."""
+    lm = DummyLM([{"sentiment": "neutral"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, num_samples=5, classification_field="sentiment")
+    assert classifier.classification_field == "sentiment"
+
+
+def test_single_literal_mismatching_field_raises():
+    """Explicit classification_field that doesn't match the only Literal field raises ValueError."""
+    with pytest.raises(ValueError, match="does not match the only Literal-typed output field"):
+        Classifier(SentimentSignature, num_samples=5, classification_field="wrong_field")
+
+
+def test_explicit_classification_field_multi_literal():
+    """User-specified classification_field selects among multiple Literal fields."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    lm = DummyLM([{"sentiment": "positive", "topic": "sports"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(MultiLiteralSignature, need_confidence=True, num_samples=5, classification_field="topic")
+    assert classifier.classification_field == "topic"
+
+    result = classifier(sentence="The team won!")
+    assert result.topic == "sports"
+    assert result.prediction_counts == {"sports": 5}
+
+
+def test_multiple_literal_fields_wrong_field_raises():
+    """Explicit classification_field not in multiple Literal fields raises ValueError."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    with pytest.raises(ValueError, match="multiple Literal-typed output fields"):
+        Classifier(MultiLiteralSignature, num_samples=5, classification_field="wrong_field")
+
+
+def test_no_literal_field_raises():
+    """When no Literal field exists, raise ValueError."""
+    with pytest.raises(ValueError, match="requires at least one Literal-typed output field"):
+        Classifier(PlainSignature, num_samples=5)
+
+
+def test_multiple_literal_fields_raises():
+    """When multiple Literal fields exist without explicit classification_field, raise ValueError."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    with pytest.raises(ValueError, match="multiple Literal-typed output fields"):
+        Classifier(MultiLiteralSignature, num_samples=5)
+
+
+def test_multiple_literal_fields_with_explicit_field():
+    """When multiple Literal fields exist, specifying classification_field works."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    lm = DummyLM([{"sentiment": "positive", "topic": "sports"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(MultiLiteralSignature, num_samples=5, classification_field="sentiment")
+    assert classifier.classification_field == "sentiment"
+
+
+def test_custom_num_samples():
+    """Verify num_samples controls the number of completions requested."""
+    answers = [{"sentiment": "positive"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=5)
+    result = classifier(sentence="Good book!")
+
+    assert sum(result.prediction_counts.values()) == 5
+
+
+def test_temperature_set_when_absent():
+    """When no temperature in call config, Classifier sets minimum 0.7 for diversity."""
+    captured_configs = []
+
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    import unittest.mock as mock
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!")
+
+    assert len(captured_configs) == 10
+    assert all(c.get("temperature") == pytest.approx(0.7) for c in captured_configs)
+    # Classifier explicitly sets n=1 to ensure compatibility with models that don't support n > 1
+    assert all(c.get("n") == 1 for c in captured_configs)
+
+
+def test_temperature_bumped_from_low():
+    """Temperature < 0.7 in call config is bumped to 0.7."""
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    import unittest.mock as mock
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 0.15})
+
+    assert all(c.get("temperature") == pytest.approx(0.7) for c in captured_configs)
+
+
+def test_high_temperature_preserved():
+    """Temperature >= 0.7 in call config is preserved."""
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    import unittest.mock as mock
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 1.0})
+
+    assert all(c.get("temperature") == pytest.approx(1.0) for c in captured_configs)
+
+
+@pytest.mark.asyncio
+async def test_async_forward():
+    """aforward produces the same structure as forward."""
+    answers = [{"sentiment": "positive"}] * 8 + [{"sentiment": "negative"}] * 2
+    lm = DummyLM(answers)
+    with dspy.context(lm=lm):
+        classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+        result = await classifier.acall(sentence="Really enjoyed it!")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(0.8)
+    assert hasattr(result, "entropy")
+    assert hasattr(result, "prediction_counts")
+    assert result.prediction_counts == {"positive": 8, "negative": 2}

--- a/tests/retrievers/test_embeddings.py
+++ b/tests/retrievers/test_embeddings.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 import pytest
 
-from dspy.retrievers.embeddings import Embeddings
+from dspy.retrievers.embeddings import Embeddings, EmbeddingsWithScores
 
 
 def dummy_corpus():
@@ -132,3 +132,38 @@ def test_embeddings_from_saved():
 def test_embeddings_load_nonexistent_path():
     with pytest.raises((FileNotFoundError, OSError)):
         Embeddings.from_saved("/nonexistent/path", dummy_embedder)
+
+
+def test_embeddings_with_scores_basic_search():
+    corpus = dummy_corpus()
+    retriever = EmbeddingsWithScores(corpus=corpus, embedder=dummy_embedder, k=2)
+
+    result = retriever("A dog is barking.")
+
+    assert result.passages == ["The dog barked at the mailman.", "The cat sat on the mat."]
+    assert result.indices == [1, 0]
+    assert result.scores == pytest.approx([1.0, 0.0])
+
+
+def test_embeddings_with_scores_save_load():
+    corpus = dummy_corpus()
+    original_retriever = EmbeddingsWithScores(
+        corpus=corpus,
+        embedder=dummy_embedder,
+        k=2,
+        normalize=False,
+        brute_force_threshold=1000,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        save_path = os.path.join(temp_dir, "test_embeddings_with_scores")
+
+        original_retriever.save(save_path)
+        loaded_retriever = EmbeddingsWithScores.from_saved(save_path, dummy_embedder)
+
+        original_result = original_retriever("cat sitting")
+        loaded_result = loaded_retriever("cat sitting")
+
+        assert loaded_result.passages == original_result.passages
+        assert loaded_result.indices == original_result.indices
+        assert loaded_result.scores == pytest.approx(original_result.scores)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "(python_full_version >= '3.14' and sys_platform != 'win32') or (python_full_version >= '3.12.4' and sys_platform == 'win32')",
@@ -808,7 +808,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.54.2" },
     { name = "langchain-core", marker = "extra == 'langchain'" },
     { name = "langchain-core", marker = "extra == 'test-extras'" },
-    { name = "litellm", specifier = ">=1.64.0" },
+    { name = "litellm", specifier = ">=1.64.0,<=1.82.6" },
     { name = "litellm", marker = "(python_full_version == '3.14.*' and extra == 'dev') or (sys_platform == 'win32' and extra == 'dev')", specifier = ">=1.64.0" },
     { name = "litellm", extras = ["proxy"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = ">=1.64.0" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'" },


### PR DESCRIPTION
## Motivation

Following the removal of misleading LLM-generated confidence: float scores (PR #9495), this PR introduces a `Classifier` module that provides statistically principled confidence metrics based on consistency across repeated model runs.

## Changes Made

The `Classifier` module:
1. Auto-detects classification fields from Literal-typed output fields in the signature
2. Single prediction mode (default): Returns prediction directly without confidence metrics
3. Confidence mode (`need_confidence=True`):
  * Runs prediction num_samples times with rollout_id to bypass cache
  * Uses elevated temperature (≥0.5) for diverse sampling
  * Returns principled confidence metrics:
    - `agreement_rate`: Fraction of predictions matching majority class
    - `entropy`: Normalized Shannon entropy (0 = perfect agreement, 1 = max disagreement)
    - `prediction_counts`: Distribution of predicted classes


## Example Usage

``` python
classifier = Classifier(
    Signature("sentence -> sentiment: Literal['positive', 'negative']"),
    need_confidence=True,
    num_samples=10
)
result = classifier(sentence="Great movie!")
# result.sentiment, result.agreement_rate, result.entropy, result.prediction_counts
```
See this [colab notebook](https://colab.research.google.com/drive/1mXP9DC8ajUaAsXzio3x6eIc7JIslykLJ?usp=sharing) for more details. 