### PR TITLE
feat(json_adapter): make auto-fallback visible and raise structured-output failures to ERROR

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, get_origin
+from typing import Any, Generator, get_origin
 
 import json_repair
 import pydantic
@@ -24,17 +24,21 @@ from dspy.utils.exceptions import AdapterParseError
 logger = logging.getLogger(__name__)
 
 
-def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
+def _open_ended_mapping_field_names(signature: SignatureMeta) -> Generator[str, None, None]:
+    """Yield names of output fields typed as ``dict[...]``. Structured Outputs require
+    explicit properties, so such fields are incompatible and force a fallback to
+    ``{"type": "json_object"}``.
     """
-    Check whether any output field in the signature has an open-ended mapping type,
-    such as dict[str, Any]. Structured Outputs require explicit properties, so such fields
-    are incompatible.
-    """
-    for field in signature.output_fields.values():
-        annotation = field.annotation
-        if get_origin(annotation) is dict:
-            return True
-    return False
+    for name, field in signature.output_fields.items():
+        if get_origin(field.annotation) is dict:
+            yield name
+
+
+def _non_native_tool_call_field_names(signature: SignatureMeta) -> Generator[str, None, None]:
+    """Yield names of output fields with ``dspy.ToolCalls`` annotations."""
+    for name, field in signature.output_fields.items():
+        if field.annotation == ToolCalls:
+            yield name
 
 
 class JSONAdapter(ChatAdapter):
@@ -47,11 +51,29 @@ class JSONAdapter(ChatAdapter):
         if "response_format" not in lm.supported_params:
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 
-        has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
+        open_ended_mappings = list(_open_ended_mapping_field_names(signature))
+        non_native_tool_calls = (
+            list(_non_native_tool_call_field_names(signature)) if not self.use_native_function_calling else []
+        )
 
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
-            # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
-            # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
+        # Warn on signature-level causes that force the fallback; the user can act on these.
+        # The supports_response_schema=False case is a model capability fact, not a fixable config, so it stays silent.
+        if open_ended_mappings:
+            logger.warning(
+                f"Signature {signature.__name__} has open-ended mapping output field(s) "
+                f"{', '.join(open_ended_mappings)}; falling back to json_object mode because unbounded "
+                "key-sets can't be expressed as a strict JSON Schema. Consider a pydantic.BaseModel or "
+                "typing.TypedDict with explicit fields for more reliable structured output."
+            )
+        if non_native_tool_calls:
+            logger.warning(
+                f"Signature {signature.__name__} has dspy.ToolCalls output field(s) "
+                f"{', '.join(non_native_tool_calls)} with use_native_function_calling=False; falling back "
+                "to json_object mode. Structured outputs compose poorly with JSON-mode tool calling; "
+                "consider use_native_function_calling=True for more reliable behavior."
+            )
+
+        if open_ended_mappings or non_native_tool_calls or not lm.supports_response_schema:
             lm_kwargs["response_format"] = {"type": "json_object"}
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -95,8 +95,8 @@ class JSONAdapter(ChatAdapter):
             )
             lm_kwargs["response_format"] = structured_output_model
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
-        except Exception:
-            logger.warning("Failed to use structured output format, falling back to JSON mode.")
+        except Exception as e:
+            logger.error(f"Failed to use structured output format; falling back to JSON mode. Reason: {e}")
             lm_kwargs["response_format"] = {"type": "json_object"}
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
 
@@ -118,8 +118,8 @@ class JSONAdapter(ChatAdapter):
             )
             lm_kwargs["response_format"] = structured_output_model
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
-        except Exception:
-            logger.warning("Failed to use structured output format, falling back to JSON mode.")
+        except Exception as e:
+            logger.error(f"Failed to use structured output format; falling back to JSON mode. Reason: {e}")
             lm_kwargs["response_format"] = {"type": "json_object"}
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -82,7 +82,7 @@ class JSONAdapter(ChatAdapter):
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().__call__)
-        if result:
+        if result is not None:
             return result
 
         try:
@@ -105,7 +105,7 @@ class JSONAdapter(ChatAdapter):
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().acall)
-        if result:
+        if result is not None:
             return await result
 
         try:

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Generator, get_origin
+from typing import Any, get_origin
 
 import json_repair
 import pydantic
@@ -24,21 +24,17 @@ from dspy.utils.exceptions import AdapterParseError
 logger = logging.getLogger(__name__)
 
 
-def _open_ended_mapping_field_names(signature: SignatureMeta) -> Generator[str, None, None]:
-    """Yield names of output fields typed as ``dict[...]``. Structured Outputs require
+def _get_open_ended_mapping_field_names(signature: SignatureMeta) -> list[str]:
+    """Return names of output fields typed as `dict[...]`. Structured Outputs require
     explicit properties, so such fields are incompatible and force a fallback to
-    ``{"type": "json_object"}``.
+    `{"type": "json_object"}`.
     """
-    for name, field in signature.output_fields.items():
-        if get_origin(field.annotation) is dict:
-            yield name
+    return [name for name, field in signature.output_fields.items() if get_origin(field.annotation) is dict]
 
 
-def _non_native_tool_call_field_names(signature: SignatureMeta) -> Generator[str, None, None]:
-    """Yield names of output fields with ``dspy.ToolCalls`` annotations."""
-    for name, field in signature.output_fields.items():
-        if field.annotation == ToolCalls:
-            yield name
+def _get_non_native_tool_call_field_names(signature: SignatureMeta) -> list[str]:
+    """Return names of output fields with `dspy.ToolCalls` annotations."""
+    return [name for name, field in signature.output_fields.items() if field.annotation == ToolCalls]
 
 
 class JSONAdapter(ChatAdapter):
@@ -51,9 +47,9 @@ class JSONAdapter(ChatAdapter):
         if "response_format" not in lm.supported_params:
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 
-        open_ended_mappings = list(_open_ended_mapping_field_names(signature))
+        open_ended_mappings = _get_open_ended_mapping_field_names(signature)
         non_native_tool_calls = (
-            list(_non_native_tool_call_field_names(signature)) if not self.use_native_function_calling else []
+            _get_non_native_tool_call_field_names(signature) if not self.use_native_function_calling else []
         )
 
         # Warn on signature-level causes that force the fallback; the user can act on these.

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1112,3 +1112,53 @@ def test_json_adapter_does_not_warn_for_schema_compatible_signature(caplog, _pro
 
     warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == _JSON_ADAPTER_LOGGER]
     assert warnings == [], f"expected no warnings, got: {[r.message for r in warnings]}"
+
+
+def test_json_adapter_logs_error_on_structured_output_failure(caplog, _propagate_dspy_logs):
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o", cache=False), adapter=dspy.JSONAdapter())
+    program = dspy.Predict(TestSignature)
+
+    with (
+        caplog.at_level(logging.ERROR, logger=_JSON_ADAPTER_LOGGER),
+        mock.patch("litellm.completion") as mock_completion,
+    ):
+        mock_completion.side_effect = [
+            RuntimeError("Structured output rejected"),
+            ModelResponse(choices=[Choices(message=Message(content='{"answer": "ok"}'))]),
+        ]
+        program(question="x")
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR and r.name == _JSON_ADAPTER_LOGGER]
+    assert any("Failed to use structured output format" in r.message for r in errors), (
+        f"expected ERROR-level structured-output failure log, got: {[(r.levelname, r.message) for r in caplog.records]}"
+    )
+    assert any("Structured output rejected" in r.message for r in errors), (
+        "expected the underlying exception reason to appear in the error log"
+    )
+
+
+@pytest.mark.asyncio
+async def test_json_adapter_logs_error_on_structured_output_failure_async(caplog, _propagate_dspy_logs):
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    program = dspy.Predict(TestSignature)
+
+    with (
+        caplog.at_level(logging.ERROR, logger=_JSON_ADAPTER_LOGGER),
+        mock.patch("litellm.acompletion") as mock_acompletion,
+    ):
+        mock_acompletion.side_effect = [
+            RuntimeError("Structured output rejected"),
+            ModelResponse(choices=[Choices(message=Message(content='{"answer": "ok"}'))]),
+        ]
+        with dspy.context(lm=dspy.LM(model="openai/gpt-4o", cache=False), adapter=dspy.JSONAdapter()):
+            await program.acall(question="x")
+
+    errors = [r for r in caplog.records if r.levelno == logging.ERROR and r.name == _JSON_ADAPTER_LOGGER]
+    assert any("Failed to use structured output format" in r.message for r in errors)

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1,3 +1,5 @@
+import logging
+from typing import Any
 from unittest import mock
 
 import pydantic
@@ -1016,3 +1018,97 @@ Outputs will be a JSON object with the following fields.
 In adhering to this structure, your objective is: 
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+_JSON_ADAPTER_LOGGER = "dspy.adapters.json_adapter"
+
+
+@pytest.fixture
+def _propagate_dspy_logs():
+    """Allow caplog (attached to root) to see dspy logs. dspy sets propagate=False by default."""
+    dspy_logger = logging.getLogger("dspy")
+    original = dspy_logger.propagate
+    dspy_logger.propagate = True
+    try:
+        yield
+    finally:
+        dspy_logger.propagate = original
+
+
+def test_json_adapter_warns_on_open_ended_mapping_fallback(caplog, _propagate_dspy_logs):
+    class OpenEndedSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        mapping: dict[str, Any] = dspy.OutputField()
+
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o", cache=False), adapter=dspy.JSONAdapter())
+    program = dspy.Predict(OpenEndedSignature)
+
+    with (
+        caplog.at_level(logging.WARNING, logger=_JSON_ADAPTER_LOGGER),
+        mock.patch("litellm.completion") as mock_completion,
+    ):
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content='{"mapping": {"a": 1}}'))]
+        )
+        program(question="x")
+
+    _, call_kwargs = mock_completion.call_args
+    assert call_kwargs.get("response_format") == {"type": "json_object"}
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == _JSON_ADAPTER_LOGGER]
+    assert any("open-ended mapping output field(s) mapping" in r.message for r in warnings), (
+        f"expected open-ended mapping warning, got: {[r.message for r in warnings]}"
+    )
+
+
+def test_json_adapter_warns_on_non_native_toolcalls_fallback(caplog, _propagate_dspy_logs):
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        answer: str = dspy.OutputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    def get_weather(city: str) -> str:
+        return f"The weather in {city} is sunny"
+
+    adapter = dspy.JSONAdapter(use_native_function_calling=False)
+    lm = dspy.LM(model="openai/gpt-4o-mini", cache=False)
+
+    with (
+        caplog.at_level(logging.WARNING, logger=_JSON_ADAPTER_LOGGER),
+        mock.patch("litellm.completion") as mock_completion,
+    ):
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content='{"answer": "sunny", "tool_calls": {"tool_calls": []}}'))],
+            model="openai/gpt-4o-mini",
+        )
+        adapter(lm, {}, ToolSignature, [], {"question": "weather?", "tools": [dspy.Tool(get_weather)]})
+
+    _, call_kwargs = mock_completion.call_args
+    assert call_kwargs["response_format"] == {"type": "json_object"}
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == _JSON_ADAPTER_LOGGER]
+    assert any("dspy.ToolCalls output field(s) tool_calls" in r.message for r in warnings), (
+        f"expected ToolCalls warning, got: {[r.message for r in warnings]}"
+    )
+
+
+def test_json_adapter_does_not_warn_for_schema_compatible_signature(caplog, _propagate_dspy_logs):
+    class CleanSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o", cache=False), adapter=dspy.JSONAdapter())
+    program = dspy.Predict(CleanSignature)
+
+    with (
+        caplog.at_level(logging.WARNING, logger=_JSON_ADAPTER_LOGGER),
+        mock.patch("litellm.completion") as mock_completion,
+    ):
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content='{"answer": "ok"}'))]
+        )
+        program(question="x")
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING and r.name == _JSON_ADAPTER_LOGGER]
+    assert warnings == [], f"expected no warnings, got: {[r.message for r in warnings]}"

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1162,3 +1162,6 @@ async def test_json_adapter_logs_error_on_structured_output_failure_async(caplog
 
     errors = [r for r in caplog.records if r.levelno == logging.ERROR and r.name == _JSON_ADAPTER_LOGGER]
     assert any("Failed to use structured output format" in r.message for r in errors)
+    assert any("Structured output rejected" in r.message for r in errors), (
+        "expected the underlying exception reason to appear in the async error log"
+    )


### PR DESCRIPTION
Two small observability improvements to `JSONAdapter` w/ no public changes.

1) _Warnings on fixable auto-fallback causes._`JSONAdapter` silently drops to `{"type": "json_object"}` when the signature has a `dict[...]` output or uses `ToolCalls` without native function calling. Both are user-fixable — simplify the signature, or flip `use_native_function_calling=True`. 

**This PR adds `logger.warning` at both sites explaining why and what to change.** The third fallback case (`supports_response_schema=False`) stays silent.

2) _Bump structured-output-failure log to ERROR._ When the structured-output call raises at the wire (e.g., provider rejects the schema), `__call__`/`acall` catch, log, and retry with `{"type": "json_object"}`. Today that log is `warning`; 

**This PR bumps it to `error` and includes the exception reason.**