### PR TITLE
fix(base_lm): guard response.usage access to handle missing usage field

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -100,14 +100,13 @@ class BaseLM:
 
         # Logging, with removed api key & where `cost` is None on cache hit.
         kwargs = {k: v for k, v in kwargs.items() if not k.startswith("api_")}
-        response_usage = getattr(response, "usage", None)
         entry = {
             "prompt": prompt,
             "messages": messages,
             "kwargs": kwargs,
             "response": response,
             "outputs": outputs,
-            "usage": dict(response_usage) if response_usage is not None else {},
+            "usage": dict(getattr(response, "usage", {})),
             "cost": getattr(response, "_hidden_params", {}).get("response_cost"),
             "timestamp": datetime.datetime.now().isoformat(),
             "uuid": str(uuid.uuid4()),

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -100,13 +100,14 @@ class BaseLM:
 
         # Logging, with removed api key & where `cost` is None on cache hit.
         kwargs = {k: v for k, v in kwargs.items() if not k.startswith("api_")}
+        response_usage = getattr(response, "usage", None)
         entry = {
             "prompt": prompt,
             "messages": messages,
             "kwargs": kwargs,
             "response": response,
             "outputs": outputs,
-            "usage": dict(response.usage) if hasattr(response, "usage") else {},
+            "usage": dict(response_usage) if response_usage is not None else {},
             "cost": getattr(response, "_hidden_params", {}).get("response_cost"),
             "timestamp": datetime.datetime.now().isoformat(),
             "uuid": str(uuid.uuid4()),

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -106,7 +106,7 @@ class BaseLM:
             "kwargs": kwargs,
             "response": response,
             "outputs": outputs,
-            "usage": dict(response.usage),
+            "usage": dict(response.usage) if hasattr(response, "usage") else {},
             "cost": getattr(response, "_hidden_params", {}).get("response_cost"),
             "timestamp": datetime.datetime.now().isoformat(),
             "uuid": str(uuid.uuid4()),

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -193,8 +193,8 @@ class LM(BaseLM):
 
         self._check_truncation(results)
 
-        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
-            settings.usage_tracker.add_usage(self.model, dict(results.usage))
+        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker:
+            settings.usage_tracker.add_usage(self.model, dict(getattr(results, "usage", {})))
         return results
 
     async def aforward(
@@ -234,8 +234,8 @@ class LM(BaseLM):
 
         self._check_truncation(results)
 
-        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker and hasattr(results, "usage"):
-            settings.usage_tracker.add_usage(self.model, dict(results.usage))
+        if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker:
+            settings.usage_tracker.add_usage(self.model, dict(getattr(results, "usage", {})))
         return results
 
     def launch(self, launch_kwargs: dict[str, Any] | None = None):


### PR DESCRIPTION
## Problem

The release-time `test_before_testpypi` job in `build_and_release.yml` started failing with:

```
AttributeError: 'ModelResponse' object has no attribute 'usage'
```

on `tests/predict/test_chain_of_thought.py::test_chain_of_thought_with_native_reasoning` and `test_chain_of_thought_with_manual_reasoning`. See failing job: https://github.com/stanfordnlp/dspy/actions/runs/24674269210/job/72153640776

## Root cause

Upstream behavior change in `litellm==1.82.6`. In `litellm.utils.ModelResponse.__init__`, when `usage` isn't passed explicitly, it used to default to `Usage()` and populate it on the model. In 1.82.6 it was changed to:

```python
elif stream is None or stream is False:
    usage = None  # avoid constructing throwaway Usage; set by convert_to_model_response_object
```

Now the `ModelResponse` has no `usage` attribute at all when not provided. `dspy/clients/base_lm.py` was accessing it unconditionally via `dict(response.usage)` inside `_process_lm_response`, raising `AttributeError`.

The main `run_tests.yml` CI didn't surface this because `uv.lock` pins `litellm==1.68.0` / `1.72.6`. Only the release pre-flight (`pip install dist/*.whl pytest pytest-asyncio`) resolves `litellm` fresh and picks up 1.82.6.

## Fix

Guard the `response.usage` access with `hasattr` and fall back to `{}`, matching the existing pattern already used in `dspy/clients/lm.py`:

```python
"usage": dict(response.usage) if hasattr(response, "usage") else {},
```

This also protects real user code that mocks `litellm.completion` on top of litellm 1.82.6 from hitting the same error through history logging.

## Verification

Reproduced the failure locally on Python 3.11 + `litellm==1.82.6`. After the fix, all 4 tests in `tests/predict/test_chain_of_thought.py` pass.