### PR TITLE
fix: sanitize config in Predict.load_state to prevent SSRF bypass

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -100,11 +100,14 @@ class Predict(Module, Parameter):
         Returns:
             Self to allow method chaining.
         """
-        excluded_keys = ["signature", "extended_signature", "lm"]
+        excluded_keys = ["signature", "extended_signature", "lm", "config"]
         for name, value in state.items():
             # `excluded_keys` are fields that go through special handling.
             if name not in excluded_keys:
                 setattr(self, name, value)
+
+        if "config" in state:
+            self.config = _sanitize_lm_state(state["config"], allow_unsafe_lm_state)
 
         self.signature = self.signature.load_state(state["signature"])
         sanitized_lm_state = _sanitize_lm_state(state["lm"], allow_unsafe_lm_state) if state["lm"] else None

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -443,6 +443,37 @@ def test_load_blocks_serialized_model_list_unless_opted_in(tmp_path):
     assert opt_in_deployments[0]["api_base"] == override_url
 
 
+@pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
+def test_load_state_sanitizes_config_endpoint_override(endpoint_override_key):
+    """Config dict in state must not bypass LM endpoint sanitization."""
+    override_url = "http://attacker.example.com/v1"
+    original_predict = dspy.Predict("q->a")
+    saved_state = original_predict.dump_state()
+    saved_state["config"] = {endpoint_override_key: override_url, "temperature": 0.5}
+
+    with patch("dspy.predict.predict.logger.warning") as warning_mock:
+        loaded_predict = dspy.Predict("q->a")
+        loaded_predict.load_state(saved_state)
+
+    assert endpoint_override_key not in loaded_predict.config
+    assert loaded_predict.config["temperature"] == 0.5
+    warning_mock.assert_called_once()
+
+
+@pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
+def test_load_state_allows_config_endpoint_override_with_opt_in(endpoint_override_key):
+    """allow_unsafe_lm_state=True preserves config endpoint overrides."""
+    override_url = "http://trusted.local/v1"
+    original_predict = dspy.Predict("q->a")
+    saved_state = original_predict.dump_state()
+    saved_state["config"] = {endpoint_override_key: override_url}
+
+    loaded_predict = dspy.Predict("q->a")
+    loaded_predict.load_state(saved_state, allow_unsafe_lm_state=True)
+
+    assert loaded_predict.config[endpoint_override_key] == override_url
+
+
 def test_load_uses_env_api_key_without_honoring_serialized_endpoint_override(tmp_path, monkeypatch):
     file_path = tmp_path / "model.json"
     override_url = "http://override.local/v1"


### PR DESCRIPTION
## Summary

`Predict.load_state` applies endpoint sanitization (`_sanitize_lm_state`) only to the `lm` sub-key of a deserialized state dict. The `config` attribute was not in `excluded_keys` and was set via the generic `setattr` loop with no sanitization. Since `config` flows directly into LM call kwargs at inference time, an attacker could embed `api_base`/`base_url` inside `config` in a tampered state file to redirect all LLM API traffic — including the victim's API key and prompt content — to an attacker-controlled endpoint.

## Fix

- Add `"config"` to `excluded_keys` in `load_state`
- Apply the same `UNSAFE_LM_STATE_KEYS` sanitization to `config` that already protects `lm` state
- Respect the existing `allow_unsafe_lm_state` opt-in flag for trusted files

## Tests

Added 4 parametrized tests covering:
- `api_base` and `base_url` are stripped from config by default
- Safe config keys (e.g. `temperature`) are preserved
- `allow_unsafe_lm_state=True` preserves endpoint overrides in config