### PR TITLE
fix: make Module.load_state atomic — rollback on partial failure

### DIFF
--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -159,11 +159,23 @@ class BaseModule:
     def load_state(self, state, *, allow_unsafe_lm_state=False):
         from dspy.predict.predict import Predict
 
-        for name, param in self.named_parameters():
-            if isinstance(param, Predict):
-                param.load_state(state[name], allow_unsafe_lm_state=allow_unsafe_lm_state)
-            else:
-                param.load_state(state[name])
+        # Snapshot current state of every parameter so we can roll back
+        # atomically if any key is missing or any load_state call raises.
+        snapshots = {name: param.dump_state() for name, param in self.named_parameters()}
+
+        try:
+            for name, param in self.named_parameters():
+                if isinstance(param, Predict):
+                    param.load_state(state[name], allow_unsafe_lm_state=allow_unsafe_lm_state)
+                else:
+                    param.load_state(state[name])
+        except Exception:
+            # Roll back every parameter to its pre-load snapshot so the
+            # module is never left in a partially-updated (corrupted) state.
+            for name, param in self.named_parameters():
+                if name in snapshots:
+                    param.load_state(snapshots[name])
+            raise
 
     def save(self, path, save_program=False, modules_to_serialize=None):
         """Save the module.


### PR DESCRIPTION
fixes #9589

## Problem

`Module.load_state` mutates parameters in-place one by one. If any parameter's key is missing from the saved state (signature drift, manual edit, truncated file), an exception fires **after** earlier parameters have already been overwritten. Callers that catch the exception end up with a module that is a mix of saved demos and fresh defaults — silently corrupted, with no way to tell it apart from a clean module.

## Fix

Snapshot every parameter's current state via `dump_state()` **before** starting the loop. If any exception is raised, restore each parameter from its snapshot before re-raising.

```python
# Before (non-transactional)
for name, param in self.named_parameters():
    param.load_state(state[name])   # partial mutation on failure

# After (atomic)
snapshots = {name: param.dump_state() for name, param in self.named_parameters()}
try:
    for name, param in self.named_parameters():
        param.load_state(state[name])
except Exception:
    for name, param in self.named_parameters():
        param.load_state(snapshots[name])   # rollback
    raise
```

## Verification

reproducer from #9589:

```
BEFORE load: template.a.predict.demos = []
load raised: KeyError: 'b.predict'
AFTER  load: template.a.predict.demos = []   # ← was corrupted before fix

✅ PASS: module rolled back correctly, demos are empty (not corrupted)
```

```
pytest tests/primitives/ -x -q
46 passed, 45 skipped in 0.73s
```