### PR TITLE
docs: add docstrings to utils_finetune.py

### DIFF
--- a/dspy/clients/utils_finetune.py
+++ b/dspy/clients/utils_finetune.py
@@ -1,3 +1,10 @@
+"""Utilities for fine-tuning data preparation, validation, and persistence.
+
+This module provides helpers used by the DSPy fine-tuning pipeline to infer
+data formats, save training data to disk, and validate that datasets conform
+to expected schemas (chat or completion format).
+"""
+
 import os
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
@@ -12,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class TrainingStatus(str, Enum):
+    """Status of a fine-tuning training job."""
+
     not_started = "not_started"
     pending = "pending"
     running = "running"
@@ -21,32 +30,44 @@ class TrainingStatus(str, Enum):
 
 
 class TrainDataFormat(str, Enum):
+    """Supported training data formats for fine-tuning."""
+
     CHAT = "chat"
     COMPLETION = "completion"
     GRPO_CHAT = "grpo_chat"
 
 
 class Message(TypedDict):
+    """A single chat message with a role and content."""
+
     role: Literal["user"] | Literal["assistant"] | Literal["system"]
     content: str
 
 
 class MessageAssistant(TypedDict):
+    """A chat message restricted to the assistant role."""
+
     role: Literal["assistant"]
     content: str
 
 
 class GRPOChatData(TypedDict):
+    """A single GRPO training example with messages, completion, and reward."""
+
     messages: list[Message]
     completion: MessageAssistant
     reward: float
 
 
 class GRPOGroup(TypedDict):
+    """A batch group of GRPO training examples."""
+
     batch_id: int | None
     group: list[GRPOChatData]
 
 class GRPOStatus(TypedDict):
+    """Status of a GRPO fine-tuning job, including checkpoint information."""
+
     job_id: str
     status: str | None = None
     current_model: str
@@ -56,12 +77,32 @@ class GRPOStatus(TypedDict):
 
 
 def infer_data_format(adapter: "Adapter") -> str:
+    """Infer the training data format from the given adapter type.
+
+    Args:
+        adapter: A DSPy adapter instance (e.g. ``ChatAdapter``).
+
+    Returns:
+        The corresponding ``TrainDataFormat`` value.
+
+    Raises:
+        ValueError: If the adapter type is not recognized.
+    """
     if isinstance(adapter, dspy.ChatAdapter):
         return TrainDataFormat.CHAT
     raise ValueError(f"Could not infer the data format for: {adapter}")
 
 
 def get_finetune_directory() -> str:
+    """Return the directory path used for storing fine-tuning artifacts.
+
+    Uses the ``DSPY_FINETUNEDIR`` environment variable if set, otherwise
+    defaults to ``<DSPY_CACHEDIR>/finetune``. Creates the directory if it
+    does not exist.
+
+    Returns:
+        Absolute path to the fine-tuning directory.
+    """
     default_finetunedir = os.path.join(DSPY_CACHEDIR, "finetune")
     finetune_dir = os.environ.get("DSPY_FINETUNEDIR") or default_finetunedir
     finetune_dir = os.path.abspath(finetune_dir)
@@ -69,7 +110,13 @@ def get_finetune_directory() -> str:
     return finetune_dir
 
 
-def write_lines(file_path, data):
+def write_lines(file_path: str, data: list[Any]) -> None:
+    """Write a list of JSON-serializable objects as newline-delimited JSON.
+
+    Args:
+        file_path: Destination file path.
+        data: Items to serialize; each is written as a single JSON line.
+    """
     with open(file_path, "wb") as f:
         for item in data:
             f.write(orjson.dumps(item) + b"\n")
@@ -78,6 +125,17 @@ def write_lines(file_path, data):
 def save_data(
     data: list[dict[str, Any]],
 ) -> str:
+    """Persist training data to a JSONL file named by its content hash.
+
+    The file is saved in the fine-tuning directory returned by
+    :func:`get_finetune_directory`.
+
+    Args:
+        data: Training examples to save.
+
+    Returns:
+        Absolute path to the written JSONL file.
+    """
     from dspy.utils.hasher import Hasher
 
     # Assign a unique name to the file based on the data hash
@@ -96,7 +154,21 @@ def save_data(
 def validate_data_format(
     data: list[dict[str, Any]],
     data_format: TrainDataFormat,
-):
+) -> None:
+    """Validate that every item in *data* conforms to *data_format*.
+
+    Checks each dictionary in the list against the expected schema for the
+    given format. If any errors are found, they are logged to a file and a
+    ``ValueError`` is raised.
+
+    Args:
+        data: List of training examples to validate.
+        data_format: The expected format (``CHAT`` or ``COMPLETION``).
+
+    Raises:
+        AssertionError: If *data_format* is not supported.
+        ValueError: If *data* is not a list or contains invalid entries.
+    """
     find_err_funcs = {
         TrainDataFormat.CHAT: find_data_error_chat,
         TrainDataFormat.COMPLETION: find_data_errors_completion,
@@ -129,6 +201,14 @@ def validate_data_format(
 
 
 def find_data_errors_completion(data_dict: dict[str, str]) -> str | None:
+    """Check a single completion-format example for schema errors.
+
+    Args:
+        data_dict: A dictionary expected to have ``prompt`` and ``completion`` keys.
+
+    Returns:
+        An error message string if validation fails, or ``None`` if valid.
+    """
     keys = ["prompt", "completion"]
 
     assert isinstance(data_dict, dict)
@@ -145,6 +225,17 @@ def find_data_errors_completion(data_dict: dict[str, str]) -> str | None:
 # Following functions are modified from the OpenAI cookbook:
 # https://cookbook.openai.com/examples/chat_finetuning_data_prep
 def find_data_error_chat(messages: dict[str, Any]) -> str | None:
+    """Check a single chat-format example for schema errors.
+
+    Validates that the dictionary has a ``messages`` key containing a list
+    of well-formed message dictionaries.
+
+    Args:
+        messages: A dictionary expected to have a ``messages`` key.
+
+    Returns:
+        An error message string if validation fails, or ``None`` if valid.
+    """
     assert isinstance(messages, dict)
 
     expected_keys = ["messages"]
@@ -162,6 +253,14 @@ def find_data_error_chat(messages: dict[str, Any]) -> str | None:
 
 
 def find_data_error_chat_message(message: dict[str, Any]) -> str | None:
+    """Check a single chat message dictionary for schema errors.
+
+    Args:
+        message: A dictionary expected to have ``role`` and ``content`` keys.
+
+    Returns:
+        An error message string if validation fails, or ``None`` if valid.
+    """
     assert isinstance(message, dict)
 
     message_keys = sorted(["role", "content"])


### PR DESCRIPTION
Fixes #9535

Adds Google-style docstrings to all public functions, TypedDict classes, and Enum classes in `dspy/clients/utils_finetune.py`, plus a module-level docstring.

**Functions documented:**
- `infer_data_format`
- `get_finetune_directory`
- `write_lines`
- `save_data`
- `validate_data_format`
- `find_data_errors_completion`
- `find_data_error_chat`
- `find_data_error_chat_message`

**Classes documented:**
- `TrainingStatus`, `TrainDataFormat`, `Message`, `MessageAssistant`, `GRPOChatData`, `GRPOGroup`, `GRPOStatus`

Resolves part of #8926.