### PR TITLE
fix(react): suppress spurious execution error when finish receives extra args

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -109,6 +109,10 @@ class ReAct(Module):
             try:
                 trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](**pred.next_tool_args)
             except Exception as err:
+                if pred.next_tool_name == "finish":
+                    # The model placed output fields in next_tool_args for the finish step.
+                    # This is not a real tool failure; the extraction pass handles the values.
+                    break
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
 
             if pred.next_tool_name == "finish":
@@ -134,6 +138,10 @@ class ReAct(Module):
             try:
                 trajectory[f"observation_{idx}"] = await self.tools[pred.next_tool_name].acall(**pred.next_tool_args)
             except Exception as err:
+                if pred.next_tool_name == "finish":
+                    # The model placed output fields in next_tool_args for the finish step.
+                    # This is not a real tool failure; the extraction pass handles the values.
+                    break
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
 
             if pred.next_tool_name == "finish":


### PR DESCRIPTION
## Summary

Fixes #9424

`ReAct.forward()` and `aforward()` record an "Execution error" in the trajectory whenever calling the built-in `finish` tool raises an exception. This happens when a model puts output-field values into `next_tool_args` for the `finish` step - the tool validator rejects the unknown kwargs and raises `ValueError: Arg type is not in the tool's args.`

The error is spurious: `ReAct` immediately breaks out of the tool loop after `finish` is called (regardless of success or failure), and the extraction pass resolves the final prediction correctly. The net result is a polluted trajectory with a fake tool failure and noisy logs on otherwise-successful runs.

## Fix

Inside the `except Exception` handler, check whether the failing tool was `finish` and break without recording an error observation:

```python
except Exception as err:
    if pred.next_tool_name == "finish":
        # Model placed output fields in next_tool_args - not a real failure.
        break
    trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
```

Applied to both `forward()` and `aforward()`.
