### PR TITLE
fix: tolerate missing or null message content in chat completions

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -259,7 +259,10 @@ class BaseLM:
         outputs = []
         for c in response.choices:
             output = {}
-            output["text"] = c.message.content if hasattr(c, "message") else c["text"]
+            if hasattr(c, "message"):
+                output["text"] = getattr(c.message, "content", "") or ""
+            else:
+                output["text"] = c["text"]
 
             if hasattr(c, "message") and hasattr(c.message, "reasoning_content") and c.message.reasoning_content:
                 output["reasoning_content"] = c.message.reasoning_content

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -16,6 +16,8 @@ from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response_reasoning_item import Summary
 
 import dspy
+from dspy.clients.base_lm import BaseLM
+from dspy.dsp.utils.utils import dotdict
 from dspy.utils.usage_tracker import track_usage
 
 
@@ -44,6 +46,28 @@ def make_response(output_blocks):
         usage=ResponseAPIUsage(input_tokens=1, output_tokens=1, total_tokens=2),
         user=None,
     )
+
+
+class DummyLM(BaseLM):
+    pass
+
+
+@pytest.mark.parametrize(
+    "message_kwargs",
+    [
+        pytest.param({"tool_calls": None}, id="content_missing"),
+        pytest.param({"content": None, "tool_calls": None}, id="content_none"),
+    ],
+)
+def test_process_completion_tolerates_missing_message_content(message_kwargs):
+    lm = DummyLM("dummy", model_type="chat")
+    response = dotdict(
+        choices=[dotdict(message=dotdict(**message_kwargs), finish_reason="stop")],
+        usage=dotdict(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+        model="dummy",
+    )
+
+    assert lm._process_completion(response, {}) == [""]
 
 
 def test_chat_lms_can_be_queried(litellm_test_server):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -10,7 +10,7 @@ import litellm
 import pydantic
 import pytest
 from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
-from litellm.utils import Choices, Message, ModelResponse
+from litellm.utils import ChatCompletionMessageToolCall, Choices, Function, Message, ModelResponse
 from openai import RateLimitError
 from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response_reasoning_item import Summary
@@ -68,6 +68,32 @@ def test_process_completion_tolerates_missing_message_content(message_kwargs):
     )
 
     assert lm._process_completion(response, {}) == [""]
+
+
+def test_process_completion_tool_call_with_no_content():
+    """Tool-call responses may legitimately omit assistant text content.
+
+    _process_completion should preserve the tool_calls payload and normalize the
+    text field to an empty string instead of crashing.
+    """
+    lm = DummyLM("dummy", model_type="chat")
+    tool_call = ChatCompletionMessageToolCall(
+        id="call_abc123",
+        type="function",
+        function=Function(name="get_weather", arguments='{"location":"London"}'),
+    )
+    response = ModelResponse(
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="tool_calls",
+                message=Message(role="assistant", content=None, tool_calls=[tool_call]),
+            )
+        ],
+        model="dummy",
+    )
+
+    assert lm._process_completion(response, {}) == [{"text": "", "tool_calls": [tool_call]}]
 
 
 def test_chat_lms_can_be_queried(litellm_test_server):


### PR DESCRIPTION
## Summary

`BaseLM._process_completion` crashes with `AttributeError` when a chat completion choice has a `message` object but no `content` attribute (or `content=None`). This can happen with tool-only responses or certain provider edge cases where the message is present but content is omitted.

The existing adapter layer (`dspy/adapters/base.py`) already handles empty LM responses gracefully via `AdapterParseError`, but the crash in `_process_completion` prevents that error path from ever being reached.

## Reproduction

```python
from dspy.clients.base_lm import BaseLM
from dspy.dsp.utils.utils import dotdict

class DummyLM(BaseLM):
    pass

lm = DummyLM("dummy", model_type="chat")
response = dotdict(
    choices=[dotdict(message=dotdict(tool_calls=None), finish_reason="stop")],
    usage=dotdict(prompt_tokens=0, completion_tokens=0, total_tokens=0),
    model="dummy",
)

# Before fix: AttributeError: 'dotdict' object has no attribute 'content'
# After fix: returns [""]
lm._process_completion(response, {})
```

## Fix

Replace the direct `c.message.content` access with `getattr(c.message, "content", "") or ""`, which handles both missing and `None` content by normalizing to empty string. This preserves the existing architecture where adapters decide how to handle empty responses.

## Changes

- `dspy/clients/base_lm.py`: 3-line fix in `_process_completion`
- `tests/clients/test_lm.py`: Parametrized regression test covering both `content` missing and `content=None`

## Testing

```bash
uv run pytest tests/clients/test_lm.py -k missing_message_content -v
# 2 passed (content_missing, content_none)

uv run ruff check dspy/clients/base_lm.py tests/clients/test_lm.py
# All checks passed

uv run pre-commit run --files dspy/clients/base_lm.py tests/clients/test_lm.py
# All passed
```

Note: `ruff format --check` reports pre-existing formatting drift in `base_lm.py` outside the bugfix hunk. This PR intentionally does not include unrelated formatting changes to keep the diff minimal and reviewable.