### PR TITLE
chore: add uv exclude-newer to limit dependency resolution window

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,3 +186,6 @@ ban-relative-imports = "all"
     "E402",  # Allow imports not at the top of the file (needed for certain __init__ patterns)
     "F405",  # Allow undefined names from wildcard imports (common in __init__ files)
 ]
+
+[tool.uv]
+exclude-newer = "1 week"

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 
+[options]
+exclude-newer = "2026-04-09T00:43:22.62855Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"


### PR DESCRIPTION
Adds `exclude-newer = "1 week"` to `[tool.uv]` in `pyproject.toml`. This tells uv to only resolve packages published within the last week when updating the lockfile, reducing exposure to supply chain attacks from newly published malicious versions.

The corresponding `[options]` block in `uv.lock` is updated automatically by uv.