### PR TITLE
fix: cloudpickle serialization of Signature on Python 3.14

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -173,6 +173,14 @@ class SignatureMeta(type(BaseModel)):
         ordered_annotations.update({k: v for k, v in raw_annotations.items() if k not in ordered_annotations})
         namespace["__annotations__"] = ordered_annotations
 
+        # On Python 3.14+, prevent Pydantic from capturing this frame's locals via
+        # parent_frame_namespace(). Those locals include references to the __annotate__
+        # closure and the class namespace dict, which contain unpicklable _abc._abc_data
+        # and break cloudpickle. This is safe because DSPy eagerly resolves all
+        # annotations above.
+        if sys.version_info >= (3, 14):
+            kwargs["__pydantic_reset_parent_namespace__"] = False
+
         # Let Pydantic do its thing
         cls = super().__new__(mcs, signature_name, bases, namespace, **kwargs)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "anyio",
     "asyncer==0.0.8",
     "cachetools>=5.5.0",
-    "cloudpickle>=3.0.0",
+    "cloudpickle>=3.1.2",
     "numpy>=1.26.0",
     "xxhash>=3.5.0",
     "gepa[dspy]==0.0.27",

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -1,6 +1,8 @@
+import pickle
 from types import UnionType
 from typing import Any, Optional, Union
 
+import cloudpickle
 import pydantic
 import pytest
 
@@ -578,3 +580,32 @@ def test_pep604_union_type_with_custom_types():
     custom_obj = CustomType(value="test")
     pred = dspy.Predict(sig)(input=custom_obj)
     assert pred.output == "processed"
+
+
+def test_signature_cloudpickle_roundtrip():
+    class MySignature(Signature):
+        """Answer the question."""
+        context: list[str] = InputField()
+        question: str = InputField()
+        answer: str = OutputField()
+
+    data = cloudpickle.dumps(MySignature)
+    loaded = pickle.loads(data)
+
+    assert loaded.__name__ == "MySignature"
+    assert list(loaded.input_fields.keys()) == ["context", "question"]
+    assert list(loaded.output_fields.keys()) == ["answer"]
+    assert loaded.instructions == "Answer the question."
+
+
+def test_predict_cloudpickle_roundtrip():
+    class QA(Signature):
+        """Answer the question."""
+        question: str = InputField()
+        answer: str = OutputField()
+
+    predict = dspy.Predict(QA)
+    data = cloudpickle.dumps(predict)
+    loaded = pickle.loads(data)
+
+    assert list(loaded.signature.fields.keys()) == ["question", "answer"]

--- a/uv.lock
+++ b/uv.lock
@@ -522,11 +522,11 @@ wheels = [
 
 [[package]]
 name = "cloudpickle"
-version = "3.1.1"
+version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/39/069100b84d7418bc358d81669d5748efb14b9cceacd2f9c75f550424132f/cloudpickle-3.1.1.tar.gz", hash = "sha256:b216fa8ae4019d5482a8ac3c95d8f6346115d8835911fd4aefd1a445e4242c64", size = 22113, upload-time = "2025-01-14T17:02:05.085Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/e8/64c37fadfc2816a7701fa8a6ed8d87327c7d54eacfbfb6edab14a2f2be75/cloudpickle-3.1.1-py3-none-any.whl", hash = "sha256:c8c5a44295039331ee9dad40ba100a9c7297b6f988e50e87ccdf3765a668350e", size = 20992, upload-time = "2025-01-14T17:02:02.417Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ requires-dist = [
     { name = "asyncer", specifier = "==0.0.8" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.3" },
     { name = "cachetools", specifier = ">=5.5.0" },
-    { name = "cloudpickle", specifier = ">=3.0.0" },
+    { name = "cloudpickle", specifier = ">=3.1.2" },
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
     { name = "diskcache", specifier = ">=5.6.0" },


### PR DESCRIPTION
## Problem

On Python 3.14, `cloudpickle.dumps()` fails on `dspy.Signature` subclasses (and `Predict` modules wrapping them) with:

```
TypeError: cannot pickle '_abc._abc_data' object
```

Two things changed in Python 3.14 that combine to cause this:

### 1. PEP 649 added `__annotate_func__` to every class

PEP 649 (deferred evaluation of annotations) stores a lazy `__annotate__` closure on every class dict. This closure captures the class namespace, which includes `_abc._abc_data` -- an unpicklable C-level object from the ABC machinery. cloudpickle tries to serialize it and fails.

**Fixed upstream** in [cloudpipe/cloudpickle#578](https://github.com/cloudpipe/cloudpickle/pull/578), released as cloudpickle 3.1.2.

### 2. Pydantic captures `SignatureMeta.__new__` locals via frame introspection

Pydantic's `ModelMetaclass.__new__` calls `parent_frame_namespace()`, which uses `sys._getframe(2)` to grab the local variables of whatever code called the metaclass. This is a [hack to support forward references](https://github.com/pydantic/pydantic/blob/main/pydantic/_internal/_typing_extra.py#L213-L274) in local scopes (e.g. a model defined inside a function that references a local type alias).

For a plain `BaseModel` subclass, frame depth 2 lands on the user's code (module scope or function body) -- harmless. But DSPy's `SignatureMeta.__new__` calls `super().__new__()`, which inserts an extra frame. So depth 2 lands on `SignatureMeta.__new__` instead, and Pydantic captures *its* locals into `cls.__pydantic_parent_namespace__`. On Python 3.14, those locals now include:

- `annotate_func` -- the PEP 649 `__annotate__` closure (which references `_abc._abc_data`)  
- `field` -- a cell variable holding the class namespace dict (which also contains `_abc._abc_data`)

cloudpickle tries to serialize `__pydantic_parent_namespace__`, hits these, and fails.

Pydantic itself never hits this because `ModelMetaclass` isn't wrapped by another metaclass, so `sys._getframe(2)` always lands on user code. This is DSPy-specific.

## Fix

1. **Bump `cloudpickle>=3.1.2`** -- handles issue 1 (same fix [Pydantic shipped](https://github.com/pydantic/pydantic/pull/12473)).
2. **Pass `__pydantic_reset_parent_namespace__=False`** on Python 3.14+ -- tells Pydantic to skip the frame introspection entirely. This is safe because `SignatureMeta.__new__` eagerly resolves all annotations before calling `super()`, so the captured namespace would never be used.

## Reproduction

```python
import cloudpickle
import dspy

class Foo(dspy.Signature):
    """Test signature."""
    x: str = dspy.InputField()
    y: str = dspy.OutputField()

cloudpickle.dumps(Foo)  # TypeError: cannot pickle '_abc._abc_data' object
```

## References

- [cloudpipe/cloudpickle#572](https://github.com/cloudpipe/cloudpickle/issues/572) -- cloudpickle issue
- [python/cpython#140820](https://github.com/python/cpython/issues/140820) -- CPython issue (closed, deferred to cloudpickle)
- [cloudpipe/cloudpickle#578](https://github.com/cloudpipe/cloudpickle/pull/578) -- cloudpickle fix (released in 3.1.2)
- [pydantic/pydantic#11991](https://github.com/pydantic/pydantic/pull/11991) -- Pydantic Python 3.14 support (xfailed cloudpickle tests)
- [pydantic/pydantic#12473](https://github.com/pydantic/pydantic/pull/12473) -- Pydantic bumps cloudpickle to 3.1.2

Fixes #9615