### PR TITLE
fix(predict): drop extra kwargs instead of only warning (#9472)

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -193,6 +193,8 @@ class Predict(Module, Parameter):
                 extra_fields,
                 list(signature.input_fields.keys()),
             )
+            for k in extra_fields:
+                kwargs.pop(k)
 
         # Validate input field types match signature
         if settings.warn_on_type_mismatch:

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -502,6 +502,38 @@ def test_forward_method2():
     assert result.answer2 == "my second answer"
 
 
+def test_extra_fields_not_in_signature_are_dropped_from_trace():
+    # #9472: extras passed to Predict used to leak into the trace and the LM payload.
+    program = Predict("question -> answer")
+    lm = DummyLM([{"answer": "ok"}])
+    dspy.configure(lm=lm)
+    with dspy.context(trace=[]):
+        with patch.object(lm, "forward", wraps=lm.forward) as spy:
+            program(question="q", answer="leaked", unused_meta=42)
+        trace = dspy.settings.trace
+
+    assert len(trace) == 1
+    _, recorded_inputs, _ = trace[0]
+    assert recorded_inputs == {"question": "q"}
+
+    rendered = orjson.dumps(spy.call_args.kwargs).decode()
+    assert "leaked" not in rendered
+    assert "unused_meta" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_extra_fields_dropped_on_async_path():
+    # aforward shares _forward_preprocess with forward, so the fix should cover both.
+    program = Predict("question -> answer")
+    dspy.configure(lm=DummyLM([{"answer": "ok"}]))
+    with dspy.context(trace=[]):
+        await program.acall(question="q", answer="leaked")
+        trace = dspy.settings.trace
+    assert len(trace) == 1
+    _, recorded_inputs, _ = trace[0]
+    assert recorded_inputs == {"question": "q"}
+
+
 def test_config_management():
     predict_instance = Predict("input -> output")
     predict_instance.update_config(new_key="value")

--- a/tests/teleprompt/test_bootstrap.py
+++ b/tests/teleprompt/test_bootstrap.py
@@ -77,6 +77,30 @@ def test_bootstrap_effectiveness():
     assert prediction.output == trainset[0].output
 
 
+def test_bootstrap_with_output_field_marked_as_input():
+    # #9472: with_inputs() covering an output field used to crash bootstrap with
+    # TypeError: Example() got multiple values for keyword argument 'output'.
+    student = SimpleModule("input -> output")
+    teacher = SimpleModule("input -> output")
+    lm = DummyLM([{"output": "blue"}])
+    dspy.configure(lm=lm, trace=[])
+
+    bad_trainset = [
+        Example(input="What is the color of the sky?", output="blue").with_inputs("input", "output"),
+    ]
+
+    # max_errors=1 so the old bug would raise instead of being swallowed.
+    bootstrap = BootstrapFewShot(
+        metric=simple_metric, max_bootstrapped_demos=1, max_labeled_demos=0, max_errors=1
+    )
+    compiled_student = bootstrap.compile(student, teacher=teacher, trainset=bad_trainset)
+
+    assert bootstrap.error_count == 0
+    assert len(compiled_student.predictor.demos) == 1
+    assert compiled_student.predictor.demos[0].input == bad_trainset[0].input
+    assert compiled_student.predictor.demos[0].output == bad_trainset[0].output
+
+
 def test_error_handling_during_bootstrap():
     """
     Test to verify error handling during the bootstrapping process


### PR DESCRIPTION
resolve #9472   

  `Predict._forward_preprocess` warned that extra kwargs not in the signature "will be ignored", but never actually dropped them. They leaked through into `dspy.settings.trace`and into the adapter payload. Downstream, `BootstrapFewShot` (bootstrap.py:226) and `simba_utils.py:93` both do `dspy.Example(augmented=True, **inputs, **outputs)`, which crashes with `TypeError: got multiple values for keyword argument 'X'` when a leaked extra collides with an output field name - for example, when a user marks an output field as an input via `with_inputs(...)`.

  Fix: pop the extras after warning, so the warning's own contract is honored.                                                                                                  
   
  ### Behavior change                                                                                                                                                           
  `dspy.settings.trace[-1][1]` (the `inputs` dict on each step) now contains only signature-declared input fields. I audited first-party trace consumers (`bootstrap.py`,
  `simba_utils.py`, `refine.py`, `best_of_n.py`, `bootstrap_trace.py`, `gepa/`) - none rely on the leak. Two (`bootstrap.py`, `simba_utils.py`) were actively broken by it, so  
  this resolves both crash sites with one change.
                                                                                                                                                                                
  ### Tests       
  Three regressions, all verified to fail on reverted fix:
  - `test_extra_fields_not_in_signature_are_dropped_from_trace` - asserts extras don't appear in the trace or the LM payload (spies on `lm.forward`).                           
  - `test_extra_fields_dropped_on_async_path` - same contract through `acall`/`aforward`.                                                                                       
  - `test_bootstrap_with_output_field_marked_as_input` - end-to-end repro of #9472 through `BootstrapFewShot` with `max_errors=1`.                                              
                                                                                                                                                                                
  Full `tests/predict/test_predict.py` + `tests/teleprompt/test_bootstrap.py` → 83 passed locally.