### PR TITLE
fix(rlm): handle None code/reasoning from weaker models gracefully

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -554,6 +554,13 @@ class RLM(Module):
             repl_history=history,
             iteration=f"{iteration + 1}/{self.max_iterations}",
         )
+        # Coerce None fields to safe defaults so the loop can continue.
+        # Weaker models sometimes fail to produce reasoning or code.
+        if action.reasoning is None:
+            action.reasoning = ""
+        if action.code is None:
+            action.code = ""
+
         if self.verbose:
             logger.info(
                 f"RLM iteration {iteration + 1}/{self.max_iterations}\n"

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -545,6 +545,55 @@ class TestRLMMaxIterationsFallback:
         assert result.final_reasoning == "Extract forced final output"
 
 
+class TestRLMNoneCodeAndReasoning:
+    """Tests that RLM handles None code/reasoning from weaker models gracefully."""
+
+    def test_none_code_recovers(self):
+        """Test that None code is coerced and the loop continues."""
+        mock = MockInterpreter(responses=[
+            "no code error",
+            FinalOutput({"answer": "42"}),
+        ])
+        rlm = RLM("query -> answer", max_iterations=5, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Thinking...", "code": None},
+            {"reasoning": "Now I know", "code": 'SUBMIT("42")'},
+        ])
+
+        result = rlm.forward(query="test")
+        assert result.answer == "42"
+
+    def test_none_reasoning_recovers(self):
+        """Test that None reasoning is coerced and the loop continues."""
+        mock = MockInterpreter(responses=[
+            "exploring",
+            FinalOutput({"answer": "42"}),
+        ])
+        rlm = RLM("query -> answer", max_iterations=5, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": None, "code": "print('hello')"},
+            {"reasoning": "Got it", "code": 'SUBMIT("42")'},
+        ])
+
+        result = rlm.forward(query="test")
+        assert result.answer == "42"
+
+    def test_none_code_and_reasoning_recovers(self):
+        """Test that both None code and reasoning are handled."""
+        mock = MockInterpreter(responses=[
+            "error",
+            FinalOutput({"answer": "42"}),
+        ])
+        rlm = RLM("query -> answer", max_iterations=5, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": None, "code": None},
+            {"reasoning": "Now working", "code": 'SUBMIT("42")'},
+        ])
+
+        result = rlm.forward(query="test")
+        assert result.answer == "42"
+
+
 class TestRLMToolExceptions:
     """Tests for tool exception handling."""
 


### PR DESCRIPTION
## Problem

When weaker or cheaper LLMs are used as the main model in RLM (e.g. smaller open-source models via OpenRouter), they sometimes fail to produce valid output for the `code` or `reasoning` fields, returning `None` instead of a string.

This causes two crashes:

1. **`AttributeError` in `_strip_code_fences`** — `code.strip()` fails when `code` is `None`
2. **`pydantic.ValidationError` in `REPLEntry`** — `reasoning` field expects `str`, gets `None`

Both terminate the entire RLM execution loop instead of allowing the model to recover on the next iteration.

## Fix

Coerce `None` values to empty strings in `_execute_iteration()`, before they reach `_strip_code_fences` or `_process_execution_result`. This allows the loop to continue and gives the model another chance to produce valid code.

The fix is minimal (4 lines + comment) and follows the same defensive pattern used elsewhere in the codebase (e.g. #9638 guarding `response.usage`).

## Tests

Added `TestRLMNoneCodeAndReasoning` with 3 test cases covering:
- `None` code only
- `None` reasoning only
- Both `None` simultaneously

All existing tests continue to pass.

## Reproduction

```python
import dspy

# Use a cheap/weak model that sometimes fails to follow output format
lm = dspy.LM("openrouter/openai/gpt-oss-20b:nitro", api_key="...")
dspy.configure(lm=lm)

rlm = dspy.RLM("data, query -> answer", max_iterations=50)
result = rlm(data="...", query="...")  # Crashes on iteration where model returns None
```

```
AttributeError: 'NoneType' object has no attribute 'strip'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)