### PR TITLE
Make COPRO eval_kwargs parameter truly optional

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -120,7 +120,7 @@ class COPRO(Teleprompter):
         assert hasattr(predictor, "signature")
         predictor.signature = updated_signature
 
-    def compile(self, student, *, trainset, eval_kwargs):
+    def compile(self, student, *, trainset, eval_kwargs=None):
         """
         optimizes `signature` of `student` program - note that it may be zero-shot or already pre-optimized (demos already chosen - `demos != []`)
 
@@ -132,6 +132,7 @@ class COPRO(Teleprompter):
 
         Returns optimized version of `student`.
         """
+        eval_kwargs = eval_kwargs or {}
         module = student.deepcopy()
         evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
         total_calls = 0


### PR DESCRIPTION
## Summary
- Set `eval_kwargs` default to `None` in `COPRO.compile()` and fall back to `{}`, making it truly optional as documented in the docstring.

## Test plan
- [ ] Call `COPRO.compile(program, trainset=trainset)` without `eval_kwargs` and verify it no longer raises a `TypeError`
- [ ] Call with `eval_kwargs={"num_threads": 4}` and verify existing behavior is unchanged

Fixes #9080

🤖 Generated with [Claude Code](https://claude.com/claude-code)