### PR TITLE
docs: fix duplicate 'the the' typos across docs, source, and tests

### DIFF
--- a/docs/docs/api/optimizers/GEPA/overview.md
+++ b/docs/docs/api/optimizers/GEPA/overview.md
@@ -83,7 +83,7 @@ Rather than evolving just the _best_ global candidate (which leads to local opti
 
 ### Algorithm Summary
 
-1. **Initialize** the candidate pool with the the unoptimized program.
+1. **Initialize** the candidate pool with the unoptimized program.
 2. **Iterate**:
    - **Sample a candidate** (from Pareto frontier).
    - **Sample a minibatch** from the train set.

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -249,7 +249,7 @@ class ChatAdapter(Adapter):
         """
         Formats the values of the specified fields according to the field's DSPy type (input or output),
         annotation (e.g. str, int, etc.), and the type of the value itself. Joins the formatted values
-        into a single string, which is is a multiline string if there are multiple fields.
+        into a single string, which is a multiline string if there are multiple fields.
 
         Args:
             fields_with_values: A dictionary mapping information about a field to its corresponding

--- a/dspy/teleprompt/bootstrap_finetune.py
+++ b/dspy/teleprompt/bootstrap_finetune.py
@@ -284,7 +284,7 @@ def assert_structural_equivalency(program1: object, program2: object):
 
     num1 = len(program1.predictors())
     num2 = len(program2.predictors())
-    err = f"Structurally equivalent programs must have the the number of predictors. The number of predictors for the two modules do not match: {num1} != {num2}"
+    err = f"Structurally equivalent programs must have the same number of predictors. The number of predictors for the two modules do not match: {num1} != {num2}"
     assert num1 == num2, err
 
     pzip = zip(program1.named_predictors(), program2.named_predictors(), strict=False)

--- a/tests/reliability/utils.py
+++ b/tests/reliability/utils.py
@@ -65,7 +65,7 @@ def known_failing_models(models: list[str]):
 @contextmanager
 def judge_dspy_configuration(**extra_judge_config):
     """
-    Context manager to temporarily configure the DSPy to use the the judge model
+    Context manager to temporarily configure DSPy to use the judge model
     from `reliability_conf.yaml`.
 
     Args:


### PR DESCRIPTION
### Why

While reading through the codebase I noticed the phrase "the the" repeated in four places. Three are pure duplicate-word typos in docstrings / a doc page. The fourth (`bootstrap_finetune.py`) is inside an assertion error message where the phrase is not only duplicated but also semantically off — "must have the the number of predictors" — and reads correctly as "must have the **same** number of predictors", which is consistent with the sentence that follows ("The number of predictors for the two modules do not match: ...").

Per `CONTRIBUTING.md`: _"For minor changes (simple bug fixes or documentation fixes), feel free to open a PR without discussion."_

### What

- `docs/docs/api/optimizers/GEPA/overview.md` — Algorithm Summary step 1
- `dspy/adapters/chat_adapter.py` — `format_field_with_value` docstring
- `dspy/teleprompt/bootstrap_finetune.py` — `assert_structural_equivalency` error message (`the the` -> `the same`)
- `tests/reliability/utils.py` — `judge_dspy_configuration` docstring (also drops a stray "the" before "DSPy")

No behavior change. 4 files, +4/-4 lines.

---
_Part of open-source blockchain work from [kcolbchain.com](https://kcolbchain.com) — maintained by [Abhishek Krishna](https://abhishekkrishna.com). PR opened via [kcolbchain contrib-bot](https://github.com/kcolbchain/kcolbchain.github.io/blob/master/deploy/contrib-bot/README.md)._