### PR TITLE
feat(json_adapter): Adds escape hatch to force structured outputs on vLLM and other inference engines 

### DIFF
--- a/docs/docs/api/adapters/JSONAdapter.md
+++ b/docs/docs/api/adapters/JSONAdapter.md
@@ -19,6 +19,7 @@
             - format_task_description
             - format_user_message_content
             - parse
+            - response_format
             - user_message_output_requirements
         show_source: true
         show_root_heading: true

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -93,8 +93,8 @@ class JSONAdapter(ChatAdapter):
                 except Exception as e:
                     logger.warning(f"Failed to build structured output format, falling back to JSON mode: {e}")
                     return {"type": "json_object"}
-            case _:
-                raise ValueError(f"Invalid schema enforcement mode: {self.schema_enforcement_mode}")
+            case unknown:
+                raise ValueError(f"Invalid schema enforcement mode: {unknown}")
 
     def _effective_enforcement_mode(self, lm: BaseLM, signature: SignatureMeta) -> EffectiveEnforcement:
         open_ended_mapping_fields = _open_ended_mapping_field_names(signature)

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -54,12 +54,14 @@ def _non_native_tool_call_field_names(signature: SignatureMeta) -> Generator[str
             yield name
 
 
-SchemaEnforcement = Literal["auto", "strict", "prompted"]
-"""Which ``response_format`` payload ``JSONAdapter`` ships.
+EffectiveEnforcement = Literal["json_schema", "json_object"]
+
+SchemaEnforcement = Literal["auto"] | EffectiveEnforcement
+"""Which ``response_format`` payload ``JSONAdapter`` ships. Values name the OpenAI-compatible ``response_format.type`` that reaches the wire.
 
 ``"auto"`` delegates to ``lm.supports_response_schema`` unless the signature has open-ended mapping fields or non-native tool calls.
-``"strict"`` forces a Pydantic class (serialized to strict ``json_schema``) -- use for known openai-compatible endpoints.
-``"prompted"`` forces ``{"type": "json_object"}`` with schema hints in the prompt.
+``"json_schema"`` forces the Pydantic-class response_format, shipped as ``{"type": "json_schema", "strict": true, "schema": {...}}``; use for known openai-compatible endpoints that can use structured outputs.
+``"json_object"`` forces ``{"type": "json_object"}`` with schema hints carried in the prompt; escape hatch for LM-known models whose strict-schema backend is broken.
 """
 
 
@@ -71,21 +73,30 @@ class JSONAdapter(ChatAdapter):
         schema_enforcement_mode: SchemaEnforcement = "auto",
     ):
         super().__init__(callbacks=callbacks, use_native_function_calling=use_native_function_calling)
-        assert schema_enforcement_mode in get_args(
-            SchemaEnforcement
-        ), f"schema_enforcement_mode must be one of {SchemaEnforcement}; got {schema_enforcement_mode!r}"
+        # typing.get_args doesn't flatten Literal | Literal unions, so build the flat tuple explicitly.
+        valid_modes = ("auto", *get_args(EffectiveEnforcement))
+        assert (
+            schema_enforcement_mode in valid_modes
+        ), f"schema_enforcement_mode must be one of {valid_modes}; got {schema_enforcement_mode!r}"
         self.schema_enforcement_mode: SchemaEnforcement = schema_enforcement_mode
 
-    def _json_adapter_call_common(self, lm, lm_kwargs, signature, demos, inputs, call_fn):
-        """Common call logic to be used for both sync and async calls."""
-        if "response_format" not in lm.supported_params:
-            return call_fn(lm, lm_kwargs, signature, demos, inputs)
+    def response_format(self, lm: BaseLM, signature: SignatureMeta) -> type[pydantic.BaseModel] | dict[str, str] | None:
+        """Returns the ``response_format`` value to set on this call, or ``None`` if no response_format is needed."""
+        if self.schema_enforcement_mode == "auto" and "response_format" not in lm.supported_params:
+            return None
+        match self._effective_enforcement_mode(lm, signature):
+            case "json_object":
+                return {"type": "json_object"}
+            case "json_schema":
+                try:
+                    return _get_structured_outputs_response_format(signature, self.use_native_function_calling)
+                except Exception as e:
+                    logger.warning(f"Failed to build structured output format, falling back to JSON mode: {e}")
+                    return {"type": "json_object"}
+            case _:
+                raise ValueError(f"Invalid schema enforcement mode: {self.schema_enforcement_mode}")
 
-        if self._effective_schema_enforcement_mode(lm, signature) == "prompted":
-            lm_kwargs["response_format"] = {"type": "json_object"}
-            return call_fn(lm, lm_kwargs, signature, demos, inputs)
-
-    def _effective_schema_enforcement_mode(self, lm: BaseLM, signature: SignatureMeta) -> SchemaEnforcement:
+    def _effective_enforcement_mode(self, lm: BaseLM, signature: SignatureMeta) -> EffectiveEnforcement:
         open_ended_mapping_fields = _open_ended_mapping_field_names(signature)
         has_non_native_tool_calls = not self.use_native_function_calling and any(
             _non_native_tool_call_field_names(signature)
@@ -93,23 +104,23 @@ class JSONAdapter(ChatAdapter):
         if self.schema_enforcement_mode == "auto":
             # open-ended dicts aren't JSON-Schema-expressible; ToolCalls + non-native fcall misbehaves (see warnings below).
             if has_non_native_tool_calls or any(open_ended_mapping_fields):
-                return "prompted"
-            return "strict" if lm.supports_response_schema else "prompted"
-        if self.schema_enforcement_mode == "strict":
+                return "json_object"
+            return "json_schema" if lm.supports_response_schema else "json_object"
+        if self.schema_enforcement_mode == "json_schema":
             if any(open_ended_mapping_fields):
                 names = ", ".join(_open_ended_mapping_field_names(signature))
                 logger.warning(
-                    f"Signature {signature.__name__} has open-ended output mapping field(s) {names}; most structured output inference engines"
-                    f" cannot express these, so the {self.__class__.__name__} will fall back to prompted mode. "
-                    f"Either consider using different Signature types or use {self.__class__.__name__}.schema_enforcement_mode='prompted'.",
+                    f"Signature {signature.__name__} has open-ended output mapping field(s) {names}; most structured output "
+                    f"inference engines cannot express these. Consider replacing the open-ended mapping with a typed schema "
+                    f"(e.g., a pydantic.BaseModel with explicit fields, or typing.TypedDict) for more reliable behavior from {signature.__name__} when using {self.__class__.__name__}.",
                 )
             if has_non_native_tool_calls:
                 names = ", ".join(_non_native_tool_call_field_names(signature))
                 logger.warning(
-                    f"Signature {signature.__name__} has dspy.ToolCalls output field(s) {names} but {self.__class__.__name__}.use_native_function_calling=False and {self.__class__.__name__}.schema_enforcement_mode='strict'; "
-                    "strict schema mode is known to compose poorly with JSON-mode tool calling and may produce "
-                    f"unreliable output. Consider {self.__class__.__name__}.use_native_function_calling=True or "
-                    f"{self.__class__.__name__}.schema_enforcement_mode='prompted' for more reliable behavior from {signature.__name__}.",
+                    f"Signature {signature.__name__} has dspy.ToolCalls output field(s) {names} but {self.__class__.__name__}.use_native_function_calling=False and {self.__class__.__name__}.schema_enforcement_mode='json_schema'; "
+                    "json_schema mode is known to compose poorly with JSON-mode tool calling and may produce unreliable output. "
+                    f" Consider {self.__class__.__name__}.use_native_function_calling=True or "
+                    f"{self.__class__.__name__}.schema_enforcement_mode='json_object' for more reliable behavior from {signature.__name__} when using {self.__class__.__name__}.",
                 )
         return self.schema_enforcement_mode
 
@@ -121,18 +132,15 @@ class JSONAdapter(ChatAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().__call__)
-        if result:
-            return result
-
+        rf = self.response_format(lm, signature)
+        if rf is not None:
+            lm_kwargs["response_format"] = rf
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
-            lm_kwargs["response_format"] = structured_output_model
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
-        except Exception:
-            logger.warning("Failed to use structured output format, falling back to JSON mode.")
+        except Exception as e:
+            if not isinstance(rf, type):
+                raise
+            logger.error(f"Structured output call failed; automatically retrying with JSON mode. Reason: {e}")
             lm_kwargs["response_format"] = {"type": "json_object"}
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
 
@@ -144,18 +152,15 @@ class JSONAdapter(ChatAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().acall)
-        if result:
-            return await result
-
+        rf = self.response_format(lm, signature)
+        if rf is not None:
+            lm_kwargs["response_format"] = rf
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
-            lm_kwargs["response_format"] = structured_output_model
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
-        except Exception:
-            logger.warning("Failed to use structured output format, falling back to JSON mode.")
+        except Exception as e:
+            if not isinstance(rf, type):
+                raise
+            logger.error(f"Structured output call failed; automatically retrying with JSON mode. Reason: {e}")
             lm_kwargs["response_format"] = {"type": "json_object"}
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -26,20 +26,10 @@ logger = logging.getLogger(__name__)
 
 
 def _open_ended_mapping_field_names(signature: SignatureMeta) -> Generator[str, None, None]:
-    """Yield names of output fields with open-ended mapping annotations.
-
-    "Open-ended" here means the key-set is unbounded at the type level: an annotation
-    like ``dict[str, Any]`` declares "some string keys to values" without naming which
-    keys. A strict JSON Schema requires every property enumerated (``properties`` +
-    ``required`` + ``additionalProperties: false``) -- impossible without a known
-    key-set -- so these fields force the prompted fallback.
-
-    Covers any ``collections.abc.Mapping`` subclass: ``dict``, ``Mapping``,
-    ``MutableMapping``, ``OrderedDict``, ``defaultdict``, ``Counter``, ``ChainMap``,
-    and any user class inheriting from ``Mapping``. Correctly excludes ``TypedDict``
-    subclasses -- they declare a fixed named key-set at the type level and *are*
-    strict-schema-expressible; Python treats them as ``dict``-at-runtime but not as
-    ``Mapping`` subclasses, so ``issubclass`` returns False.
+    """Yield names of output fields typed as a ``collections.abc.Mapping`` subclass
+    (``dict``, ``Mapping``, ``MutableMapping``, ``OrderedDict``, ``defaultdict``,
+    ``Counter``, ``ChainMap``). Unbounded key-sets can't be expressed as a strict
+    JSON Schema. ``TypedDict`` has fixed keys and is correctly excluded.
     """
     for name, field in signature.output_fields.items():
         origin = get_origin(field.annotation) or field.annotation

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -7,6 +7,7 @@ import json_repair
 import pydantic
 import regex
 from pydantic.fields import FieldInfo
+from typing_extensions import is_typeddict
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
 from dspy.adapters.types.tool import ToolCalls
@@ -33,6 +34,8 @@ def _open_ended_mapping_field_names(signature: SignatureMeta) -> Generator[str, 
     """
     for name, field in signature.output_fields.items():
         origin = get_origin(field.annotation) or field.annotation
+        if is_typeddict(origin):
+            continue
         if isinstance(origin, type) and issubclass(origin, Mapping):
             yield name
 
@@ -81,6 +84,8 @@ class JSONAdapter(ChatAdapter):
                 try:
                     return _get_structured_outputs_response_format(signature, self.use_native_function_calling)
                 except Exception as e:
+                    if self.schema_enforcement_mode == "json_schema":
+                        raise
                     logger.warning(f"Failed to build structured output format, falling back to JSON mode: {e}")
                     return {"type": "json_object"}
             case unknown:
@@ -128,7 +133,7 @@ class JSONAdapter(ChatAdapter):
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
-            if not isinstance(rf, type):
+            if not isinstance(rf, type) or self.schema_enforcement_mode == "json_schema":
                 raise
             logger.error(f"Structured output call failed; automatically retrying with JSON mode. Reason: {e}")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -148,7 +153,7 @@ class JSONAdapter(ChatAdapter):
         try:
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
-            if not isinstance(rf, type):
+            if not isinstance(rf, type) or self.schema_enforcement_mode == "json_schema":
                 raise
             logger.error(f"Structured output call failed; automatically retrying with JSON mode. Reason: {e}")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -276,12 +281,11 @@ def _get_structured_outputs_response_format(
     is raised so that the caller can fall back to using a plain "json_object" response_format.
     """
     # Although we've already performed an early check, we keep this here as a final guard.
-    for name, field in signature.output_fields.items():
-        annotation = field.annotation
-        if get_origin(annotation) is dict:
-            raise ValueError(
-                f"Field '{name}' has an open-ended mapping type which is not supported by Structured Outputs."
-            )
+    if open_ended_mapping_fields := list(_open_ended_mapping_field_names(signature)):
+        names = ", ".join(open_ended_mapping_fields)
+        raise ValueError(
+            f"Output field(s) {names} have open-ended mapping types which are not supported by Structured Outputs."
+        )
 
     fields = {}
     for name, field in signature.output_fields.items():

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,6 +1,7 @@
 import json
 import logging
-from typing import Any, get_origin
+from collections.abc import Mapping
+from typing import Any, Generator, Literal, get_args, get_origin
 
 import json_repair
 import pydantic
@@ -24,36 +25,93 @@ from dspy.utils.exceptions import AdapterParseError
 logger = logging.getLogger(__name__)
 
 
-def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
+def _open_ended_mapping_field_names(signature: SignatureMeta) -> Generator[str, None, None]:
+    """Yield names of output fields with open-ended mapping annotations.
+
+    "Open-ended" here means the key-set is unbounded at the type level: an annotation
+    like ``dict[str, Any]`` declares "some string keys to values" without naming which
+    keys. A strict JSON Schema requires every property enumerated (``properties`` +
+    ``required`` + ``additionalProperties: false``) -- impossible without a known
+    key-set -- so these fields force the prompted fallback.
+
+    Covers any ``collections.abc.Mapping`` subclass: ``dict``, ``Mapping``,
+    ``MutableMapping``, ``OrderedDict``, ``defaultdict``, ``Counter``, ``ChainMap``,
+    and any user class inheriting from ``Mapping``. Correctly excludes ``TypedDict``
+    subclasses -- they declare a fixed named key-set at the type level and *are*
+    strict-schema-expressible; Python treats them as ``dict``-at-runtime but not as
+    ``Mapping`` subclasses, so ``issubclass`` returns False.
     """
-    Check whether any output field in the signature has an open-ended mapping type,
-    such as dict[str, Any]. Structured Outputs require explicit properties, so such fields
-    are incompatible.
-    """
-    for field in signature.output_fields.values():
-        annotation = field.annotation
-        if get_origin(annotation) is dict:
-            return True
-    return False
+    for name, field in signature.output_fields.items():
+        origin = get_origin(field.annotation) or field.annotation
+        if isinstance(origin, type) and issubclass(origin, Mapping):
+            yield name
+
+
+def _non_native_tool_call_field_names(signature: SignatureMeta) -> Generator[str, None, None]:
+    """Yield names of output fields with ToolCalls annotations."""
+    for name, field in signature.output_fields.items():
+        if field.annotation == ToolCalls:
+            yield name
+
+
+SchemaEnforcement = Literal["auto", "strict", "prompted"]
+"""Which ``response_format`` payload ``JSONAdapter`` ships.
+
+``"auto"`` delegates to ``lm.supports_response_schema`` unless the signature has open-ended mapping fields or non-native tool calls.
+``"strict"`` forces a Pydantic class (serialized to strict ``json_schema``) -- use for known openai-compatible endpoints.
+``"prompted"`` forces ``{"type": "json_object"}`` with schema hints in the prompt.
+"""
 
 
 class JSONAdapter(ChatAdapter):
-    def __init__(self, callbacks: list[BaseCallback] | None = None, use_native_function_calling: bool = True):
-        # JSONAdapter uses native function calling by default.
+    def __init__(
+        self,
+        callbacks: list[BaseCallback] | None = None,
+        use_native_function_calling: bool = True,
+        schema_enforcement_mode: SchemaEnforcement = "auto",
+    ):
         super().__init__(callbacks=callbacks, use_native_function_calling=use_native_function_calling)
+        assert schema_enforcement_mode in get_args(
+            SchemaEnforcement
+        ), f"schema_enforcement_mode must be one of {SchemaEnforcement}; got {schema_enforcement_mode!r}"
+        self.schema_enforcement_mode: SchemaEnforcement = schema_enforcement_mode
 
     def _json_adapter_call_common(self, lm, lm_kwargs, signature, demos, inputs, call_fn):
         """Common call logic to be used for both sync and async calls."""
         if "response_format" not in lm.supported_params:
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 
-        has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
-
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
-            # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
-            # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
+        if self._effective_schema_enforcement_mode(lm, signature) == "prompted":
             lm_kwargs["response_format"] = {"type": "json_object"}
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
+
+    def _effective_schema_enforcement_mode(self, lm: BaseLM, signature: SignatureMeta) -> SchemaEnforcement:
+        open_ended_mapping_fields = _open_ended_mapping_field_names(signature)
+        has_non_native_tool_calls = not self.use_native_function_calling and any(
+            _non_native_tool_call_field_names(signature)
+        )
+        if self.schema_enforcement_mode == "auto":
+            # open-ended dicts aren't JSON-Schema-expressible; ToolCalls + non-native fcall misbehaves (see warnings below).
+            if has_non_native_tool_calls or any(open_ended_mapping_fields):
+                return "prompted"
+            return "strict" if lm.supports_response_schema else "prompted"
+        if self.schema_enforcement_mode == "strict":
+            if any(open_ended_mapping_fields):
+                names = ", ".join(_open_ended_mapping_field_names(signature))
+                logger.warning(
+                    f"Signature {signature.__name__} has open-ended output mapping field(s) {names}; most structured output inference engines"
+                    f" cannot express these, so the {self.__class__.__name__} will fall back to prompted mode. "
+                    f"Either consider using different Signature types or use {self.__class__.__name__}.schema_enforcement_mode='prompted'.",
+                )
+            if has_non_native_tool_calls:
+                names = ", ".join(_non_native_tool_call_field_names(signature))
+                logger.warning(
+                    f"Signature {signature.__name__} has dspy.ToolCalls output field(s) {names} but {self.__class__.__name__}.use_native_function_calling=False and {self.__class__.__name__}.schema_enforcement_mode='strict'; "
+                    "strict schema mode is known to compose poorly with JSON-mode tool calling and may produce "
+                    f"unreliable output. Consider {self.__class__.__name__}.use_native_function_calling=True or "
+                    f"{self.__class__.__name__}.schema_enforcement_mode='prompted' for more reliable behavior from {signature.__name__}.",
+                )
+        return self.schema_enforcement_mode
 
     def __call__(
         self,

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -711,6 +711,194 @@ async def test_json_adapter_json_mode_no_structured_outputs_async():
         assert call_kwargs.get("response_format") == {"type": "json_object"}
 
 
+def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupported_lm():
+    """For openai-compatible endpoints LiteLLM doesn't recognize by name (self-hosted vLLM,
+    Ollama, etc.), users can opt into the strict-schema path by setting
+    ``JSONAdapter(schema_enforcement_mode="strict")`` even when
+    ``litellm.supports_response_schema`` reports False.
+    """
+
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(desc="String output field")
+
+    dspy.configure(
+        lm=dspy.LM(model="openai/some-unrecognized-model", cache=False),
+        adapter=dspy.JSONAdapter(schema_enforcement_mode="strict"),
+    )
+    program = dspy.Predict(TestSignature)
+
+    with (
+        mock.patch("litellm.completion") as mock_completion,
+        mock.patch("litellm.get_supported_openai_params") as mock_get_supported_openai_params,
+        mock.patch("litellm.supports_response_schema") as mock_supports_response_schema,
+    ):
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="{'answer': 'Test output'}"))]
+        )
+        mock_get_supported_openai_params.return_value = ["response_format"]
+        mock_supports_response_schema.return_value = False  # LiteLLM says unsupported
+
+        result = program(question="Dummy question!")
+
+        assert mock_completion.call_count == 1
+        assert result.answer == "Test output"
+
+        _, call_kwargs = mock_completion.call_args_list[0]
+        rf = call_kwargs.get("response_format")
+        # Override wins: strict Pydantic class reaches LiteLLM, not json_object fallback.
+        assert isinstance(rf, type) and issubclass(rf, pydantic.BaseModel), (
+            f"expected Pydantic class, got {rf!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupported_lm_async():
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(desc="String output field")
+
+    program = dspy.Predict(TestSignature)
+
+    with (
+        mock.patch("litellm.acompletion") as mock_acompletion,
+        mock.patch("litellm.get_supported_openai_params") as mock_get_supported_openai_params,
+        mock.patch("litellm.supports_response_schema") as mock_supports_response_schema,
+    ):
+        mock_acompletion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="{'answer': 'Test output'}"))]
+        )
+        mock_get_supported_openai_params.return_value = ["response_format"]
+        mock_supports_response_schema.return_value = False
+
+        lm = dspy.LM(model="openai/some-unrecognized-model", cache=False)
+        adapter = dspy.JSONAdapter(schema_enforcement_mode="strict")
+        with dspy.context(lm=lm, adapter=adapter):
+            result = await program.acall(question="Dummy question!")
+
+        assert mock_acompletion.call_count == 1
+        assert result.answer == "Test output"
+
+        _, call_kwargs = mock_acompletion.call_args_list[0]
+        rf = call_kwargs.get("response_format")
+        assert isinstance(rf, type) and issubclass(rf, pydantic.BaseModel), (
+            f"expected Pydantic class, got {rf!r}"
+        )
+
+
+def test_json_adapter_schema_enforcement_prompted_suppresses_schema_on_supported_lm():
+    """Escape hatch: even for LiteLLM-known models where supports_response_schema is True,
+    ``JSONAdapter(schema_enforcement_mode="prompted")`` forces the schemaless fallback.
+    """
+
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(desc="String output field")
+
+    dspy.configure(
+        lm=dspy.LM(model="openai/gpt-4o", cache=False),
+        adapter=dspy.JSONAdapter(schema_enforcement_mode="prompted"),
+    )
+    program = dspy.Predict(TestSignature)
+
+    with (
+        mock.patch("litellm.completion") as mock_completion,
+        mock.patch("litellm.get_supported_openai_params") as mock_get_supported_openai_params,
+        mock.patch("litellm.supports_response_schema") as mock_supports_response_schema,
+    ):
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="{'answer': 'Test output'}"))]
+        )
+        mock_get_supported_openai_params.return_value = ["response_format"]
+        mock_supports_response_schema.return_value = True  # LiteLLM says supported
+
+        result = program(question="Dummy question!")
+
+        assert mock_completion.call_count == 1
+        assert result.answer == "Test output"
+
+        _, call_kwargs = mock_completion.call_args_list[0]
+        # Override suppresses strict schema despite LiteLLM saying supported.
+        assert call_kwargs.get("response_format") == {"type": "json_object"}
+
+
+def test_json_adapter_schema_enforcement_rejects_invalid_value():
+    """The kwarg validates its input at construction time so typos fail loud."""
+    with pytest.raises(AssertionError, match="schema_enforcement_mode must be one of"):
+        dspy.JSONAdapter(schema_enforcement_mode="strickt")  # typo
+
+    with pytest.raises(AssertionError, match="schema_enforcement_mode must be one of"):
+        dspy.JSONAdapter(schema_enforcement_mode=True)  # wrong type entirely
+
+
+def test_json_adapter_schema_enforcement_strict_no_false_positive_warning(caplog):
+    """Regression: strict mode with use_native_function_calling=False must not emit
+    the ToolCalls warning for a signature that has no ToolCalls output field. An
+    earlier refactor used the mapping-fields generator in place of the tool-calls
+    check; a generator object is always truthy, which caused the warning to fire
+    for any plain signature whenever native function calling was disabled.
+    """
+    import logging
+
+    class PlainSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter(
+        schema_enforcement_mode="strict",
+        use_native_function_calling=False,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="dspy.adapters.json_adapter"):
+        # lm is never accessed on the explicit-strict branch, so None is safe here.
+        resolved = adapter._effective_schema_enforcement_mode(lm=None, signature=PlainSignature)
+
+    assert resolved == "strict"
+    assert not caplog.records, (
+        f"Expected no warnings for a plain signature, got: "
+        f"{[r.getMessage() for r in caplog.records]}"
+    )
+
+
+def test_json_adapter_open_ended_mapping_check_covers_mapping_abcs():
+    """The open-ended mapping check must catch any Mapping subclass, not just dict.
+    Users can write ``Mapping[str, Any]``, ``MutableMapping[...]``, ``OrderedDict[...]``,
+    etc. -- all are open-ended in the strict-schema sense. Plain scalar fields must NOT
+    be flagged.
+    """
+    from collections import OrderedDict
+    from collections.abc import MutableMapping
+    from typing import Any, Mapping
+
+    from dspy.adapters.json_adapter import _open_ended_mapping_field_names
+
+    class SigDict(dspy.Signature):
+        question: str = dspy.InputField()
+        metadata: dict[str, Any] = dspy.OutputField()
+
+    class SigMapping(dspy.Signature):
+        question: str = dspy.InputField()
+        metadata: Mapping[str, Any] = dspy.OutputField()
+
+    class SigMutableMapping(dspy.Signature):
+        question: str = dspy.InputField()
+        metadata: MutableMapping[str, Any] = dspy.OutputField()
+
+    class SigOrderedDict(dspy.Signature):
+        question: str = dspy.InputField()
+        metadata: OrderedDict[str, Any] = dspy.OutputField()
+
+    class SigNoMapping(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    assert list(_open_ended_mapping_field_names(SigDict)) == ["metadata"]
+    assert list(_open_ended_mapping_field_names(SigMapping)) == ["metadata"]
+    assert list(_open_ended_mapping_field_names(SigMutableMapping)) == ["metadata"]
+    assert list(_open_ended_mapping_field_names(SigOrderedDict)) == ["metadata"]
+    assert list(_open_ended_mapping_field_names(SigNoMapping)) == []
+
+
 @pytest.mark.asyncio
 async def test_json_adapter_fallback_to_json_mode_on_structured_output_failure_async():
     class TestSignature(dspy.Signature):

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -786,6 +786,63 @@ async def test_json_adapter_schema_enforcement_json_schema_forces_schema_on_unsu
         )
 
 
+def test_json_adapter_schema_enforcement_json_schema_surfaces_provider_failure():
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(desc="String output field")
+
+    provider_error = RuntimeError("provider rejected json_schema")
+    program = dspy.Predict(TestSignature)
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.side_effect = [
+            provider_error,
+            ModelResponse(choices=[Choices(message=Message(content='{"answer": "fallback"}'))]),
+        ]
+
+        with (
+            dspy.context(
+                lm=dspy.LM(model="openai/gpt-4o", cache=False),
+                adapter=dspy.JSONAdapter(schema_enforcement_mode="json_schema"),
+            ),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            program(question="Dummy question!")
+
+    assert exc_info.value is provider_error
+    assert mock_completion.call_count == 1
+    _, call_kwargs = mock_completion.call_args_list[0]
+    assert issubclass(call_kwargs.get("response_format"), pydantic.BaseModel)
+
+
+@pytest.mark.asyncio
+async def test_json_adapter_schema_enforcement_json_schema_surfaces_provider_failure_async():
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(desc="String output field")
+
+    provider_error = RuntimeError("provider rejected json_schema")
+    program = dspy.Predict(TestSignature)
+
+    with mock.patch("litellm.acompletion") as mock_acompletion:
+        mock_acompletion.side_effect = [
+            provider_error,
+            ModelResponse(choices=[Choices(message=Message(content='{"answer": "fallback"}'))]),
+        ]
+
+        with dspy.context(
+            lm=dspy.LM(model="openai/gpt-4o", cache=False),
+            adapter=dspy.JSONAdapter(schema_enforcement_mode="json_schema"),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                await program.acall(question="Dummy question!")
+
+    assert exc_info.value is provider_error
+    assert mock_acompletion.call_count == 1
+    _, call_kwargs = mock_acompletion.call_args_list[0]
+    assert issubclass(call_kwargs.get("response_format"), pydantic.BaseModel)
+
+
 def test_json_adapter_schema_enforcement_json_object_suppresses_schema_on_supported_lm():
     """Escape hatch: even for LiteLLM-known models where supports_response_schema is True,
     ``JSONAdapter(schema_enforcement_mode="json_object")`` forces the schemaless fallback.
@@ -944,6 +1001,46 @@ def test_json_adapter_open_ended_mapping_check_covers_mapping_abcs():
     assert list(_open_ended_mapping_field_names(SigMutableMapping)) == ["metadata"]
     assert list(_open_ended_mapping_field_names(SigOrderedDict)) == ["metadata"]
     assert list(_open_ended_mapping_field_names(SigNoMapping)) == []
+
+
+def test_json_adapter_open_ended_mapping_check_excludes_typed_dict():
+    from typing_extensions import TypedDict
+
+    from dspy.adapters.json_adapter import (
+        _get_structured_outputs_response_format,
+        _open_ended_mapping_field_names,
+    )
+
+    class Metadata(TypedDict):
+        source: str
+        score: float
+
+    class SigTypedDict(dspy.Signature):
+        question: str = dspy.InputField()
+        metadata: Metadata = dspy.OutputField()
+
+    assert list(_open_ended_mapping_field_names(SigTypedDict)) == []
+
+    response_model = _get_structured_outputs_response_format(SigTypedDict)
+    assert issubclass(response_model, pydantic.BaseModel)
+    assert "metadata" in response_model.model_fields
+
+
+def test_json_adapter_structured_outputs_rejects_open_ended_mapping_schema():
+    from typing import Any, Mapping
+
+    from dspy.adapters.json_adapter import _get_structured_outputs_response_format
+
+    class SigMapping(dspy.Signature):
+        question: str = dspy.InputField()
+        metadata: Mapping[str, Any] = dspy.OutputField()
+
+    with pytest.raises(ValueError, match="metadata.*open-ended mapping"):
+        _get_structured_outputs_response_format(SigMapping)
+
+    adapter = dspy.JSONAdapter(schema_enforcement_mode="json_schema")
+    with pytest.raises(ValueError, match="metadata.*open-ended mapping"):
+        adapter.response_format(lm=mock.Mock(), signature=SigMapping)
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -711,10 +711,10 @@ async def test_json_adapter_json_mode_no_structured_outputs_async():
         assert call_kwargs.get("response_format") == {"type": "json_object"}
 
 
-def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupported_lm():
+def test_json_adapter_schema_enforcement_json_schema_forces_schema_on_unsupported_lm():
     """For openai-compatible endpoints LiteLLM doesn't recognize by name (self-hosted vLLM,
     Ollama, etc.), users can opt into the strict-schema path by setting
-    ``JSONAdapter(schema_enforcement_mode="strict")`` even when
+    ``JSONAdapter(schema_enforcement_mode="json_schema")`` even when
     ``litellm.supports_response_schema`` reports False.
     """
 
@@ -724,7 +724,7 @@ def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupported_lm(
 
     dspy.configure(
         lm=dspy.LM(model="openai/some-unrecognized-model", cache=False),
-        adapter=dspy.JSONAdapter(schema_enforcement_mode="strict"),
+        adapter=dspy.JSONAdapter(schema_enforcement_mode="json_schema"),
     )
     program = dspy.Predict(TestSignature)
 
@@ -753,7 +753,7 @@ def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupported_lm(
 
 
 @pytest.mark.asyncio
-async def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupported_lm_async():
+async def test_json_adapter_schema_enforcement_json_schema_forces_schema_on_unsupported_lm_async():
     class TestSignature(dspy.Signature):
         question: str = dspy.InputField()
         answer: str = dspy.OutputField(desc="String output field")
@@ -772,7 +772,7 @@ async def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupport
         mock_supports_response_schema.return_value = False
 
         lm = dspy.LM(model="openai/some-unrecognized-model", cache=False)
-        adapter = dspy.JSONAdapter(schema_enforcement_mode="strict")
+        adapter = dspy.JSONAdapter(schema_enforcement_mode="json_schema")
         with dspy.context(lm=lm, adapter=adapter):
             result = await program.acall(question="Dummy question!")
 
@@ -786,9 +786,9 @@ async def test_json_adapter_schema_enforcement_strict_forces_schema_on_unsupport
         )
 
 
-def test_json_adapter_schema_enforcement_prompted_suppresses_schema_on_supported_lm():
+def test_json_adapter_schema_enforcement_json_object_suppresses_schema_on_supported_lm():
     """Escape hatch: even for LiteLLM-known models where supports_response_schema is True,
-    ``JSONAdapter(schema_enforcement_mode="prompted")`` forces the schemaless fallback.
+    ``JSONAdapter(schema_enforcement_mode="json_object")`` forces the schemaless fallback.
     """
 
     class TestSignature(dspy.Signature):
@@ -797,7 +797,7 @@ def test_json_adapter_schema_enforcement_prompted_suppresses_schema_on_supported
 
     dspy.configure(
         lm=dspy.LM(model="openai/gpt-4o", cache=False),
-        adapter=dspy.JSONAdapter(schema_enforcement_mode="prompted"),
+        adapter=dspy.JSONAdapter(schema_enforcement_mode="json_object"),
     )
     program = dspy.Predict(TestSignature)
 
@@ -831,8 +831,8 @@ def test_json_adapter_schema_enforcement_rejects_invalid_value():
         dspy.JSONAdapter(schema_enforcement_mode=True)  # wrong type entirely
 
 
-def test_json_adapter_schema_enforcement_strict_no_false_positive_warning(caplog):
-    """Regression: strict mode with use_native_function_calling=False must not emit
+def test_json_adapter_schema_enforcement_json_schema_no_false_positive_warning(caplog):
+    """Regression: json_schema mode with use_native_function_calling=False must not emit
     the ToolCalls warning for a signature that has no ToolCalls output field. An
     earlier refactor used the mapping-fields generator in place of the tool-calls
     check; a generator object is always truthy, which caused the warning to fire
@@ -845,19 +845,66 @@ def test_json_adapter_schema_enforcement_strict_no_false_positive_warning(caplog
         answer: str = dspy.OutputField()
 
     adapter = dspy.JSONAdapter(
-        schema_enforcement_mode="strict",
+        schema_enforcement_mode="json_schema",
         use_native_function_calling=False,
     )
 
     with caplog.at_level(logging.WARNING, logger="dspy.adapters.json_adapter"):
-        # lm is never accessed on the explicit-strict branch, so None is safe here.
-        resolved = adapter._effective_schema_enforcement_mode(lm=None, signature=PlainSignature)
+        # lm is never accessed on the explicit json_schema branch, so None is safe here.
+        resolved = adapter._effective_enforcement_mode(lm=None, signature=PlainSignature)
 
-    assert resolved == "strict"
+    assert resolved == "json_schema"
     assert not caplog.records, (
         f"Expected no warnings for a plain signature, got: "
         f"{[r.getMessage() for r in caplog.records]}"
     )
+
+
+def test_json_adapter_schema_enforcement_explicit_forwards_through_unsupported_provider():
+    """Explicit schema_enforcement_mode forcibly sets ``response_format`` on the
+    completion call even when ``lm.supported_params`` doesn't include it. If the
+    provider or LiteLLM rejects the payload, that error surfaces from the right
+    layer -- DSPy's job is to honor the caller's intent, not to pre-empt. ``"auto"``
+    still silently skips Tier 1 (prompt-only) since the user didn't specify.
+    """
+
+    class PlainSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    # json_object: should still set {"type":"json_object"} despite supported_params=[].
+    with (
+        mock.patch("litellm.completion") as mock_completion,
+        mock.patch("litellm.get_supported_openai_params", return_value=[]),
+    ):
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content='{"answer": "x"}'))]
+        )
+        with dspy.context(
+            lm=dspy.LM(model="openai/some-model", cache=False),
+            adapter=dspy.JSONAdapter(schema_enforcement_mode="json_object"),
+        ):
+            dspy.Predict(PlainSignature)(question="test")
+        _, call_kwargs = mock_completion.call_args_list[0]
+        assert call_kwargs.get("response_format") == {"type": "json_object"}
+
+    # json_schema: should still ship a Pydantic class despite supported_params=[].
+    with (
+        mock.patch("litellm.completion") as mock_completion,
+        mock.patch("litellm.get_supported_openai_params", return_value=[]),
+        mock.patch("litellm.supports_response_schema", return_value=False),
+    ):
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content='{"answer": "x"}'))]
+        )
+        with dspy.context(
+            lm=dspy.LM(model="openai/some-model", cache=False),
+            adapter=dspy.JSONAdapter(schema_enforcement_mode="json_schema"),
+        ):
+            dspy.Predict(PlainSignature)(question="test")
+        _, call_kwargs = mock_completion.call_args_list[0]
+        rf = call_kwargs.get("response_format")
+        assert isinstance(rf, type) and issubclass(rf, pydantic.BaseModel)
 
 
 def test_json_adapter_open_ended_mapping_check_covers_mapping_abcs():


### PR DESCRIPTION
_tl;dr: `JSONAdapter` now has explicit response-format control, so users can force strict `json_schema` for self-hosted OpenAI-compatible engines without subclassing `LM` or modifying LiteLLM's registry._

Today, `JSONAdapter`'s default behavior is tied to LiteLLM capability metadata. When LiteLLM does not recognize a model name, `lm.supports_response_schema` can report `False`, so `JSONAdapter` falls back to `{"type": "json_object"}`. For self-hosted model names like `openai/Qwen/...`, `hosted_vllm/...`, or `openai/meta-llama/...`, that means vLLM/SGLang users can get loose JSON mode even when their inference engine supports strict `json_schema` / [structured output mode](https://docs.vllm.ai/en/latest/features/structured_outputs/#experimental-automatic-parsing-openai-api).

This PR adds a `schema_enforcement_mode` kwarg on `JSONAdapter`:

- `"auto"` keeps the existing default behavior: DSPy uses structured outputs when the model is known to support them, otherwise falls back to `json_object`. Automatic structured-output attempts may still fall back to `json_object` if schema construction or the structured call fails.
- `"json_schema"` forces the strict Pydantic response format even when LiteLLM metadata says the model is unsupported. This mode is intentionally strict: schema-build, LiteLLM/provider, and parse errors surface to the caller, and DSPy does not retry with `json_object`.
- `"json_object"` forces `{"type": "json_object"}` for users who want the prompt-guided JSON path even when structured outputs are available.

The PR also tightens schema feasibility checks for open-ended mappings:

- `dict`, `Mapping`, `MutableMapping`, `OrderedDict`, and similar mapping types are treated as open-ended because strict structured outputs require explicit object properties.
- `TypedDict` is excluded because it has a fixed key set and can be represented as a schema.
- `_get_structured_outputs_response_format` uses the same helper, so `Mapping[str, Any]` cannot silently become an incorrect closed empty-object schema.

Warnings still name fields for risky combinations, such as open-ended mappings or `dspy.ToolCalls` with non-native function calling.

Tested locally:

```bash
uv run --extra dev pytest tests/adapters/test_json_adapter.py
uv run --extra dev ruff check dspy/adapters/json_adapter.py
```

Manual validation: tested against vLLM 0.19.x.

## Why not just subclass `LM`?

Mechanically it works:

```python
class VLLMLM(dspy.LM):
    @property
    def supports_response_schema(self) -> bool:
        return True
```

But `ChatAdapter`, DSPy's default adapter, never reads `supports_response_schema`; only `JSONAdapter` does. A user who subclasses `LM` but forgets to also configure `JSONAdapter` gets no structured output and no signal that the override did nothing.

This kwarg puts the opt-in/opt-out at the adapter layer the user configured. Default behavior remains unchanged, and the capability check stays behind `lm.supports_response_schema`, so this should not complicate future LiteLLM decoupling.
