### PR TITLE
fix: handle None code field in RLM to avoid AttributeError on strip()

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -66,6 +66,8 @@ _PYTHON_FENCE_LANGS = {"python", "py", "python3", "py3", ""}
 
 def _strip_code_fences(code: str) -> str:
     """Extract Python code from markdown fences, or return as-is if no fences."""
+    if code is None:
+        raise ValueError("LM returned None for code field; the model may have failed to generate a response.")
     code = code.strip()
     if "```" not in code:
         return code
@@ -562,8 +564,8 @@ class RLM(Module):
 
         try:
             code = _strip_code_fences(action.code)
-        except SyntaxError as e:
-            code = action.code
+        except (SyntaxError, ValueError) as e:
+            code = action.code or ""
             result = f"[Error] {e}"
             return self._process_execution_result(action, code, result, history, output_field_names)
         result = self._execute_code(repl, code, input_args)
@@ -650,8 +652,8 @@ class RLM(Module):
 
         try:
             code = _strip_code_fences(pred.code)
-        except SyntaxError as e:
-            code = pred.code
+        except (SyntaxError, ValueError) as e:
+            code = pred.code or ""
             result = f"[Error] {e}"
             return self._process_execution_result(pred, code, result, history, output_field_names)
         result = self._execute_code(repl, code, input_args)


### PR DESCRIPTION
fixes #9632

when the LM fails to produce a `code` output (returns `None`), `_strip_code_fences()` crashes immediately at `code.strip()` with:

```
AttributeError: 'NoneType' object has no attribute 'strip'
```

**root cause:** `_strip_code_fences` has no guard for `None` input. both the sync (`_run_iteration`) and async (`_run_iteration_async`) call sites catch `SyntaxError` but not `AttributeError`.

**fix:**
- add a `None` check at the top of `_strip_code_fences`, raising a `ValueError` with a clear message
- widen the `except` clause at both call sites to catch `ValueError` alongside `SyntaxError`, so a None-code iteration is treated as a recoverable error (logged as `[Error] ...`) and RLM continues to the next iteration instead of crashing

the error message is surfaced through the existing result-processing path, so it shows up in the trajectory and the model can attempt to recover on the next step.