### PR TITLE
fix(rlm): handle None code in _strip_code_fences gracefully

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -66,6 +66,8 @@ _PYTHON_FENCE_LANGS = {"python", "py", "python3", "py3", ""}
 
 def _strip_code_fences(code: str) -> str:
     """Extract Python code from markdown fences, or return as-is if no fences."""
+    if code is None:
+        return ""
     code = code.strip()
     if "```" not in code:
         return code


### PR DESCRIPTION
## Fix: Handle None code in _strip_code_fences

When the LLM fails to generate code, `action.code` and `pred.code` can be `None`.
The `_strip_code_fences()` function called `code.strip()` without checking if `code` is `None` first, causing an `AttributeError`.

### Fix

Added a None check at the start of `_strip_code_fences()`:

```python
def _strip_code_fences(code: str) -> str:
    """Extract Python code from markdown fences, or return as-is if no fences."""
    if code is None:
        return ""
    code = code.strip()
    # ... rest unchanged
```

Fixes #9632.
