### PR TITLE
Fix streaming completion path skipping retry params

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -339,6 +339,7 @@ def _get_stream_completion_fn(
     cache_kwargs: dict[str, Any],
     sync=True,
     headers: dict[str, Any] | None = None,
+    num_retries: int = 0,
 ):
     stream = dspy.settings.send_stream
     caller_predict = dspy.settings.caller_predict
@@ -357,6 +358,8 @@ def _get_stream_completion_fn(
         response = await litellm.acompletion(
             cache=cache_kwargs,
             stream=True,
+            num_retries=num_retries,
+            retry_strategy="exponential_backoff_retry",
             headers=headers,
             **request,
         )
@@ -387,7 +390,7 @@ def litellm_completion(request: dict[str, Any], num_retries: int, cache: dict[st
     request = dict(request)
     request.pop("rollout_id", None)
     headers = _add_dspy_identifier_to_headers(request.pop("headers", None))
-    stream_completion = _get_stream_completion_fn(request, cache, sync=True, headers=headers)
+    stream_completion = _get_stream_completion_fn(request, cache, sync=True, headers=headers, num_retries=num_retries)
     if stream_completion is None:
         return litellm.completion(
             cache=cache,
@@ -435,7 +438,7 @@ async def alitellm_completion(request: dict[str, Any], num_retries: int, cache: 
     request = dict(request)
     request.pop("rollout_id", None)
     headers = request.pop("headers", None)
-    stream_completion = _get_stream_completion_fn(request, cache, sync=False)
+    stream_completion = _get_stream_completion_fn(request, cache, sync=False, num_retries=num_retries)
     if stream_completion is None:
         return await litellm.acompletion(
             cache=cache,


### PR DESCRIPTION
## Summary
- Pass `num_retries` and `retry_strategy="exponential_backoff_retry"` to `litellm.acompletion` inside `_get_stream_completion_fn`, matching the non-streaming path behavior
- Forward `num_retries` from both `litellm_completion` and `alitellm_completion` call sites to `_get_stream_completion_fn`
- Ensures rate limit errors (429) are retried with exponential backoff when using `dspy.streamify()`

Fixes #9459

## Test plan
- [ ] Verify streaming calls with `dspy.streamify()` now retry on 429 rate limit errors instead of crashing immediately
- [ ] Verify non-streaming path behavior is unchanged
- [ ] Verify `num_retries=0` default preserves existing behavior when retry is not configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)