### PR TITLE
fix(streaming): reset StreamListener per-stream state between streamify calls

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+import copy
 import logging
 import threading
 from asyncio import iscoroutinefunction
@@ -166,26 +167,43 @@ def streamify(
     if not any(isinstance(c, StatusStreamingCallback) for c in callbacks):
         callbacks.append(status_streaming_callback)
 
-    async def generator(args, kwargs, stream: MemoryObjectSendStream):
-        with settings.context(send_stream=stream, callbacks=callbacks, stream_listeners=stream_listeners):
+    async def generator(args, kwargs, stream: MemoryObjectSendStream, call_listeners: list[StreamListener]):
+        with settings.context(send_stream=stream, callbacks=callbacks, stream_listeners=call_listeners):
             prediction = await program(*args, **kwargs)
 
         await stream.send(prediction)
 
     async def async_streamer(*args, **kwargs):
+        # Per-call listener clones. Without this, two concurrent invocations
+        # of the streamified program would share the same listener instances
+        # and stomp on each other's mutable state (queues, stream_end,
+        # cache_hit). Cloning also gives us a clean state for serial reuse
+        # so a listener whose `stream_end` is still True from a previous
+        # call doesn't silently drop every chunk on the next call (#8425).
+        listener_to_clone: dict[int, StreamListener] = {
+            id(listener): copy.copy(listener) for listener in stream_listeners
+        }
+        for clone in listener_to_clone.values():
+            clone._reset_stream_state()
+        call_listeners = [listener_to_clone[id(listener)] for listener in stream_listeners]
+        call_predict_id_to_listener = {
+            predict_id: [listener_to_clone[id(listener)] for listener in listeners]
+            for predict_id, listeners in predict_id_to_listener.items()
+        }
+
         send_stream, receive_stream = create_memory_object_stream(16)
         async with create_task_group() as tg, send_stream, receive_stream:
-            tg.start_soon(generator, args, kwargs, send_stream)
+            tg.start_soon(generator, args, kwargs, send_stream, call_listeners)
 
             async for value in receive_stream:
                 if isinstance(value, ModelResponseStream):
-                    if len(predict_id_to_listener) == 0:
+                    if len(call_predict_id_to_listener) == 0:
                         # No listeners are configured, yield the chunk directly for backwards compatibility.
                         yield value
                     else:
                         # We are receiving a chunk from the LM's response stream, delegate it to the listeners to
                         # determine if we should yield a value to the user.
-                        for listener in predict_id_to_listener[value.predict_id]:
+                        for listener in call_predict_id_to_listener[value.predict_id]:
                             # In some special cases such as Citation API, it is possible that multiple listeners
                             # return values at the same time due to the chunk buffer of the listener.
                             if output := listener.receive(value):
@@ -194,16 +212,16 @@ def streamify(
                     yield value
                 elif isinstance(value, Prediction):
                     # Flush remaining buffered tokens before yielding the Prediction instance
-                    for listener in stream_listeners:
+                    for listener in call_listeners:
                         if final_chunk := listener.finalize():
                             yield final_chunk
 
                     if include_final_prediction_in_output_stream:
                         yield value
                     elif (
-                        len(stream_listeners) == 0
-                        or any(listener.cache_hit for listener in stream_listeners)
-                        or not any(listener.stream_start for listener in stream_listeners)
+                        len(call_listeners) == 0
+                        or any(listener.cache_hit for listener in call_listeners)
+                        or not any(listener.stream_start for listener in call_listeners)
                     ):
                         yield value
                     return

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -77,6 +77,18 @@ class StreamListener:
             },
         }
 
+    def _reset_stream_state(self) -> None:
+        """Reset per-stream state so the listener can be reused across successive calls
+        to a streamified program. This clears buffered tokens and start/end flags while
+        keeping configuration (signature_field_name, predict, allow_reuse, etc.) intact.
+        """
+        self.field_start_queue = []
+        self.field_end_queue = Queue()
+        self.stream_start = False
+        self.stream_end = False
+        self.cache_hit = False
+        self.json_adapter_state = {"field_accumulated_messages": ""}
+
     def _buffered_message_end_with_start_identifier(self, concat_message: str, start_identifier: str) -> str:
         for i in range(len(concat_message)):
             if start_identifier.startswith(concat_message[len(concat_message) - i - 1 :]):

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -950,6 +950,100 @@ async def test_stream_listener_allow_reuse():
 
 
 @pytest.mark.anyio
+async def test_stream_listener_reset_state_between_streamify_calls():
+    """Regression test for #8425: stream listeners must reset per-stream state
+    between successive calls to a streamified program so that each call yields
+    its own stream chunks, even without allow_reuse=True.
+    """
+
+    async def gpt_4o_mini_stream(*args, **kwargs):
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="[["))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" answer"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ]]\n\n"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="Paris"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="!\n\n[[ ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" completed"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ]]"))])
+
+    async def completion_side_effect(*args, **kwargs):
+        return gpt_4o_mini_stream()
+
+    program = dspy.streamify(
+        dspy.Predict("question->answer"),
+        stream_listeners=[dspy.streaming.StreamListener(signature_field_name="answer")],
+    )
+
+    with mock.patch("litellm.acompletion", side_effect=completion_side_effect):
+        with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):
+            call_1_chunks = []
+            async for value in program(question="What is the capital of France?"):
+                if isinstance(value, dspy.streaming.StreamResponse):
+                    call_1_chunks.append(value.chunk)
+
+            call_2_chunks = []
+            async for value in program(question="What is the capital of Germany?"):
+                if isinstance(value, dspy.streaming.StreamResponse):
+                    call_2_chunks.append(value.chunk)
+
+    # Both calls must receive the streamed answer chunks.
+    assert "".join(call_1_chunks) == "Paris!"
+    assert "".join(call_2_chunks) == "Paris!"
+
+
+@pytest.mark.anyio
+async def test_stream_listener_caller_reference_per_stream_state_not_mutated():
+    """Regression test for #8425: per-call listener cloning must keep the
+    caller's original StreamListener's per-stream state pristine (queues,
+    stream_start, stream_end, cache_hit). Previously the streamify loop
+    mutated these on the shared listener so concurrent invocations would
+    stomp on each other's state.
+
+    Note: `predict`/`predict_name` are still bound on the original listener
+    at streamify() construction time (see `find_predictor_for_stream_listeners`),
+    which is out of scope for this fix.
+    """
+
+    async def gpt_4o_mini_stream(*args, **kwargs):
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="[["))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" answer"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ]]\n\n"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="Paris"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="!\n\n[[ ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" completed"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ##"))])
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ]]"))])
+
+    async def completion_side_effect(*args, **kwargs):
+        return gpt_4o_mini_stream()
+
+    original_listener = dspy.streaming.StreamListener(signature_field_name="answer")
+    program = dspy.streamify(
+        dspy.Predict("question->answer"),
+        stream_listeners=[original_listener],
+    )
+
+    with mock.patch("litellm.acompletion", side_effect=completion_side_effect):
+        with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):
+            chunks = []
+            async for value in program(question="What is the capital of France?"):
+                if isinstance(value, dspy.streaming.StreamResponse):
+                    chunks.append(value.chunk)
+
+    assert "".join(chunks) == "Paris!"
+    # The caller's listener instance must not have been mutated by streamify.
+    assert original_listener.stream_start is False
+    assert original_listener.stream_end is False
+    assert original_listener.cache_hit is False
+    assert original_listener.field_start_queue == []
+    assert original_listener.field_end_queue.qsize() == 0
+
+
+@pytest.mark.anyio
 async def test_stream_listener_returns_correct_chunk_xml_adapter():
     class MyProgram(dspy.Module):
         def __init__(self):


### PR DESCRIPTION
## Summary

A streamified program silently produced zero streamed chunks from the second call onwards when the same `StreamListener` instance was reused across invocations. This is the common FastAPI / global-factory pattern where a streamified module is built once and called many times.

Fixes #8425

## Root cause

`StreamListener.stream_end` is set to `True` when the first stream finishes. `streamify()` captures the same `stream_listeners` list in closure, so on every call after the first, `listener.receive()` early-returns at the top check, silently dropping every chunk. The `allow_reuse=True` path resets state on a per-prediction basis inside a single call — it does not help across calls.

## Fix

1. New `StreamListener._reset_stream_state()` clears the mutable per-stream fields (`field_start_queue`, `field_end_queue`, `stream_start`, `stream_end`, `cache_hit`, `json_adapter_state`) while preserving configuration (`signature_field_name`, `predict`, `allow_reuse`, `adapter_identifiers`).
2. `streamify.async_streamer` now clones the configured listeners with `copy.copy` and calls `_reset_stream_state()` on each clone at the start of every invocation. The clones are then used for the `settings.context`, the predict-id-to-listener map, `receive()`, and `finalize()` for the lifetime of that call. The caller's original listener instances are never mutated across calls, so concurrent invocations of the same streamified program also stop stomping on each other's state.

## Tests

`tests/streaming/test_streaming.py`:

- `test_stream_listener_reset_state_between_streamify_calls` — streamifies `dspy.Predict` with a single `ChatAdapter` listener, replays the same chunk sequence twice, asserts `\"\".join(chunks) == \"Paris!\"` for both calls.
- `test_stream_listener_caller_reference_per_stream_state_not_mutated` — asserts the caller's original listener's per-stream fields (`stream_start`, `stream_end`, `cache_hit`, `field_start_queue`, `field_end_queue`) are unchanged after a full streaming call.

Locally on `darwin/arm64`:

- `pytest tests/streaming/test_streaming.py -k listener` → 13 passed, 2 skipped (unchanged by this diff).
- The two pre-existing fixture errors (`test_streamify_yields_expected_response_chunks`, `test_streaming_response_yields_expected_response_chunks`) require `litellm_test_server` and also fail on unmodified main; not caused by this change.

## Risk notes

- `copy.copy(listener)` is shallow; the current `StreamListener` has no nested mutable state that needs deep-copy, so this is safe. External subclasses with additional mutable attributes should override `_reset_stream_state()` if they need to extend the contract.
- `predict` / `predict_name` are still bound onto the original listener at `streamify()` construction time by `find_predictor_for_stream_listeners`; this is a pre-existing behaviour and is intentionally out of scope for this fix.