### PR TITLE
Refactor: Make `litellm`, lazy-loaded dependency

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -15,7 +15,6 @@ from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, en
 from dspy.utils.asyncify import asyncify
 from dspy.utils.syncify import syncify
 from dspy.utils.saving import load
-from dspy.streaming.streamify import streamify
 from dspy.utils.usage_tracker import track_usage
 
 from dspy.dsp.utils.settings import settings
@@ -33,3 +32,16 @@ context = settings.context
 BootstrapRS = BootstrapFewShotWithRandomSearch
 
 cache = DSPY_CACHE
+
+
+def __getattr__(name):
+    """Lazy access for litellm-dependent names (LM, Embedder, streamify)."""
+    if name in ("LM", "Embedder"):
+        from dspy.clients import __getattr__ as _clients_getattr
+
+        return _clients_getattr(name)
+    if name == "streamify":
+        from dspy.streaming.streamify import streamify
+
+        return streamify
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -2,12 +2,8 @@ import logging
 import os
 from pathlib import Path
 
-import litellm
-
 from dspy.clients.base_lm import BaseLM, inspect_history
 from dspy.clients.cache import Cache
-from dspy.clients.embedding import Embedder
-from dspy.clients.lm import LM
 from dspy.clients.provider import Provider, TrainingJob
 
 logger = logging.getLogger(__name__)
@@ -48,8 +44,70 @@ def configure_cache(
     dspy.cache = DSPY_CACHE
 
 
-litellm.telemetry = False
-litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
+def _configure_litellm_defaults():
+    """Configure litellm defaults. Called lazily on first litellm use."""
+    try:
+        import litellm
+    except ImportError:
+        return
+
+    litellm.telemetry = False
+    litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
+    _suppress_litellm_logging()
+
+
+def _suppress_litellm_logging():
+    """Suppress litellm logging by default."""
+    try:
+        import litellm
+        from litellm._logging import verbose_logger
+
+        litellm.suppress_debug_info = True
+        numeric_level = logging.ERROR
+        verbose_logger.setLevel(numeric_level)
+        for h in verbose_logger.handlers:
+            h.setLevel(numeric_level)
+    except ImportError:
+        pass
+
+
+_litellm_configured = False
+
+
+def _ensure_litellm_configured():
+    """Ensure litellm defaults are set. Safe to call multiple times."""
+    global _litellm_configured
+    if not _litellm_configured:
+        _configure_litellm_defaults()
+        _litellm_configured = True
+
+
+def configure_litellm_logging(level: str = "ERROR"):
+    """Configure LiteLLM logging to the specified level."""
+    _ensure_litellm_configured()
+    from litellm._logging import verbose_logger
+
+    numeric_logging_level = getattr(logging, level)
+
+    verbose_logger.setLevel(numeric_logging_level)
+    for h in verbose_logger.handlers:
+        h.setLevel(numeric_logging_level)
+
+
+def enable_litellm_logging():
+    import litellm
+
+    _ensure_litellm_configured()
+    litellm.suppress_debug_info = False
+    configure_litellm_logging("DEBUG")
+
+
+def disable_litellm_logging():
+    import litellm
+
+    _ensure_litellm_configured()
+    litellm.suppress_debug_info = True
+    configure_litellm_logging("ERROR")
 
 
 def _get_dspy_cache():
@@ -79,38 +137,31 @@ def _get_dspy_cache():
 
 DSPY_CACHE = _get_dspy_cache()
 
-def configure_litellm_logging(level: str = "ERROR"):
-    """Configure LiteLLM logging to the specified level."""
-    # Litellm uses a global logger called `verbose_logger` to control all loggings.
-    from litellm._logging import verbose_logger
 
-    numeric_logging_level = getattr(logging, level)
+def __getattr__(name):
+    """Lazy imports for litellm-dependent classes."""
+    if name == "LM":
+        _ensure_litellm_configured()
+        from dspy.clients.lm import LM
+        return LM
+    if name == "Embedder":
+        _ensure_litellm_configured()
+        from dspy.clients.embedding import Embedder
+        return Embedder
+    # Allow normal submodule access (e.g., dspy.clients.lm)
+    import importlib
 
-    verbose_logger.setLevel(numeric_logging_level)
-    for h in verbose_logger.handlers:
-        h.setLevel(numeric_logging_level)
+    try:
+        return importlib.import_module(f".{name}", __name__)
+    except ImportError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-
-def enable_litellm_logging():
-    litellm.suppress_debug_info = False
-    configure_litellm_logging("DEBUG")
-
-
-def disable_litellm_logging():
-    litellm.suppress_debug_info = True
-    configure_litellm_logging("ERROR")
-
-
-# By default, we disable LiteLLM logging for clean logging
-disable_litellm_logging()
 
 __all__ = [
     "BaseLM",
-    "LM",
     "Provider",
     "TrainingJob",
     "inspect_history",
-    "Embedder",
     "enable_litellm_logging",
     "disable_litellm_logging",
     "configure_cache",

--- a/dspy/predict/knn.py
+++ b/dspy/predict/knn.py
@@ -1,11 +1,15 @@
+from typing import TYPE_CHECKING
+
 import numpy as np
 
-from dspy.clients import Embedder
 from dspy.primitives import Example
+
+if TYPE_CHECKING:
+    from dspy.clients.embedding import Embedder
 
 
 class KNN:
-    def __init__(self, k: int, trainset: list[Example], vectorizer: Embedder):
+    def __init__(self, k: int, trainset: list[Example], vectorizer: "Embedder"):
         """
         A k-nearest neighbors retriever that finds similar examples from a training set.
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -8,7 +8,6 @@ from typeguard import TypeCheckError, check_type
 
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.clients.base_lm import BaseLM
-from dspy.clients.lm import LM
 from dspy.dsp.utils.settings import settings
 from dspy.predict.parameter import Parameter
 from dspy.primitives.module import Module
@@ -108,7 +107,12 @@ class Predict(Module, Parameter):
 
         self.signature = self.signature.load_state(state["signature"])
         sanitized_lm_state = _sanitize_lm_state(state["lm"], allow_unsafe_lm_state) if state["lm"] else None
-        self.lm = LM(**sanitized_lm_state) if sanitized_lm_state else None
+        if sanitized_lm_state:
+            from dspy.clients.lm import LM
+
+            self.lm = LM(**sanitized_lm_state)
+        else:
+            self.lm = None
 
         if "extended_signature" in state:  # legacy, up to and including 2.5, for CoT.
             raise NotImplementedError("Loading extended_signature is no longer supported in DSPy 2.6+")

--- a/dspy/streaming/__init__.py
+++ b/dspy/streaming/__init__.py
@@ -1,5 +1,4 @@
 from dspy.streaming.messages import StatusMessage, StatusMessageProvider, StreamResponse
-from dspy.streaming.streamify import apply_sync_streaming, streamify, streaming_response
 from dspy.streaming.streaming_listener import StreamListener
 
 __all__ = [
@@ -11,3 +10,16 @@ __all__ = [
     "streaming_response",
     "apply_sync_streaming",
 ]
+
+
+def __getattr__(name):
+    if name in ("streamify", "streaming_response", "apply_sync_streaming"):
+        from dspy.streaming.streamify import apply_sync_streaming, streamify, streaming_response
+
+        _map = {
+            "streamify": streamify,
+            "streaming_response": streaming_response,
+            "apply_sync_streaming": apply_sync_streaming,
+        }
+        return _map[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -6,11 +6,9 @@ from asyncio import iscoroutinefunction
 from queue import Queue
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator
 
-import litellm
 import orjson
 from anyio import create_memory_object_stream, create_task_group
 from anyio.streams.memory import MemoryObjectSendStream
-from litellm import ModelResponseStream
 
 from dspy.dsp.utils.settings import settings
 from dspy.primitives.prediction import Prediction
@@ -22,6 +20,15 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from dspy.primitives.module import Module
+
+
+def _is_model_response_stream(value) -> bool:
+    try:
+        from litellm import ModelResponseStream
+
+        return isinstance(value, ModelResponseStream)
+    except ImportError:
+        return False
 
 
 def streamify(
@@ -178,7 +185,7 @@ def streamify(
             tg.start_soon(generator, args, kwargs, send_stream)
 
             async for value in receive_stream:
-                if isinstance(value, ModelResponseStream):
+                if _is_model_response_stream(value):
                     if len(predict_id_to_listener) == 0:
                         # No listeners are configured, yield the chunk directly for backwards compatibility.
                         yield value
@@ -271,7 +278,7 @@ async def streaming_response(streamer: AsyncGenerator) -> AsyncGenerator:
         if isinstance(value, Prediction):
             data = {"prediction": dict(value.items(include_dspy=False))}
             yield f"data: {orjson.dumps(data).decode()}\n\n"
-        elif isinstance(value, litellm.ModelResponseStream):
+        elif _is_model_response_stream(value):
             data = {"chunk": value.json()}
             yield f"data: {orjson.dumps(data).decode()}\n\n"
         elif isinstance(value, str) and value.startswith("data:"):

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -5,7 +5,6 @@ from queue import Queue
 from typing import TYPE_CHECKING, Any
 
 import jiter
-from litellm import ModelResponseStream
 
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
@@ -15,6 +14,8 @@ from dspy.dsp.utils.settings import settings
 from dspy.streaming.messages import StreamResponse
 
 if TYPE_CHECKING:
+    from litellm import ModelResponseStream
+
     from dspy.primitives.module import Module
 
 ADAPTER_SUPPORT_STREAMING = [ChatAdapter, XMLAdapter, JSONAdapter]
@@ -112,7 +113,7 @@ class StreamListener:
 
         return False
 
-    def receive(self, chunk: ModelResponseStream):
+    def receive(self, chunk: "ModelResponseStream"):
         adapter_name = settings.adapter.__class__.__name__ if settings.adapter else "ChatAdapter"
         if adapter_name not in self.adapter_identifiers:
             raise ValueError(

--- a/dspy/teleprompt/bootstrap_finetune.py
+++ b/dspy/teleprompt/bootstrap_finetune.py
@@ -1,11 +1,19 @@
 import logging
 from collections import defaultdict
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import dspy
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
-from dspy.clients.lm import LM
+
+if TYPE_CHECKING:
+    from dspy.clients.lm import LM
+
+
+def _is_lm_keyed_dict(arg: dict) -> bool:
+    from dspy.clients.lm import LM
+
+    return all(isinstance(k, LM) for k in arg.keys())
 from dspy.clients.utils_finetune import infer_data_format
 from dspy.dsp.utils.settings import settings
 from dspy.predict.predict import Predict
@@ -20,14 +28,14 @@ logger = logging.getLogger(__name__)
 class FinetuneTeleprompter(Teleprompter):
     def __init__(
         self,
-        train_kwargs: dict[str, Any] | dict[LM, dict[str, Any]] | None = None,
+        train_kwargs: "dict[str, Any] | dict[LM, dict[str, Any]] | None" = None,
     ):
         self.train_kwargs: dict[LM, Any] = self.convert_to_lm_dict(train_kwargs or {})
 
     @staticmethod
-    def convert_to_lm_dict(arg) -> dict[LM, Any]:
+    def convert_to_lm_dict(arg) -> "dict[LM, Any]":
         non_empty_dict = arg and isinstance(arg, dict)
-        if non_empty_dict and all(isinstance(k, LM) for k in arg.keys()):
+        if non_empty_dict and _is_lm_keyed_dict(arg):
             return arg
         # Default to using the same value for all LMs
         return defaultdict(lambda: arg)
@@ -38,8 +46,8 @@ class BootstrapFinetune(FinetuneTeleprompter):
         self,
         metric: Callable | None = None,
         multitask: bool = True,
-        train_kwargs: dict[str, Any] | dict[LM, dict[str, Any]] | None = None,
-        adapter: Adapter | dict[LM, Adapter] | None = None,
+        train_kwargs: "dict[str, Any] | dict[LM, dict[str, Any]] | None" = None,
+        adapter: "Adapter | dict[LM, Adapter] | None" = None,
         exclude_demos: bool = False,
         num_threads: int | None = None,
     ):
@@ -134,7 +142,7 @@ class BootstrapFinetune(FinetuneTeleprompter):
         return student
 
     @staticmethod
-    def finetune_lms(finetune_dict) -> dict[Any, LM]:
+    def finetune_lms(finetune_dict) -> "dict[Any, LM]":
         num_jobs = len(finetune_dict)
         logger.info(f"Starting {num_jobs} fine-tuning job(s)...")
         # TODO(nit) Pass an identifier to the job so that we can tell the logs
@@ -165,7 +173,7 @@ class BootstrapFinetune(FinetuneTeleprompter):
 
         return key_to_lm
 
-    def _prepare_finetune_data(self, trace_data: list[dict[str, Any]], lm: LM, pred_ind: int | None = None):
+    def _prepare_finetune_data(self, trace_data: list[dict[str, Any]], lm: "LM", pred_ind: int | None = None):
         # TODO(nit) Log dataset details/size; make logs nicer
         if self.metric:
             logger.info(f"Collected data for {len(trace_data)} examples")
@@ -305,7 +313,7 @@ def assert_no_shared_predictor(program1: Module, program2: Module):
     assert not shared_ids, err
 
 
-def get_unique_lms(program: Module) -> list[LM]:
+def get_unique_lms(program: Module) -> "list[LM]":
     lms = [pred.lm for pred in program.predictors()]
     return list(set(lms))
 

--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -2,13 +2,14 @@ import inspect
 import logging
 import random
 from dataclasses import dataclass
-from typing import Any, Literal, Optional, Protocol, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Protocol, Union
 
 from gepa import GEPAResult
 from gepa.core.adapter import ProposalFn
 from gepa.proposer.reflective_mutation.base import ReflectionComponentSelector
 
-from dspy.clients.lm import LM
+if TYPE_CHECKING:
+    from dspy.clients.lm import LM
 from dspy.primitives import Example, Module, Prediction
 from dspy.teleprompt.gepa.gepa_utils import DspyAdapter, DSPyTrace, PredictorFeedbackFn, ScoreWithFeedback
 from dspy.teleprompt.teleprompt import Teleprompter
@@ -338,7 +339,7 @@ class GEPA(Teleprompter):
         # Reflection configuration
         reflection_minibatch_size: int = 3,
         candidate_selection_strategy: Literal["pareto", "current_best"] = "pareto",
-        reflection_lm: LM | None = None,
+        reflection_lm: "LM | None" = None,
         skip_perfect_score: bool = True,
         add_format_failure_as_feedback: bool = False,
         instruction_proposer: "ProposalFn | None" = None,

--- a/dspy/teleprompt/grpo.py
+++ b/dspy/teleprompt/grpo.py
@@ -2,12 +2,14 @@ import logging
 import random
 import time
 from collections import Counter, deque
-from typing import Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.xml_adapter import XMLAdapter
-from dspy.clients.lm import LM
+
+if TYPE_CHECKING:
+    from dspy.clients.lm import LM
 from dspy.clients.utils_finetune import GRPOGroup, GRPOStatus, TrainDataFormat
 from dspy.dsp.utils.settings import settings
 from dspy.evaluate.evaluate import Evaluate
@@ -28,8 +30,8 @@ class GRPO(FinetuneTeleprompter):
         self,
         metric: Callable | None = None,
         multitask: bool = True,
-        train_kwargs: dict[str, Any] | dict[LM, dict[str, Any]] | None = None,
-        adapter: Adapter | dict[LM, Adapter] | None = None,
+        train_kwargs: "dict[str, Any] | dict[LM, dict[str, Any]] | None" = None,
+        adapter: "Adapter | dict[LM, Adapter] | None" = None,
         exclude_demos: bool = False,
         num_threads: int = 6,
         num_train_steps: int = 100,

--- a/dspy/teleprompt/knn_fewshot.py
+++ b/dspy/teleprompt/knn_fewshot.py
@@ -1,15 +1,17 @@
 import types
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from dspy.clients import Embedder
 from dspy.predict.knn import KNN
+
+if TYPE_CHECKING:
+    from dspy.clients.embedding import Embedder
 from dspy.primitives import Example
 from dspy.teleprompt import BootstrapFewShot
 from dspy.teleprompt.teleprompt import Teleprompter
 
 
 class KNNFewShot(Teleprompter):
-    def __init__(self, k: int, trainset: list[Example], vectorizer: Embedder, **few_shot_bootstrap_args: dict[str, Any]):
+    def __init__(self, k: int, trainset: list[Example], vectorizer: "Embedder", **few_shot_bootstrap_args: dict[str, Any]):
         """
         KNNFewShot is an optimizer that uses an in-memory KNN retriever to find the k nearest neighbors
         in a trainset at test time. For each input example in a forward call, it identifies the k most

--- a/tests/clients/test_lazy_litellm.py
+++ b/tests/clients/test_lazy_litellm.py
@@ -1,0 +1,152 @@
+"""Test that litellm is not required at import time.
+
+DSPy should be importable and usable for basic operations (e.g., BaseLM
+subclasses, signatures, modules) without litellm being installed. LiteLLM
+should only be needed when dspy.LM, dspy.Embedder, or streaming features
+are actually used.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_snippet(snippet: str, *, timeout: int = 30) -> subprocess.CompletedProcess:
+    """Run a Python snippet in a subprocess with litellm poisoned."""
+    # The snippet is prefixed with code that makes `import litellm` raise ImportError
+    # before dspy is imported, simulating litellm not being installed.
+    wrapper = textwrap.dedent("""\
+        import importlib.abc
+        import importlib.machinery
+        import sys
+
+        # Poison litellm: any import of litellm or its submodules will raise ImportError
+        class _LitellmBlocker(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+            def find_spec(self, fullname, path, target=None):
+                if fullname == "litellm" or fullname.startswith("litellm."):
+                    return importlib.machinery.ModuleSpec(fullname, self)
+                return None
+            def create_module(self, spec):
+                return None
+            def exec_module(self, module):
+                raise ImportError(f"Poisoned: {module.__name__} is not available")
+
+        sys.meta_path.insert(0, _LitellmBlocker())
+
+        # Remove litellm if it was already imported
+        for key in list(sys.modules):
+            if key == "litellm" or key.startswith("litellm."):
+                del sys.modules[key]
+
+    """)
+    full_code = wrapper + textwrap.dedent(snippet)
+    return subprocess.run(
+        [sys.executable, "-c", full_code],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_import_dspy_without_litellm():
+    """Importing dspy should succeed without litellm."""
+    result = _run_snippet("import dspy; print('ok')")
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ok" in result.stdout
+
+
+def test_baselm_subclass_without_litellm():
+    """A custom BaseLM subclass should work without litellm."""
+    result = _run_snippet("""\
+        import dspy
+
+        class MyLM(dspy.BaseLM):
+            def forward(self, prompt=None, messages=None, **kwargs):
+                class R:
+                    choices = [type('C', (), {'message': type('M', (), {'content': 'hello', 'tool_calls': None, 'reasoning_content': None})()})]
+                    usage = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0}
+                    model = 'test'
+                return R()
+
+        lm = MyLM(model="test")
+        result = lm("hi")
+        print(result)
+        print("ok")
+    """)
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ok" in result.stdout
+
+
+def test_signatures_without_litellm():
+    """Signature creation should work without litellm."""
+    result = _run_snippet("""\
+        import dspy
+
+        class QA(dspy.Signature):
+            question: str = dspy.InputField()
+            answer: str = dspy.OutputField()
+
+        print(QA)
+        print("ok")
+    """)
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ok" in result.stdout
+
+
+def test_predict_module_creation_without_litellm():
+    """Creating a Predict module should work without litellm."""
+    result = _run_snippet("""\
+        import dspy
+
+        predict = dspy.Predict("question -> answer")
+        print(predict)
+        print("ok")
+    """)
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ok" in result.stdout
+
+
+def test_adapter_call_with_custom_baselm_without_litellm():
+    """A full adapter → custom BaseLM round-trip should work without litellm."""
+    result = _run_snippet("""\
+        import dspy
+
+        class MyLM(dspy.BaseLM):
+            def forward(self, prompt=None, messages=None, **kwargs):
+                class R:
+                    choices = [type('C', (), {
+                        'message': type('M', (), {
+                            'content': '[[ ## answer ## ]]\\nParis\\n\\n[[ ## completed ## ]]',
+                            'tool_calls': None,
+                            'reasoning_content': None,
+                        })(),
+                        'finish_reason': 'stop',
+                    })]
+                    usage = {'prompt_tokens': 0, 'completion_tokens': 0, 'total_tokens': 0}
+                    model = 'test'
+                return R()
+
+        lm = MyLM(model="test")
+        dspy.configure(lm=lm)
+        result = dspy.Predict("question -> answer")(question="What is the capital of France?")
+        assert result.answer == "Paris", f"got: {result.answer}"
+        print("ok")
+    """)
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ok" in result.stdout
+
+
+def test_dspy_lm_fails_gracefully_without_litellm():
+    """dspy.LM() should raise a clear error when litellm is not available."""
+    result = _run_snippet("""\
+        import dspy
+
+        try:
+            lm = dspy.LM("openai/gpt-4o")
+            print("should have failed")
+        except ImportError as e:
+            print(f"ImportError: {e}")
+            print("ok")
+    """)
+    assert result.returncode == 0, f"stderr:\n{result.stderr}"
+    assert "ok" in result.stdout


### PR DESCRIPTION
> [!IMPORTANT]
> This does NOT make litellm an optional dependency. It could be the next pr, with the appropriate version bump, release note and warning to install litellm. Or, we could wait that we have other `BaseLM` subclass before doing that change. I am agnostic. 

**Related Epic:** Relates to #9514 (Phase 4)

**What this PR does**
This PR completely isolates `litellm` from DSPy's core import path, it is only loaded if a user explicitly instantiates `dspy.LM`, `dspy.Embedder`, or uses `litellm`-backed streaming.
* **Lazy Loading via `__getattr__`**: Updates `dspy/__init__.py`, `dspy/clients/__init__.py`, and `dspy/streaming/__init__.py` to use module-level `__getattr__`. This defers the importing of `litellm`-dependent classes until they are actually accessed.
* **Type Hint Scrubbing**: Moves all internal imports of `LM`, `Embedder`, and `litellm` behind `if TYPE_CHECKING:` blocks across the `teleprompt`, `predict`, and `streaming` modules.
* **Safe Instance Checking**: Introduces safe helpers like `_is_model_response_stream` and `_is_lm_keyed_dict` that check types without triggering an eager import.
* **Strict Dependency Testing**: Adds `tests/clients/test_lazy_litellm.py`, which uses a custom `importlib` loader to "poison" `litellm` in a subprocess. This guarantees that importing `dspy`, creating signatures, making modules, and running custom `BaseLM` backends all execute perfectly in a zero-`litellm` environment.

**Why this is needed**
Prior to this PR, `litellm` was imported immediately upon `import dspy`. This added  seconds to DSPy's boot time and forced users to install it even if they exclusively used custom `BaseLM` backends.

DSPy approaches dependency inversion in `BaseLM`. 

<img width="901" height="374" alt="image" src="https://github.com/user-attachments/assets/1d3ebf1e-8926-4f60-ab08-d728f6ffa501" />
