### PR TITLE
Add population_metric support to Evaluate for aggregate metrics

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -73,6 +73,7 @@ class Evaluate:
         *,
         devset: list["dspy.Example"],
         metric: Callable | None = None,
+        population_metric: Callable | None = None,
         num_threads: int | None = None,
         display_progress: bool = False,
         display_table: bool | int = False,
@@ -86,7 +87,15 @@ class Evaluate:
         """
         Args:
             devset (list[dspy.Example]): the evaluation dataset.
-            metric (Callable): The metric function to use for evaluation.
+            metric (Callable): The metric function to use for evaluation. This is a sample-wise metric that is called
+                as ``metric(example, prediction) -> score`` for each individual example.
+            population_metric (Callable): An optional population-wise / aggregate metric that is called once with all
+                examples and predictions: ``population_metric(examples, predictions) -> float``. This is useful for
+                metrics that need to see the full population, such as Pearson correlation, Spearman rank, or corpus
+                BLEU. When provided, the final ``EvaluationResult.score`` is determined by this metric instead of the
+                average of per-sample scores. If both ``metric`` and ``population_metric`` are provided, the per-sample
+                ``metric`` is still used for display and per-row scoring but ``population_metric`` determines the
+                overall score.
             num_threads (Optional[int]): The number of threads to use for parallel evaluation.
             display_progress (bool): Whether to display progress during evaluation.
             display_table (Union[bool, int]): Whether to display the evaluation results in a table.
@@ -101,6 +110,7 @@ class Evaluate:
         """
         self.devset = devset
         self.metric = metric
+        self.population_metric = population_metric
         self.num_threads = num_threads
         self.display_progress = display_progress
         self.display_table = display_table
@@ -118,6 +128,7 @@ class Evaluate:
         self,
         program: "dspy.Module",
         metric: Callable | None = None,
+        population_metric: Callable | None = None,
         devset: list["dspy.Example"] | None = None,
         num_threads: int | None = None,
         display_progress: bool | None = None,
@@ -130,6 +141,8 @@ class Evaluate:
         Args:
             program (dspy.Module): The DSPy program to evaluate.
             metric (Callable): The metric function to use for evaluation. if not provided, use `self.metric`.
+            population_metric (Callable): An optional population-wise / aggregate metric. if not provided, use
+                `self.population_metric`. Called as ``population_metric(examples, predictions) -> float``.
             devset (list[dspy.Example]): the evaluation dataset. if not provided, use `self.devset`.
             num_threads (Optional[int]): The number of threads to use for parallel evaluation. if not provided, use
                 `self.num_threads`.
@@ -142,11 +155,13 @@ class Evaluate:
         Returns:
             The evaluation results are returned as a dspy.EvaluationResult object containing the following attributes:
 
-            - score: A float percentage score (e.g., 67.30) representing overall performance
+            - score: A float percentage score (e.g., 67.30) representing overall performance.
+              When ``population_metric`` is provided, this is the value returned by ``population_metric``.
 
             - results: a list of (example, prediction, score) tuples for each example in devset
         """
         metric = metric if metric is not None else self.metric
+        population_metric = population_metric if population_metric is not None else self.population_metric
         devset = devset if devset is not None else self.devset
         num_threads = num_threads if num_threads is not None else self.num_threads
         display_progress = display_progress if display_progress is not None else self.display_progress
@@ -164,27 +179,56 @@ class Evaluate:
             disable_progress_bar=not display_progress,
             max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
             provide_traceback=self.provide_traceback,
-            compare_results=True,
+            compare_results=(metric is not None),
         )
 
-        def process_item(example):
-            prediction = program(**example.inputs())
-            score = metric(example, prediction)
-            return prediction, score
+        if metric is not None:
+            def process_item(example):
+                prediction = program(**example.inputs())
+                score = metric(example, prediction)
+                return prediction, score
+        else:
+            # When only population_metric is provided (no per-sample metric), we still need
+            # to run the program on each example but there is no per-sample score.
+            def process_item(example):
+                prediction = program(**example.inputs())
+                return prediction, None
 
         results = executor.execute(process_item, devset)
         assert len(devset) == len(results)
 
         results = [((dspy.Prediction(), self.failure_score) if r is None else r) for r in results]
         results = [(example, prediction, score) for example, (prediction, score) in zip(devset, results, strict=False)]
-        ncorrect, ntotal = sum(score for *_, score in results), len(devset)
 
-        logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
+        if population_metric is not None:
+            examples = [example for example, _, _ in results]
+            predictions = [prediction for _, prediction, _ in results]
+            overall_score = population_metric(examples, predictions)
+        else:
+            ncorrect, ntotal = sum(score for *_, score in results), len(devset)
+            overall_score = round(100 * ncorrect / ntotal, 2)
+
+        if metric is not None:
+            ncorrect, ntotal = sum(score for *_, score in results), len(devset)
+            logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
+
+        if population_metric is not None:
+            logger.info(f"Population Metric: {overall_score}")
+
+        # Resolve a display name for the metric column
+        if metric is not None:
+            metric_name = metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
+        elif population_metric is not None:
+            metric_name = (
+                population_metric.__name__
+                if isinstance(population_metric, types.FunctionType)
+                else population_metric.__class__.__name__
+            )
+        else:
+            metric_name = "metric"
 
         if display_table:
             if importlib.util.find_spec("pandas") is not None:
-                # Rename the 'correct' column to the name of the metric object
-                metric_name = metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
                 # Construct a pandas DataFrame from the results
                 result_df = self._construct_result_table(results, metric_name)
 
@@ -193,11 +237,6 @@ class Evaluate:
                 logger.warning("Skipping table display since `pandas` is not installed.")
 
         if save_as_csv:
-            metric_name = (
-                metric.__name__
-                if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__
-            )
             data = self._prepare_results_output(results, metric_name)
 
             with open(save_as_csv, "w", newline="") as csvfile:
@@ -208,11 +247,6 @@ class Evaluate:
                 for row in data:
                     writer.writerow(row)
         if save_as_json:
-            metric_name = (
-                metric.__name__
-                if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__
-            )
             data = self._prepare_results_output(results, metric_name)
             with open(
                     save_as_json,
@@ -221,7 +255,7 @@ class Evaluate:
                 json.dump(data, f)
 
         return EvaluationResult(
-            score=round(100 * ncorrect / ntotal, 2),
+            score=overall_score,
             results=results,
         )
 

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -423,3 +423,144 @@ def test_evaluate_save_as_csv_with_history():
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
 
+
+def test_evaluate_population_metric_only():
+    """Test Evaluate with only a population_metric (no per-sample metric)."""
+    dspy.configure(
+        lm=DummyLM(
+            {
+                "What is 1+1?": {"answer": "2"},
+                "What is 2+2?": {"answer": "4"},
+                "What is 3+3?": {"answer": "6"},
+            }
+        )
+    )
+    devset = [
+        new_example("What is 1+1?", "2"),
+        new_example("What is 2+2?", "4"),
+        new_example("What is 3+3?", "6"),
+    ]
+    program = Predict("question -> answer")
+
+    def pop_metric(examples, predictions):
+        # Simple population metric: fraction of exact matches
+        correct = sum(
+            1 for ex, pred in zip(examples, predictions) if ex.answer == pred.answer
+        )
+        return round(correct / len(examples), 2)
+
+    ev = Evaluate(
+        devset=devset,
+        population_metric=pop_metric,
+        display_progress=False,
+    )
+    result = ev(program)
+    assert result.score == 1.0
+    assert len(result.results) == 3
+    # Per-sample scores should be None when no sample-wise metric is given
+    for _, _, score in result.results:
+        assert score is None
+
+
+def test_evaluate_population_metric_with_sample_metric():
+    """Test Evaluate with both a per-sample metric and a population_metric.
+    The per-sample metric should still produce per-row scores, but the
+    overall EvaluationResult.score should come from population_metric.
+    """
+    dspy.configure(
+        lm=DummyLM(
+            {
+                "What is 1+1?": {"answer": "2"},
+                "What is 2+2?": {"answer": "4"},
+            }
+        )
+    )
+    devset = [
+        new_example("What is 1+1?", "2"),
+        new_example("What is 2+2?", "4"),
+    ]
+    program = Predict("question -> answer")
+
+    def pop_metric(examples, predictions):
+        # Always returns a fixed value so we can assert it overrides the sample average
+        return 42.0
+
+    ev = Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        population_metric=pop_metric,
+        display_progress=False,
+    )
+    result = ev(program)
+    # The overall score comes from the population_metric, not the per-sample average
+    assert result.score == 42.0
+    # But per-sample scores should still be present from the sample metric
+    for _, _, score in result.results:
+        assert score is not None
+
+
+def test_evaluate_population_metric_pearson():
+    """End-to-end test using Pearson correlation as a population_metric.
+    This is the motivating use-case from issue #9076.
+    """
+    from scipy.stats import pearsonr
+
+    dspy.configure(
+        lm=DummyLM(
+            {
+                "Rate item A": {"rating": "5"},
+                "Rate item B": {"rating": "3"},
+                "Rate item C": {"rating": "1"},
+                "Rate item D": {"rating": "4"},
+            }
+        )
+    )
+    devset = [
+        dspy.Example(text="Rate item A", rating=5).with_inputs("text"),
+        dspy.Example(text="Rate item B", rating=3).with_inputs("text"),
+        dspy.Example(text="Rate item C", rating=1).with_inputs("text"),
+        dspy.Example(text="Rate item D", rating=4).with_inputs("text"),
+    ]
+    program = Predict("text -> rating")
+
+    def pearson_population_metric(examples, predictions):
+        ground_truth = [float(ex.rating) for ex in examples]
+        predicted = [float(pred.rating) for pred in predictions]
+        r, _ = pearsonr(ground_truth, predicted)
+        return round(r, 4)
+
+    ev = Evaluate(
+        devset=devset,
+        population_metric=pearson_population_metric,
+        display_progress=False,
+    )
+    result = ev(program)
+    # The DummyLM returns perfect predictions, so Pearson r should be 1.0
+    assert result.score == 1.0
+
+
+def test_evaluate_backward_compatible_without_population_metric():
+    """Ensure that existing behavior is unchanged when population_metric is not provided."""
+    dspy.configure(
+        lm=DummyLM(
+            {
+                "What is 1+1?": {"answer": "2"},
+                "What is 2+2?": {"answer": "4"},
+            }
+        )
+    )
+    devset = [
+        new_example("What is 1+1?", "2"),
+        new_example("What is 2+2?", "4"),
+    ]
+    program = Predict("question -> answer")
+    ev = Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        display_progress=False,
+    )
+    result = ev(program)
+    # Original behavior: score is the percentage of correct answers
+    assert result.score == 100.0
+    assert len(result.results) == 2
+


### PR DESCRIPTION
## Summary

Closes #9076

- Adds an optional `population_metric` parameter to `Evaluate.__init__()` and `__call__()` that accepts a callable with the signature `population_metric(examples: list, predictions: list) -> float`
- When provided, the overall `EvaluationResult.score` is determined by `population_metric` instead of the average of per-sample scores
- When both `metric` and `population_metric` are provided, the per-sample `metric` is still used for per-row display/logging, while `population_metric` determines the final score
- Fully backward-compatible: when `population_metric` is not provided, behavior is identical to before

### Usage example — Pearson correlation

```python
from scipy.stats import pearsonr
import dspy
from dspy.evaluate import Evaluate

def pearson_metric(examples, predictions):
    """Population-wise metric: Pearson r between ground-truth and predicted ratings."""
    truth = [float(ex.rating) for ex in examples]
    preds = [float(pred.rating) for pred in predictions]
    r, _ = pearsonr(truth, preds)
    return round(r, 4)

evaluator = Evaluate(
    devset=my_devset,
    population_metric=pearson_metric,
    display_progress=True,
)
result = evaluator(my_program)
print(result.score)  # e.g. 0.8732
```

You can also combine it with a per-sample metric for display purposes:

```python
evaluator = Evaluate(
    devset=my_devset,
    metric=my_per_sample_metric,        # used for per-row scores in table/CSV
    population_metric=pearson_metric,    # used for overall EvaluationResult.score
    display_progress=True,
)
```

## Test plan

- [x] `test_evaluate_population_metric_only` — population_metric without a per-sample metric
- [x] `test_evaluate_population_metric_with_sample_metric` — both metric and population_metric together
- [x] `test_evaluate_population_metric_pearson` — end-to-end Pearson correlation example
- [x] `test_evaluate_backward_compatible_without_population_metric` — existing behavior unchanged
- [x] All existing tests continue to pass