### PR TITLE
ci(release): give TestPyPI its own GitHub environment

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -19,7 +19,7 @@ jobs:
     needs: extract-tag
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: testpypi
     permissions:
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:


### PR DESCRIPTION
Stacked on #9648. Splits TestPyPI off the shared `pypi` environment onto a dedicated `testpypi` environment (PyPA-recommended).

```diff
   build-and-publish-test-pypi:
     environment:
-      name: pypi
+      name: testpypi
```

The `testpypi` environment has been created in this repo and a Trusted Publisher for it is registered on test.pypi.org.