### PR TITLE
chore: refresh uv.lock to match pyproject 3.2.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -739,7 +739,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "3.1.3"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
The 3.2.0 release updated `pyproject.toml` and `dspy/__metadata__.py` but left `uv.lock` pinned at 3.1.3. Running `uv lock` produces a minimal 1-line diff bumping only the dspy package entry; no transitive dependencies change.

```
Updated dspy v3.1.3 -> v3.2.0
```

This keeps `uv sync` / `uv lock --check` warning-free for contributors.