### PR TITLE
fix(mcp): accept both isError and is_error on tool results

### DIFF
--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -21,7 +21,12 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if len(text_contents) == 1:
         tool_content = tool_content[0]
 
-    if call_tool_result.isError:
+    # mcp.types.CallToolResult uses `isError` (JSON-RPC convention);
+    # fastmcp's CallToolResult uses `is_error` (snake_case). Accept either.
+    is_error = getattr(call_tool_result, "isError", None)
+    if is_error is None:
+        is_error = getattr(call_tool_result, "is_error", False)
+    if is_error:
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
 
     return tool_content or non_text_contents

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -3,10 +3,52 @@ import importlib
 
 import pytest
 
-from dspy.utils.mcp import convert_mcp_tool
+from dspy.utils.mcp import _convert_mcp_tool_result, convert_mcp_tool
 
 if importlib.util.find_spec("mcp") is None:
     pytest.skip(reason="mcp is not installed", allow_module_level=True)
+
+
+class _MCPStyleResult:
+    """Mirrors mcp.types.CallToolResult: camelCase `isError` (JSON-RPC convention)."""
+
+    def __init__(self, content, isError):
+        self.content = content
+        self.isError = isError
+
+
+class _FastmcpStyleResult:
+    """Mirrors fastmcp.client.client.CallToolResult: snake_case `is_error` (PEP 8)."""
+
+    def __init__(self, content, is_error):
+        self.content = content
+        self.is_error = is_error
+
+
+def test_convert_mcp_tool_result_raises_on_camelcase_isError():
+    """Official MCP SDK result shape must surface tool errors as RuntimeError."""
+    from mcp.types import TextContent
+
+    result = _MCPStyleResult([TextContent(type="text", text="error message")], isError=True)
+    with pytest.raises(RuntimeError, match="Failed to call a MCP tool: error message"):
+        _convert_mcp_tool_result(result)
+
+
+def test_convert_mcp_tool_result_raises_on_snakecase_is_error():
+    """fastmcp's CallToolResult uses `is_error`; regression test for #8760."""
+    from mcp.types import TextContent
+
+    result = _FastmcpStyleResult([TextContent(type="text", text="fastmcp error")], is_error=True)
+    with pytest.raises(RuntimeError, match="Failed to call a MCP tool: fastmcp error"):
+        _convert_mcp_tool_result(result)
+
+
+def test_convert_mcp_tool_result_returns_content_when_not_error():
+    """Result with isError=False returns content unchanged."""
+    from mcp.types import TextContent
+
+    result = _MCPStyleResult([TextContent(type="text", text="ok")], isError=False)
+    assert _convert_mcp_tool_result(result) == "ok"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary
`_convert_mcp_tool_result` accesses `call_tool_result.isError` directly. The official `mcp.types.CallToolResult` uses `isError` (JSON-RPC camelCase), but `fastmcp.client.client.CallToolResult` uses `is_error` (snake_case). Users passing `fastmcp.Client.call_tool()` results into DSPy hit `AttributeError`. Closes #8760.

### Change
Read both attribute names defensively. Two-step `getattr` so `isError=False` on the official type is honored before falling back to `is_error`.

```python
is_error = getattr(call_tool_result, "isError", None)
if is_error is None:
    is_error = getattr(call_tool_result, "is_error", False)
if is_error:
    raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
```

### Tests
Three new unit tests in `tests/utils/test_mcp.py` covering camelCase, snake_case, and the no-error path. Stub classes mirror each library's `CallToolResult` shape so no `fastmcp` dependency is added. Existing integration test (`test_convert_mcp_tool`) still passes. Full `tests/utils/` suite: **79 passed, 2 skipped**.

### Reproduction
```python
from dspy.utils.mcp import _convert_mcp_tool_result

class FastmcpStyleResult:
    content = []
    is_error = True

_convert_mcp_tool_result(FastmcpStyleResult())
# main:        AttributeError: 'FastmcpStyleResult' object has no attribute 'isError'
# this branch: RuntimeError: Failed to call a MCP tool: ...
```

### AI disclosure
Investigated and edited with Claude Code. I understand each line and reproduced the bug locally before writing the fix.

Prompts focused on:
- Confirming both libraries' attribute names from their installed source (`mcp.types.CallToolResult` is a Pydantic model with field `isError`; `fastmcp.client.client.CallToolResult` is a dataclass with field `is_error`).
- Whether to use a single `or`-chained `getattr` or an explicit two-step check — chose two-step so `isError=False` on the official type is honored before falling back.
- Whether to add `fastmcp` as a test dep — chose stub classes that mirror each shape instead, to keep the test suite hermetic.
