### PR TITLE
docs: add Kelly Intelligence example to OpenAI-compatible providers list

### DIFF
--- a/docs/docs/learn/programming/language_models.md
+++ b/docs/docs/learn/programming/language_models.md
@@ -143,6 +143,14 @@ dspy.configure(lm=lm)
         lm = dspy.LM('openai/your-model-name', api_key='PROVIDER_API_KEY', api_base='YOUR_PROVIDER_URL')
         dspy.configure(lm=lm)
         ```
+
+        For example, [Kelly Intelligence](https://api.thedailylesson.com) exposes an OpenAI-compatible endpoint with a built-in 162,000-word vocabulary RAG layer (built on Claude under the hood). Set `KELLY_API_KEY` and use:
+
+        ```python linenums="1"
+        import dspy
+        lm = dspy.LM('openai/kelly-haiku', api_base='https://api.thedailylesson.com/v1', api_key='YOUR_KELLY_API_KEY')
+        dspy.configure(lm=lm)
+        ```
 If you run into errors, please refer to the [LiteLLM Docs](https://docs.litellm.ai/docs/providers) to verify if you are using the same variable names/following the right procedure.
 
 ## Calling the LM directly.


### PR DESCRIPTION
## Summary

The **Other providers** tab in `docs/docs/learn/programming/language_models.md` already documents the OpenAI-compatible pattern:

```python
lm = dspy.LM('openai/your-model-name', api_key='PROVIDER_API_KEY', api_base='YOUR_PROVIDER_URL')
```

…but only with placeholder values. This PR adds a single concrete worked example so readers can copy-paste a runnable snippet without guessing what the placeholders should look like.

The example uses [Kelly Intelligence](https://api.thedailylesson.com), an OpenAI-compatible HTTP endpoint with a built-in 162,000-word vocabulary RAG layer (built on Claude under the hood). It is operated by [Lesson of the Day, PBC](https://lotdpbc.com) and has a free tier with no credit card required.

## Why a real example helps

Readers landing on the **Other providers** tab today have to invent values for `your-model-name`, `PROVIDER_API_KEY`, and `YOUR_PROVIDER_URL` before the snippet runs. A concrete example with a free, no-signup endpoint makes the OpenAI-compatible pattern testable in 30 seconds — useful for anyone evaluating DSPy with a non-OpenAI backend, especially for vocabulary, tutoring, or language-learning use cases where the RAG layer matters.

## Scope

- 8 lines added to one file
- No new dependencies, no code changes, no test impact
- The existing placeholder snippet is preserved unchanged

## Test plan

- [x] Endpoint reachability verified: `curl https://api.thedailylesson.com/v1/models` returns 200
- [x] The free `/v1/demo` endpoint accepts an unauthenticated POST so reviewers can validate the example without signing up
- [x] Markdown renders cleanly under the existing tab structure