### PR TITLE
fix: correct demo index assignment in MIPROv2 optimizer

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -780,7 +780,7 @@ class MIPROv2(Teleprompter):
                 predictor.demos = demo_candidates[i][demos_idx]
                 trial_logs[trial_num][f"{i}_predictor_demos"] = demos_idx
                 chosen_params.append(f"Predictor {i}: Few-Shot Set {demos_idx}")
-                raw_chosen_params[f"{i}_predictor_demos"] = instruction_idx
+                raw_chosen_params[f"{i}_predictor_demos"] = demos_idx
 
         return chosen_params, raw_chosen_params
 


### PR DESCRIPTION
## Summary

- Fix a copy-paste bug in `dspy/teleprompt/mipro_optimizer_v2.py` where `raw_chosen_params[f"{i}_predictor_demos"]` was incorrectly assigned `instruction_idx` instead of `demos_idx`
- Line 776 correctly records `instruction_idx` for instructions, and line 781 correctly uses `demos_idx` to set `predictor.demos`, but line 783 mistakenly reuses `instruction_idx` when recording the chosen demo index
- This causes `raw_chosen_params` to feed wrong demo indices back to optuna's Bayesian optimizer, corrupting its parameter history and degrading MIPROv2 optimization quality

## Changes

```diff
- raw_chosen_params[f"{i}_predictor_demos"] = instruction_idx
+ raw_chosen_params[f"{i}_predictor_demos"] = demos_idx
```

## Test plan

- [x] Verified the surrounding code context confirms the correct variable is `demos_idx` (lines 779-782 all use `demos_idx`)
- [ ] Run existing MIPROv2 optimizer tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)