### PR TITLE
Fix apply_sync_streaming silently swallowing exceptions

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -232,6 +232,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
 
+    _exception_sentinel = object()  # Sentinel to signal an exception occurred
+
     def producer():
         """Runs in a background thread to fetch items asynchronously."""
 
@@ -239,6 +241,9 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except BaseException as exc:
+                # Propagate the exception to the consumer thread
+                queue.put((_exception_sentinel, exc))
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -254,6 +259,9 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        # Re-raise exceptions from the producer thread
+        if isinstance(item, tuple) and len(item) == 2 and item[0] is _exception_sentinel:
+            raise item[1]
         yield item
 
 


### PR DESCRIPTION
## Summary

When using `streamify` with `async_streaming=False`, exceptions raised in the async generator were silently swallowed. The consumer would simply stop iterating with no error — making debugging extremely difficult.

**Root cause:** The `try/finally` in the producer only sent the stop sentinel on completion. Exceptions were caught by `finally` but never propagated to the consumer thread.

**Fix:** Added an explicit `except BaseException` that puts the exception in the queue as a tagged tuple. The consumer checks for this tag and re-raises the original exception with its full traceback.

```python
# Before: exception lost
try:
    async for item in async_generator:
        queue.put(item)
finally:
    queue.put(stop_sentinel)

# After: exception propagated
try:
    async for item in async_generator:
        queue.put(item)
except BaseException as exc:
    queue.put((_exception_sentinel, exc))
finally:
    queue.put(stop_sentinel)
```

Closes #9142