### PR TITLE
fix: make Module.load_state transactional to prevent partial corruption on error

### DIFF
--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -159,7 +159,20 @@ class BaseModule:
     def load_state(self, state, *, allow_unsafe_lm_state=False):
         from dspy.predict.predict import Predict
 
-        for name, param in self.named_parameters():
+        param_items = list(self.named_parameters())
+
+        # Two-phase load: validate all keys are present before mutating any parameter.
+        # Without this check, a missing key would raise after earlier parameters have already
+        # been overwritten, leaving the module in a partially-hydrated (corrupted) state.
+        missing = [name for name, _ in param_items if name not in state]
+        if missing:
+            raise KeyError(
+                f"Saved state is missing required keys for the following parameters: {missing}. "
+                "This can happen when the saved state was created from a different version of the "
+                "module (e.g. a parameter was added or renamed). No parameters were modified."
+            )
+
+        for name, param in param_items:
             if isinstance(param, Predict):
                 param.load_state(state[name], allow_unsafe_lm_state=allow_unsafe_lm_state)
             else:

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import dspy
 from dspy.primitives.module import Module, set_attribute_by_name  # Adjust the import based on your file structure
 from dspy.utils import DummyLM
@@ -176,6 +177,59 @@ def test_named_parameters_duplicate_references():
     # Only testing for whether exceptions are thrown or not
     # As Module.named_parameters() is recursive, this is mainly for catching infinite recursion
     module.named_parameters()
+
+
+def test_load_state_is_transactional_on_missing_key():
+    """
+    Regression test for: Module.load_state silently corrupts modules on partial failure.
+
+    When a saved state is missing a key (e.g. due to schema/signature drift), load_state
+    must raise BEFORE mutating any parameters. A module whose load fails should still have
+    all parameters at their original (pre-load) values.
+    """
+    import json
+    import tempfile
+    from pathlib import Path as _Path
+
+    from dspy.primitives.example import Example
+
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    class Prog(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.a = dspy.ChainOfThought(Sig)
+            self.b = dspy.ChainOfThought(Sig)
+
+    # 1. Save a program with non-default demo state on both predictors
+    source = Prog()
+    sentinel = Example(question="q1", answer="a1").with_inputs("question")
+    source.a.predict.demos = [sentinel]
+    source.b.predict.demos = [sentinel]
+
+    with tempfile.TemporaryDirectory() as d:
+        path = _Path(d) / "state.json"
+        source.save(str(path), save_program=False)
+
+        # 2. Corrupt the saved state by removing b.predict's entry (simulate signature drift)
+        raw = json.loads(path.read_text())
+        corrupted = {k: v for k, v in raw.items() if "b." not in k}
+        path.write_text(json.dumps(corrupted))
+
+        # 3. Load should raise before mutating any parameters
+        template = Prog()
+        assert template.a.predict.demos == [], "Pre-condition: a.predict.demos should be empty before load"
+
+        with pytest.raises(KeyError, match="missing required keys"):
+            template.load(str(path))
+
+        # 4. The critical assertion: a.predict.demos must still be empty (not corrupted)
+        assert template.a.predict.demos == [], (
+            "load_state must not partially mutate the module when it fails — "
+            "template.a.predict.demos was corrupted despite the load raising an exception"
+        )
 
 
 def test_load_dspy_program_cross_version():

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+
 import dspy
 from dspy.primitives.module import Module, set_attribute_by_name  # Adjust the import based on your file structure
 from dspy.utils import DummyLM
@@ -26,7 +27,7 @@ def test_named_predictors():
     module = HopModule()
     named_preds = module.named_predictors()
     assert len(named_preds) == 2, "Should identify correct number of Predict instances"
-    names, preds = zip(*named_preds, strict=False)
+    names, _preds = zip(*named_preds, strict=False)
     assert "predict1" in names and "predict2" in names, "Named predictors should include 'predict1' and 'predict2'"
 
 


### PR DESCRIPTION
## Summary

Fixes #9589

`Module.load_state` was a non-transactional mutation loop. If any parameter key was missing from the saved state (e.g. due to signature drift, schema migration, or a manual edit to the JSON file), the `KeyError` would fire **after** earlier parameters had already been overwritten. Callers that caught the exception would continue using a partially-hydrated module with no way to detect the corruption.

## Root cause

```python
# Before fix:
def load_state(self, state, *, allow_unsafe_lm_state=False):
    for name, param in self.named_parameters():  # mutates as it goes
        param.load_state(state[name])  # KeyError here leaves earlier params dirty
```

## Fix: two-phase validate-then-apply

Collect all parameter names first, then validate **all** keys are present before mutating **any** of them:

```python
def load_state(self, state, *, allow_unsafe_lm_state=False):
    param_items = list(self.named_parameters())

    # Phase 1: validate — fail before touching anything
    missing = [name for name, _ in param_items if name not in state]
    if missing:
        raise KeyError(
            f"Saved state is missing required keys for the following parameters: {missing}. "
            "This can happen when the saved state was created from a different version of the "
            "module (e.g. a parameter was added or renamed). No parameters were modified."
        )

    # Phase 2: apply — only runs if all keys are present
    for name, param in param_items:
        ...
```

This is **Option A** from the issue (preferred by the reporter) — it handles the common case (missing keys) at zero performance cost. If `param.load_state` itself can fail on malformed values, Option B (deep-copy + swap) can be layered on top later, but that's a separate concern.

## What changed

- `dspy/primitives/base_module.py`: two-phase validate-then-apply in `load_state`
- `tests/primitives/test_module.py`: regression test verifying that when a load fails due to a missing key, all parameters remain at their pre-load (clean template) values

## Test

```
PASSED tests/primitives/test_module.py::test_load_state_is_transactional_on_missing_key
```

Reproducer from the issue now raises cleanly with no partial mutation:
```
BEFORE load: template.a.predict.demos = []
load raised: KeyError: "Saved state is missing required keys..."
AFTER  load: template.a.predict.demos = []  # ✅ unchanged
```
Previously `AFTER load` would show the sentinel demo from the partial load.