### PR TITLE
Add `Classifier` module with principled consistency-based confidence scoring

### DIFF
--- a/dspy/predict/__init__.py
+++ b/dspy/predict/__init__.py
@@ -1,6 +1,7 @@
 from dspy.predict.aggregation import majority
 from dspy.predict.best_of_n import BestOfN
 from dspy.predict.chain_of_thought import ChainOfThought
+from dspy.predict.classifier import Classifier
 from dspy.predict.code_act import CodeAct
 from dspy.predict.knn import KNN
 from dspy.predict.multi_chain_comparison import MultiChainComparison
@@ -15,6 +16,7 @@ __all__ = [
     "majority",
     "BestOfN",
     "ChainOfThought",
+    "Classifier",
     "CodeAct",
     "KNN",
     "MultiChainComparison",

--- a/dspy/predict/classifier.py
+++ b/dspy/predict/classifier.py
@@ -1,0 +1,135 @@
+import asyncio
+import math
+from collections import Counter
+from typing import Literal, get_origin
+
+import dspy
+from dspy.primitives.module import Module
+from dspy.signatures.signature import ensure_signature
+
+
+class Classifier(Module):
+    def __init__(self, signature, need_confidence=False, num_samples=10, classification_field=None, **config):
+        """A module that classifies inputs, optionally computing statistical confidence from multiple samples.
+
+        By default, runs a single prediction and returns the result directly. When
+        need_confidence=True, runs the prediction num_samples times and computes
+        confidence from the distribution of answers instead of asking the LM to
+        hallucinate a confidence score.
+
+        Args:
+            signature: The signature of the module.
+            need_confidence: If True, run num_samples predictions and return confidence
+                metrics (agreement_rate, entropy, prediction_counts). Default False.
+            num_samples: Number of times to run the prediction when need_confidence=True
+                (default 10).
+            classification_field: The output field to aggregate on. Auto-detected from
+                Literal-typed fields if not specified.
+            **config: Additional configuration passed to the underlying Predict module.
+        """
+        super().__init__()
+        self.signature = ensure_signature(signature)
+        self.need_confidence = need_confidence
+        self.num_samples = num_samples
+        self.classification_field = self._detect_classification_field(classification_field)
+        self.predict = dspy.Predict(self.signature, **config)
+
+    def _detect_classification_field(self, classification_field = None):
+        """Resolve the classification field from Literal-typed output fields."""
+        literal_fields = [
+            name for name, field_info in self.signature.output_fields.items()
+            if get_origin(field_info.annotation) is Literal
+        ]
+        if len(literal_fields) == 0:
+            raise ValueError(
+                "Classifier requires at least one Literal-typed output field. "
+                "Example: `label: Literal['positive', 'negative'] = dspy.OutputField()`"
+            )
+        if len(literal_fields) == 1:
+            if classification_field is None or classification_field == literal_fields[0]:
+                return literal_fields[0]
+            raise ValueError(
+                f"classification_field='{classification_field}' does not match the only "
+                f"Literal-typed output field '{literal_fields[0]}'."
+            )
+        # len(literal_fields) > 1
+        if classification_field in literal_fields:
+            return classification_field
+        raise ValueError(
+            f"Signature has multiple Literal-typed output fields: {literal_fields}. "
+            + (
+                f"classification_field='{classification_field}' is not among them. "
+                if classification_field is not None
+                else ""
+            )
+            + "Please specify which to use via `classification_field`."
+        )
+
+    def _aggregate_and_score(self, predictions):
+        """Compute majority vote and confidence metrics from independent predictions."""
+        field = self.classification_field
+        values = [pred[field] for pred in predictions]
+
+        # Majority vote
+        counts = Counter(values)
+        majority_value, majority_count = counts.most_common(1)[0]
+
+        # Agreement rate: fraction of predictions matching the most common class
+        agreement_rate = majority_count / len(values)
+
+        # Normalized Shannon entropy (0 = perfect agreement, 1 = max disagreement)
+        num_unique = len(counts)
+        if num_unique <= 1:
+            entropy = 0.0
+        else:
+            n = len(values)
+            raw_entropy = -sum((c / n) * math.log2(c / n) for c in counts.values())
+            entropy = raw_entropy / math.log2(num_unique)
+
+        # Build result from first prediction matching majority
+        for pred in predictions:
+            if pred[field] == majority_value:
+                result = pred
+                break
+
+        result.agreement_rate = agreement_rate
+        result.entropy = entropy
+        result.prediction_counts = dict(counts)
+        return result
+
+    def _ensure_config(self, kwargs):
+        """Extract config and set minimum temperature for diverse sampling.
+        
+        Explicitly sets n=1 to ensure compatibility with models that don't support
+        n > 1, since Classifier achieves multiple samples via separate calls.
+        """
+        config = {**kwargs.pop("config", {})}
+        # Explicitly set n=1 to override any LM-level n setting.
+        # Classifier makes num_samples separate calls instead of using batch n.
+        config["n"] = 1
+        temperature = config.get("temperature")
+        if temperature is not None and temperature < 0.15:
+            config["temperature"] = 0.5
+        return config, kwargs
+
+    def forward(self, **kwargs):
+        if not self.need_confidence:
+            return self.predict(**kwargs)
+        config, kwargs = self._ensure_config(kwargs)
+        predictions = [
+            self.predict(**kwargs, config={**config, "rollout_id": i})
+            for i in range(self.num_samples)
+        ]
+        return self._aggregate_and_score(predictions)
+
+    async def aforward(self, **kwargs):
+        if not self.need_confidence:
+            return await self.predict.acall(**kwargs)
+        config, kwargs = self._ensure_config(kwargs)
+        predictions = await asyncio.gather(
+            *[
+                self.predict.acall(**kwargs, config={**config, "rollout_id": i})
+                for i in range(self.num_samples)
+            ]
+        )
+        return self._aggregate_and_score(predictions)

--- a/tests/predict/test_classifier.py
+++ b/tests/predict/test_classifier.py
@@ -1,4 +1,3 @@
-import math
 from typing import Literal
 
 import pytest

--- a/tests/predict/test_classifier.py
+++ b/tests/predict/test_classifier.py
@@ -1,0 +1,267 @@
+import math
+from typing import Literal
+
+import pytest
+
+import dspy
+from dspy import Classifier
+from dspy.utils import DummyLM
+
+
+class SentimentSignature(dspy.Signature):
+    """Classify sentiment of a given sentence."""
+    sentence: str = dspy.InputField()
+    sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
+
+
+class PlainSignature(dspy.Signature):
+    """Answer a question."""
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField()
+
+
+class MultiOutputSignature(dspy.Signature):
+    """Classify a sentence with a topic and sentiment."""
+    sentence: str = dspy.InputField()
+    topic: str = dspy.OutputField()
+    sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
+
+
+def test_single_prediction_default():
+    """Default (need_confidence=False) runs a single prediction with no confidence fields."""
+    lm = DummyLM([{"sentiment": "positive"}])
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature)
+    result = classifier(sentence="Great movie!")
+
+    assert result.sentiment == "positive"
+    assert not hasattr(result, "agreement_rate")
+    assert not hasattr(result, "entropy")
+    assert not hasattr(result, "prediction_counts")
+
+
+def test_unanimous_agreement():
+    """All N samples return the same class → agreement_rate=1.0, entropy=0.0."""
+    answers = [{"sentiment": "positive"}] * 10
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Great movie!")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == 1.0
+    assert result.entropy == 0.0
+    assert result.prediction_counts == {"positive": 10}
+
+
+def test_mixed_responses():
+    """7/10 positive, 3/10 negative → majority positive, agreement_rate=0.7."""
+    answers = [{"sentiment": "positive"}] * 7 + [{"sentiment": "negative"}] * 3
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Mostly good but some issues.")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(0.7)
+    assert 0.0 < result.entropy < 1.0
+    assert result.prediction_counts == {"positive": 7, "negative": 3}
+
+
+def test_entropy_max_disagreement():
+    """5/10 positive, 5/10 negative → entropy == 1.0 (max for 2 classes)."""
+    answers = [{"sentiment": "positive"}] * 5 + [{"sentiment": "negative"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Mixed feelings.")
+
+    assert result.agreement_rate == pytest.approx(0.5)
+    assert result.entropy == pytest.approx(1.0)
+
+
+def test_auto_detect_literal_field():
+    """Signature with Literal field is auto-detected as the classification field."""
+    lm = DummyLM([{"sentiment": "neutral"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, num_samples=5)
+    assert classifier.classification_field == "sentiment"
+
+
+def test_single_literal_explicit_matching_field():
+    """Explicit classification_field matching the only Literal field is accepted."""
+    lm = DummyLM([{"sentiment": "neutral"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, num_samples=5, classification_field="sentiment")
+    assert classifier.classification_field == "sentiment"
+
+
+def test_single_literal_mismatching_field_raises():
+    """Explicit classification_field that doesn't match the only Literal field raises ValueError."""
+    with pytest.raises(ValueError, match="does not match the only Literal-typed output field"):
+        Classifier(SentimentSignature, num_samples=5, classification_field="wrong_field")
+
+
+def test_explicit_classification_field_multi_literal():
+    """User-specified classification_field selects among multiple Literal fields."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    lm = DummyLM([{"sentiment": "positive", "topic": "sports"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(MultiLiteralSignature, need_confidence=True, num_samples=5, classification_field="topic")
+    assert classifier.classification_field == "topic"
+
+    result = classifier(sentence="The team won!")
+    assert result.topic == "sports"
+    assert result.prediction_counts == {"sports": 5}
+
+
+def test_multiple_literal_fields_wrong_field_raises():
+    """Explicit classification_field not in multiple Literal fields raises ValueError."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    with pytest.raises(ValueError, match="multiple Literal-typed output fields"):
+        Classifier(MultiLiteralSignature, num_samples=5, classification_field="wrong_field")
+
+
+def test_no_literal_field_raises():
+    """When no Literal field exists, raise ValueError."""
+    with pytest.raises(ValueError, match="requires at least one Literal-typed output field"):
+        Classifier(PlainSignature, num_samples=5)
+
+
+def test_multiple_literal_fields_raises():
+    """When multiple Literal fields exist without explicit classification_field, raise ValueError."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    with pytest.raises(ValueError, match="multiple Literal-typed output fields"):
+        Classifier(MultiLiteralSignature, num_samples=5)
+
+
+def test_multiple_literal_fields_with_explicit_field():
+    """When multiple Literal fields exist, specifying classification_field works."""
+    class MultiLiteralSignature(dspy.Signature):
+        """Classify both sentiment and topic."""
+        sentence: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+        topic: Literal["sports", "politics"] = dspy.OutputField()
+
+    lm = DummyLM([{"sentiment": "positive", "topic": "sports"}] * 5)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(MultiLiteralSignature, num_samples=5, classification_field="sentiment")
+    assert classifier.classification_field == "sentiment"
+
+
+def test_custom_num_samples():
+    """Verify num_samples controls the number of completions requested."""
+    answers = [{"sentiment": "positive"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=5)
+    result = classifier(sentence="Good book!")
+
+    assert sum(result.prediction_counts.values()) == 5
+
+
+def test_temperature_set_when_absent():
+    """When no temperature in call config, Classifier does not inject one."""
+    captured_configs = []
+
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    import unittest.mock as mock
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!")
+
+    assert len(captured_configs) == 10
+    assert all(c.get("temperature") is None for c in captured_configs)
+    # Classifier explicitly sets n=1 to ensure compatibility with models that don't support n > 1
+    assert all(c.get("n") == 1 for c in captured_configs)
+
+
+def test_temperature_bumped_from_low():
+    """Temperature < 0.15 in call config is bumped to 0.5."""
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    import unittest.mock as mock
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 0.1})
+
+    assert all(c.get("temperature") == pytest.approx(0.5) for c in captured_configs)
+
+
+def test_high_temperature_preserved():
+    """Temperature >= 0.7 in call config is preserved."""
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    import unittest.mock as mock
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 1.0})
+
+    assert all(c.get("temperature") == pytest.approx(1.0) for c in captured_configs)
+
+
+@pytest.mark.asyncio
+async def test_async_forward():
+    """aforward produces the same structure as forward."""
+    answers = [{"sentiment": "positive"}] * 8 + [{"sentiment": "negative"}] * 2
+    lm = DummyLM(answers)
+    with dspy.context(lm=lm):
+        classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+        result = await classifier.acall(sentence="Really enjoyed it!")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(0.8)
+    assert hasattr(result, "entropy")
+    assert hasattr(result, "prediction_counts")
+    assert result.prediction_counts == {"positive": 8, "negative": 2}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.15"
 resolution-markers = [
     "(python_full_version >= '3.14' and sys_platform != 'win32') or (python_full_version >= '3.12.4' and sys_platform == 'win32')",
@@ -808,7 +808,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.54.2" },
     { name = "langchain-core", marker = "extra == 'langchain'" },
     { name = "langchain-core", marker = "extra == 'test-extras'" },
-    { name = "litellm", specifier = ">=1.64.0" },
+    { name = "litellm", specifier = ">=1.64.0,<=1.82.6" },
     { name = "litellm", marker = "(python_full_version == '3.14.*' and extra == 'dev') or (sys_platform == 'win32' and extra == 'dev')", specifier = ">=1.64.0" },
     { name = "litellm", extras = ["proxy"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = ">=1.64.0" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'" },


### PR DESCRIPTION
## Motivation

Following the removal of misleading LLM-generated confidence: float scores (PR #9495), this PR introduces a `Classifier` module that provides statistically principled confidence metrics based on consistency across repeated model runs.

## Changes Made

The `Classifier` module:
1. Auto-detects classification fields from Literal-typed output fields in the signature
2. Single prediction mode (default): Returns prediction directly without confidence metrics
3. Confidence mode (`need_confidence=True`):
  * Runs prediction num_samples times with rollout_id to bypass cache
  * Uses elevated temperature (≥0.5) for diverse sampling
  * Returns principled confidence metrics:
    - `agreement_rate`: Fraction of predictions matching majority class
    - `entropy`: Normalized Shannon entropy (0 = perfect agreement, 1 = max disagreement)
    - `prediction_counts`: Distribution of predicted classes


## Example Usage

``` python
classifier = Classifier(
    Signature("sentence -> sentiment: Literal['positive', 'negative']"),
    need_confidence=True,
    num_samples=10
)
result = classifier(sentence="Great movie!")
# result.sentiment, result.agreement_rate, result.entropy, result.prediction_counts
```
See this [colab notebook](https://colab.research.google.com/drive/1mXP9DC8ajUaAsXzio3x6eIc7JIslykLJ?usp=sharing) for more details. 