### PR TITLE
fix(copro): make eval_kwargs optional with default None

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -120,7 +120,7 @@ class COPRO(Teleprompter):
         assert hasattr(predictor, "signature")
         predictor.signature = updated_signature
 
-    def compile(self, student, *, trainset, eval_kwargs):
+    def compile(self, student, *, trainset, eval_kwargs=None):
         """
         optimizes `signature` of `student` program - note that it may be zero-shot or already pre-optimized (demos already chosen - `demos != []`)
 
@@ -133,7 +133,7 @@ class COPRO(Teleprompter):
         Returns optimized version of `student`.
         """
         module = student.deepcopy()
-        evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
+        evaluate = Evaluate(devset=trainset, metric=self.metric, **(eval_kwargs or {}))
         total_calls = 0
         results_best = {
             id(p): {"depth": [], "max": [], "average": [], "min": [], "std": []} for p in module.predictors()


### PR DESCRIPTION
## Summary

Fixes #9080

`COPRO.compile()` declared `eval_kwargs` as a required keyword-only argument despite the documentation listing it as optional. Callers who omitted it received a `TypeError` - the only workaround was passing an empty dict `{}`.

## Fix

Changed the signature to `eval_kwargs=None` and expanded it at the `Evaluate` call site:

```python
# Before
def compile(self, student, *, trainset, eval_kwargs):
    evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)

# After
def compile(self, student, *, trainset, eval_kwargs=None):
    evaluate = Evaluate(devset=trainset, metric=self.metric, **(eval_kwargs or {}))
```
