### PR TITLE
fix(evaluate): expose timeout and straggler_limit params in Evaluate

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -81,6 +81,8 @@ class Evaluate:
         failure_score: float = 0.0,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int | None = None,
+        straggler_limit: int | None = None,
         **kwargs,
     ):
         """
@@ -97,6 +99,11 @@ class Evaluate:
             failure_score (float): The default score to use if evaluation fails due to an exception.
             save_as_csv (Optional[str]): The file name where the csv will be saved.
             save_as_json (Optional[str]): The file name where the json will be saved.
+            timeout (Optional[int]): The straggler timeout in seconds for parallel evaluation.
+                If ``None``, uses the ``ParallelExecutor`` default (120s). Set to ``0`` to disable
+                straggler resubmission entirely, which is useful for long-running evaluations.
+            straggler_limit (Optional[int]): The number of remaining tasks below which
+                straggler detection kicks in. If ``None``, uses the ``ParallelExecutor`` default (3).
 
         """
         self.devset = devset
@@ -109,6 +116,8 @@ class Evaluate:
         self.failure_score = failure_score
         self.save_as_csv = save_as_csv
         self.save_as_json = save_as_json
+        self.timeout = timeout
+        self.straggler_limit = straggler_limit
 
         if "return_outputs" in kwargs:
             raise ValueError("`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object.")
@@ -125,6 +134,8 @@ class Evaluate:
         callback_metadata: dict[str, Any] | None = None,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int | None = None,
+        straggler_limit: int | None = None,
     ) -> EvaluationResult:
         """
         Args:
@@ -138,6 +149,10 @@ class Evaluate:
             display_table (Union[bool, int]): Whether to display the evaluation results in a table. if not provided, use
                 `self.display_table`. If a number is passed, the evaluation results will be truncated to that number before displayed.
             callback_metadata (dict): Metadata to be used for evaluate callback handlers.
+            timeout (Optional[int]): The straggler timeout in seconds for parallel evaluation. if not provided, use
+                `self.timeout`. Set to ``0`` to disable straggler resubmission.
+            straggler_limit (Optional[int]): The number of remaining tasks below which straggler detection kicks in.
+                if not provided, use `self.straggler_limit`.
 
         Returns:
             The evaluation results are returned as a dspy.EvaluationResult object containing the following attributes:
@@ -153,19 +168,27 @@ class Evaluate:
         display_table = display_table if display_table is not None else self.display_table
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
+        timeout = timeout if timeout is not None else self.timeout
+        straggler_limit = straggler_limit if straggler_limit is not None else self.straggler_limit
 
         if callback_metadata:
             logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
 
         tqdm.tqdm._instances.clear()
 
-        executor = ParallelExecutor(
+        executor_kwargs = dict(
             num_threads=num_threads,
             disable_progress_bar=not display_progress,
             max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
             provide_traceback=self.provide_traceback,
             compare_results=True,
         )
+        if timeout is not None:
+            executor_kwargs["timeout"] = timeout
+        if straggler_limit is not None:
+            executor_kwargs["straggler_limit"] = straggler_limit
+
+        executor = ParallelExecutor(**executor_kwargs)
 
         def process_item(example):
             prediction = program(**example.inputs())

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -166,6 +166,82 @@ def test_multi_thread_evaluate_call_cancelled(monkeypatch):
         ev(program)
 
 
+def test_evaluate_timeout_params_passed_to_executor():
+    """Evaluate should pass timeout and straggler_limit to ParallelExecutor."""
+    dspy.configure(
+        lm=DummyLM({"What is 1+1?": {"answer": "2"}, "What is 2+2?": {"answer": "4"}})
+    )
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    program = Predict("question -> answer")
+
+    with patch("dspy.evaluate.evaluate.ParallelExecutor") as MockExecutor:
+        mock_instance = MockExecutor.return_value
+        mock_instance.execute.return_value = [(dspy.Prediction(answer="2"), True), (dspy.Prediction(answer="4"), True)]
+
+        ev = Evaluate(
+            devset=devset,
+            metric=answer_exact_match,
+            display_progress=False,
+            num_threads=2,
+            timeout=0,
+            straggler_limit=5,
+        )
+        ev(program)
+
+        call_kwargs = MockExecutor.call_args[1]
+        assert call_kwargs["timeout"] == 0
+        assert call_kwargs["straggler_limit"] == 5
+
+
+def test_evaluate_timeout_defaults_omit_params():
+    """When timeout and straggler_limit are not set, they should not be passed to ParallelExecutor."""
+    dspy.configure(
+        lm=DummyLM({"What is 1+1?": {"answer": "2"}, "What is 2+2?": {"answer": "4"}})
+    )
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    program = Predict("question -> answer")
+
+    with patch("dspy.evaluate.evaluate.ParallelExecutor") as MockExecutor:
+        mock_instance = MockExecutor.return_value
+        mock_instance.execute.return_value = [(dspy.Prediction(answer="2"), True), (dspy.Prediction(answer="4"), True)]
+
+        ev = Evaluate(
+            devset=devset,
+            metric=answer_exact_match,
+            display_progress=False,
+            num_threads=2,
+        )
+        ev(program)
+
+        call_kwargs = MockExecutor.call_args[1]
+        assert "timeout" not in call_kwargs
+        assert "straggler_limit" not in call_kwargs
+
+
+def test_evaluate_timeout_zero_disables_straggler_resubmission():
+    """Setting timeout=0 should disable straggler resubmission for long-running evaluations."""
+    import time
+
+    class SlowLM(DummyLM):
+        def __call__(self, *args, **kwargs):
+            time.sleep(0.5)
+            return super().__call__(*args, **kwargs)
+
+    dspy.configure(lm=SlowLM({"What is 1+1?": {"answer": "2"}, "What is 2+2?": {"answer": "4"}}))
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    program = Predict("question -> answer")
+
+    ev = Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        display_progress=False,
+        num_threads=2,
+        timeout=0,
+    )
+    result = ev(program)
+    assert result.score == 100.0
+
+
 def test_evaluate_call_wrong_answer():
     dspy.configure(lm=DummyLM({"What is 1+1?": {"answer": "0"}, "What is 2+2?": {"answer": "0"}}))
     devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]


### PR DESCRIPTION
## Summary

`Evaluate` doesn't expose `ParallelExecutor`'s `timeout` and `straggler_limit` params. The hardcoded 120s straggler timeout causes `cannot schedule new futures after shutdown` errors on long-running evaluations (e.g., LLM-as-judge metrics that take >2 minutes per example).

This follows the same pattern as #9199, which exposed these params in `Parallel` and `Module.batch()`.

## Changes

- Add `timeout` and `straggler_limit` params to `Evaluate.__init__()` and `Evaluate.__call__()`
- Pass them through to `ParallelExecutor` only when explicitly set (preserves existing defaults)
- Setting `timeout=0` disables straggler resubmission entirely

## Usage

```python
# Disable straggler resubmission for long evals
evaluator = dspy.Evaluate(devset=devset, metric=metric, timeout=0)

# Custom timeout (e.g., 10 minutes)
evaluator = dspy.Evaluate(devset=devset, metric=metric, timeout=600)

# Override per-call
evaluator(program, timeout=0, straggler_limit=5)
```

## Tests

3 new tests:
- `test_evaluate_timeout_params_passed_to_executor` — verifies params reach `ParallelExecutor`
- `test_evaluate_timeout_defaults_omit_params` — verifies defaults don't override `ParallelExecutor` defaults
- `test_evaluate_timeout_zero_disables_straggler_resubmission` — end-to-end with slow LM

Closes #9574