### PR TITLE
docs: add docstrings to Dataset base class in dspy/datasets/dataset.py

### DIFF
--- a/dspy/datasets/dataset.py
+++ b/dspy/datasets/dataset.py
@@ -10,6 +10,37 @@ from dspy.dsp.utils import dotdict
 
 
 class Dataset:
+    """Base class for DSPy datasets.
+
+    Provides a standard interface for loading, shuffling, and splitting datasets
+    into train, dev, and test sets. Subclasses should populate ``_train``, ``_dev``,
+    and ``_test`` iterables of dictionaries representing examples.
+
+    The class handles shuffling (controlled by seed) and optional size-limiting
+    for each split, converting raw dicts into :class:`dspy.Example` objects.
+
+    Args:
+        train_seed: Random seed for shuffling the training split. Defaults to 0.
+        train_size: Maximum number of training examples to use. ``None`` means use all.
+        eval_seed: Random seed for shuffling the dev and test splits. Defaults to 0.
+        dev_size: Maximum number of dev examples to use. ``None`` means use all.
+        test_size: Maximum number of test examples to use. ``None`` means use all.
+        input_keys: List of keys to mark as input fields on each :class:`dspy.Example`.
+
+    Examples:
+        Subclass ``Dataset`` and set ``_train``, ``_dev``, ``_test``::
+
+            class MyDataset(Dataset):
+                def __init__(self, **kwargs):
+                    super().__init__(**kwargs)
+                    self._train = [{"question": "What is 1+1?", "answer": "2"}]
+                    self._dev = [{"question": "What is 2+2?", "answer": "4"}]
+                    self._test = []
+
+            dataset = MyDataset(train_size=1, input_keys=["question"])
+            print(dataset.train[0].question)
+    """
+
     def __init__(
         self,
         train_seed: int = 0,
@@ -39,6 +70,18 @@ class Dataset:
         dev_size: int | None = None,
         test_size: int | None = None,
     ) -> None:
+        """Reset the seeds and sizes for the dataset splits, clearing cached data.
+
+        After calling this method, the next access to ``train``, ``dev``, or ``test``
+        will reshuffle and resample with the updated parameters.
+
+        Args:
+            train_seed: New random seed for the training split.
+            train_size: New maximum size for the training split.
+            eval_seed: New random seed for the dev and test splits.
+            dev_size: New maximum size for the dev split.
+            test_size: New maximum size for the test split.
+        """
         self.train_size = train_size or self.train_size
         self.train_seed = train_seed or self.train_seed
         self.dev_size = dev_size or self.dev_size
@@ -57,6 +100,7 @@ class Dataset:
 
     @property
     def train(self) -> list[Example]:
+        """Return the training split as a list of :class:`dspy.Example` objects."""
         if not hasattr(self, "_train_"):
             self._train_ = self._shuffle_and_sample("train", self._train, self.train_size, self.train_seed)
 
@@ -64,6 +108,7 @@ class Dataset:
 
     @property
     def dev(self) -> list[Example]:
+        """Return the dev (validation) split as a list of :class:`dspy.Example` objects."""
         if not hasattr(self, "_dev_"):
             self._dev_ = self._shuffle_and_sample("dev", self._dev, self.dev_size, self.dev_seed)
 
@@ -71,6 +116,7 @@ class Dataset:
 
     @property
     def test(self) -> list[Example]:
+        """Return the test split as a list of :class:`dspy.Example` objects."""
         if not hasattr(self, "_test_"):
             self._test_ = self._shuffle_and_sample("test", self._test, self.test_size, self.test_seed)
 
@@ -112,6 +158,25 @@ class Dataset:
         eval_seed: int = 2023,
         **kwargs: Any,
     ) -> Any:
+        """Prepare multiple train/eval splits using different random seeds.
+
+        Creates one training set per seed and optionally divides the evaluation set
+        across seeds for cross-validation-style evaluation.
+
+        Args:
+            train_seeds: List of random seeds for generating training splits.
+                Defaults to ``[1, 2, 3, 4, 5]``.
+            train_size: Number of training examples per seed. Defaults to 16.
+            dev_size: Total number of dev examples. Defaults to 1000.
+            divide_eval_per_seed: If ``True``, divides the dev set evenly across seeds.
+                If ``False``, each seed gets the full dev set. Defaults to ``True``.
+            eval_seed: Random seed for the dev split. Defaults to 2023.
+            **kwargs: Additional keyword arguments passed to the dataset constructor.
+
+        Returns:
+            A ``dotdict`` with ``train_sets`` (list of training sets) and
+            ``eval_sets`` (list of evaluation sets), one per seed.
+        """
         train_seeds = train_seeds or [1, 2, 3, 4, 5]
         data_args = dotdict(train_size=train_size, eval_seed=eval_seed, dev_size=dev_size, test_size=0, **kwargs)
         dataset = cls(**data_args)


### PR DESCRIPTION
Fixes #9525

Adds comprehensive docstrings to the `Dataset` base class in `dspy/datasets/dataset.py`:

- **Class docstring** with description, args, and usage example
- **`reset_seeds()`** method docstring with args
- **`train`**, **`dev`**, **`test`** property docstrings
- **`prepare_by_seed()`** classmethod docstring with args and return description

All docstrings follow Google-style conventions consistent with the rest of the codebase.