### PR TITLE
fix(lm): preserve per-message structure in Responses API conversion

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -516,8 +516,9 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     """
     request = dict(request)
     if "messages" in request:
-        content_blocks = []
+        input_items = []
         for msg in request.pop("messages"):
+            content_blocks = []
             c = msg.get("content")
             if isinstance(c, str):
                 content_blocks.append({"type": "input_text", "text": c})
@@ -525,7 +526,8 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
                 # Convert each content item from Chat API format to Responses API format
                 for item in c:
                     content_blocks.append(_convert_content_item_to_responses_format(item))
-        request["input"] = [{"role": msg.get("role", "user"), "content": content_blocks}]
+            input_items.append({"role": msg.get("role", "user"), "content": content_blocks})
+        request["input"] = input_items
     # Convert `reasoning_effort` to reasoning format supported by the Responses API
     if "reasoning_effort" in request:
         effort = request.pop("reasoning_effort")

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -882,6 +882,37 @@ def test_responses_api_converts_files_correctly():
     assert content[0]["filename"] == "report.pdf"
 
 
+def test_responses_api_preserves_multi_message_structure():
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "model": "openai/gpt-5-mini",
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "4"},
+            {"role": "user", "content": "And 3+3?"},
+        ],
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert "input" in result
+    assert len(result["input"]) == 4
+
+    assert result["input"][0]["role"] == "system"
+    assert result["input"][0]["content"] == [{"type": "input_text", "text": "You are a helpful assistant."}]
+
+    assert result["input"][1]["role"] == "user"
+    assert result["input"][1]["content"] == [{"type": "input_text", "text": "What is 2+2?"}]
+
+    assert result["input"][2]["role"] == "assistant"
+    assert result["input"][2]["content"] == [{"type": "input_text", "text": "4"}]
+
+    assert result["input"][3]["role"] == "user"
+    assert result["input"][3]["content"] == [{"type": "input_text", "text": "And 3+3?"}]
+
+
 def test_responses_api_with_image_input():
     api_response = make_response(
         output_blocks=[


### PR DESCRIPTION
## Summary

`_convert_chat_request_to_responses_request` flattens all Chat API messages into a single Responses API input entry, breaking multi-turn conversations for `model_type="responses"`.

## Bug

`content_blocks` is initialized once before the message loop. Every message's content is appended to the same shared list. After the loop, the code wraps everything into one entry using the loop variable `msg` — which is the *last* message. The result is a single input entry with the last message's role and all content from all messages merged together.

Before (wrong — 4 messages become 1):
```python
content_blocks = []
for msg in request.pop("messages"):
    c = msg.get("content")
    if isinstance(c, str):
        content_blocks.append(...)
    elif isinstance(c, list):
        for item in c:
            content_blocks.append(...)
request["input"] = [{"role": msg.get("role", "user"), "content": content_blocks}]
#                         ^^^ always last message's role
```

For a typical DSPy call with `[system, user, assistant, user]` messages, the Responses API receives a single `user` message containing the system prompt, few-shot demos, and the actual query all merged together.

## Fix

Move `content_blocks` inside the loop so each message builds its own content list and is appended individually:

```python
input_items = []
for msg in request.pop("messages"):
    content_blocks = []
    ...
    input_items.append({"role": msg.get("role", "user"), "content": content_blocks})
request["input"] = input_items
```

## Test

Added `test_responses_api_preserves_multi_message_structure` — verifies that a 4-message conversation (system → user → assistant → user) produces 4 separate input entries with correct roles and content.

All existing responses-related tests still pass (7 passed, 1 skipped).