### PR TITLE
fix: correct demo index assignment in MIPROv2 raw_chosen_params

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -780,7 +780,7 @@ class MIPROv2(Teleprompter):
                 predictor.demos = demo_candidates[i][demos_idx]
                 trial_logs[trial_num][f"{i}_predictor_demos"] = demos_idx
                 chosen_params.append(f"Predictor {i}: Few-Shot Set {demos_idx}")
-                raw_chosen_params[f"{i}_predictor_demos"] = instruction_idx
+                raw_chosen_params[f"{i}_predictor_demos"] = demos_idx
 
         return chosen_params, raw_chosen_params
 


### PR DESCRIPTION
## Summary

Fixes #9626.

In `MIPROv2._select_and_insert_instructions_and_demos`, `raw_chosen_params[f\"{i}_predictor_demos\"]` was being assigned `instruction_idx` instead of `demos_idx` — a copy-paste error where the key correctly refers to the demo axis but the value came from the instruction axis.

## Change

One-line fix in `dspy/teleprompt/mipro_optimizer_v2.py`:

```diff
-raw_chosen_params[f\"{i}_predictor_demos\"] = instruction_idx
+raw_chosen_params[f\"{i}_predictor_demos\"] = demos_idx
```

The three surrounding lines (`trial_logs`, `chosen_params`, and the `_predictor_instruction` branch immediately above) all already use the correct index — this line was the outlier.

## Why this matters

`raw_chosen_params` is returned by this method and used by callers that inspect raw numerical indices (e.g. reconstructing a trial's configuration from logs). When `len(instruction_candidates[i]) != len(demo_candidates[i])`, the stored index can be out of range for the demo axis; otherwise it silently points to the wrong demo set.

## Notes

- Re-submitting after previously closing #9577 without an issue. This time the bug is documented in #9626 first per the preferred workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)