### PR TITLE
fix: strip x-* vendor extensions from schemas sent to LM providers

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -10,6 +10,7 @@ from pydantic.fields import FieldInfo
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
 from dspy.adapters.types.tool import ToolCalls
 from dspy.adapters.utils import (
+    _strip_vendor_extensions,
     format_field_value,
     get_annotation_name,
     parse_value,
@@ -249,9 +250,9 @@ def _get_structured_outputs_response_format(
     # Generate the initial schema.
     schema = pydantic_model.model_json_schema()
 
-    # Remove any DSPy-specific metadata.
-    for prop in schema.get("properties", {}).values():
-        prop.pop("json_schema_extra", None)
+    # Strip vendor-extension keys (x-*) that Pydantic 2.x merges from
+    # json_schema_extra.  Strict-schema providers (e.g. Bedrock) reject them.
+    schema = _strip_vendor_extensions(schema)
 
     def enforce_required(schema_part: dict):
         """

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -74,6 +74,22 @@ def format_field_value(field_info: FieldInfo, value: Any, assume_text=True) -> s
         return {"type": "text", "text": string_value}
 
 
+def _strip_vendor_extensions(schema):
+    """Recursively remove ``x-*`` vendor-extension keys from a JSON schema.
+
+    Pydantic 2.x merges ``json_schema_extra`` dict entries as sibling keys
+    (e.g. ``x-comparison``) rather than nesting them under a
+    ``json_schema_extra`` key.  These vendor extensions are not part of the
+    JSON Schema standard that LM providers validate against, so strict-schema
+    providers (e.g. AWS Bedrock) reject them.
+    """
+    if isinstance(schema, dict):
+        return {k: _strip_vendor_extensions(v) for k, v in schema.items() if not (isinstance(k, str) and k.startswith("x-"))}
+    elif isinstance(schema, list):
+        return [_strip_vendor_extensions(item) for item in schema]
+    return schema
+
+
 def _get_json_schema(field_type):
     def move_type_to_front(d):
         # Move the 'type' key to the front of the dictionary, recursively, for LLM readability/adherence.
@@ -86,6 +102,7 @@ def _get_json_schema(field_type):
         return d
 
     schema = pydantic.TypeAdapter(field_type).json_schema()
+    schema = _strip_vendor_extensions(schema)
     schema = move_type_to_front(schema)
     return schema
 

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1016,3 +1016,55 @@ Outputs will be a JSON object with the following fields.
 In adhering to this structure, your objective is: 
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+def test_vendor_extensions_stripped_from_structured_output_schema():
+    """x-* keys from json_schema_extra must not leak into the schema sent to LM providers.
+
+    Pydantic 2.x merges json_schema_extra dict entries as sibling keys (e.g.
+    x-comparison) rather than nesting them under "json_schema_extra".  Strict-
+    schema providers like AWS Bedrock reject these unknown keys.
+
+    Regression test for https://github.com/stanfordnlp/dspy/issues/9686
+    """
+    from typing import Optional
+    from dspy.adapters.json_adapter import _get_structured_outputs_response_format
+
+    class Form(pydantic.BaseModel):
+        name: Optional[str] = pydantic.Field(
+            default=None,
+            json_schema_extra={"x-comparison": {"comparator": "exact"}},
+        )
+
+    class Extract(dspy.Signature):
+        text: str = dspy.InputField()
+        form: Form = dspy.OutputField()
+
+    model = _get_structured_outputs_response_format(
+        Extract, use_native_function_calling=True
+    )
+    schema = model.model_json_schema()
+    schema_str = str(schema)
+    assert "x-comparison" not in schema_str, f"vendor extension leaked into schema: {schema}"
+
+
+def test_vendor_extensions_stripped_from_prompt_schema():
+    """x-* keys must not appear in the schema snippet embedded in the prompt text.
+
+    Regression test for https://github.com/stanfordnlp/dspy/issues/9686
+    """
+    from typing import Optional
+    from dspy.adapters.utils import _get_json_schema
+
+    class Form(pydantic.BaseModel):
+        name: Optional[str] = pydantic.Field(
+            default=None,
+            json_schema_extra={"x-foo": "bar", "x-score": 42},
+        )
+
+    schema = _get_json_schema(Form)
+    schema_str = str(schema)
+    assert "x-foo" not in schema_str, f"vendor extension leaked: {schema}"
+    assert "x-score" not in schema_str, f"vendor extension leaked: {schema}"
+    # The non-x-* fields should still be present
+    assert "name" in schema_str


### PR DESCRIPTION
Fixes #9686

Pydantic 2.x merges `json_schema_extra` dict entries as sibling keys (e.g. `x-comparison`) rather than nesting them under a `json_schema_extra` key. The existing `pop('json_schema_extra')` in `json_adapter.py` was a no-op, so vendor extensions leaked into both the `response_format` schema and the prompt text.

Strict-schema providers like AWS Bedrock Converse reject these unknown keys:

```
BedrockException - 400: For 'anyOf', 'x-comparison' is not supported
```

The adapter then falls back to plain JSON mode and returns empty predictions.

### Changes

- Added `_strip_vendor_extensions()` recursive helper in `utils.py` that removes all `x-*` keys from a schema dict
- Applied it in `_get_json_schema()` (prompt text path)
- Replaced the dead `pop()` with `_strip_vendor_extensions()` in `_get_structured_outputs_response_format()` (response_format path)
- Two regression tests confirming both paths are clean

All existing tests pass (`pytest tests/adapters/test_json_adapter.py` — 30 passed).