### PR TITLE
fix: type assistant content as output_text in Responses API conversion

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -518,15 +518,22 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     if "messages" in request:
         input_items = []
         for msg in request.pop("messages"):
+            role = msg.get("role", "user")
+            # Responses API requires assistant text to be typed "output_text";
+            # user/system/developer text must be "input_text". Using "input_text"
+            # for an assistant message causes OpenAI to reject the request with
+            # `Invalid value: 'input_text'. Supported values are: 'output_text'
+            # and 'refusal'.`
+            text_type = "output_text" if role == "assistant" else "input_text"
             content_blocks = []
             c = msg.get("content")
             if isinstance(c, str):
-                content_blocks.append({"type": "input_text", "text": c})
+                content_blocks.append({"type": text_type, "text": c})
             elif isinstance(c, list):
                 # Convert each content item from Chat API format to Responses API format
                 for item in c:
-                    content_blocks.append(_convert_content_item_to_responses_format(item))
-            input_items.append({"role": msg.get("role", "user"), "content": content_blocks})
+                    content_blocks.append(_convert_content_item_to_responses_format(item, role=role))
+            input_items.append({"role": role, "content": content_blocks})
         request["input"] = input_items
     # Convert `reasoning_effort` to reasoning format supported by the Responses API
     if "reasoning_effort" in request:
@@ -548,7 +555,7 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     return request
 
 
-def _convert_content_item_to_responses_format(item: dict[str, Any]) -> dict[str, Any]:
+def _convert_content_item_to_responses_format(item: dict[str, Any], role: str = "user") -> dict[str, Any]:
     """
     Convert a content item from Chat API format to Responses API format.
 
@@ -560,7 +567,8 @@ def _convert_content_item_to_responses_format(item: dict[str, Any]) -> dict[str,
     For text, converts from:
         {"type": "text", "text": "..."}
     To:
-        {"type": "input_text", "text": "..."}
+        {"type": "input_text", "text": "..."} for user/system/developer/tool roles,
+        {"type": "output_text", "text": "..."} for assistant role.
 
     For other types, passes through as-is.
     """
@@ -571,8 +579,9 @@ def _convert_content_item_to_responses_format(item: dict[str, Any]) -> dict[str,
             "image_url": image_url,
         }
     elif item.get("type") == "text":
+        text_type = "output_text" if role == "assistant" else "input_text"
         return {
-            "type": "input_text",
+            "type": text_type,
             "text": item.get("text", ""),
         }
     elif item.get("type") == "file":

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -907,10 +907,31 @@ def test_responses_api_preserves_multi_message_structure():
     assert result["input"][1]["content"] == [{"type": "input_text", "text": "What is 2+2?"}]
 
     assert result["input"][2]["role"] == "assistant"
-    assert result["input"][2]["content"] == [{"type": "input_text", "text": "4"}]
+    assert result["input"][2]["content"] == [{"type": "output_text", "text": "4"}]
 
     assert result["input"][3]["role"] == "user"
     assert result["input"][3]["content"] == [{"type": "input_text", "text": "And 3+3?"}]
+
+
+def test_responses_api_types_assistant_list_content_as_output_text():
+    """Assistant messages with list-form content must be typed output_text,
+    not input_text. Regression guard for the Responses API rejecting
+    'input_text' on assistant input items."""
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "What is 2+2?"}]},
+            {"role": "assistant", "content": [{"type": "text", "text": "4"}]},
+        ],
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert result["input"][0]["role"] == "user"
+    assert result["input"][0]["content"] == [{"type": "input_text", "text": "What is 2+2?"}]
+    assert result["input"][1]["role"] == "assistant"
+    assert result["input"][1]["content"] == [{"type": "output_text", "text": "4"}]
 
 
 def test_responses_api_with_image_input():


### PR DESCRIPTION
#9580 fixed message flattening in `_convert_chat_request_to_responses_request` and began emitting each chat message as its own Responses API `input` item with its original role. That fix is a prerequisite for this one — it is what first caused assistant content to actually reach OpenAI with its role intact.

With flattening fixed, the next layer of the bug surfaces: the converter still types every message's content as `input_text` regardless of role. The OpenAI Responses API requires `output_text` (or `refusal`) for `assistant` input items, so any chat request containing an assistant message — including DSPy's own few-shot demos — now fails with:

    OpenAIException: Invalid value: 'input_text'. Supported values are:
    'output_text' and 'refusal'.
    param: input[2].content[0]

This commit makes the content type role-aware: `assistant` -> `output_text`, everything else (`user`, `system`, `developer`, `tool`) -> `input_text`. List-form content goes through the same role-aware mapping. Image and file items are unchanged. `tool`-role handling is unchanged and remains a separate known gap (Responses API wants `function_call_output` items, not a message).

Unblocks any DSPy module that uses few-shot assistant demos via the Responses API, and restores the behavior #9580 intended end-to-end.

Tests: updates `test_responses_api_preserves_multi_message_structure` and adds a list-form assistant content case.