### PR TITLE
docs: add docstrings for dspy/datasets public APIs (refs #8926)

### DIFF
--- a/dspy/datasets/colors.py
+++ b/dspy/datasets/colors.py
@@ -145,6 +145,31 @@ all_colors = [
 
 
 class Colors(Dataset):
+    """Toy color-name dataset used in DSPy examples and tutorials.
+
+    Wraps the matplotlib-derived ``all_colors`` list and splits it into
+    train/dev partitions. By default, names are sorted by their reversed
+    string so that visually similar colors (for example, the various ``blue``
+    suffixes) cluster together; the first 60% becomes the train split and the
+    rest becomes dev. Both splits are then deterministically shuffled with
+    seed ``0`` before being handed to the ``Dataset`` base class for further
+    seeded sampling.
+
+    Args:
+        sort_by_suffix: If ``True`` (the default), sort colors by reversed
+            name so that similar colors are not split between train and dev.
+            If ``False``, preserve the original ``all_colors`` ordering.
+        *args: Forwarded to ``Dataset.__init__``.
+        **kwargs: Forwarded to ``Dataset.__init__``.
+
+    Examples:
+        >>> from dspy.datasets.colors import Colors
+        >>> data = Colors(input_keys=["color"])
+        >>> example = data.train[0]
+        >>> "color" in example
+        True
+    """
+
     def __init__(self, sort_by_suffix=True, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -163,6 +188,22 @@ class Colors(Dataset):
         random.Random(0).shuffle(self._dev)
 
     def sorted_by_suffix(self, colors):
+        """Return ``colors`` sorted by reversed name when ``sort_by_suffix`` is set.
+
+        Sorting on the reversed string groups colors with the same suffix
+        (for example, ``"navy blue"`` and ``"sky blue"``) so a contiguous
+        train/dev split keeps related colors together rather than scattering
+        them across both partitions.
+
+        Args:
+            colors: Either a list of color-name strings, or a list of dicts
+                with a ``"color"`` key.
+
+        Returns:
+            The input list sorted by reversed color name when
+            ``self.sort_by_suffix`` is ``True``, otherwise the input
+            unchanged.
+        """
         if not self.sort_by_suffix:
             return colors
 

--- a/dspy/datasets/dataset.py
+++ b/dspy/datasets/dataset.py
@@ -10,6 +10,49 @@ from dspy.dsp.utils import dotdict
 
 
 class Dataset:
+    """Base class for DSPy datasets with deterministic train/dev/test splits.
+
+    The base class is responsible for shuffling and sampling the underlying
+    splits with a fixed seed so that downstream evaluations are reproducible.
+    Subclasses are expected to populate the raw splits (``self._train``,
+    ``self._dev``, ``self._test``) with iterables of dictionaries; the public
+    ``train``/``dev``/``test`` properties then turn those records into
+    ``dspy.Example`` instances on first access and cache the result.
+
+    Args:
+        train_seed: Seed used to shuffle the training split. Defaults to ``0``.
+        train_size: Optional cap on the number of training examples returned
+            after shuffling. ``None`` keeps the full split.
+        eval_seed: Seed used to shuffle both the dev and test splits. Defaults
+            to ``0``.
+        dev_size: Optional cap on the number of dev examples returned after
+            shuffling. ``None`` keeps the full split.
+        test_size: Optional cap on the number of test examples returned after
+            shuffling. ``None`` keeps the full split.
+        input_keys: Field names that should be marked as inputs on each
+            generated ``dspy.Example`` (via ``with_inputs``). Defaults to an
+            empty list.
+
+    Attributes:
+        do_shuffle: When ``True`` (the default), splits are shuffled with the
+            configured seeds before sampling. Set to ``False`` in subclasses
+            that need to preserve the source ordering.
+        name: The subclass name; useful for logging and identifying the
+            dataset in mixed pipelines.
+
+    Examples:
+        Subclasses populate ``self._train``/``self._dev``/``self._test``::
+
+            class MyDataset(Dataset):
+                def __init__(self, **kwargs):
+                    super().__init__(**kwargs)
+                    self._train = [{"question": "1+1?", "answer": "2"}]
+                    self._dev = [{"question": "2+2?", "answer": "4"}]
+
+            data = MyDataset(input_keys=["question"])
+            example = data.train[0]  # dspy.Example with question marked as input
+    """
+
     def __init__(
         self,
         train_seed: int = 0,
@@ -39,6 +82,25 @@ class Dataset:
         dev_size: int | None = None,
         test_size: int | None = None,
     ) -> None:
+        """Update the shuffling seeds and split sizes, then invalidate caches.
+
+        Any argument left as ``None`` keeps the existing value. Cached splits
+        (``_train_``/``_dev_``/``_test_``) are removed so that the next access
+        of ``train``/``dev``/``test`` re-shuffles and re-samples with the new
+        configuration.
+
+        Args:
+            train_seed: New seed for the training split, or ``None`` to keep
+                the current value.
+            train_size: New cap on the training split, or ``None`` to keep the
+                current value.
+            eval_seed: New seed for both dev and test splits, or ``None`` to
+                keep the current values.
+            dev_size: New cap on the dev split, or ``None`` to keep the
+                current value.
+            test_size: New cap on the test split, or ``None`` to keep the
+                current value.
+        """
         self.train_size = train_size or self.train_size
         self.train_seed = train_seed or self.train_seed
         self.dev_size = dev_size or self.dev_size
@@ -57,6 +119,12 @@ class Dataset:
 
     @property
     def train(self) -> list[Example]:
+        """Lazily build and cache the shuffled, sampled training split.
+
+        Returns:
+            A list of ``dspy.Example`` instances drawn from ``self._train``,
+            shuffled with ``self.train_seed`` and capped at ``self.train_size``.
+        """
         if not hasattr(self, "_train_"):
             self._train_ = self._shuffle_and_sample("train", self._train, self.train_size, self.train_seed)
 
@@ -64,6 +132,12 @@ class Dataset:
 
     @property
     def dev(self) -> list[Example]:
+        """Lazily build and cache the shuffled, sampled dev split.
+
+        Returns:
+            A list of ``dspy.Example`` instances drawn from ``self._dev``,
+            shuffled with ``self.dev_seed`` and capped at ``self.dev_size``.
+        """
         if not hasattr(self, "_dev_"):
             self._dev_ = self._shuffle_and_sample("dev", self._dev, self.dev_size, self.dev_seed)
 
@@ -71,6 +145,12 @@ class Dataset:
 
     @property
     def test(self) -> list[Example]:
+        """Lazily build and cache the shuffled, sampled test split.
+
+        Returns:
+            A list of ``dspy.Example`` instances drawn from ``self._test``,
+            shuffled with ``self.test_seed`` and capped at ``self.test_size``.
+        """
         if not hasattr(self, "_test_"):
             self._test_ = self._shuffle_and_sample("test", self._test, self.test_size, self.test_seed)
 
@@ -112,6 +192,35 @@ class Dataset:
         eval_seed: int = 2023,
         **kwargs: Any,
     ) -> Any:
+        """Build aligned training and evaluation sets for a list of seeds.
+
+        Useful for sweeps where you want to evaluate the same model across
+        several training seeds while keeping evaluation data consistent (or
+        partitioned) across runs.
+
+        Args:
+            train_seeds: Seeds used to draw distinct training sets. Defaults
+                to ``[1, 2, 3, 4, 5]``.
+            train_size: Number of examples in each training set. Defaults to
+                ``16``.
+            dev_size: Total number of dev examples to draw before optional
+                per-seed partitioning. Defaults to ``1000``.
+            divide_eval_per_seed: If ``True``, the dev set is partitioned into
+                disjoint slices of ``dev_size // len(train_seeds)`` examples,
+                one per seed. If ``False``, every seed reuses the full dev
+                slice. Defaults to ``True``.
+            eval_seed: Seed used to shuffle the dev split. Defaults to
+                ``2023``.
+            **kwargs: Additional keyword arguments forwarded to the dataset
+                constructor (for example, dataset-specific options).
+
+        Returns:
+            A ``dotdict`` with two fields:
+
+            - ``train_sets``: list of training-example lists, one per seed.
+            - ``eval_sets``: list of evaluation-example lists aligned with
+              ``train_sets``.
+        """
         train_seeds = train_seeds or [1, 2, 3, 4, 5]
         data_args = dotdict(train_size=train_size, eval_seed=eval_seed, dev_size=dev_size, test_size=0, **kwargs)
         dataset = cls(**data_args)

--- a/dspy/datasets/gsm8k.py
+++ b/dspy/datasets/gsm8k.py
@@ -4,6 +4,35 @@ import tqdm
 
 
 class GSM8K:
+    """Loader for the GSM8K grade-school math word-problem benchmark.
+
+    Downloads the Hugging Face ``gsm8k`` (``main`` config) dataset and turns
+    each row into a ``dspy.Example`` with three fields:
+
+    - ``question``: the natural-language word problem.
+    - ``gold_reasoning``: the chain-of-thought rationale included in the
+      original answer (everything before the final ``####`` marker).
+    - ``answer``: the integer final answer as a string.
+
+    The constructor splits the official train set into a fixed train/dev
+    pair (200 train + 300 dev examples after a seeded shuffle) and exposes
+    the entire official test set.
+
+    Attributes:
+        train: First 200 shuffled training examples.
+        dev: Next 300 shuffled training examples (used as a held-out dev set
+            because the GSM8K release exposes only train and test splits).
+        test: The official GSM8K test split, shuffled deterministically.
+        do_shuffle: ``False`` so that downstream consumers (for example,
+            ``dspy.Dataset`` subclasses) preserve this loader's ordering.
+
+    Examples:
+        >>> from dspy.datasets.gsm8k import GSM8K
+        >>> data = GSM8K()  # doctest: +SKIP
+        >>> example = data.train[0]  # doctest: +SKIP
+        >>> example.question, example.answer  # doctest: +SKIP
+    """
+
     def __init__(self):
         self.do_shuffle = False
 
@@ -60,6 +89,30 @@ class GSM8K:
 
 
 def parse_integer_answer(answer, only_first_line=True):
+    """Extract the final integer answer from a free-form model response.
+
+    The function walks the response from left to right looking for the last
+    whitespace-separated token that contains a digit, drops everything after
+    a decimal point, strips non-digit characters, and parses the result as an
+    integer. If no digits can be recovered, ``0`` is returned so that callers
+    can compare against gold answers without raising.
+
+    Args:
+        answer: The model output to parse. Will be coerced to a string by
+            callers.
+        only_first_line: If ``True`` (the default), restrict parsing to the
+            first line of ``answer``. Useful when the model emits a final
+            answer on the first line followed by additional commentary.
+
+    Returns:
+        The parsed integer, or ``0`` if no number could be extracted.
+
+    Examples:
+        >>> parse_integer_answer("The answer is 42.")
+        42
+        >>> parse_integer_answer("no digits here")
+        0
+    """
     try:
         if only_first_line:
             answer = answer.strip().split("\n")[0]
@@ -77,4 +130,22 @@ def parse_integer_answer(answer, only_first_line=True):
 
 
 def gsm8k_metric(gold, pred, trace=None):
+    """Exact-match metric for GSM8K predictions.
+
+    Both ``gold.answer`` and ``pred.answer`` are normalized through
+    :func:`parse_integer_answer` before comparison, which makes the metric
+    tolerant of free-form model outputs (for example, ``"The answer is 42"``)
+    and stringified gold answers.
+
+    Args:
+        gold: A ``dspy.Example`` (or any object with an ``answer`` attribute)
+            holding the reference answer.
+        pred: A ``dspy.Prediction`` (or any object with an ``answer``
+            attribute) holding the model's prediction.
+        trace: Unused; accepted so this function matches the signature
+            expected by ``dspy.Evaluate`` and the teleprompters.
+
+    Returns:
+        ``1`` if the parsed integer answers match, ``0`` otherwise.
+    """
     return int(parse_integer_answer(str(gold.answer))) == int(parse_integer_answer(str(pred.answer)))

--- a/dspy/datasets/hotpotqa.py
+++ b/dspy/datasets/hotpotqa.py
@@ -4,6 +4,44 @@ from dspy.datasets.dataset import Dataset
 
 
 class HotPotQA(Dataset):
+    """Loader for the HotPotQA multi-hop question-answering benchmark.
+
+    Pulls the ``hotpot_qa`` dataset (``fullwiki`` config) from Hugging Face
+    and exposes its train/dev/test splits through the standard
+    ``dspy.Dataset`` interface. Only "hard" examples from the official train
+    split are kept; by default a 75/25 partition of those hard examples is
+    used as ``train``/``dev``, and the official validation split is exposed
+    as ``test``. Setting ``unofficial_dev=False`` disables the synthetic dev
+    split so that ``dev`` is ``None``.
+
+    Args:
+        *args: Forwarded to ``Dataset.__init__``.
+        only_hard_examples: Must be ``True`` (default). The flag exists so
+            that future support for easy examples can be added without
+            changing the call sites; passing ``False`` raises an
+            ``AssertionError`` because dev consistency with the official
+            HotPotQA dev split would be broken.
+        keep_details: Controls which fields are retained on training
+            examples. Accepts:
+
+            - ``True``: keep ``id``, ``question``, ``answer``, ``type``,
+              ``supporting_facts``, and ``context``.
+            - ``"dev_titles"`` (default): keep ``question``, ``answer``, and
+              the supporting-fact titles only on the synthetic dev split.
+            - any other value: keep only ``question`` and ``answer``.
+        unofficial_dev: If ``True`` (default), use the last 25% of the hard
+            train split as a synthetic dev set. If ``False``, leave ``dev``
+            as ``None`` and rely solely on the official test split.
+        **kwargs: Forwarded to ``Dataset.__init__`` (for example,
+            ``train_size``, ``dev_size``, ``input_keys``).
+
+    Examples:
+        >>> from dspy.datasets.hotpotqa import HotPotQA
+        >>> data = HotPotQA(train_size=16, dev_size=200, test_size=0)  # doctest: +SKIP
+        >>> example = data.train[0]  # doctest: +SKIP
+        >>> example.question  # doctest: +SKIP
+    """
+
     def __init__(
         self,
         *args,
@@ -78,16 +116,3 @@ if __name__ == "__main__":
     print(dataset.train[15].question)
 
     print(len(dataset.train), len(dataset.dev), len(dataset.test))
-
-    print(dataset.dev[0].question)
-    print(dataset.dev[340].question)
-    print(dataset.dev[937].question)
-
-"""
-What was the population of the city where Woodward Avenue ends in 2010?
-Where did the star , who is also an executive producer, of the Mick begin her carrer?
-16 1000 0
-Both London and German have seen attacks during war, there was one specific type of attack that Germany called the blitz, what did London call a similar attack?
-Pre-Madonna was a collection of demos by the singer who was a leading presence during the emergence of what network?
-Alan Mills composed the classic folk song that tells the story of what?
-"""


### PR DESCRIPTION
Picks off some of #8926's docstring backlog. Happy to do more in follow-ups.

Adds Google-style docstrings to public APIs in `dspy/datasets/`:

- `dspy/datasets/dataset.py`: `Dataset` class, `reset_seeds`, `train`/`dev`/`test` properties, and `prepare_by_seed`.
- `dspy/datasets/colors.py`: `Colors` class and `sorted_by_suffix`.
- `dspy/datasets/gsm8k.py`: `GSM8K` class, `parse_integer_answer`, and `gsm8k_metric`.
- `dspy/datasets/hotpotqa.py`: `HotPotQA` class.

Pure documentation diff: no behavior, signatures, or imports changed. Style follows the Google Python docstring convention used in `dspy/primitives/module.py` and `dspy/utils/callback.py`.