### PR TITLE
docs: add docstrings to Embedder.acall and Dataset base class

### DIFF
--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -136,7 +136,37 @@ class Embedder:
             embeddings_list.extend(compute_embeddings(self.model, batch, caching=caching, **kwargs))
         return self._postprocess(embeddings_list, is_single_input)
 
-    async def acall(self, inputs, batch_size=None, caching=None, **kwargs):
+    async def acall(self, inputs: str | list[str], batch_size: int | None = None, caching: bool | None = None, **kwargs: dict[str, Any]) -> np.ndarray:
+        """Asynchronously compute embeddings for the given inputs.
+
+        This is the async version of `__call__`. It uses asynchronous API calls for hosted models
+        via ``litellm.aembedding``, which can be useful when you want to compute embeddings without
+        blocking the event loop.
+
+        Args:
+            inputs: The inputs to compute embeddings for, can be a single string or a list of strings.
+            batch_size (int, optional): The batch size for processing inputs. If None, defaults to the batch_size set
+                during initialization.
+            caching (bool, optional): Whether to cache the embedding response when using a hosted model. If None,
+                defaults to the caching setting from initialization.
+            **kwargs: Additional keyword arguments to pass to the embedding model. These will override the default
+                kwargs provided during initialization.
+
+        Returns:
+            numpy.ndarray: If the input is a single string, returns a 1D numpy array representing the embedding.
+            If the input is a list of strings, returns a 2D numpy array of embeddings, one embedding per row.
+
+        Examples:
+            ```python
+            import dspy
+            import asyncio
+
+            embedder = dspy.Embedder("openai/text-embedding-3-small", batch_size=100)
+            embeddings = asyncio.run(embedder.acall(["hello", "world"]))
+
+            assert embeddings.shape == (2, 1536)
+            ```
+        """
         input_batches, caching, kwargs, is_single_input = self._preprocess(inputs, batch_size, caching, **kwargs)
 
         embeddings_list = []

--- a/dspy/datasets/dataset.py
+++ b/dspy/datasets/dataset.py
@@ -10,6 +10,50 @@ from dspy.dsp.utils import dotdict
 
 
 class Dataset:
+    """Base class for all DSPy datasets.
+
+    The ``Dataset`` class provides a standard interface for loading, shuffling, and splitting data into
+    train, dev, and test sets. Subclasses should populate the ``_train``, ``_dev``, and ``_test`` attributes
+    with raw data (iterables of dicts), and this base class handles shuffling, sampling, and wrapping
+    each record as a :class:`dspy.Example`.
+
+    Shuffling is seeded for reproducibility. You can control the random seeds and split sizes at
+    construction time or later via :meth:`reset_seeds`.
+
+    Args:
+        train_seed (int): Random seed used for shuffling the training set. Defaults to 0.
+        train_size (int, optional): Maximum number of training examples to return. If None, all
+            available training examples are returned.
+        eval_seed (int): Random seed used for shuffling both the dev and test sets. Defaults to 0.
+        dev_size (int, optional): Maximum number of dev examples to return. If None, all available
+            dev examples are returned.
+        test_size (int, optional): Maximum number of test examples to return. If None, all available
+            test examples are returned.
+        input_keys (list[str], optional): Field names to mark as inputs on every example via
+            :meth:`Example.with_inputs`. If None, no input keys are set.
+
+    Examples:
+        ```python
+        import dspy
+
+        class MyDataset(dspy.Dataset):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self._train = [
+                    {"question": "What is 2+2?", "answer": "4"},
+                    {"question": "What is 3+3?", "answer": "6"},
+                ]
+                self._dev = [
+                    {"question": "What is 4+4?", "answer": "8"},
+                ]
+                self._test = []
+
+        dataset = MyDataset(train_size=1, input_keys=["question"])
+        print(len(dataset.train))  # 1
+        print(dataset.train[0].question)
+        ```
+    """
+
     def __init__(
         self,
         train_seed: int = 0,
@@ -39,6 +83,23 @@ class Dataset:
         dev_size: int | None = None,
         test_size: int | None = None,
     ) -> None:
+        """Reset the random seeds and split sizes, clearing any cached splits.
+
+        After calling this method, the next access to :attr:`train`, :attr:`dev`, or :attr:`test`
+        will re-shuffle and re-sample the data with the updated seeds and sizes.
+
+        Args:
+            train_seed (int, optional): New random seed for the training split. If None, keeps the
+                current seed.
+            train_size (int, optional): New maximum number of training examples. If None, keeps the
+                current size.
+            eval_seed (int, optional): New random seed for both the dev and test splits. If None,
+                keeps the current seed.
+            dev_size (int, optional): New maximum number of dev examples. If None, keeps the current
+                size.
+            test_size (int, optional): New maximum number of test examples. If None, keeps the
+                current size.
+        """
         self.train_size = train_size or self.train_size
         self.train_seed = train_seed or self.train_seed
         self.dev_size = dev_size or self.dev_size
@@ -57,6 +118,14 @@ class Dataset:
 
     @property
     def train(self) -> list[Example]:
+        """Return the training split as a list of :class:`dspy.Example` objects.
+
+        The result is shuffled and sampled on first access using :attr:`train_seed` and
+        :attr:`train_size`, then cached. Call :meth:`reset_seeds` to regenerate.
+
+        Returns:
+            list[Example]: The training examples.
+        """
         if not hasattr(self, "_train_"):
             self._train_ = self._shuffle_and_sample("train", self._train, self.train_size, self.train_seed)
 
@@ -64,6 +133,14 @@ class Dataset:
 
     @property
     def dev(self) -> list[Example]:
+        """Return the development (validation) split as a list of :class:`dspy.Example` objects.
+
+        The result is shuffled and sampled on first access using :attr:`dev_seed` and
+        :attr:`dev_size`, then cached. Call :meth:`reset_seeds` to regenerate.
+
+        Returns:
+            list[Example]: The dev examples.
+        """
         if not hasattr(self, "_dev_"):
             self._dev_ = self._shuffle_and_sample("dev", self._dev, self.dev_size, self.dev_seed)
 
@@ -71,6 +148,14 @@ class Dataset:
 
     @property
     def test(self) -> list[Example]:
+        """Return the test split as a list of :class:`dspy.Example` objects.
+
+        The result is shuffled and sampled on first access using :attr:`test_seed` and
+        :attr:`test_size`, then cached. Call :meth:`reset_seeds` to regenerate.
+
+        Returns:
+            list[Example]: The test examples.
+        """
         if not hasattr(self, "_test_"):
             self._test_ = self._shuffle_and_sample("test", self._test, self.test_size, self.test_seed)
 


### PR DESCRIPTION
## Summary

- Add Google-style docstring to `Embedder.acall()` in `dspy/clients/embedding.py`, mirroring the existing `__call__` docstring with an async example.
- Add class-level docstring to `Dataset` in `dspy/datasets/dataset.py`, along with docstrings for `reset_seeds()`, `train`, `dev`, and `test` properties.

Resolves #9523
Resolves #9525
Part of #8926

## Test plan

- [ ] Verify docstrings render correctly with `pydoc` or `help()`
- [ ] Confirm no behavioral changes — only docstring additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)