### PR TITLE
Revert "fix: set LITELLM_LOCAL_MODEL_COST_MAP before litellm import to avoid HTTP fetch (#9388)"

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -1,6 +1,3 @@
-import os
-os.environ.setdefault("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-
 from dspy.predict import *
 from dspy.primitives import *
 from dspy.retrievers import *

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -87,10 +87,6 @@ def _get_dspy_cache():
 
 DSPY_CACHE = _get_dspy_cache()
 
-if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
-    # Accessed at run time by litellm; i.e., fine to keep after import
-    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
-
 
 def configure_litellm_logging(level: str = "ERROR"):
     """Configure LiteLLM logging to the specified level."""

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -87,6 +87,11 @@ def _get_dspy_cache():
 
 DSPY_CACHE = _get_dspy_cache()
 
+if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
+    # Accessed at run time by litellm; i.e., fine to keep after import
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+
+
 def configure_litellm_logging(level: str = "ERROR"):
     """Configure LiteLLM logging to the specified level."""
     # Litellm uses a global logger called `verbose_logger` to control all loggings.


### PR DESCRIPTION
Reverts #9388 (commit 30ebe34f9efaafae5be6e473210fa30d6b2f2ff9), and additionally deletes the `LITELLM_LOCAL_MODEL_COST_MAP` setdefault block from `dspy/clients/__init__.py` that the revert would otherwise restore as dead code.

## Why revert

Setting `LITELLM_LOCAL_MODEL_COST_MAP=True` before litellm is imported forces litellm to use the **bundled local copy** of `model_prices_and_context_window.json` instead of fetching the latest version from GitHub on import.

While this saved ~95ms on `import dspy`, it has a real correctness cost for users: the bundled cost/context-window map ships with whatever version of litellm is pinned in the environment, which means **for any model released (or re-priced, or re-contexted) after that litellm version was cut, users will see inaccurate or outdated information**. This includes:

- Stale pricing (cost-per-token) for newly released or recently re-priced models
- Outdated context window sizes for newer models
- Missing entries entirely for models added upstream after the pinned litellm version

For users on slightly older litellm versions (which is common), this quietly produces wrong numbers in cost tracking and can cause "unknown model" behavior for models that litellm actually supports upstream. The network fetch exists precisely to keep this information fresh, and silently disabling it is a footgun.

## Why also delete the block in `dspy/clients/__init__.py`

A plain revert of #9388 would restore this block:

```python
if "LITELLM_LOCAL_MODEL_COST_MAP" not in os.environ:
    # Accessed at run time by litellm; i.e., fine to keep after import
    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
```

The comment is factually wrong for current litellm. `LITELLM_LOCAL_MODEL_COST_MAP` is read exactly once, at litellm's own module-import time, inside `get_model_cost_map()` which is called at the top of `litellm/__init__.py`:

```python
# litellm/__init__.py
model_cost = get_model_cost_map(url=model_cost_map_url)
```

```python
# litellm/litellm_core_utils/get_model_cost_map.py
def get_model_cost_map(url: str) -> dict:
    if (os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", False)
        or os.getenv("LITELLM_LOCAL_MODEL_COST_MAP", False) == "True"):
        # use bundled backup
        ...
    # else: fetch from GitHub with 5s timeout, fall back to bundled on failure
```

Because `dspy/clients/__init__.py` runs *after* `import litellm` (litellm is pulled in much earlier via the streaming module chain: `dspy/__init__` -> `predict` -> `utils` -> `streaming/streamify.py`), the setdefault has been a **no-op the entire time it has existed** (added in #1735, Nov 2024). Deleting it:

- Matches litellm's own default behavior (fetch-fresh, bundled fallback on network failure).
- Matches what DSPy has *actually* done for the ~17 months this block has existed.
- Still respects user-set env vars: a user who exports `LITELLM_LOCAL_MODEL_COST_MAP=True` before `import dspy` will have that value honored by litellm at its own import time — this happens automatically without dspy needing to forward it.
- Removes dead code with a misleading comment.

## Follow-up

The underlying import-time cost #9388 was trying to solve will be addressed properly in #9514, which makes litellm optional. Once litellm is no longer imported eagerly via the streaming module chain, the network fetch is no longer paid on every `import dspy`, and we can reintroduce a scoped/opt-in version of this optimization without trading off model metadata freshness.
