### PR TITLE
docs: add docstrings to LabeledFewShot in dspy/teleprompt/vanilla.py

### DIFF
--- a/dspy/teleprompt/vanilla.py
+++ b/dspy/teleprompt/vanilla.py
@@ -4,10 +4,32 @@ from dspy.teleprompt.teleprompt import Teleprompter
 
 
 class LabeledFewShot(Teleprompter):
+    """A simple teleprompter that assigns labeled training examples as few-shot demonstrations.
+
+    Randomly samples up to ``k`` examples from the training set and attaches them
+    as demonstrations to each predictor in the student program. No bootstrapping
+    or optimization is performed—the labeled examples are used directly.
+
+    Args:
+        k: Maximum number of labeled demonstrations to attach per predictor.
+            Defaults to 16.
+    """
+
     def __init__(self, k=16):
         self.k = k
 
     def compile(self, student, *, trainset, sample=True):
+        """Compile the student program by attaching labeled demonstrations.
+
+        Args:
+            student: The student :class:`dspy.Module` to compile.
+            trainset: A list of :class:`dspy.Example` objects to sample demonstrations from.
+            sample: If ``True``, randomly sample up to ``k`` examples. If ``False``,
+                take the first ``k`` examples in order. Defaults to ``True``.
+
+        Returns:
+            The compiled student module with demonstrations attached to its predictors.
+        """
         self.student = student.reset_copy()
         self.trainset = trainset
 


### PR DESCRIPTION
Fixes #9547

Adds docstrings to the `LabeledFewShot` class and its `compile()` method in `dspy/teleprompt/vanilla.py`, covering class description, args, and return values. Part of the broader docstring effort in #8926.