### PR TITLE
fix(parallel): guard straggler resubmission against executor shutdown

### DIFF
--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -209,13 +209,17 @@ class ParallelExecutor:
                                     st = start_time_map.get(sid, None)
                                 if st and (now - st) >= self.timeout:
                                     resubmitted.add(f)
-                                    nf = executor.submit(
-                                        worker,
-                                        parent_overrides,
-                                        submission_counter,
-                                        idx,
-                                        item,
-                                    )
+                                    try:
+                                        nf = executor.submit(
+                                            worker,
+                                            parent_overrides,
+                                            submission_counter,
+                                            idx,
+                                            item,
+                                        )
+                                    except RuntimeError:
+                                        # Executor already shut down; skip resubmission
+                                        break
                                     futures_map[nf] = (submission_counter, idx, item)
                                     futures_set.add(nf)
                                     submission_counter += 1


### PR DESCRIPTION
## Summary

- Guard `executor.submit()` in `ParallelExecutor`'s straggler resubmission path with `try/except RuntimeError` to prevent `"cannot schedule new futures after shutdown"` crashes on long-running evaluations
- When the executor is already shut down (e.g. due to cancellation, signal handling, or interpreter exit), the resubmission is gracefully skipped instead of raising

## Context

When `ParallelExecutor`'s straggler timeout (default 120s) fires and attempts to resubmit slow futures, the `ThreadPoolExecutor` may already be shut down, causing a `RuntimeError`. This is a defensive fix at the executor level — complementary to #9588 which exposes `timeout`/`straggler_limit` params so users can tune or disable straggler resubmission.

## Test plan

- [ ] Existing `tests/utils/test_parallelizer.py` tests pass
- [ ] Verify that long-running evaluations no longer crash with `RuntimeError: cannot schedule new futures after shutdown`

Closes #9574

🤖 Generated with [Claude Code](https://claude.com/claude-code)