### PR TITLE
chore(deps): remove litellm upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "tqdm>=4.66.1",
     "requests>=2.31.0",
     "pydantic>=2.0",
-    "litellm>=1.64.0,<=1.82.6",
+    "litellm>=1.64.0",
     "diskcache>=5.6.0",
     "json-repair>=0.54.2",
     "tenacity>=8.2.3",

--- a/uv.lock
+++ b/uv.lock
@@ -827,7 +827,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.54.2" },
     { name = "langchain-core", marker = "extra == 'langchain'" },
     { name = "langchain-core", marker = "extra == 'test-extras'" },
-    { name = "litellm", specifier = ">=1.64.0,<=1.82.6" },
+    { name = "litellm", specifier = ">=1.64.0" },
     { name = "litellm", marker = "(python_full_version == '3.14.*' and extra == 'dev') or (sys_platform == 'win32' and extra == 'dev')", specifier = ">=1.64.0" },
     { name = "litellm", extras = ["proxy"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = ">=1.64.0" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'" },


### PR DESCRIPTION
Drops the `<=1.82.6` cap on `litellm` in `pyproject.toml` (now `>=1.64.0`) and refreshes `uv.lock`. Hard upper bounds in a library propagate to every downstream user and block security patches; pinning belongs in application lockfiles, not here.