### PR TITLE
docs(observability): quote admonition titles so they render correctly

### DIFF
--- a/docs/docs/tutorials/observability/index.md
+++ b/docs/docs/tutorials/observability/index.md
@@ -188,7 +188,7 @@ the [MLflow Tracing Guide](https://mlflow.org/docs/3.0.0rc0/tracing).
 
 
 
-!!! info Learn more about MLflow
+!!! info "Learn more about MLflow"
 
     MLflow is an end-to-end LLMOps platform that offers extensive features like experiment tracking, evaluation, and deployment. To learn more about DSPy and MLflow integration, visit [this tutorial](../deployment/index.md#deploying-with-mlflow).
 
@@ -242,6 +242,6 @@ dspy.configure(callbacks=[AgentLoggingCallback()])
 ...
 ```
 
-!!! info Handling Inputs and Outputs in Callbacks
+!!! info "Handling Inputs and Outputs in Callbacks"
 
     Be cautious when working with input or output data in callbacks. Mutating them in-place can modify the original data passed to the program, potentially leading to unexpected behavior. To avoid this, it's strongly recommended to create a copy of the data before performing any operations that may alter it.


### PR DESCRIPTION
## Summary

Fixes a MkDocs Material rendering bug in `docs/tutorials/observability/index.md`.

`!!! info Learn more about MLflow` and `!!! info Handling Inputs and Outputs in Callbacks` were missing quotes around the title text. Without quotes, the title tokens are parsed as additional CSS classes and the rendered admonition title falls back to the type name (`Info`) instead of the intended descriptive title.

The live HTML before the fix:

```html
<div class="admonition info learn more about mlflow">
  <p class="admonition-title">Info</p>   <!-- expected: "Learn more about MLflow" -->
  ...
</div>
<div class="admonition info handling inputs and outputs in callbacks">
  <p class="admonition-title">Info</p>   <!-- expected: "Handling Inputs and Outputs in Callbacks" -->
  ...
</div>
```

Fix: wrap the titles in double quotes (`!!! info "Learn more about MLflow"`).

## Before / After screenshots

### MLflow tutorial admonition

| Before | After |
| --- | --- |
| ![obs1-before](https://raw.githubusercontent.com/cmpnd-ai/dspy/assets/docs-rendering-fixes-screenshots/screenshots/obs1-before.png) | ![obs1-after](https://raw.githubusercontent.com/cmpnd-ai/dspy/assets/docs-rendering-fixes-screenshots/screenshots/obs1-after.png) |

### Callbacks admonition

| Before | After |
| --- | --- |
| ![obs2-before](https://raw.githubusercontent.com/cmpnd-ai/dspy/assets/docs-rendering-fixes-screenshots/screenshots/obs2-before.png) | ![obs2-after](https://raw.githubusercontent.com/cmpnd-ai/dspy/assets/docs-rendering-fixes-screenshots/screenshots/obs2-after.png) |

## Verification

Built locally with `mkdocs serve` from `docs/` and confirmed both admonitions now show their intended titles.

## Notes

The previous version of this PR also un-hid an HTML-commented `Loading Dataset from sources` section in `docs/learn/evaluation/data.md`. That change was dropped after confirming the section was deliberately commented out in the docs reorg in #1790, and that the `[cheatsheet snippets](/cheatsheet/#dspy-dataloaders)` link inside that section now points at an anchor that no longer exists (the `## DSPy DataLoaders` cheatsheet section was removed in #8499). Surfacing that section is better handled in a follow-up that also restores or replaces the dead anchor.
