### PR TITLE
fix(rlm): recover from missing or empty code

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -64,9 +64,18 @@ You have max {max_llm_calls} sub-LLM calls. When done, call SUBMIT() with your o
 _PYTHON_FENCE_LANGS = {"python", "py", "python3", "py3", ""}
 
 
-def _strip_code_fences(code: str) -> str:
-    """Extract Python code from markdown fences, or return as-is if no fences."""
+def _strip_code_fences(code: str | None) -> str:
+    """Extract Python code from markdown fences, or return as-is if no fences.
+
+    Malformed model outputs can omit the `code` field entirely. Treat that as a
+    recoverable syntax-style error instead of crashing the whole RLM loop.
+    """
+    if code is None:
+        raise SyntaxError("No code returned by the model. Return Python code in the `code` field.")
+
     code = code.strip()
+    if not code:
+        raise SyntaxError("Empty code block returned by the model. Return Python code in the `code` field.")
     if "```" not in code:
         return code
 
@@ -563,7 +572,7 @@ class RLM(Module):
         try:
             code = _strip_code_fences(action.code)
         except SyntaxError as e:
-            code = action.code
+            code = action.code if isinstance(action.code, str) else ""
             result = f"[Error] {e}"
             return self._process_execution_result(action, code, result, history, output_field_names)
         result = self._execute_code(repl, code, input_args)
@@ -651,7 +660,7 @@ class RLM(Module):
         try:
             code = _strip_code_fences(pred.code)
         except SyntaxError as e:
-            code = pred.code
+            code = pred.code if isinstance(pred.code, str) else ""
             result = f"[Error] {e}"
             return self._process_execution_result(pred, code, result, history, output_field_names)
         result = self._execute_code(repl, code, input_args)

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -78,9 +78,20 @@ You have max {max_llm_calls} sub-LLM calls. When done, call SUBMIT() with your o
 _PYTHON_FENCE_LANGS = {"python", "py", "python3", "py3", ""}
 
 
-def _strip_code_fences(code: str) -> str:
-    """Extract Python code from markdown fences, or return as-is if no fences."""
+def _strip_code_fences(code: str | None) -> str:
+    """Extract Python code from markdown fences, or return as-is if no fences.
+
+    Malformed model outputs can omit the `code` field entirely. Treat that as a
+    recoverable syntax-style error instead of crashing the whole RLM loop.
+    """
+    if code is None:
+        raise SyntaxError("No code returned by the model. Return Python code in the `code` field.")
+    if not isinstance(code, str):
+        raise TypeError(f"Expected `code` to be str or None, got {type(code).__name__}.")
+
     code = code.strip()
+    if not code:
+        raise SyntaxError("Empty code block returned by the model. Return Python code in the `code` field.")
     if "```" not in code:
         return code
 
@@ -613,25 +624,27 @@ class RLM(Module):
         Returns:
             Prediction if FINAL was called successfully, else updated REPLHistory
         """
+        reasoning = "" if pred.reasoning is None else pred.reasoning
+
         # Handle error strings from caught exceptions
         if isinstance(result, str) and result.startswith("[Error]"):
             output = self._format_output(result)
-            return history.append(reasoning=pred.reasoning, code=code, output=output)
+            return history.append(reasoning=reasoning, code=code, output=output)
 
         # Handle FINAL output
         if isinstance(result, FinalOutput):
             parsed_outputs, error = self._process_final_output(result, output_field_names)
 
             if error:
-                return history.append(reasoning=pred.reasoning, code=code, output=error)
+                return history.append(reasoning=reasoning, code=code, output=error)
 
             final_history = history.append(
-                reasoning=pred.reasoning, code=code, output=f"FINAL: {parsed_outputs}"
+                reasoning=reasoning, code=code, output=f"FINAL: {parsed_outputs}"
             )
             return Prediction(
                 **parsed_outputs,
                 trajectory=[e.model_dump() for e in final_history],
-                final_reasoning=pred.reasoning,
+                final_reasoning=reasoning,
             )
 
         # Format non-final result as output
@@ -643,7 +656,7 @@ class RLM(Module):
         output = self._format_output(output)
         if self.verbose:
             logger.info(REPLEntry.format_output(output, self.max_output_chars))
-        return history.append(reasoning=pred.reasoning, code=code, output=output)
+        return history.append(reasoning=reasoning, code=code, output=output)
 
     def _execute_code(
         self,
@@ -680,7 +693,7 @@ class RLM(Module):
         try:
             code = _strip_code_fences(action.code)
         except SyntaxError as e:
-            code = action.code
+            code = action.code if isinstance(action.code, str) else ""
             result = f"[Error] {e}"
             return self._process_execution_result(action, code, result, history, output_field_names)
         result = self._execute_code(repl, code)
@@ -772,7 +785,7 @@ class RLM(Module):
         try:
             code = _strip_code_fences(pred.code)
         except SyntaxError as e:
-            code = pred.code
+            code = pred.code if isinstance(pred.code, str) else ""
             result = f"[Error] {e}"
             return self._process_execution_result(pred, code, result, history, output_field_names)
         result = self._execute_code(repl, code)

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -299,6 +299,12 @@ class TestRLMCodeFenceParsing:
         with pytest.raises(SyntaxError, match="json"):
             _strip_code_fences('```json\n{"a": 1}\n```')
 
+    def test_strip_code_fences_rejects_missing_or_empty_code(self):
+        with pytest.raises(SyntaxError, match="No code returned"):
+            _strip_code_fences(None)
+        with pytest.raises(SyntaxError, match="Empty code block returned"):
+            _strip_code_fences("")
+
 
 class TestRLMFormatting:
     """Tests for RLM formatting helpers."""
@@ -614,6 +620,22 @@ class TestRLMToolExceptions:
         assert result.answer == "recovered"
         assert result.trajectory[0]["output"].startswith("[Error]")
 
+    def test_missing_code_field_is_recoverable(self):
+        """Malformed actions with code=None should not crash the RLM loop."""
+        mock = MockInterpreter(responses=[
+            FinalOutput({"answer": "recovered"}),
+        ])
+        rlm = RLM("query -> answer", max_iterations=5, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Malformed action", "code": None},
+            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+        ])
+
+        result = rlm.forward(query="test")
+        assert result.answer == "recovered"
+        assert result.trajectory[0]["code"] == ""
+        assert result.trajectory[0]["output"].startswith("[Error] No code returned by the model")
+
 
 class TestRLMDynamicSignature:
     """Tests for the dynamically built RLM signatures."""
@@ -890,6 +912,23 @@ class TestRLMAsyncMock:
 
         result = await rlm.aforward(query="test")
         assert result.answer == "done"
+
+    @pytest.mark.asyncio
+    async def test_aforward_missing_code_field_is_recoverable(self):
+        """Malformed actions with code=None should not crash the async RLM loop."""
+        mock = MockInterpreter(responses=[
+            FinalOutput({"answer": "recovered"}),
+        ])
+        rlm = RLM("query -> answer", max_iterations=5, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Malformed action", "code": None},
+            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+        ])
+
+        result = await rlm.aforward(query="test")
+        assert result.answer == "recovered"
+        assert result.trajectory[0]["code"] == ""
+        assert result.trajectory[0]["output"].startswith("[Error] No code returned by the model")
 
 
 class TestRLMTypeCoercionMock:

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -613,6 +613,22 @@ class TestRLMCodeFenceParsing:
         with pytest.raises(SyntaxError, match="json"):
             _strip_code_fences('```json\n{"a": 1}\n```')
 
+    @pytest.mark.parametrize(
+        ("code", "message"),
+        [
+            (None, "No code returned"),
+            ("", "Empty code block returned"),
+            (" \n\t", "Empty code block returned"),
+        ],
+    )
+    def test_strip_code_fences_rejects_missing_or_empty_code(self, code, message):
+        with pytest.raises(SyntaxError, match=message):
+            _strip_code_fences(code)
+
+    def test_strip_code_fences_rejects_unexpected_type(self):
+        with pytest.raises(TypeError, match="Expected `code` to be str or None, got int"):
+            _strip_code_fences(42)
+
 
 class TestRLMFormatting:
     """Tests for RLM formatting helpers."""
@@ -968,6 +984,42 @@ class TestRLMToolExceptions:
         with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
             await rlm.aforward(mock, query="test")
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("run_async", "malformed_code", "expected_error"),
+        [
+            (False, None, "[Error] No code returned by the model. Return Python code in the `code` field."),
+            (True, None, "[Error] No code returned by the model. Return Python code in the `code` field."),
+            (False, " \n\t", "[Error] Empty code block returned by the model. Return Python code in the `code` field."),
+            (True, " \n\t", "[Error] Empty code block returned by the model. Return Python code in the `code` field."),
+        ],
+    )
+    async def test_missing_or_blank_code_is_recoverable(self, run_async, malformed_code, expected_error):
+        mock = MockInterpreter(responses=[
+            "",
+            FinalOutput({"answer": "recovered"}),
+        ])
+        rlm = RLM("query -> answer", max_iters=5)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": None, "code": malformed_code},
+            {"reasoning": None, "code": 'SUBMIT("recovered")'},
+        ])
+
+        if run_async:
+            result = await rlm.aforward(mock, query="test")
+        else:
+            result = rlm.forward(mock, query="test")
+
+        assert result.answer == "recovered"
+        assert result.final_reasoning == ""
+        assert result.trajectory[0]["reasoning"] == ""
+        assert result.trajectory[0]["code"] == (malformed_code or "")
+        assert result.trajectory[0]["output"] == expected_error
+        assert mock.call_history == [
+            ("pass", {"query": "test"}),
+            ('SUBMIT("recovered")', {}),
+        ]
+
 
 class TestRLMDynamicSignature:
     """Tests for the dynamically built RLM signatures."""
@@ -1258,7 +1310,6 @@ class TestRLMAsyncMock:
 
         result = await rlm.aforward(mock, query="test")
         assert result.answer == "done"
-
 
 class TestRLMTypeCoercionMock:
     """Unit tests for RLM type coercion using MockInterpreter (no Deno required)."""


### PR DESCRIPTION
## Issue / repro

RLM action generation can return a malformed action with both fields missing:

```text
Reasoning: None
Code: None
```

That is observed in #9632 with a local Qwen model. Today the failure happens before RLM's normal per-iteration recovery boundary:

```python
code = _strip_code_fences(action.code)
# code.strip() -> AttributeError: 'NoneType' object has no attribute 'strip'
```

One malformed model turn therefore terminates the whole RLM call.

Fixes #9632.

## Root cause

RLM already treats invalid generated Python as an iteration-level error: it records an `[Error]` entry in the trajectory and lets the next action see that feedback. Missing or blank `code` never reaches that contract because `_strip_code_fences` assumes it received a non-empty string.

`reasoning=None` is the same malformed-action shape. Once code recovery works, the strict trajectory model rejects that value and causes a second crash.

## Why this fixes the root cause

The shared parsing boundary now classifies missing and blank code as `SyntaxError`. Both sync and async loops already catch that exact exception and feed it through the existing trajectory recovery path:

```python
try:
    code = _strip_code_fences(action.code)
except SyntaxError as error:
    return self._process_execution_result(
        action,
        code="" if action.code is None else action.code,
        result=f"[Error] {error}",
        ...,
    )
```

The malformed snippet is not executed. The next iteration receives an explicit error in history and can correct the action without a provider-specific retry mechanism or cache override.

## Why this is the concise boundary

- One parser check covers both sync and async execution.
- One shared result-normalization point maps only `reasoning=None` to the trajectory's required string shape.
- No retry policy, provider branch, fallback interpreter, or broad exception handling is added.
- Unexpected non-`None` code types remain visible as `TypeError` instead of being silently coerced.

## What changes

- `code=None`, `""`, and whitespace-only code become recoverable trajectory errors.
- Missing code is recorded as `""`; whitespace is retained verbatim for debugging.
- `reasoning=None` and `final_reasoning=None` are recorded as `""`.
- Blank generated code is never sent to the interpreter.
- The malformed action still consumes one of `max_iters`, like any other failed action.

## Review map

This is one focused commit stacked on #10017.

- `dspy/predict/rlm.py`: define and route the malformed-action contract.
- `tests/predict/test_rlm.py`: cover direct parsing plus exact sync/async history and interpreter-call behavior.

## Compatibility boundaries / downside

- Empty and whitespace-only snippets previously reached the interpreter as no-ops. They now produce visible feedback, so a custom interpreter will no longer observe those blank executions.
- A malformed turn still counts toward `max_iters`; this PR does not grant hidden retries.
- Only `None` is normalized. Other invalid reasoning/code types continue to fail validation rather than being coerced. Normal DSPy adapters coerce parsed code values to `str` and use `None` for a missing field, so a different non-string value indicates a custom predictor or internal contract violation.
- The trajectory schema requires strings, so an absent code value is represented as `""` after the error explains that it was missing.

## Stack contract behind the inherited review finding

Greptile's scoped-variable finding is outside this PR's diff and concerns parent #10017. `CodeInterpreter` explicitly requires one persistent namespace across `execute()` calls; variables installed by one call remain available until shutdown. RLM's existing `SandboxSerializable` path already depends on that contract by initializing a value in one execution and using it in later model-generated code.

An interpreter that makes `variables=` call-local is therefore not a conforming RLM interpreter. Re-injecting inputs on every turn would not make that abstraction sound: it would restore the #10017 bug by overwriting mutations made by prior model code.

## Verification

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — `154 passed, 2 skipped`
- Focused missing/blank sync+async matrix — `8 passed`
- Changed-file pre-commit hooks — passed

