### PR TITLE
feat: add cost tracking and budget-aware optimization

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -17,6 +17,7 @@ from dspy.utils.syncify import syncify
 from dspy.utils.saving import load
 from dspy.streaming.streamify import streamify
 from dspy.utils.usage_tracker import track_usage
+from dspy.utils.cost_tracker import CostTracker, BudgetExceededError, track_cost, register_model_pricing
 
 from dspy.dsp.utils.settings import settings
 from dspy.dsp.colbertv2 import ColBERTv2

--- a/dspy/utils/cost_tracker.py
+++ b/dspy/utils/cost_tracker.py
@@ -1,0 +1,406 @@
+"""Cost tracking and budget-aware optimization utilities for DSPy.
+
+This module provides cost tracking capabilities that build on top of DSPy's
+existing usage tracking infrastructure. It leverages litellm's model cost
+database to automatically calculate costs per LM call, and supports budget
+limits to warn or stop when a spending threshold is exceeded.
+
+Example usage:
+
+    with dspy.track_cost() as cost_tracker:
+        result = my_dspy_program(input_data)
+
+    print(f"Total cost: ${cost_tracker.total_cost:.4f}")
+    print(cost_tracker.get_costs_by_model())
+"""
+
+import logging
+import threading
+import warnings
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import Any, Generator
+
+import litellm
+
+from dspy.dsp.utils.settings import settings
+
+logger = logging.getLogger(__name__)
+
+
+class BudgetExceededError(Exception):
+    """Raised when total cost exceeds the configured budget limit."""
+
+    def __init__(self, budget: float, total_cost: float, model: str | None = None):
+        self.budget = budget
+        self.total_cost = total_cost
+        self.model = model
+        model_info = f" (triggered by {model})" if model else ""
+        super().__init__(
+            f"Budget of ${budget:.4f} exceeded: total cost is ${total_cost:.4f}{model_info}"
+        )
+
+
+# Default pricing for models not found in litellm's cost map.
+# Users can override this via CostTracker.set_model_pricing().
+_DEFAULT_PRICING: dict[str, dict[str, float]] = {}
+
+
+class CostTracker:
+    """Tracks LLM costs automatically during DSPy program execution.
+
+    The CostTracker calculates costs per LM call using token counts from
+    usage data and per-model pricing from litellm's cost database. It
+    supports cumulative cost tracking, per-model cost breakdown, budget
+    limits (warn or hard stop), and custom pricing overrides.
+
+    Attributes:
+        total_cost: The cumulative cost in USD across all tracked calls.
+        budget: Optional maximum budget in USD. When set, the tracker
+            will warn or raise an error when the budget is exceeded.
+        budget_action: What to do when the budget is exceeded. One of
+            "warn" (log a warning) or "stop" (raise BudgetExceededError).
+    """
+
+    def __init__(
+        self,
+        budget: float | None = None,
+        budget_action: str = "warn",
+    ):
+        """Initialize a CostTracker.
+
+        Args:
+            budget: Optional maximum budget in USD. Set to None for no limit.
+            budget_action: Action when budget is exceeded. Either "warn"
+                (default) to emit a warning, or "stop" to raise
+                BudgetExceededError.
+        """
+        if budget_action not in ("warn", "stop"):
+            raise ValueError(f"budget_action must be 'warn' or 'stop', got '{budget_action}'")
+        if budget is not None and budget <= 0:
+            raise ValueError(f"budget must be positive, got {budget}")
+
+        self.budget = budget
+        self.budget_action = budget_action
+        self.total_cost: float = 0.0
+
+        # Per-model cost tracking: {model_name: total_cost_usd}
+        self._model_costs: dict[str, float] = defaultdict(float)
+        # Per-model token tracking: {model_name: {prompt_tokens: N, completion_tokens: N}}
+        self._model_tokens: dict[str, dict[str, int]] = defaultdict(
+            lambda: {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        )
+        # Detailed call log: list of per-call entries
+        self._call_log: list[dict[str, Any]] = []
+        # Custom per-model pricing overrides
+        self._custom_pricing: dict[str, dict[str, float]] = {}
+        # Thread safety lock
+        self._lock = threading.Lock()
+        # Whether budget warning has been emitted (to avoid spamming)
+        self._budget_warned = False
+
+    def set_model_pricing(
+        self,
+        model: str,
+        input_cost_per_token: float,
+        output_cost_per_token: float,
+    ) -> None:
+        """Set custom pricing for a specific model.
+
+        This overrides litellm's built-in pricing for the given model.
+
+        Args:
+            model: The model name (e.g., "openai/gpt-4o-mini").
+            input_cost_per_token: Cost in USD per input (prompt) token.
+            output_cost_per_token: Cost in USD per output (completion) token.
+        """
+        self._custom_pricing[model] = {
+            "input_cost_per_token": input_cost_per_token,
+            "output_cost_per_token": output_cost_per_token,
+        }
+
+    def _get_model_pricing(self, model: str) -> dict[str, float] | None:
+        """Look up pricing for a model.
+
+        Checks custom pricing first, then litellm's cost map, then
+        the global default pricing registry.
+
+        Returns:
+            A dict with 'input_cost_per_token' and 'output_cost_per_token',
+            or None if no pricing is found.
+        """
+        # Check custom pricing first
+        if model in self._custom_pricing:
+            return self._custom_pricing[model]
+
+        # Check litellm's model cost map
+        model_info = _lookup_litellm_pricing(model)
+        if model_info is not None:
+            return model_info
+
+        # Check the global default pricing registry
+        if model in _DEFAULT_PRICING:
+            return _DEFAULT_PRICING[model]
+
+        return None
+
+    def _calculate_cost(
+        self,
+        model: str,
+        prompt_tokens: int,
+        completion_tokens: int,
+    ) -> float | None:
+        """Calculate the cost of a single LM call.
+
+        Args:
+            model: The model name.
+            prompt_tokens: Number of input tokens.
+            completion_tokens: Number of output tokens.
+
+        Returns:
+            The cost in USD, or None if pricing is unavailable.
+        """
+        pricing = self._get_model_pricing(model)
+        if pricing is None:
+            return None
+
+        input_cost = prompt_tokens * pricing["input_cost_per_token"]
+        output_cost = completion_tokens * pricing["output_cost_per_token"]
+        return input_cost + output_cost
+
+    def add_usage(self, model: str, usage_entry: dict[str, Any]) -> None:
+        """Record usage from a single LM call and update cost tracking.
+
+        This method is called automatically by the DSPy LM infrastructure
+        when cost tracking is active.
+
+        Args:
+            model: The model name (e.g., "openai/gpt-4o-mini").
+            usage_entry: A dict containing token usage, typically with
+                keys like 'prompt_tokens', 'completion_tokens', 'total_tokens'.
+        """
+        if not usage_entry:
+            return
+
+        prompt_tokens = usage_entry.get("prompt_tokens", 0) or 0
+        completion_tokens = usage_entry.get("completion_tokens", 0) or 0
+        total_tokens = usage_entry.get("total_tokens", 0) or 0
+
+        cost = self._calculate_cost(model, prompt_tokens, completion_tokens)
+
+        with self._lock:
+            # Update token counts
+            self._model_tokens[model]["prompt_tokens"] += prompt_tokens
+            self._model_tokens[model]["completion_tokens"] += completion_tokens
+            self._model_tokens[model]["total_tokens"] += total_tokens
+
+            # Update cost
+            if cost is not None:
+                self._model_costs[model] += cost
+                self.total_cost += cost
+
+            # Add to call log
+            self._call_log.append({
+                "model": model,
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": total_tokens,
+                "cost": cost,
+            })
+
+            # Check budget
+            self._check_budget(model)
+
+    def _check_budget(self, model: str | None = None) -> None:
+        """Check if the total cost exceeds the budget.
+
+        Must be called while holding self._lock.
+        """
+        if self.budget is None:
+            return
+
+        if self.total_cost > self.budget:
+            if self.budget_action == "stop":
+                raise BudgetExceededError(
+                    budget=self.budget,
+                    total_cost=self.total_cost,
+                    model=model,
+                )
+            elif self.budget_action == "warn" and not self._budget_warned:
+                self._budget_warned = True
+                warnings.warn(
+                    f"Budget of ${self.budget:.4f} exceeded: total cost is "
+                    f"${self.total_cost:.4f}. Set budget_action='stop' to halt execution.",
+                    stacklevel=4,
+                )
+
+    def get_costs_by_model(self) -> dict[str, float]:
+        """Get a breakdown of costs by model.
+
+        Returns:
+            A dict mapping model names to their total cost in USD.
+        """
+        with self._lock:
+            return dict(self._model_costs)
+
+    def get_tokens_by_model(self) -> dict[str, dict[str, int]]:
+        """Get a breakdown of token usage by model.
+
+        Returns:
+            A dict mapping model names to their token counts
+            (prompt_tokens, completion_tokens, total_tokens).
+        """
+        with self._lock:
+            return {model: dict(tokens) for model, tokens in self._model_tokens.items()}
+
+    def get_call_log(self) -> list[dict[str, Any]]:
+        """Get the detailed log of all tracked LM calls.
+
+        Returns:
+            A list of dicts, each containing model, token counts, and cost
+            for a single call.
+        """
+        with self._lock:
+            return list(self._call_log)
+
+    @property
+    def num_calls(self) -> int:
+        """Total number of tracked LM calls."""
+        with self._lock:
+            return len(self._call_log)
+
+    @property
+    def budget_remaining(self) -> float | None:
+        """Remaining budget in USD, or None if no budget is set."""
+        if self.budget is None:
+            return None
+        return max(0.0, self.budget - self.total_cost)
+
+    @property
+    def budget_utilization(self) -> float | None:
+        """Budget utilization as a fraction (0.0 to 1.0+), or None if no budget."""
+        if self.budget is None:
+            return None
+        return self.total_cost / self.budget
+
+    def get_summary(self) -> dict[str, Any]:
+        """Get a comprehensive summary of cost tracking data.
+
+        Returns:
+            A dict containing total cost, per-model costs, per-model tokens,
+            number of calls, and budget information.
+        """
+        with self._lock:
+            summary: dict[str, Any] = {
+                "total_cost": self.total_cost,
+                "num_calls": len(self._call_log),
+                "costs_by_model": dict(self._model_costs),
+                "tokens_by_model": {
+                    model: dict(tokens) for model, tokens in self._model_tokens.items()
+                },
+            }
+            if self.budget is not None:
+                summary["budget"] = self.budget
+                summary["budget_remaining"] = max(0.0, self.budget - self.total_cost)
+                summary["budget_utilization"] = self.total_cost / self.budget
+            return summary
+
+    def get_total_tokens(self) -> dict[str, dict[str, int]]:
+        """Get total token usage by model.
+
+        This method provides compatibility with the UsageTracker interface
+        so that CostTracker can be used as a drop-in replacement via the
+        settings.usage_tracker slot.
+
+        Returns:
+            A dict mapping model names to their aggregated token counts.
+        """
+        with self._lock:
+            return {model: dict(tokens) for model, tokens in self._model_tokens.items()}
+
+    def reset(self) -> None:
+        """Reset all tracked costs and usage data."""
+        with self._lock:
+            self.total_cost = 0.0
+            self._model_costs.clear()
+            self._model_tokens.clear()
+            self._call_log.clear()
+            self._budget_warned = False
+
+    def __repr__(self) -> str:
+        budget_str = f", budget=${self.budget:.4f}" if self.budget else ""
+        return f"CostTracker(total_cost=${self.total_cost:.4f}, num_calls={self.num_calls}{budget_str})"
+
+
+def _lookup_litellm_pricing(model: str) -> dict[str, float] | None:
+    """Look up model pricing from litellm's cost database.
+
+    Tries the model name as-is, then strips the provider prefix
+    (e.g., "openai/gpt-4o-mini" -> "gpt-4o-mini").
+
+    Returns:
+        A dict with 'input_cost_per_token' and 'output_cost_per_token',
+        or None if not found.
+    """
+    for name in [model, model.split("/", 1)[-1] if "/" in model else None]:
+        if name is None:
+            continue
+        info = litellm.model_cost.get(name)
+        if info and "input_cost_per_token" in info and "output_cost_per_token" in info:
+            return {
+                "input_cost_per_token": info["input_cost_per_token"],
+                "output_cost_per_token": info["output_cost_per_token"],
+            }
+    return None
+
+
+def register_model_pricing(
+    model: str,
+    input_cost_per_token: float,
+    output_cost_per_token: float,
+) -> None:
+    """Register default pricing for a model globally.
+
+    This is useful for models that are not in litellm's cost database.
+    Pricing registered here will be used by all CostTracker instances
+    unless overridden by CostTracker.set_model_pricing().
+
+    Args:
+        model: The model name (e.g., "my-provider/custom-model").
+        input_cost_per_token: Cost in USD per input token.
+        output_cost_per_token: Cost in USD per output token.
+    """
+    _DEFAULT_PRICING[model] = {
+        "input_cost_per_token": input_cost_per_token,
+        "output_cost_per_token": output_cost_per_token,
+    }
+
+
+@contextmanager
+def track_cost(
+    budget: float | None = None,
+    budget_action: str = "warn",
+) -> Generator[CostTracker, None, None]:
+    """Context manager for tracking LLM costs during DSPy program execution.
+
+    Automatically tracks token usage and calculates costs for all LM calls
+    made within the context. Optionally enforces a budget limit.
+
+    Args:
+        budget: Optional maximum budget in USD. Set to None for no limit.
+        budget_action: What to do when budget is exceeded. Either "warn"
+            (default) to emit a warning, or "stop" to raise BudgetExceededError.
+
+    Yields:
+        A CostTracker instance with cost data populated as calls are made.
+
+    Example:
+        >>> with track_cost(budget=1.00) as tracker:
+        ...     result = my_program(input_data)
+        >>> print(f"Total cost: ${tracker.total_cost:.4f}")
+        >>> print(tracker.get_costs_by_model())
+    """
+    tracker = CostTracker(budget=budget, budget_action=budget_action)
+
+    with settings.context(usage_tracker=tracker, track_usage=True):
+        yield tracker

--- a/tests/utils/test_cost_tracker.py
+++ b/tests/utils/test_cost_tracker.py
@@ -1,0 +1,558 @@
+"""Comprehensive tests for the CostTracker and cost tracking utilities."""
+
+import threading
+from unittest import mock
+
+import pytest
+
+import dspy
+from dspy.utils.cost_tracker import (
+    BudgetExceededError,
+    CostTracker,
+    _lookup_litellm_pricing,
+    register_model_pricing,
+    track_cost,
+)
+
+
+# ---------------------------------------------------------------------------
+# CostTracker initialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestCostTrackerInit:
+    def test_default_init(self):
+        tracker = CostTracker()
+        assert tracker.total_cost == 0.0
+        assert tracker.budget is None
+        assert tracker.budget_action == "warn"
+        assert tracker.num_calls == 0
+
+    def test_init_with_budget(self):
+        tracker = CostTracker(budget=5.0)
+        assert tracker.budget == 5.0
+        assert tracker.budget_remaining == 5.0
+        assert tracker.budget_utilization == 0.0
+
+    def test_init_with_budget_stop(self):
+        tracker = CostTracker(budget=10.0, budget_action="stop")
+        assert tracker.budget_action == "stop"
+
+    def test_invalid_budget_action(self):
+        with pytest.raises(ValueError, match="budget_action must be"):
+            CostTracker(budget_action="invalid")
+
+    def test_negative_budget(self):
+        with pytest.raises(ValueError, match="budget must be positive"):
+            CostTracker(budget=-1.0)
+
+    def test_zero_budget(self):
+        with pytest.raises(ValueError, match="budget must be positive"):
+            CostTracker(budget=0.0)
+
+
+# ---------------------------------------------------------------------------
+# add_usage and cost calculation tests
+# ---------------------------------------------------------------------------
+
+
+class TestAddUsage:
+    def test_add_single_usage(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("test-model", 0.001, 0.002)
+        tracker.add_usage("test-model", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        assert tracker.num_calls == 1
+        # cost = 100 * 0.001 + 50 * 0.002 = 0.1 + 0.1 = 0.2
+        assert abs(tracker.total_cost - 0.2) < 1e-9
+
+    def test_add_multiple_usages_same_model(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("test-model", 0.001, 0.002)
+
+        tracker.add_usage("test-model", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        tracker.add_usage("test-model", {
+            "prompt_tokens": 200,
+            "completion_tokens": 100,
+            "total_tokens": 300,
+        })
+
+        assert tracker.num_calls == 2
+        # cost = (100*0.001 + 50*0.002) + (200*0.001 + 100*0.002) = 0.2 + 0.4 = 0.6
+        assert abs(tracker.total_cost - 0.6) < 1e-9
+
+    def test_add_usages_multiple_models(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+        tracker.set_model_pricing("model-b", 0.01, 0.02)
+
+        tracker.add_usage("model-a", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        tracker.add_usage("model-b", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+
+        costs = tracker.get_costs_by_model()
+        assert abs(costs["model-a"] - 0.2) < 1e-9
+        assert abs(costs["model-b"] - 2.0) < 1e-9
+        assert abs(tracker.total_cost - 2.2) < 1e-9
+
+    def test_add_empty_usage(self):
+        tracker = CostTracker()
+        tracker.add_usage("test-model", {})
+        assert tracker.num_calls == 0
+        assert tracker.total_cost == 0.0
+
+    def test_add_usage_with_none_tokens(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("test-model", 0.001, 0.002)
+        tracker.add_usage("test-model", {
+            "prompt_tokens": None,
+            "completion_tokens": None,
+            "total_tokens": None,
+        })
+        assert tracker.num_calls == 1
+        assert tracker.total_cost == 0.0
+
+    def test_add_usage_unknown_model_no_pricing(self):
+        tracker = CostTracker()
+        tracker.add_usage("unknown/model-xyz", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        # Should still track tokens, but cost is None
+        assert tracker.num_calls == 1
+        assert tracker.total_cost == 0.0
+        tokens = tracker.get_tokens_by_model()
+        assert tokens["unknown/model-xyz"]["prompt_tokens"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Token tracking tests
+# ---------------------------------------------------------------------------
+
+
+class TestTokenTracking:
+    def test_get_tokens_by_model(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+        tracker.add_usage("model-a", {"prompt_tokens": 200, "completion_tokens": 100, "total_tokens": 300})
+
+        tokens = tracker.get_tokens_by_model()
+        assert tokens["model-a"]["prompt_tokens"] == 300
+        assert tokens["model-a"]["completion_tokens"] == 150
+        assert tokens["model-a"]["total_tokens"] == 450
+
+    def test_get_total_tokens_compatibility(self):
+        """Test that get_total_tokens works for UsageTracker compatibility."""
+        tracker = CostTracker()
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+
+        total = tracker.get_total_tokens()
+        assert total["model-a"]["prompt_tokens"] == 100
+        assert total["model-a"]["completion_tokens"] == 50
+        assert total["model-a"]["total_tokens"] == 150
+
+
+# ---------------------------------------------------------------------------
+# Call log tests
+# ---------------------------------------------------------------------------
+
+
+class TestCallLog:
+    def test_call_log_entries(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+
+        log = tracker.get_call_log()
+        assert len(log) == 1
+        assert log[0]["model"] == "model-a"
+        assert log[0]["prompt_tokens"] == 100
+        assert log[0]["completion_tokens"] == 50
+        assert log[0]["cost"] is not None
+        assert abs(log[0]["cost"] - 0.2) < 1e-9
+
+    def test_call_log_multiple_entries(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+        tracker.set_model_pricing("model-b", 0.01, 0.02)
+
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+        tracker.add_usage("model-b", {"prompt_tokens": 200, "completion_tokens": 100, "total_tokens": 300})
+
+        log = tracker.get_call_log()
+        assert len(log) == 2
+        assert log[0]["model"] == "model-a"
+        assert log[1]["model"] == "model-b"
+
+
+# ---------------------------------------------------------------------------
+# Budget enforcement tests
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetEnforcement:
+    def test_budget_exceeded_warn(self):
+        tracker = CostTracker(budget=0.1, budget_action="warn")
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        with pytest.warns(UserWarning, match="Budget of \\$0.1000 exceeded"):
+            tracker.add_usage("model-a", {
+                "prompt_tokens": 500,
+                "completion_tokens": 500,
+                "total_tokens": 1000,
+            })
+
+    def test_budget_exceeded_stop(self):
+        tracker = CostTracker(budget=0.1, budget_action="stop")
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        with pytest.raises(BudgetExceededError, match="Budget of \\$0.1000 exceeded"):
+            tracker.add_usage("model-a", {
+                "prompt_tokens": 500,
+                "completion_tokens": 500,
+                "total_tokens": 1000,
+            })
+
+    def test_budget_not_exceeded(self):
+        tracker = CostTracker(budget=10.0, budget_action="stop")
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        # Should not raise
+        tracker.add_usage("model-a", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        assert tracker.total_cost < tracker.budget
+
+    def test_budget_warning_only_once(self):
+        tracker = CostTracker(budget=0.05, budget_action="warn")
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        with pytest.warns(UserWarning, match="Budget"):
+            tracker.add_usage("model-a", {
+                "prompt_tokens": 500,
+                "completion_tokens": 500,
+                "total_tokens": 1000,
+            })
+
+        # Second call should NOT warn again
+        # (no pytest.warns context - if it warned, the test would still pass,
+        # but we verify the flag)
+        tracker.add_usage("model-a", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        assert tracker._budget_warned is True
+
+    def test_budget_remaining(self):
+        tracker = CostTracker(budget=1.0)
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        # cost = 100*0.001 + 50*0.002 = 0.2
+        assert abs(tracker.budget_remaining - 0.8) < 1e-9
+
+    def test_budget_utilization(self):
+        tracker = CostTracker(budget=1.0)
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        assert abs(tracker.budget_utilization - 0.2) < 1e-9
+
+    def test_no_budget_remaining_is_none(self):
+        tracker = CostTracker()
+        assert tracker.budget_remaining is None
+        assert tracker.budget_utilization is None
+
+    def test_budget_exceeded_error_attributes(self):
+        err = BudgetExceededError(budget=1.0, total_cost=1.5, model="gpt-4o")
+        assert err.budget == 1.0
+        assert err.total_cost == 1.5
+        assert err.model == "gpt-4o"
+        assert "gpt-4o" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Custom pricing tests
+# ---------------------------------------------------------------------------
+
+
+class TestCustomPricing:
+    def test_set_model_pricing_override(self):
+        tracker = CostTracker()
+        # Even if litellm has pricing for gpt-4o-mini, custom pricing should take precedence
+        tracker.set_model_pricing("gpt-4o-mini", 0.005, 0.01)
+
+        tracker.add_usage("gpt-4o-mini", {
+            "prompt_tokens": 100,
+            "completion_tokens": 50,
+            "total_tokens": 150,
+        })
+        # cost = 100 * 0.005 + 50 * 0.01 = 0.5 + 0.5 = 1.0
+        assert abs(tracker.total_cost - 1.0) < 1e-9
+
+    def test_register_global_pricing(self):
+        register_model_pricing("custom/my-model", 0.0001, 0.0002)
+
+        tracker = CostTracker()
+        tracker.add_usage("custom/my-model", {
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+            "total_tokens": 1500,
+        })
+        # cost = 1000 * 0.0001 + 500 * 0.0002 = 0.1 + 0.1 = 0.2
+        assert abs(tracker.total_cost - 0.2) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Litellm pricing lookup tests
+# ---------------------------------------------------------------------------
+
+
+class TestLitellmPricing:
+    def test_lookup_known_model(self):
+        pricing = _lookup_litellm_pricing("gpt-4o-mini")
+        if pricing is not None:
+            assert "input_cost_per_token" in pricing
+            assert "output_cost_per_token" in pricing
+            assert pricing["input_cost_per_token"] > 0
+            assert pricing["output_cost_per_token"] > 0
+
+    def test_lookup_with_provider_prefix(self):
+        pricing = _lookup_litellm_pricing("openai/gpt-4o-mini")
+        # Should find it by stripping the prefix
+        if pricing is not None:
+            assert pricing["input_cost_per_token"] > 0
+
+    def test_lookup_unknown_model(self):
+        pricing = _lookup_litellm_pricing("totally-unknown-model-xyz-999")
+        assert pricing is None
+
+
+# ---------------------------------------------------------------------------
+# Summary and reporting tests
+# ---------------------------------------------------------------------------
+
+
+class TestSummaryReporting:
+    def test_get_summary_no_budget(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+
+        summary = tracker.get_summary()
+        assert "total_cost" in summary
+        assert "num_calls" in summary
+        assert "costs_by_model" in summary
+        assert "tokens_by_model" in summary
+        assert "budget" not in summary
+        assert summary["num_calls"] == 1
+
+    def test_get_summary_with_budget(self):
+        tracker = CostTracker(budget=5.0)
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+
+        summary = tracker.get_summary()
+        assert summary["budget"] == 5.0
+        assert summary["budget_remaining"] > 0
+        assert summary["budget_utilization"] > 0
+
+    def test_repr(self):
+        tracker = CostTracker(budget=5.0)
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+
+        repr_str = repr(tracker)
+        assert "CostTracker" in repr_str
+        assert "$" in repr_str
+        assert "budget" in repr_str
+
+
+# ---------------------------------------------------------------------------
+# Reset tests
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    def test_reset_clears_all_data(self):
+        tracker = CostTracker(budget=5.0)
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        tracker.add_usage("model-a", {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150})
+        assert tracker.total_cost > 0
+        assert tracker.num_calls > 0
+
+        tracker.reset()
+        assert tracker.total_cost == 0.0
+        assert tracker.num_calls == 0
+        assert len(tracker.get_costs_by_model()) == 0
+        assert len(tracker.get_tokens_by_model()) == 0
+        assert len(tracker.get_call_log()) == 0
+
+
+# ---------------------------------------------------------------------------
+# Thread safety tests
+# ---------------------------------------------------------------------------
+
+
+class TestThreadSafety:
+    def test_concurrent_add_usage(self):
+        tracker = CostTracker()
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        num_threads = 10
+        calls_per_thread = 100
+
+        def add_calls():
+            for _ in range(calls_per_thread):
+                tracker.add_usage("model-a", {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "total_tokens": 15,
+                })
+
+        threads = [threading.Thread(target=add_calls) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert tracker.num_calls == num_threads * calls_per_thread
+        expected_cost = num_threads * calls_per_thread * (10 * 0.001 + 5 * 0.002)
+        assert abs(tracker.total_cost - expected_cost) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# track_cost context manager tests
+# ---------------------------------------------------------------------------
+
+
+class TestTrackCostContextManager:
+    def test_track_cost_basic(self):
+        with track_cost() as tracker:
+            assert isinstance(tracker, CostTracker)
+            # Verify the tracker is set as the usage_tracker in settings
+            from dspy.dsp.utils.settings import settings
+            assert settings.usage_tracker is tracker
+            assert settings.track_usage is True
+
+    def test_track_cost_with_budget(self):
+        with track_cost(budget=10.0, budget_action="stop") as tracker:
+            assert tracker.budget == 10.0
+            assert tracker.budget_action == "stop"
+
+    def test_track_cost_context_restores_settings(self):
+        from dspy.dsp.utils.settings import settings
+
+        original_tracker = settings.get("usage_tracker")
+
+        with track_cost() as tracker:
+            assert settings.usage_tracker is tracker
+
+        # After context, the setting should be restored
+        assert settings.get("usage_tracker") is not tracker
+
+    def test_track_cost_with_manual_usage(self):
+        with track_cost() as tracker:
+            tracker.set_model_pricing("test-model", 0.001, 0.002)
+            tracker.add_usage("test-model", {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+            })
+
+        assert tracker.total_cost > 0
+        assert tracker.num_calls == 1
+
+    def test_track_cost_invalid_budget_action(self):
+        with pytest.raises(ValueError, match="budget_action must be"):
+            with track_cost(budget_action="explode") as tracker:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests with mocked LM
+# ---------------------------------------------------------------------------
+
+
+class TestIntegrationWithMockedLM:
+    def test_cost_tracked_via_settings(self):
+        """Test that CostTracker receives usage data through the settings mechanism."""
+        tracker = CostTracker()
+        tracker.set_model_pricing("openai/gpt-4o-mini", 0.00015, 0.0006)
+
+        from dspy.dsp.utils.settings import settings
+
+        with settings.context(usage_tracker=tracker, track_usage=True):
+            # Simulate what LM.forward does after a completion
+            tracker.add_usage("openai/gpt-4o-mini", {
+                "prompt_tokens": 500,
+                "completion_tokens": 100,
+                "total_tokens": 600,
+            })
+            tracker.add_usage("openai/gpt-4o-mini", {
+                "prompt_tokens": 300,
+                "completion_tokens": 200,
+                "total_tokens": 500,
+            })
+
+        assert tracker.num_calls == 2
+        # cost = (500*0.00015 + 100*0.0006) + (300*0.00015 + 200*0.0006)
+        #      = (0.075 + 0.06) + (0.045 + 0.12) = 0.135 + 0.165 = 0.3
+        assert abs(tracker.total_cost - 0.3) < 1e-9
+
+        costs = tracker.get_costs_by_model()
+        assert "openai/gpt-4o-mini" in costs
+
+        tokens = tracker.get_tokens_by_model()
+        assert tokens["openai/gpt-4o-mini"]["prompt_tokens"] == 800
+        assert tokens["openai/gpt-4o-mini"]["completion_tokens"] == 300
+
+    def test_budget_stop_raises_during_execution(self):
+        """Test that budget_action='stop' actually halts execution."""
+        tracker = CostTracker(budget=0.01, budget_action="stop")
+        tracker.set_model_pricing("model-a", 0.001, 0.002)
+
+        with pytest.raises(BudgetExceededError):
+            for _ in range(100):
+                tracker.add_usage("model-a", {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 50,
+                    "total_tokens": 150,
+                })
+
+        # Should have stopped before completing all 100 calls
+        assert tracker.num_calls < 100


### PR DESCRIPTION
## Summary

Implements cost tracking and budget-aware optimization capabilities for DSPy, as requested in #9200.

- **`CostTracker`**: A new utility class that automatically calculates and tracks LLM costs using token counts and litellm's model cost database. Supports cumulative cost tracking across sessions, per-model cost breakdowns, detailed call logs, and custom pricing overrides.
- **`track_cost()` context manager**: Drop-in replacement for `track_usage()` that additionally computes dollar costs. Can be used with optional budget limits.
- **Budget enforcement**: Configurable budget limits with two actions — `"warn"` (emit a warning) or `"stop"` (raise `BudgetExceededError`) when spending exceeds the threshold.
- **`register_model_pricing()`**: Global pricing registration for custom/private models not in litellm's cost database.
- **Full compatibility**: `CostTracker` implements the same `add_usage()` / `get_total_tokens()` interface as `UsageTracker`, so it works seamlessly as a drop-in replacement in the `settings.usage_tracker` slot.

### Usage example

```python
import dspy
from dspy.utils.cost_tracker import track_cost

dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))

with track_cost(budget=1.00) as tracker:
    result = my_program(input_data)

print(f"Total cost: ${tracker.total_cost:.4f}")
print(f"By model: {tracker.get_costs_by_model()}")
print(f"Budget remaining: ${tracker.budget_remaining:.4f}")
```

### Files changed

| File | Lines | Description |
|------|-------|-------------|
| `dspy/utils/cost_tracker.py` | +406 | Core implementation: `CostTracker`, `BudgetExceededError`, `track_cost()`, `register_model_pricing()` |
| `tests/utils/test_cost_tracker.py` | +558 | 41 test cases covering init, cost calculation, token tracking, call logs, budget enforcement, custom pricing, litellm lookup, summaries, reset, thread safety, context manager, and integration |
| `dspy/__init__.py` | +1 | Export new public API symbols |

Closes #9200

## Test plan

- [x] All 41 new tests pass (`pytest tests/utils/test_cost_tracker.py -v`)
- [x] All existing `test_usage_tracker.py` tests still pass (no regressions)
- [x] Thread safety validated with concurrent usage from 10 threads
- [x] Budget enforcement tested for both `warn` and `stop` modes
- [x] Litellm pricing lookup tested for known models, prefixed models, and unknown models

🤖 Generated with [Claude Code](https://claude.com/claude-code)