### PR TITLE
fix(adapters): strip x-* vendor extensions from schemas sent to the LM

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -10,6 +10,7 @@ from pydantic.fields import FieldInfo
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
 from dspy.adapters.types.tool import ToolCalls
 from dspy.adapters.utils import (
+    _strip_vendor_extensions,
     format_field_value,
     get_annotation_name,
     parse_value,
@@ -249,9 +250,10 @@ def _get_structured_outputs_response_format(
     # Generate the initial schema.
     schema = pydantic_model.model_json_schema()
 
-    # Remove any DSPy-specific metadata.
-    for prop in schema.get("properties", {}).values():
-        prop.pop("json_schema_extra", None)
+    # Strip vendor-only x-* extensions that Pydantic merged into the schema via json_schema_extra;
+    # strict-schema providers (Bedrock, OpenAI structured outputs) reject unknown keys.
+    # Details: https://swagger.io/docs/specification/v3_0/openapi-extensions/
+    schema = _strip_vendor_extensions(schema)
 
     def enforce_required(schema_part: dict):
         """

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -74,6 +74,21 @@ def format_field_value(field_info: FieldInfo, value: Any, assume_text=True) -> s
         return {"type": "text", "text": string_value}
 
 
+def _strip_vendor_extensions(node):
+    # Pydantic merges json_schema_extra entries into the generated schema as peer keys, and x-*
+    # is the OpenAPI / JSON Schema convention for vendor-only extensions. Strict-schema providers
+    # (AWS Bedrock, OpenAI structured outputs) reject these unknown keys, so drop them before send.
+    if isinstance(node, Mapping):
+        return {
+            k: _strip_vendor_extensions(v)
+            for k, v in node.items()
+            if not (isinstance(k, str) and k.startswith("x-"))
+        }
+    elif isinstance(node, list):
+        return [_strip_vendor_extensions(item) for item in node]
+    return node
+
+
 def _get_json_schema(field_type):
     def move_type_to_front(d):
         # Move the 'type' key to the front of the dictionary, recursively, for LLM readability/adherence.
@@ -87,6 +102,7 @@ def _get_json_schema(field_type):
 
     schema = pydantic.TypeAdapter(field_type).json_schema()
     schema = move_type_to_front(schema)
+    schema = _strip_vendor_extensions(schema)
     return schema
 
 

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -1,11 +1,13 @@
 # ruff: noqa: UP007
 
+import json
 from typing import Literal, Optional, Union
 
+import pydantic
 import pytest
 from pydantic import BaseModel
 
-from dspy.adapters.utils import parse_value
+from dspy.adapters.utils import _get_json_schema, parse_value
 
 
 class Profile(BaseModel):
@@ -105,3 +107,24 @@ def test_parse_value_json_repair():
     malformed = "not json or literal"
     with pytest.raises(Exception):
         parse_value(malformed, dict)
+
+
+def test_get_json_schema_strips_vendor_extensions():
+    class Inner(pydantic.BaseModel):
+        b: str = pydantic.Field(
+            json_schema_extra={"x-nested": {"note": "keep out"}},
+        )
+
+    class M(pydantic.BaseModel):
+        a: str = pydantic.Field(
+            description="keep me",
+            json_schema_extra={"x-probe": True},
+        )
+        children: list[Inner] = pydantic.Field(default_factory=list)
+
+    schema = _get_json_schema(M)
+    serialized = json.dumps(schema)
+    assert "x-probe" not in serialized
+    assert "x-nested" not in serialized
+    # Non-x- annotations such as description must be preserved.
+    assert schema["properties"]["a"]["description"] == "keep me"

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import pydantic
@@ -7,6 +8,7 @@ from litellm.utils import ChatCompletionMessageToolCall, Choices, Function, Mess
 from openai.types.responses import ResponseOutputMessage
 
 import dspy
+from dspy.adapters.json_adapter import _get_structured_outputs_response_format
 
 
 def test_json_adapter_passes_structured_output_when_supported_by_model():
@@ -44,6 +46,33 @@ def test_json_adapter_passes_structured_output_when_supported_by_model():
     assert response_format is not None
     assert issubclass(response_format, pydantic.BaseModel)
     assert response_format.model_fields.keys() == {"output1", "output2", "output3", "output4_unannotated"}
+
+
+def test_json_adapter_strips_vendor_extensions_from_schema():
+    class Address(pydantic.BaseModel):
+        street: str = pydantic.Field(
+            json_schema_extra={"x-comparison": {"comparator": "fuzzy"}},
+        )
+
+    class Form(pydantic.BaseModel):
+        name: str = pydantic.Field(
+            description="user name",
+            json_schema_extra={"x-comparison": {"comparator": "exact"}},
+        )
+        addresses: list[Address] = pydantic.Field(default_factory=list)
+
+    class Extract(dspy.Signature):
+        text: str = dspy.InputField()
+        form: Form = dspy.OutputField()
+
+    model = _get_structured_outputs_response_format(Extract, use_native_function_calling=True)
+    schema = model.model_json_schema()
+
+    # x-* vendor extensions from json_schema_extra must not reach the LM provider.
+    assert "x-comparison" not in json.dumps(schema)
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["form"]
+    assert schema["$defs"]["Form"]["properties"]["name"]["description"] == "user name"
 
 
 def test_json_adapter_not_using_structured_outputs_when_not_supported_by_model():


### PR DESCRIPTION
## Summary

Strip `x-*` vendor extensions from JSON schemas before they reach the LM provider.

Closes #9686

## What

- Add `_strip_vendor_extensions()` in `dspy/adapters/utils.py` — a small recursive helper that filters out keys starting with `x-` from a schema tree.
- Call it in `_get_json_schema()` (prompt-text path) and in `_get_structured_outputs_response_format()` (response_format path), replacing the existing no-op scrub that pops a key Pydantic never emits.

## Why not a `schema_transform` hook?

`x-*` is a well-defined standard convention meaning "vendor-only, do not interoperate." Stripping it is a defensible default — not a library-specific policy that warrants a user-facing hook. This fixes a latent bug for any user hitting a strict-schema provider (AWS Bedrock, OpenAI structured outputs in strict mode) without requiring them to know about or register a transform.

## Test plan

- `test_get_json_schema_strips_vendor_extensions` — verifies the prompt-text path strips `x-*` from flat and nested models while preserving non-`x-` keys like `description`.
- `test_json_adapter_strips_vendor_extensions_from_schema` — verifies the response_format path strips `x-*` from `$defs` (nested `List[Address]`) and confirms `enforce_required` invariants (`additionalProperties: false`, `required`) still hold.
