### PR TITLE
ci(release): drop unused contents:write on TestPyPI job; add twine check --strict

### DIFF
--- a/.github/.internal_dspyai/pyproject.toml
+++ b/.github/.internal_dspyai/pyproject.toml
@@ -4,7 +4,7 @@ name="dspy-ai"
 #replace_package_version_marker
 version="3.2.0"  
 description = "DSPy"  
-readme = "README.md"  
+readme = {text = "`dspy-ai` is a compatibility alias for the [dspy](https://pypi.org/project/dspy/) package. Install `dspy` instead: `pip install dspy`.", content-type = "text/markdown"}  
 authors = [  
     { name = "Omar Khattab", email = "okhattab@stanford.edu" }  
 ]  

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -22,7 +22,6 @@ jobs:
       name: pypi
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
-      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python 3.11
@@ -50,6 +49,8 @@ jobs:
         run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-test-isaac"/;}' pyproject.toml
       - name: Build a binary wheel
         run: python3 -m build
+      - name: Validate built distributions
+        run: python3 -m twine check --strict dist/*
       # Test the locally built wheel
       - name: Create test environment
         run: python -m venv test_before_testpypi
@@ -101,6 +102,8 @@ jobs:
         run: sed -i '/#replace_package_name_marker/{n;s/__name__ *= *"[^"]*"/__name__="dspy"/;}' ./dspy/__metadata__.py
       - name: Build a binary wheel
         run: python3 -m build
+      - name: Validate built distributions
+        run: python3 -m twine check --strict dist/*
       # Test the locally built wheel before publishing to pypi
       - name: Create test environment
         run: python -m venv test_before_pypi
@@ -126,6 +129,8 @@ jobs:
           sed -i '/#replace_dspy_version_marker/{n;s/dspy>=[^"]*/dspy>=${{ needs.extract-tag.outputs.version }}/;}' .github/.internal_dspyai/pyproject.toml
       - name: Build a binary wheel (dspy-ai)
         run: python3 -m build .github/.internal_dspyai/
+      - name: Validate built distributions (dspy-ai)
+        run: python3 -m twine check --strict .github/.internal_dspyai/dist/*
       - name: Publish distribution 📦 to PyPI (dspy-ai)
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:


### PR DESCRIPTION
## Summary

Small, self-contained hardening step for the release workflow. Part 1 of a planned series to separate build/test from publish and apply least-privilege permissions per PyPA + PyPI security-model guidance.

### Changes

1. **Drop `contents: write` from `build-and-publish-test-pypi`.** That job never performs any git writes (no `git-auto-commit-action`, no `git push`, no `git merge`). The permission was unused and widened the blast radius of any compromised step in the OIDC-holding job. The prod PyPI job keeps `contents: write` for now because it still pushes the 'Update versions' commit; that separation is addressed in a follow-up PR.

2. **Add `twine check --strict dist/*` after each `python -m build`** (TestPyPI `dspy-ai-test-isaac`, PyPI `dspy`, PyPI `dspy-ai`). Malformed distributions now fail the workflow before any upload attempt.

3. **Fix the `dspy-ai` alias package's broken readme reference.** `.github/.internal_dspyai/pyproject.toml` pointed at a `README.md` that doesn't exist next to it, so setuptools silently dropped the readme setting and `long_description` was empty — `twine check --strict` flagged this. Replaces the reference with an inline one-line description clarifying that `dspy-ai` is a compatibility alias and users should install `dspy`.

<img width="2384" height="1602" alt="CleanShot 2026-04-21 at 15 28 29@2x" src="https://github.com/user-attachments/assets/4df54417-f877-4798-b95f-6826a891b5dc" />

### Local verification

- `actionlint` on the workflow: clean (1 pre-existing info finding unchanged from main).
- `python -m build` + `twine check --strict` against `dspy`: PASSED (wheel and sdist).
- `python -m build .github/.internal_dspyai/` + `twine check --strict` against `dspy-ai` (after the pyproject fix): PASSED (wheel and sdist).

### References

- PyPI security model — 'Limit the scope of your publishing job': https://docs.pypi.org/trusted-publishers/security-model/
- PyPA publishing guide: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

### Planned follow-ups (not in this PR)

- Give TestPyPI its own GitHub environment (`testpypi`) separate from `pypi`.
- Extract the post-publish `git push` into a dedicated `sync-version-to-main` job with only `contents: write`.
- Split build/test from publish via artifacts so the OIDC-holding publish job has only two steps.
- Add an install-from-TestPyPI smoke test before the prod PyPI publish.
