### PR TITLE
docs: add Google-style docstrings to DataLoader

### DIFF
--- a/dspy/datasets/dataloader.py
+++ b/dspy/datasets/dataloader.py
@@ -10,6 +10,20 @@ if TYPE_CHECKING:
 
 
 class DataLoader(Dataset):
+    """Load datasets from various sources and convert them to DSPy Examples.
+
+    The DataLoader provides a unified interface for loading data from HuggingFace,
+    CSV files, Pandas DataFrames, JSON files, Parquet files, and retrieval modules.
+    Each loader converts rows into ``dspy.Example`` objects with optional input key
+    annotations for use in DSPy programs.
+
+    Example::
+
+        loader = DataLoader()
+        data = loader.from_huggingface("dataset_name", split="train")
+        train, test = loader.train_test_split(data, train_size=0.8)
+    """
+
     def __init__(self):
         pass
 
@@ -21,6 +35,32 @@ class DataLoader(Dataset):
         fields: tuple[str] | None = None,
         **kwargs,
     ) -> Mapping[str, list[dspy.Example]] | list[dspy.Example]:
+        """Load a dataset from HuggingFace Hub and convert to DSPy Examples.
+
+        Wraps the ``datasets.load_dataset`` function and converts each row into a
+        ``dspy.Example``. When multiple splits are returned, a mapping of split
+        names to example lists is returned; otherwise a flat list is returned.
+
+        Args:
+            dataset_name: The name of the dataset on HuggingFace Hub
+                (e.g. ``"rajpurkar/squad"``).
+            *args: Additional positional arguments forwarded to
+                ``datasets.load_dataset``.
+            input_keys: Tuple of field names to mark as inputs via
+                ``Example.with_inputs()``.
+            fields: Optional tuple of field names to select from each row. If
+                ``None``, all fields are included.
+            **kwargs: Additional keyword arguments forwarded to
+                ``datasets.load_dataset`` (e.g. ``split="train"``).
+
+        Returns:
+            A dict mapping split names to lists of Examples when multiple splits
+            are loaded, or a flat list of Examples for a single split.
+
+        Raises:
+            ValueError: If ``fields`` is not a tuple or ``input_keys`` is not a
+                tuple.
+        """
         if fields and not isinstance(fields, tuple):
             raise ValueError("Invalid fields provided. Please provide a tuple of fields.")
 
@@ -66,6 +106,17 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load examples from a CSV file.
+
+        Args:
+            file_path: Path to the CSV file.
+            fields: Optional list of column names to include. If ``None``, all
+                columns are used.
+            input_keys: Tuple of field names to mark as inputs.
+
+        Returns:
+            A list of ``dspy.Example`` objects, one per row.
+        """
         from datasets import load_dataset
 
         dataset = load_dataset("csv", data_files=file_path)["train"]
@@ -81,6 +132,17 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load examples from a Pandas DataFrame.
+
+        Args:
+            df: The Pandas DataFrame to convert.
+            fields: Optional list of column names to include. If ``None``, all
+                columns are used.
+            input_keys: Tuple of field names to mark as inputs.
+
+        Returns:
+            A list of ``dspy.Example`` objects, one per row.
+        """
         if fields is None:
             fields = list(df.columns)
 
@@ -94,6 +156,17 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load examples from a JSON or JSON Lines file.
+
+        Args:
+            file_path: Path to the JSON file.
+            fields: Optional list of field names to include. If ``None``, all
+                fields are used.
+            input_keys: Tuple of field names to mark as inputs.
+
+        Returns:
+            A list of ``dspy.Example`` objects, one per row.
+        """
         from datasets import load_dataset
 
         dataset = load_dataset("json", data_files=file_path)["train"]
@@ -109,6 +182,17 @@ class DataLoader(Dataset):
         fields: list[str] | None = None,
         input_keys: tuple[str] = (),
     ) -> list[dspy.Example]:
+        """Load examples from a Parquet file.
+
+        Args:
+            file_path: Path to the Parquet file.
+            fields: Optional list of field names to include. If ``None``, all
+                fields are used.
+            input_keys: Tuple of field names to mark as inputs.
+
+        Returns:
+            A list of ``dspy.Example`` objects, one per row.
+        """
         from datasets import load_dataset
 
         dataset = load_dataset("parquet", data_files=file_path)["train"]
@@ -119,6 +203,23 @@ class DataLoader(Dataset):
         return [dspy.Example({field: row[field] for field in fields}).with_inputs(*input_keys) for row in dataset]
 
     def from_rm(self, num_samples: int, fields: list[str], input_keys: list[str]) -> list[dspy.Example]:
+        """Load examples from the configured retrieval module.
+
+        Samples objects from the retrieval model (``dspy.settings.rm``) and
+        converts them to ``dspy.Example`` objects.
+
+        Args:
+            num_samples: Number of samples to retrieve.
+            fields: List of field names to extract from each retrieved object.
+            input_keys: List of field names to mark as inputs.
+
+        Returns:
+            A list of ``dspy.Example`` objects from the retrieval module.
+
+        Raises:
+            ValueError: If no retrieval module is configured or the module does
+                not support ``get_objects``.
+        """
         try:
             rm = dspy.settings.rm
             try:
@@ -142,6 +243,22 @@ class DataLoader(Dataset):
         *args,
         **kwargs,
     ) -> list[dspy.Example]:
+        """Randomly sample examples from a dataset.
+
+        Args:
+            dataset: A list of ``dspy.Example`` objects to sample from.
+            n: Number of samples to draw.
+            *args: Additional positional arguments forwarded to
+                ``random.sample``.
+            **kwargs: Additional keyword arguments forwarded to
+                ``random.sample``.
+
+        Returns:
+            A list of ``n`` randomly selected examples.
+
+        Raises:
+            ValueError: If ``dataset`` is not a list.
+        """
         if not isinstance(dataset, list):
             raise ValueError(
                 f"Invalid dataset provided of type {type(dataset)}. Please provide a list of `dspy.Example`s."
@@ -156,6 +273,29 @@ class DataLoader(Dataset):
         test_size: int | float | None = None,
         random_state: int | None = None,
     ) -> Mapping[str, list[dspy.Example]]:
+        """Split a dataset into train and test subsets.
+
+        Randomly shuffles the dataset and divides it into training and testing
+        splits based on the specified sizes.
+
+        Args:
+            dataset: A list of ``dspy.Example`` objects to split.
+            train_size: Size of the training split. If a float between 0 and 1,
+                it represents the proportion of the dataset. If an int, it
+                represents the absolute number of samples. Defaults to 0.75.
+            test_size: Size of the test split. Accepts the same types as
+                ``train_size``. If ``None``, the remaining samples after the
+                train split are used.
+            random_state: Optional seed for reproducible shuffling.
+
+        Returns:
+            A dict with ``"train"`` and ``"test"`` keys, each mapping to a list
+            of ``dspy.Example`` objects.
+
+        Raises:
+            ValueError: If ``train_size`` or ``test_size`` are invalid, or if
+                their sum exceeds the dataset length.
+        """
         if random_state is not None:
             random.seed(random_state)
 


### PR DESCRIPTION
## Summary

Adds comprehensive Google-style docstrings to all public APIs in `dspy/datasets/dataloader.py`, as tracked in #9593 (parent issue: #8926).

## Changes

Added docstrings to 9 public symbols:

| Symbol | Type | Description |
|--------|------|-------------|
| `DataLoader` | class | Overview + usage example |
| `from_huggingface()` | method | Load from HuggingFace Hub |
| `from_csv()` | method | Load from CSV files |
| `from_pandas()` | method | Load from Pandas DataFrames |
| `from_json()` | method | Load from JSON/JSONL files |
| `from_parquet()` | method | Load from Parquet files |
| `from_rm()` | method | Load from retrieval module |
| `sample()` | method | Random sampling |
| `train_test_split()` | method | Train/test split with shuffle |

## Format

All docstrings follow **Google-style** format compatible with [mkdocstrings/griffe](https://mkdocstrings.github.io/griffe/reference/docstrings/#google-section-modules):

- One-line summary
- Extended description (where helpful)
- `Args:` section with type descriptions
- `Returns:` section
- `Raises:` section (where applicable)
- Usage example in class docstring

## Testing

- ✅ All existing docstrings preserved
- ✅ No code changes — only docstring additions
- ✅ File parses without syntax errors
- ✅ All 9 public methods + class docstring verified via AST

Closes #9593
Refs #8926