### PR TITLE
fix: detect reasoning support from response for unregistered models

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -125,7 +125,15 @@ class LM(BaseLM):
 
     @property
     def supports_reasoning(self) -> bool:
-        return litellm.supports_reasoning(self.model)
+        if litellm.supports_reasoning(self.model):
+            return True
+
+        # For models not in litellm's built-in registry (e.g., vLLM-hosted models), allow users to
+        # signal reasoning support by explicitly setting `reasoning_effort` in the LM kwargs.
+        if "reasoning_effort" in self.kwargs and self.kwargs["reasoning_effort"] is not None:
+            return True
+
+        return False
 
     @property
     def supports_response_schema(self) -> bool:

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1033,3 +1033,33 @@ async def test_streaming_passes_headers_correctly():
             mock_acompletion.assert_called_once()
             call_kwargs = mock_acompletion.call_args.kwargs
             assert call_kwargs["headers"]["Authorization"] == "Bearer my-custom-token"
+
+
+def test_supports_reasoning_with_explicit_reasoning_effort():
+    """Test that supports_reasoning returns True when reasoning_effort is explicitly set,
+    even if litellm doesn't recognize the model (e.g., vLLM-hosted models)."""
+    with mock.patch("litellm.supports_reasoning", return_value=False):
+        # Without reasoning_effort, should return False for unregistered models
+        lm = dspy.LM(model="openai/Qwen/Qwen3.5-4B", api_base="http://localhost:8000/v1")
+        assert lm.supports_reasoning is False
+
+        # With explicit reasoning_effort, should return True
+        lm = dspy.LM(
+            model="openai/Qwen/Qwen3.5-4B",
+            api_base="http://localhost:8000/v1",
+            reasoning_effort="low",
+        )
+        assert lm.supports_reasoning is True
+
+        # With reasoning_effort=None, should return False (user explicitly disabling)
+        lm = dspy.LM(
+            model="openai/Qwen/Qwen3.5-4B",
+            api_base="http://localhost:8000/v1",
+            reasoning_effort=None,
+        )
+        assert lm.supports_reasoning is False
+
+    # When litellm recognizes the model, should still return True regardless
+    with mock.patch("litellm.supports_reasoning", return_value=True):
+        lm = dspy.LM(model="anthropic/claude-3-7-sonnet-20250219", temperature=1.0, max_tokens=16000)
+        assert lm.supports_reasoning is True


### PR DESCRIPTION
## Summary

- For vLLM-hosted models not in litellm's built-in registry, `litellm.supports_reasoning()` returns `False` even when the model actually supports reasoning via the `reasoning_content` field
- This causes `dspy.Reasoning` to fall back to requesting reasoning as a text field, but the model still returns `reasoning_content` natively, leading to unexpected behavior
- Allow users to signal reasoning support by explicitly setting `reasoning_effort` in LM kwargs (e.g., `dspy.LM("openai/Qwen/Qwen3.5-4B", reasoning_effort="low")`)

## Changes

**`dspy/clients/lm.py`**: Updated `LM.supports_reasoning` property to check if `reasoning_effort` is explicitly set in `self.kwargs` as a fallback when `litellm.supports_reasoning()` returns `False`.

**`tests/clients/test_lm.py`**: Added test covering all cases: unregistered model without `reasoning_effort` (False), with `reasoning_effort` (True), with `reasoning_effort=None` (False), and litellm-recognized model (True).

## Motivation

Users hosting reasoning-capable models on vLLM (e.g., `openai/Qwen/Qwen3.5-4B`) cannot use `dspy.Reasoning` correctly because litellm's static registry doesn't know about these models. The current workaround requires calling `litellm.register_model()` manually. This fix provides a simpler path: just pass `reasoning_effort` to `dspy.LM()`.

Fixes #9503

## Test plan

- [x] New unit test `test_supports_reasoning_with_explicit_reasoning_effort` passes
- [x] Existing reasoning tests pass (`test_call_reasoning_model_with_chat_api`, `test_reasoning_*`)