### PR TITLE
feat: add Classifier module with consistency-based confidence scoring

### DIFF
--- a/dspy/predict/__init__.py
+++ b/dspy/predict/__init__.py
@@ -1,6 +1,7 @@
 from dspy.predict.aggregation import majority
 from dspy.predict.best_of_n import BestOfN
 from dspy.predict.chain_of_thought import ChainOfThought
+from dspy.predict.classifier import Classifier
 from dspy.predict.code_act import CodeAct
 from dspy.predict.knn import KNN
 from dspy.predict.multi_chain_comparison import MultiChainComparison
@@ -15,6 +16,7 @@ __all__ = [
     "majority",
     "BestOfN",
     "ChainOfThought",
+    "Classifier",
     "CodeAct",
     "KNN",
     "MultiChainComparison",

--- a/dspy/predict/classifier.py
+++ b/dspy/predict/classifier.py
@@ -1,0 +1,234 @@
+import asyncio
+import math
+from collections import Counter
+from typing import Literal, get_args, get_origin
+
+import dspy
+from dspy.primitives.module import Module
+from dspy.signatures.signature import ensure_signature
+
+
+class Classifier(Module):
+    """A module that classifies inputs using Literal-typed output fields.
+
+    The Classifier wraps ``dspy.Predict`` with a signature that has at least one
+    ``Literal``-typed output field.  It supports two modes of operation:
+
+    1. **Single prediction** (default):  Runs one prediction and returns the
+       result directly -- identical to ``dspy.Predict``.
+
+    2. **Confidence mode** (``need_confidence=True``):  Runs ``num_samples``
+       independent predictions and computes statistical confidence from the
+       distribution of answers:
+
+       * ``agreement_rate`` -- fraction of samples matching the majority class.
+       * ``entropy`` -- normalized Shannon entropy (0 = perfect agreement,
+         1 = maximum disagreement).
+       * ``prediction_counts`` -- raw count per class.
+
+    The classification field is auto-detected from ``Literal``-typed output
+    fields.  When the signature contains multiple ``Literal`` fields, the
+    caller must pass ``classification_field`` to disambiguate.
+
+    Example::
+
+        class Sentiment(dspy.Signature):
+            \"\"\"Classify the sentiment of a sentence.\"\"\"
+            sentence: str = dspy.InputField()
+            sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
+
+        classifier = dspy.Classifier(Sentiment, need_confidence=True, num_samples=10)
+        result = classifier(sentence="This movie was great!")
+        print(result.sentiment)           # "positive"
+        print(result.agreement_rate)      # 0.9
+        print(result.entropy)             # 0.12
+        print(result.prediction_counts)   # {"positive": 9, "neutral": 1}
+    """
+
+    def __init__(
+        self,
+        signature,
+        need_confidence: bool = False,
+        num_samples: int = 10,
+        classification_field: str | None = None,
+        **config,
+    ):
+        """Initialize the Classifier module.
+
+        Args:
+            signature: A DSPy signature (class or string) with at least one
+                ``Literal``-typed output field.
+            need_confidence: If ``True``, run ``num_samples`` predictions and
+                return statistical confidence metrics.  Default ``False``.
+            num_samples: Number of independent predictions to run when
+                ``need_confidence=True``.  Ignored otherwise.  Default 10.
+            classification_field: Name of the ``Literal``-typed output field to
+                aggregate on.  Auto-detected when the signature has exactly one
+                such field.
+            **config: Additional configuration forwarded to the underlying
+                ``dspy.Predict`` module.
+        """
+        super().__init__()
+        self.signature = ensure_signature(signature)
+        self.need_confidence = need_confidence
+        self.num_samples = num_samples
+        self.classification_field = self._resolve_classification_field(classification_field)
+        self._classes = self._extract_classes()
+        self.predict = dspy.Predict(self.signature, **config)
+
+    def _resolve_classification_field(self, classification_field: str | None = None) -> str:
+        """Identify the Literal-typed output field to use for classification.
+
+        Raises:
+            ValueError: If no Literal-typed output field exists, if the
+                explicit ``classification_field`` does not match any Literal
+                field, or if multiple Literal fields exist and none is specified.
+        """
+        literal_fields = [
+            name
+            for name, field_info in self.signature.output_fields.items()
+            if get_origin(field_info.annotation) is Literal
+        ]
+
+        if len(literal_fields) == 0:
+            raise ValueError(
+                "Classifier requires at least one Literal-typed output field in the "
+                "signature.  Example: `label: Literal['positive', 'negative'] = "
+                "dspy.OutputField()`"
+            )
+
+        if len(literal_fields) == 1:
+            if classification_field is None or classification_field == literal_fields[0]:
+                return literal_fields[0]
+            raise ValueError(
+                f"classification_field='{classification_field}' does not match the only "
+                f"Literal-typed output field '{literal_fields[0]}'."
+            )
+
+        # Multiple Literal-typed fields -- user must disambiguate.
+        if classification_field is not None and classification_field in literal_fields:
+            return classification_field
+
+        raise ValueError(
+            f"Signature has multiple Literal-typed output fields: {literal_fields}. "
+            + (
+                f"classification_field='{classification_field}' is not among them. "
+                if classification_field is not None
+                else ""
+            )
+            + "Please specify which to use via `classification_field`."
+        )
+
+    def _extract_classes(self) -> tuple[str, ...]:
+        """Return the allowed class labels from the Literal annotation."""
+        annotation = self.signature.output_fields[self.classification_field].annotation
+        return get_args(annotation)
+
+    # ------------------------------------------------------------------
+    # Aggregation helpers
+    # ------------------------------------------------------------------
+
+    def _aggregate_and_score(self, predictions):
+        """Compute majority vote and confidence metrics from multiple predictions.
+
+        Returns a ``dspy.Prediction`` augmented with ``agreement_rate``,
+        ``entropy``, and ``prediction_counts``.
+        """
+        field = self.classification_field
+        values = [pred[field] for pred in predictions]
+
+        counts = Counter(values)
+        majority_value, majority_count = counts.most_common(1)[0]
+
+        # Agreement rate: fraction of predictions matching the majority class.
+        agreement_rate = majority_count / len(values)
+
+        # Normalized Shannon entropy.
+        #   0.0 = perfect agreement (all samples return the same class)
+        #   1.0 = maximum disagreement (uniform distribution over observed classes)
+        num_unique = len(counts)
+        if num_unique <= 1:
+            entropy = 0.0
+        else:
+            n = len(values)
+            raw_entropy = -sum((c / n) * math.log2(c / n) for c in counts.values())
+            entropy = raw_entropy / math.log2(num_unique)
+
+        # Use the first prediction whose classification matches the majority.
+        for pred in predictions:
+            if pred[field] == majority_value:
+                result = pred
+                break
+
+        result.agreement_rate = agreement_rate
+        result.entropy = entropy
+        result.prediction_counts = dict(counts)
+        return result
+
+    # ------------------------------------------------------------------
+    # Config helpers
+    # ------------------------------------------------------------------
+
+    def _prepare_config(self, kwargs):
+        """Extract the per-call config and ensure diverse sampling settings.
+
+        When ``need_confidence=True``, Classifier makes ``num_samples`` separate
+        calls rather than relying on the ``n`` parameter (which some providers
+        do not support).  We therefore force ``n=1`` and bump very-low
+        temperatures to 0.5 so that the repeated calls can produce varied
+        outputs.
+
+        Returns:
+            A ``(config_dict, remaining_kwargs)`` tuple.
+        """
+        config = {**kwargs.pop("config", {})}
+        # Force n=1 -- Classifier achieves multiple samples via separate calls.
+        config["n"] = 1
+        temperature = config.get("temperature")
+        if temperature is not None and temperature < 0.15:
+            config["temperature"] = 0.5
+        return config, kwargs
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+
+    def forward(self, **kwargs):
+        if not self.need_confidence:
+            return self.predict(**kwargs)
+
+        config, kwargs = self._prepare_config(kwargs)
+        predictions = [
+            self.predict(**kwargs, config={**config, "rollout_id": i})
+            for i in range(self.num_samples)
+        ]
+        return self._aggregate_and_score(predictions)
+
+    async def aforward(self, **kwargs):
+        if not self.need_confidence:
+            return await self.predict.acall(**kwargs)
+
+        config, kwargs = self._prepare_config(kwargs)
+        predictions = await asyncio.gather(
+            *[
+                self.predict.acall(**kwargs, config={**config, "rollout_id": i})
+                for i in range(self.num_samples)
+            ]
+        )
+        return self._aggregate_and_score(predictions)
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def classes(self) -> tuple[str, ...]:
+        """Return the allowed class labels derived from the Literal annotation."""
+        return self._classes
+
+    def __repr__(self) -> str:
+        return (
+            f"Classifier(classification_field={self.classification_field!r}, "
+            f"classes={self._classes}, need_confidence={self.need_confidence}, "
+            f"num_samples={self.num_samples})"
+        )

--- a/tests/predict/test_classifier.py
+++ b/tests/predict/test_classifier.py
@@ -1,0 +1,546 @@
+"""Tests for the Classifier module."""
+
+import math
+import unittest.mock as mock
+from typing import Literal
+
+import pytest
+
+import dspy
+from dspy import Classifier
+from dspy.utils import DummyLM
+
+
+# ---------------------------------------------------------------------------
+# Shared signatures
+# ---------------------------------------------------------------------------
+
+class SentimentSignature(dspy.Signature):
+    """Classify sentiment of a given sentence."""
+
+    sentence: str = dspy.InputField()
+    sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
+
+
+class BinarySignature(dspy.Signature):
+    """Binary yes/no classification."""
+
+    question: str = dspy.InputField()
+    answer: Literal["yes", "no"] = dspy.OutputField()
+
+
+class PlainSignature(dspy.Signature):
+    """A signature with no Literal-typed output field."""
+
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField()
+
+
+class MultiOutputSignature(dspy.Signature):
+    """Signature with one Literal and one plain output field."""
+
+    sentence: str = dspy.InputField()
+    topic: str = dspy.OutputField()
+    sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()
+
+
+class MultiLiteralSignature(dspy.Signature):
+    """Signature with two Literal-typed output fields."""
+
+    sentence: str = dspy.InputField()
+    sentiment: Literal["positive", "negative"] = dspy.OutputField()
+    topic: Literal["sports", "politics"] = dspy.OutputField()
+
+
+# ===================================================================
+# 1. Single prediction (default mode)
+# ===================================================================
+
+def test_single_prediction_default():
+    """Default mode (need_confidence=False) runs a single prediction without confidence."""
+    lm = DummyLM([{"sentiment": "positive"}])
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature)
+    result = classifier(sentence="Great movie!")
+
+    assert result.sentiment == "positive"
+    assert not hasattr(result, "agreement_rate")
+    assert not hasattr(result, "entropy")
+    assert not hasattr(result, "prediction_counts")
+
+
+def test_single_prediction_binary():
+    """Single prediction works with binary signature."""
+    lm = DummyLM([{"answer": "yes"}])
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(BinarySignature)
+    result = classifier(question="Is the sky blue?")
+    assert result.answer == "yes"
+
+
+# ===================================================================
+# 2. Unanimous agreement
+# ===================================================================
+
+def test_unanimous_agreement():
+    """All N samples return the same class -> agreement_rate=1.0, entropy=0.0."""
+    answers = [{"sentiment": "positive"}] * 10
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Great movie!")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == 1.0
+    assert result.entropy == 0.0
+    assert result.prediction_counts == {"positive": 10}
+
+
+def test_unanimous_negative():
+    """Unanimous agreement on a non-default class."""
+    answers = [{"sentiment": "negative"}] * 8
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=8)
+    result = classifier(sentence="Terrible movie!")
+
+    assert result.sentiment == "negative"
+    assert result.agreement_rate == 1.0
+    assert result.entropy == 0.0
+    assert result.prediction_counts == {"negative": 8}
+
+
+# ===================================================================
+# 3. Mixed responses
+# ===================================================================
+
+def test_mixed_responses_majority():
+    """7/10 positive, 3/10 negative -> majority positive, agreement_rate=0.7."""
+    answers = [{"sentiment": "positive"}] * 7 + [{"sentiment": "negative"}] * 3
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Mostly good but some issues.")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(0.7)
+    assert 0.0 < result.entropy < 1.0
+    assert result.prediction_counts == {"positive": 7, "negative": 3}
+
+
+def test_three_way_split():
+    """Three-way split: 5 positive, 3 negative, 2 neutral."""
+    answers = (
+        [{"sentiment": "positive"}] * 5
+        + [{"sentiment": "negative"}] * 3
+        + [{"sentiment": "neutral"}] * 2
+    )
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Complex feelings.")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(0.5)
+    assert 0.0 < result.entropy < 1.0
+    assert result.prediction_counts == {"positive": 5, "negative": 3, "neutral": 2}
+
+
+# ===================================================================
+# 4. Entropy calculations
+# ===================================================================
+
+def test_entropy_max_two_classes():
+    """5/10 positive, 5/10 negative -> entropy == 1.0 (max for 2 classes)."""
+    answers = [{"sentiment": "positive"}] * 5 + [{"sentiment": "negative"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Mixed feelings.")
+
+    assert result.agreement_rate == pytest.approx(0.5)
+    assert result.entropy == pytest.approx(1.0)
+
+
+def test_entropy_max_three_classes():
+    """Uniform 3-way split -> entropy close to 1.0."""
+    answers = (
+        [{"sentiment": "positive"}] * 4
+        + [{"sentiment": "negative"}] * 3
+        + [{"sentiment": "neutral"}] * 3
+    )
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Eh.")
+
+    # Not perfectly uniform, but entropy should be high
+    assert result.entropy > 0.9
+
+
+def test_entropy_perfect_uniform_three_classes():
+    """Perfectly uniform 3-way split (9 samples, 3 each) -> entropy == 1.0."""
+    answers = (
+        [{"sentiment": "positive"}] * 3
+        + [{"sentiment": "negative"}] * 3
+        + [{"sentiment": "neutral"}] * 3
+    )
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=9)
+    result = classifier(sentence="Balanced.")
+
+    assert result.entropy == pytest.approx(1.0)
+
+
+# ===================================================================
+# 5. Classification field detection
+# ===================================================================
+
+def test_auto_detect_literal_field():
+    """Single Literal field is auto-detected."""
+    classifier = Classifier(SentimentSignature)
+    assert classifier.classification_field == "sentiment"
+
+
+def test_auto_detect_with_mixed_outputs():
+    """Literal field detected even when mixed with plain output fields."""
+    classifier = Classifier(MultiOutputSignature)
+    assert classifier.classification_field == "sentiment"
+
+
+def test_explicit_matching_field_accepted():
+    """Explicit classification_field matching the only Literal field is accepted."""
+    classifier = Classifier(SentimentSignature, classification_field="sentiment")
+    assert classifier.classification_field == "sentiment"
+
+
+def test_explicit_mismatching_field_raises():
+    """Explicit classification_field not matching the only Literal field raises."""
+    with pytest.raises(ValueError, match="does not match the only Literal-typed output field"):
+        Classifier(SentimentSignature, classification_field="wrong_field")
+
+
+def test_no_literal_field_raises():
+    """Signature without Literal-typed output field raises ValueError."""
+    with pytest.raises(ValueError, match="requires at least one Literal-typed output field"):
+        Classifier(PlainSignature)
+
+
+def test_multiple_literal_no_field_raises():
+    """Multiple Literal fields without explicit classification_field raises."""
+    with pytest.raises(ValueError, match="multiple Literal-typed output fields"):
+        Classifier(MultiLiteralSignature)
+
+
+def test_multiple_literal_wrong_field_raises():
+    """Explicit classification_field not in any Literal field raises."""
+    with pytest.raises(ValueError, match="multiple Literal-typed output fields"):
+        Classifier(MultiLiteralSignature, classification_field="wrong")
+
+
+def test_multiple_literal_explicit_field():
+    """Specifying classification_field among multiple Literal fields works."""
+    answers = [{"sentiment": "positive", "topic": "sports"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(
+        MultiLiteralSignature,
+        need_confidence=True,
+        num_samples=5,
+        classification_field="topic",
+    )
+    assert classifier.classification_field == "topic"
+
+    result = classifier(sentence="The team won!")
+    assert result.topic == "sports"
+    assert result.prediction_counts == {"sports": 5}
+
+
+def test_multiple_literal_select_sentiment():
+    """Can select the other Literal field when multiple exist."""
+    answers = [{"sentiment": "positive", "topic": "sports"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(
+        MultiLiteralSignature,
+        need_confidence=True,
+        num_samples=5,
+        classification_field="sentiment",
+    )
+    assert classifier.classification_field == "sentiment"
+    result = classifier(sentence="Great game!")
+    assert result.prediction_counts == {"positive": 5}
+
+
+# ===================================================================
+# 6. num_samples handling
+# ===================================================================
+
+def test_custom_num_samples():
+    """num_samples controls the number of predictions made."""
+    answers = [{"sentiment": "positive"}] * 5
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=5)
+    result = classifier(sentence="Good book!")
+
+    assert sum(result.prediction_counts.values()) == 5
+
+
+def test_num_samples_three():
+    """Works with small num_samples."""
+    answers = [{"sentiment": "positive"}] * 2 + [{"sentiment": "negative"}]
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=3)
+    result = classifier(sentence="Ok-ish.")
+
+    assert sum(result.prediction_counts.values()) == 3
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(2 / 3)
+
+
+# ===================================================================
+# 7. Temperature handling
+# ===================================================================
+
+def test_temperature_not_injected_when_absent():
+    """When no temperature is set in call config, Classifier does not inject one."""
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!")
+
+    assert len(captured_configs) == 10
+    assert all(c.get("temperature") is None for c in captured_configs)
+    assert all(c.get("n") == 1 for c in captured_configs)
+
+
+def test_low_temperature_bumped():
+    """Temperature < 0.15 is bumped to 0.5 for diverse sampling."""
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 0.1})
+
+    assert all(c.get("temperature") == pytest.approx(0.5) for c in captured_configs)
+
+
+def test_high_temperature_preserved():
+    """Temperature >= 0.15 is preserved as-is."""
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 10)
+    dspy.configure(lm=lm)
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 1.0})
+
+    assert all(c.get("temperature") == pytest.approx(1.0) for c in captured_configs)
+
+
+def test_temperature_at_boundary():
+    """Temperature exactly at 0.15 is NOT bumped (boundary is strictly less-than)."""
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 5)
+    dspy.configure(lm=lm)
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=5)
+
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 0.15})
+
+    assert all(c.get("temperature") == pytest.approx(0.15) for c in captured_configs)
+
+
+def test_zero_temperature_bumped():
+    """Temperature 0.0 is bumped to 0.5."""
+    captured_configs = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        captured_configs.append(dict(kwargs.get("config", {})))
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 5)
+    dspy.configure(lm=lm)
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=5)
+
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Nice!", config={"temperature": 0.0})
+
+    assert all(c.get("temperature") == pytest.approx(0.5) for c in captured_configs)
+
+
+# ===================================================================
+# 8. Async forward
+# ===================================================================
+
+@pytest.mark.asyncio
+async def test_async_single_prediction():
+    """Async single prediction works like sync."""
+    lm = DummyLM([{"sentiment": "positive"}])
+    with dspy.context(lm=lm):
+        classifier = Classifier(SentimentSignature)
+        result = await classifier.acall(sentence="Great movie!")
+
+    assert result.sentiment == "positive"
+    assert not hasattr(result, "agreement_rate")
+
+
+@pytest.mark.asyncio
+async def test_async_with_confidence():
+    """aforward produces the same structure as forward in confidence mode."""
+    answers = [{"sentiment": "positive"}] * 8 + [{"sentiment": "negative"}] * 2
+    lm = DummyLM(answers)
+    with dspy.context(lm=lm):
+        classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+        result = await classifier.acall(sentence="Really enjoyed it!")
+
+    assert result.sentiment == "positive"
+    assert result.agreement_rate == pytest.approx(0.8)
+    assert hasattr(result, "entropy")
+    assert hasattr(result, "prediction_counts")
+    assert result.prediction_counts == {"positive": 8, "negative": 2}
+
+
+# ===================================================================
+# 9. String signatures
+# ===================================================================
+
+def test_string_signature():
+    """Classifier works with string-based signatures containing Literal."""
+    sig = dspy.Signature("text -> label: Literal['spam', 'ham']")
+    answers = [{"label": "spam"}] * 3
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(sig, need_confidence=True, num_samples=3)
+    result = classifier(text="Buy now! Limited offer!")
+
+    assert result.label == "spam"
+    assert result.prediction_counts == {"spam": 3}
+
+
+# ===================================================================
+# 10. classes property and __repr__
+# ===================================================================
+
+def test_classes_property():
+    """The classes property returns the allowed labels."""
+    classifier = Classifier(SentimentSignature)
+    assert set(classifier.classes) == {"positive", "negative", "neutral"}
+
+
+def test_classes_property_binary():
+    """classes property works for binary classification."""
+    classifier = Classifier(BinarySignature)
+    assert set(classifier.classes) == {"yes", "no"}
+
+
+def test_repr():
+    """__repr__ includes key configuration."""
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=20)
+    r = repr(classifier)
+    assert "sentiment" in r
+    assert "need_confidence=True" in r
+    assert "num_samples=20" in r
+
+
+# ===================================================================
+# 11. Edge cases
+# ===================================================================
+
+def test_single_sample_confidence():
+    """num_samples=1 with confidence returns agreement_rate=1.0."""
+    lm = DummyLM([{"sentiment": "neutral"}])
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=1)
+    result = classifier(sentence="OK.")
+
+    assert result.sentiment == "neutral"
+    assert result.agreement_rate == 1.0
+    assert result.entropy == 0.0
+    assert result.prediction_counts == {"neutral": 1}
+
+
+def test_prediction_counts_sum_equals_num_samples():
+    """prediction_counts values always sum to num_samples."""
+    answers = (
+        [{"sentiment": "positive"}] * 6
+        + [{"sentiment": "negative"}] * 3
+        + [{"sentiment": "neutral"}] * 1
+    )
+    lm = DummyLM(answers)
+    dspy.configure(lm=lm)
+
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=10)
+    result = classifier(sentence="Somewhat good.")
+
+    assert sum(result.prediction_counts.values()) == 10
+
+
+def test_rollout_ids_are_unique():
+    """Each sample call gets a unique rollout_id in its config."""
+    captured_ids = []
+    original_forward = dspy.Predict.forward
+
+    def capturing_forward(self, **kwargs):
+        config = kwargs.get("config", {})
+        if "rollout_id" in config:
+            captured_ids.append(config["rollout_id"])
+        return original_forward(self, **kwargs)
+
+    lm = DummyLM([{"sentiment": "positive"}] * 5)
+    dspy.configure(lm=lm)
+    classifier = Classifier(SentimentSignature, need_confidence=True, num_samples=5)
+
+    with mock.patch.object(dspy.Predict, "forward", capturing_forward):
+        classifier(sentence="Test")
+
+    assert len(captured_ids) == 5
+    assert len(set(captured_ids)) == 5  # all unique


### PR DESCRIPTION
## Summary

- Add a dedicated `Classifier` module (`dspy.Classifier`) that wraps `dspy.Predict` with `Literal`-typed output fields for classification tasks
- Supports single prediction mode (default) and confidence mode (`need_confidence=True`) that runs `num_samples` independent predictions and computes statistical confidence metrics (agreement_rate, entropy, prediction_counts) from answer distributions
- Includes 34 comprehensive test cases covering all module functionality

## Motivation

Classification is one of the most common LM tasks, but DSPy currently lacks a dedicated module for it. Users who need confidence scores typically resort to asking the LM to output a confidence value, which is unreliable — LMs tend to hallucinate confidence scores rather than reflecting actual certainty.

This module provides principled, consistency-based confidence metrics by analyzing the distribution of independent predictions rather than relying on self-reported confidence.

## Changes

### New files
- `dspy/predict/classifier.py` (234 lines) — The `Classifier` module implementation
- `tests/predict/test_classifier.py` (546 lines) — 34 test cases

### Modified files
- `dspy/predict/__init__.py` — Export `Classifier` in `__all__`

## Key Features

- **Auto-detection**: Automatically identifies the classification field from `Literal`-typed output fields
- **Statistical confidence**: Majority vote, agreement rate, normalized Shannon entropy, and prediction counts
- **Async support**: Full `aforward` implementation with `asyncio.gather` for concurrent sampling
- **Temperature guardrails**: Bumps very-low temperatures (< 0.15) to 0.5 when in confidence mode to ensure diverse sampling
- **Provider compatibility**: Forces `n=1` and uses separate calls with `rollout_id` instead of batch `n`, ensuring compatibility with all LM providers
- **Introspection**: `classes` property and informative `__repr__`

## Example Usage

```python
class SentimentSignature(dspy.Signature):
    """Classify the sentiment of a sentence."""
    sentence: str = dspy.InputField()
    sentiment: Literal["positive", "negative", "neutral"] = dspy.OutputField()

classifier = dspy.Classifier(SentimentSignature, need_confidence=True, num_samples=10)
result = classifier(sentence="This movie was great!")
print(result.sentiment)          # "positive"
print(result.agreement_rate)     # 0.9
print(result.entropy)            # 0.12
print(result.prediction_counts)  # {"positive": 9, "neutral": 1}
```

## Test plan

- [x] 34 test cases all passing (`pytest tests/predict/test_classifier.py -v`)
- [x] Single prediction mode (no confidence)
- [x] Unanimous agreement (entropy=0, agreement=1.0)
- [x] Mixed responses with majority vote
- [x] Entropy calculations (2-class max, 3-class max, uniform distribution)
- [x] Classification field auto-detection and explicit specification
- [x] Error cases (no Literal field, multiple Literal fields without disambiguation, wrong field name)
- [x] Temperature handling (absent, low→bumped, high→preserved, boundary)
- [x] Async forward (single and confidence mode)
- [x] String-based signatures
- [x] Edge cases (num_samples=1, rollout_id uniqueness)

Fixes #9537

🤖 Generated with [Claude Code](https://claude.com/claude-code)