### PR TITLE
fix: handle both isError and is_error in MCP tool result (fixes #8760)

### DIFF
--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -21,7 +21,8 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if len(text_contents) == 1:
         tool_content = tool_content[0]
 
-    if call_tool_result.isError:
+    is_error = getattr(call_tool_result, "is_error", None) or getattr(call_tool_result, "isError", None)
+    if is_error:
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
 
     return tool_content or non_text_contents

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -96,3 +96,58 @@ async def test_convert_mcp_tool():
             assert current_datetime_tool.arg_types == {}
             assert current_datetime_tool.arg_desc == {}
             assert await current_datetime_tool.acall() == "2025-07-23T09:10:10.0+00:00"
+
+
+class _FakeResultWithIsError:
+    """Simulates fastmcp CallToolResult which uses is_error."""
+
+    def __init__(self, content, is_error=False):
+        self.content = content
+        self.is_error = is_error
+
+
+class _FakeResultWithCamelCase:
+    """Simulates the official MCP SDK CallToolResult which uses isError."""
+
+    def __init__(self, content, isError=False):  # noqa: N803
+        self.content = content
+        self.isError = isError
+
+
+def test_convert_mcp_tool_result_is_error_attribute():
+    """_convert_mcp_tool_result should detect errors via is_error (fastmcp)."""
+    from mcp.types import TextContent
+
+    from dspy.utils.mcp import _convert_mcp_tool_result
+
+    result = _FakeResultWithIsError(
+        content=[TextContent(type="text", text="something went wrong")],
+        is_error=True,
+    )
+    with pytest.raises(RuntimeError, match="Failed to call a MCP tool"):
+        _convert_mcp_tool_result(result)
+
+
+def test_convert_mcp_tool_result_isError_attribute():
+    """_convert_mcp_tool_result should detect errors via isError (official SDK)."""
+    from mcp.types import TextContent
+
+    from dspy.utils.mcp import _convert_mcp_tool_result
+
+    result = _FakeResultWithCamelCase(
+        content=[TextContent(type="text", text="something went wrong")],
+        isError=True,
+    )
+    with pytest.raises(RuntimeError, match="Failed to call a MCP tool"):
+        _convert_mcp_tool_result(result)
+
+
+def test_convert_mcp_tool_result_success():
+    """Non-error results should return content normally."""
+    from mcp.types import TextContent
+
+    from dspy.utils.mcp import _convert_mcp_tool_result
+
+    for fake_cls in (_FakeResultWithIsError, _FakeResultWithCamelCase):
+        result = fake_cls(content=[TextContent(type="text", text="ok")])
+        assert _convert_mcp_tool_result(result) == "ok"


### PR DESCRIPTION
## Summary

- **Root cause:** `_convert_mcp_tool_result` in `dspy/utils/mcp.py` accesses `call_tool_result.isError` directly. This works with the official MCP SDK's `CallToolResult`, but fastmcp uses `is_error` (snake_case), causing an `AttributeError`.
- **Fix:** Replace the direct attribute access with `getattr(call_tool_result, "is_error", None) or getattr(call_tool_result, "isError", None)` to support both SDKs.
- **Tests:** Added three unit tests covering error detection via `is_error`, error detection via `isError`, and successful (non-error) results.

This is a one-line compatibility fix with no changes to behavior for users of either SDK.

Fixes #8760

## Test plan

- [x] Verified fix handles `is_error=True` (fastmcp style) — raises `RuntimeError`
- [x] Verified fix handles `isError=True` (official MCP SDK style) — raises `RuntimeError`
- [x] Verified non-error results return content correctly with both attribute styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)