### PR TITLE
fix(gepa): update Feedback field when score overridden to module-level on mismatch (#8846)

### DIFF
--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -218,6 +218,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 example = data["example"]
                 prediction = data["prediction"]
                 module_score = data["score"]
+                module_feedback = module_score.get("feedback") if hasattr(module_score, "feedback") else None
                 if hasattr(module_score, "score"):
                     module_score = module_score["score"]
 
@@ -304,6 +305,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                             )
                             self.warn_on_score_mismatch = False
                         fb["score"] = module_score
+                        d["Feedback"] = module_feedback if module_feedback is not None else f"This trajectory got a score of {module_score}."
 
                 items.append(d)
 

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -342,6 +342,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 example = data["example"]
                 prediction = data["prediction"]
                 module_score = data["score"]
+                module_feedback = module_score.get("feedback") if hasattr(module_score, "feedback") else None
                 if hasattr(module_score, "score"):
                     module_score = module_score["score"]
 
@@ -428,6 +429,11 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                             )
                             self.warn_on_score_mismatch = False
                         fb["score"] = module_score
+                        d["Feedback"] = (
+                            module_feedback
+                            if module_feedback is not None
+                            else f"This trajectory got a score of {module_score}."
+                        )
 
                 items.append(d)
 

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -9,7 +9,7 @@ import dspy
 import dspy.clients
 from dspy import Example
 from dspy.predict import Predict
-from dspy.teleprompt.gepa import instruction_proposal
+from dspy.teleprompt.gepa import gepa_utils, instruction_proposal
 from dspy.utils.dummies import DummyLM
 
 
@@ -521,3 +521,89 @@ def test_alternating_half_component_selector():
             # Odd iteration should select second half: ["generator"]
             assert "generator" in selection["selected"], f"Odd iteration {selection['iteration']} should include generator"
             assert "classifier" not in selection["selected"], f"Odd iteration {selection['iteration']} should not include classifier"
+
+
+def _run_gepa_capture_feedbacks(metric_fn):
+    """Helper: run GEPA with the given metric and return all Feedback strings produced."""
+    captured_datasets = []
+    original = gepa_utils.DspyAdapter.make_reflective_dataset
+
+    def capturing_make_reflective(self, candidate, eval_batch, components_to_update):
+        result = original(self, candidate, eval_batch, components_to_update)
+        captured_datasets.append(result)
+        return result
+
+    task_lm = DummyLM([{"answer": "4"}] * 20)
+    reflection_lm = DummyLM([{"improved_instruction": "Be more precise."}] * 10)
+    trainset = [dspy.Example(question="What is 2+2?", answer="4").with_inputs("question")]
+
+    with mock.patch.object(gepa_utils.DspyAdapter, "make_reflective_dataset", capturing_make_reflective):
+        with dspy.context(lm=task_lm):
+            optimizer = dspy.GEPA(
+                metric=metric_fn,
+                reflection_lm=reflection_lm,
+                max_metric_calls=4,
+                warn_on_score_mismatch=False,
+            )
+            optimizer.compile(dspy.Predict("question -> answer"), trainset=trainset, valset=trainset)
+
+    return [
+        example["Feedback"]
+        for dataset in captured_datasets
+        for examples in dataset.values()
+        for example in examples
+    ]
+
+
+def test_gepa_feedback_updated_on_score_mismatch():
+    """
+    When a stochastic metric returns different scores at module level vs predictor level,
+    GEPA overrides fb["score"] to module_score. The Feedback field in the resulting
+    ReflectiveExample must also be updated to the module-level feedback so that score
+    and feedback describe the same evaluation.
+
+    Regression test for: https://github.com/stanfordnlp/dspy/issues/8846
+    """
+    module_feedback_sentinel = "module-level-feedback-SENTINEL"
+    predictor_feedback_sentinel = "predictor-level-feedback-SENTINEL"
+
+    def stochastic_metric(example, pred, trace=None, pred_name=None, pred_trace=None):
+        # Simulates a stochastic LLM-as-judge: different score and feedback at each call level
+        if pred_name is None:
+            return dspy.Prediction(score=0.9, feedback=module_feedback_sentinel)
+        return dspy.Prediction(score=0.3, feedback=predictor_feedback_sentinel)
+
+    all_feedbacks = _run_gepa_capture_feedbacks(stochastic_metric)
+    assert len(all_feedbacks) > 0, "No reflective examples generated — test setup issue."
+
+    for feedback in all_feedbacks:
+        assert feedback == module_feedback_sentinel, (
+            f"Score was overridden to module_score but Feedback still came from the "
+            f"predictor-level call. Expected {module_feedback_sentinel!r}, got {feedback!r}. "
+            f"See https://github.com/stanfordnlp/dspy/issues/8846"
+        )
+
+
+def test_gepa_feedback_fallback_when_no_module_feedback():
+    """
+    When the module-level metric returns no feedback field (score only), GEPA should
+    fall back to the documented default: "This trajectory got a score of {score}."
+    rather than leaving the mismatched predictor-level feedback in place.
+
+    Regression test for: https://github.com/stanfordnlp/dspy/issues/8846
+    """
+
+    def score_only_metric(example, pred, trace=None, pred_name=None, pred_trace=None):
+        # Module-level call returns score only (no feedback) — predictor level returns both
+        if pred_name is None:
+            return dspy.Prediction(score=0.9)
+        return dspy.Prediction(score=0.3, feedback="predictor-level-feedback")
+
+    all_feedbacks = _run_gepa_capture_feedbacks(score_only_metric)
+    assert len(all_feedbacks) > 0, "No reflective examples generated — test setup issue."
+
+    for feedback in all_feedbacks:
+        assert feedback == "This trajectory got a score of 0.9.", (
+            f"When module-level metric returns no feedback, expected score-based fallback, "
+            f"got {feedback!r}. See https://github.com/stanfordnlp/dspy/issues/8846"
+        )

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -5,12 +5,13 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from gepa import EvaluationBatch
 
 import dspy
 import dspy.clients
 from dspy import Example
 from dspy.predict import Predict
-from dspy.teleprompt.gepa import instruction_proposal
+from dspy.teleprompt.gepa import gepa_utils, instruction_proposal
 from dspy.utils.dummies import DummyLM
 
 
@@ -795,3 +796,49 @@ def test_batch_evaluate_is_parallel_and_preserves_context():
     assert trace_modes == [True, True, False, False, False, False]
     assert sorted(thread_budgets[-3:]) == [2, 3, 3]
     assert sum(thread_budgets[-3:]) == 8
+
+
+def _make_reflective_example(module_score):
+    student = SimpleModule("input -> output")
+    predictor_output = dspy.Prediction(output="blue")
+
+    def predictor_feedback(**kwargs):
+        return dspy.Prediction(score=0.3, feedback="predictor-level feedback")
+
+    adapter = gepa_utils.DspyAdapter(
+        student_module=student,
+        metric_fn=simple_metric,
+        feedback_map={"predictor": predictor_feedback},
+        warn_on_score_mismatch=False,
+    )
+    eval_batch = EvaluationBatch(
+        outputs=[predictor_output],
+        scores=[0.9],
+        trajectories=[
+            {
+                "trace": [(student.predictor, {"input": "sky"}, predictor_output)],
+                "example": Example(input="sky", output="blue").with_inputs("input"),
+                "prediction": predictor_output,
+                "score": module_score,
+            }
+        ],
+    )
+
+    dataset = adapter.make_reflective_dataset(
+        candidate={},
+        eval_batch=eval_batch,
+        components_to_update=["predictor"],
+    )
+    return dataset["predictor"][0]
+
+
+def test_gepa_feedback_uses_module_feedback_on_score_mismatch():
+    example = _make_reflective_example(dspy.Prediction(score=0.9, feedback="module-level feedback"))
+
+    assert example["Feedback"] == "module-level feedback"
+
+
+def test_gepa_feedback_uses_score_fallback_without_module_feedback():
+    example = _make_reflective_example(0.9)
+
+    assert example["Feedback"] == "This trajectory got a score of 0.9."


### PR DESCRIPTION
## Summary

Completes the fix started in #8777.

When a stochastic `metric_with_feedback` returns **different scores** at module level vs predictor level, `make_reflective_dataset` already corrects `fb["score"]` to `module_score` — but leaves `d["Feedback"]` from the independent predictor-level call unchanged. The resulting `ReflectiveExample` has a score and a feedback string from two different LLM evaluations.

**Example of the broken state (before this fix):**
```
score    = 0.9   ← from module-level call
Feedback = "scored 0.5. Needs improvement."  ← from predictor-level call
```

## Root Cause

`gepa_utils.py:221` extracts the float score from `module_score` but drops its `feedback` field before reaching the mismatch branch. When the branch fires and overrides `fb["score"]`, there is no module-level feedback to substitute.

## Fix

2 lines changed. Capture `module_feedback` before stripping, then unconditionally substitute when the mismatch branch fires — using the module-level feedback when available, or falling back to `f"This trajectory got a score of {score}."` (the same fallback already used by `feedback_fn_creator` at `gepa.py:542` for the predictor-level path):

```python
# Capture feedback before stripping Prediction to float
module_feedback = module_score.get("feedback") if hasattr(module_score, "feedback") else None
if hasattr(module_score, "score"):
    module_score = module_score["score"]

# ...existing mismatch branch...
if fb["score"] != module_score:
    ...
    fb["score"] = module_score
    d["Feedback"] = module_feedback if module_feedback is not None else f"This trajectory got a score of {module_score}."
```

## Tests

Two new tests added to `tests/teleprompt/test_gepa.py`:

1. **`test_gepa_feedback_updated_on_score_mismatch`** — metric returns feedback at both levels; asserts `Feedback` comes from module-level call after score override.
2. **`test_gepa_feedback_fallback_when_no_module_feedback`** — metric returns score-only at module level; asserts fallback string `"This trajectory got a score of {score}."` is used.

Both fail on unfixed main. All 17 GEPA tests pass.

## References

- Fixes #8846
- Completes #8777 (which fixed the score side but not the feedback side)

CC @LucasMartins007 (author of #8777)

## AI disclosure

AI-assisted: written with Claude Code, run through Hermes Labs' engineering infrastructure, under my review. Prompts available on request.

<!-- hermes-labs:attribution v1 -->
This contribution was produced by agents through [Hermes Labs](https://hermes-labs.ai)’ engineering infrastructure. [Rolando Bosch](https://github.com/roli-lpci) is the responsible human contributor and authorized publication from his personal GitHub account.
<!-- /hermes-labs:attribution -->