### PR TITLE
fix(react): suppress spurious execution error when model passes args to finish

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -107,7 +107,13 @@ class ReAct(Module):
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
             try:
-                trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](**pred.next_tool_args)
+                if pred.next_tool_name == "finish":
+                    # Call finish with no args regardless of what the model provided.
+                    # Models sometimes place output fields into finish's args; ignoring
+                    # them here avoids a misleading execution error in the trajectory.
+                    trajectory[f"observation_{idx}"] = self.tools["finish"]()
+                else:
+                    trajectory[f"observation_{idx}"] = self.tools[pred.next_tool_name](**pred.next_tool_args)
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
 
@@ -132,7 +138,13 @@ class ReAct(Module):
             trajectory[f"tool_args_{idx}"] = pred.next_tool_args
 
             try:
-                trajectory[f"observation_{idx}"] = await self.tools[pred.next_tool_name].acall(**pred.next_tool_args)
+                if pred.next_tool_name == "finish":
+                    # Same as in forward: ignore any args the model placed in finish.
+                    trajectory[f"observation_{idx}"] = await self.tools["finish"].acall()
+                else:
+                    trajectory[f"observation_{idx}"] = await self.tools[pred.next_tool_name].acall(
+                        **pred.next_tool_args
+                    )
             except Exception as err:
                 trajectory[f"observation_{idx}"] = f"Execution error in {pred.next_tool_name}: {_fmt_exc(err)}"
 

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -25,7 +25,6 @@ def test_tool_observation_preserves_custom_type():
     def make_images():
         return dspy.Image("https://example.com/test.png"), dspy.Image(Image.new("RGB", (100, 100), "red"))
 
-
     adapter = SpyChatAdapter()
     lm = DummyLM(
         [
@@ -424,6 +423,82 @@ async def test_async_tool_calling_with_pydantic_args():
         "observation_1": "Completed.",
     }
     assert outputs.trajectory == expected_trajectory
+
+
+def test_finish_with_extra_args_does_not_log_error():
+    """When the model passes output-field values as args to finish, no execution
+    error should appear in the trajectory (issue #9424)."""
+
+    def ask_time(prompt: str) -> str:
+        return "last week"
+
+    class MySig(dspy.Signature):
+        text: str = dspy.InputField()
+        time_type: str = dspy.OutputField()
+        confidence: float = dspy.OutputField()
+
+    react = dspy.ReAct(MySig, tools=[ask_time])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I need to ask about the time.",
+                "next_tool_name": "ask_time",
+                "next_tool_args": {"prompt": "when?"},
+            },
+            {
+                # Model places output fields into finish's args — common with
+                # structured-output signatures.
+                "next_thought": "I have all the info.",
+                "next_tool_name": "finish",
+                "next_tool_args": {"time_type": "relative", "confidence": 0.9},
+            },
+            {"reasoning": "done", "time_type": "relative", "confidence": 0.9},
+        ]
+    )
+    dspy.configure(lm=lm)
+
+    outputs = react(text="What happened last week?")
+    traj = outputs.trajectory
+
+    # The finish observation must be the normal success string, not an error.
+    assert traj["observation_1"] == "Completed.", f"Expected 'Completed.' but got: {traj['observation_1']!r}"
+    assert "Execution error" not in traj["observation_1"]
+
+
+@pytest.mark.asyncio
+async def test_async_finish_with_extra_args_does_not_log_error():
+    """Async version of test_finish_with_extra_args_does_not_log_error."""
+
+    async def ask_time(prompt: str) -> str:
+        return "last week"
+
+    class MySig(dspy.Signature):
+        text: str = dspy.InputField()
+        time_type: str = dspy.OutputField()
+        confidence: float = dspy.OutputField()
+
+    react = dspy.ReAct(MySig, tools=[ask_time])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I need to ask about the time.",
+                "next_tool_name": "ask_time",
+                "next_tool_args": {"prompt": "when?"},
+            },
+            {
+                "next_thought": "I have all the info.",
+                "next_tool_name": "finish",
+                "next_tool_args": {"time_type": "relative", "confidence": 0.9},
+            },
+            {"reasoning": "done", "time_type": "relative", "confidence": 0.9},
+        ]
+    )
+    with dspy.context(lm=lm):
+        outputs = await react.acall(text="What happened last week?")
+
+    traj = outputs.trajectory
+    assert traj["observation_1"] == "Completed.", f"Expected 'Completed.' but got: {traj['observation_1']!r}"
+    assert "Execution error" not in traj["observation_1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #9424

When a `dspy.ReAct` signature has structured output fields, some models
naturally place final output values into `next_tool_args` for the `finish`
step. Because `finish` is defined as a no-arg lambda, calling it with those
args triggers `Tool._validate_and_parse_args` to raise:

```
ValueError: Arg type is not in the tool's args.
```

This is caught by the trajectory-recording `except` block and saved as an
`"Execution error in finish: …"` string in the trajectory — even though
the run ultimately succeeds. The result is noisy, misleading logs and
trajectories that appear to indicate failure when they do not.

## Changes

- **`dspy/predict/react.py`** (`forward` and `aforward`): when
  `next_tool_name == "finish"`, call the finish tool with **no arguments**,
  regardless of what the model provided. Extra args that structured-output
  models put in `finish` are silently discarded — they are output fields
  being placed in the wrong location, not genuine tool inputs.

- **`tests/predict/test_react.py`**: two new tests
  (`test_finish_with_extra_args_does_not_log_error` and its `async`
  counterpart) that directly reproduce the failure mode described in the
  issue and assert that `observation_N == "Completed."` (not an error
  string).

## Test plan

- [ ] All existing `test_react.py` tests pass unchanged
- [ ] New `test_finish_with_extra_args_does_not_log_error` passes (sync)
- [ ] New `test_async_finish_with_extra_args_does_not_log_error` passes (async)

```
pytest tests/predict/test_react.py -v -k "not extra"
# 8 passed

pytest tests/predict/test_react.py -v -k "finish_with_extra"
# 2 passed
```