### PR TITLE
docs(deployment): fix broken [!NOTE] admonition rendering

### DIFF
--- a/docs/docs/tutorials/deployment/index.md
+++ b/docs/docs/tutorials/deployment/index.md
@@ -149,11 +149,12 @@ Then we can define the DSPy program and log it to the MLflow server. "log" is an
 we store the program information along with environment requirements in the MLflow server. This is done via the `mlflow.dspy.log_model()`
 function, please see the code below:
 
-> [!NOTE]
-> As of MLflow 2.22.0, there is a caveat that you must wrap your DSPy program in a custom DSPy Module class when deploying with MLflow.
-> This is because MLflow requires positional arguments while DSPy pre-built modules disallow positional arguments, e.g., `dspy.Predict`
-> or `dspy.ChainOfThought`. To work around this, create a wrapper class that inherits from `dspy.Module` and implement your program's
-> logic in the `forward()` method, as shown in the example below.
+!!! note
+
+    As of MLflow 2.22.0, there is a caveat that you must wrap your DSPy program in a custom DSPy Module class when deploying with MLflow.
+    This is because MLflow requires positional arguments while DSPy pre-built modules disallow positional arguments, e.g., `dspy.Predict`
+    or `dspy.ChainOfThought`. To work around this, create a wrapper class that inherits from `dspy.Module` and implement your program's
+    logic in the `forward()` method, as shown in the example below.
 
 ```python
 import dspy


### PR DESCRIPTION
## Summary

Fixes a rendering bug on the [Deployment tutorial](https://dspy.ai/tutorials/deployment/). The MLflow caveat note was authored using GitHub-flavored alert syntax (`> [!NOTE]`), which is not supported by MkDocs Material. The block was rendering as a plain blockquote with the literal text `[!NOTE]` instead of a styled admonition.

Switched to the `!!! note` admonition syntax (already enabled via `pymdownx`/`admonition` in `docs/mkdocs.yml` and used throughout the rest of the docs, e.g. `docs/api/utils/configure.md`, `docs/learn/programming/tools.md`).

I also grepped the entire repo for any other `[!NOTE]`/`[!TIP]`/`[!WARNING]`/`[!IMPORTANT]`/`[!CAUTION]` occurrences and confirmed this was the only one.

## Before

![before](https://raw.githubusercontent.com/cmpnd-ai/dspy/assets/docs-deployment-note-screenshots/screenshots/before.png)

## After

![after](https://raw.githubusercontent.com/cmpnd-ai/dspy/assets/docs-deployment-note-screenshots/screenshots/after.png)

## Verification

Built locally with `mkdocs serve` from `docs/` and confirmed the block now renders as the standard MkDocs Material "Note" admonition card with the appropriate icon and styling.
