### PR TITLE
fix(clients): drop None fields from responses-API tool_call dump

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -319,7 +319,7 @@ class BaseLM:
                 for content_item in output_item.content:
                     text_outputs.append(content_item.text)
             elif output_item_type == "function_call":
-                tool_calls.append(output_item.model_dump())
+                tool_calls.append(output_item.model_dump(exclude_none=True))
             elif output_item_type == "reasoning":
                 if getattr(output_item, "content", None) and len(output_item.content) > 0:
                     for content_item in output_item.content:


### PR DESCRIPTION
openai-python 2.x added a new optional `namespace` field on `ResponseFunctionToolCall`. Because `BaseLM._process_response` forwards `output_item.model_dump()` verbatim, the extra `namespace: None` key leaked into the returned tool_call dict and broke strict-equality assertions (e.g. tests/clients/test_lm.py::test_responses_api_tool_calls).

Dump with `exclude_none=True` so unset optional fields are omitted. Forward-compatible with future additive optional fields on the Responses-API tool-call schema; also unblocks the openai 1.75.0 -> 2.x upgrade (dependabot PR #9667).