### PR TITLE
docs(teleprompt): add Google-style docstrings to LabeledFewShot and Ensemble

### DIFF
--- a/dspy/teleprompt/ensemble.py
+++ b/dspy/teleprompt/ensemble.py
@@ -8,9 +8,35 @@ TODO: The EnsembledProgram should actually imitate the structure of the individu
 
 
 class Ensemble(Teleprompter):
-    def __init__(self, *, reduce_fn=None, size=None, deterministic=False):
-        """A common reduce_fn is dspy.majority."""
+    """A teleprompter that combines multiple compiled programs into a single ensemble.
 
+    At inference time, the returned ``EnsembledProgram`` runs a subset (or all) of
+    the compiled programs and aggregates their outputs via ``reduce_fn``. A typical
+    use-case is majority voting with ``reduce_fn=dspy.majority``.
+
+    Args:
+        reduce_fn: A callable that takes a list of program outputs and returns a
+            single aggregated output. A common choice is ``dspy.majority``.
+            If ``None``, the raw list of outputs is returned. Defaults to ``None``.
+        size: If set, randomly sample this many programs from the ensemble at each
+            forward call. If ``None``, all programs are used. Defaults to ``None``.
+        deterministic: Reserved for future use. Must be ``False``. Defaults to ``False``.
+
+    Examples:
+        ```python
+        import dspy
+
+        # Suppose we have several compiled QA programs
+        programs = [compiled_qa_v1, compiled_qa_v2, compiled_qa_v3]
+
+        teleprompter = dspy.Ensemble(reduce_fn=dspy.majority)
+        ensemble_qa = teleprompter.compile(programs)
+
+        result = ensemble_qa(question="What is the capital of France?")
+        ```
+    """
+
+    def __init__(self, *, reduce_fn=None, size=None, deterministic=False):
         assert deterministic is False, "TODO: Implement example hashing for deterministic ensemble."
 
         self.reduce_fn = reduce_fn
@@ -18,6 +44,18 @@ class Ensemble(Teleprompter):
         self.deterministic = deterministic
 
     def compile(self, programs):
+        """Combine a list of programs into a single ``EnsembledProgram``.
+
+        Args:
+            programs: A list of compiled DSPy programs (``dspy.Module`` instances)
+                to ensemble together.
+
+        Returns:
+            An ``EnsembledProgram`` that, on each forward call, runs ``size``
+            randomly sampled programs (or all programs if ``size`` is ``None``)
+            and returns either the reduced result (when ``reduce_fn`` is set) or
+            the raw list of outputs.
+        """
         size = self.size
         reduce_fn = self.reduce_fn
 
@@ -29,6 +67,7 @@ class Ensemble(Teleprompter):
                 self.programs = programs
 
             def forward(self, *args, **kwargs):
+                """Run the ensemble and return the aggregated (or raw) outputs."""
                 programs = random.sample(self.programs, size) if size else self.programs
                 outputs = [prog(*args, **kwargs) for prog in programs]
 

--- a/dspy/teleprompt/vanilla.py
+++ b/dspy/teleprompt/vanilla.py
@@ -4,10 +4,56 @@ from dspy.teleprompt.teleprompt import Teleprompter
 
 
 class LabeledFewShot(Teleprompter):
+    """A simple teleprompter that assigns labeled training examples as few-shot demos.
+
+    Unlike bootstrapping-based optimizers, ``LabeledFewShot`` does not run the
+    student program or evaluate any metric. It simply selects up to ``k`` examples
+    from the provided ``trainset`` and attaches them directly as demonstrations to
+    every predictor in the student program.
+
+    Args:
+        k: Maximum number of labeled demonstrations to attach to each predictor.
+            Defaults to 16.
+
+    Examples:
+        ```python
+        import dspy
+
+        qa = dspy.ChainOfThought("question -> answer")
+        trainset = [
+            dspy.Example(question="What is 2+2?", answer="4").with_inputs("question"),
+            dspy.Example(question="What color is the sky?", answer="Blue").with_inputs("question"),
+        ]
+
+        teleprompter = dspy.LabeledFewShot(k=2)
+        compiled_qa = teleprompter.compile(qa, trainset=trainset)
+        ```
+    """
+
     def __init__(self, k=16):
         self.k = k
 
     def compile(self, student, *, trainset, sample=True):
+        """Compile the student program with labeled few-shot demonstrations.
+
+        Attaches up to ``k`` examples from ``trainset`` as demonstrations to each
+        predictor in a reset copy of ``student``. When ``sample=True`` (default),
+        examples are drawn randomly (seeded for reproducibility); otherwise the
+        first ``k`` examples are used in order.
+
+        Args:
+            student: The DSPy program to compile. Each of its predictors will
+                receive the selected demonstrations.
+            trainset: A list of labeled ``dspy.Example`` objects to draw
+                demonstrations from.
+            sample: If ``True``, randomly sample up to ``k`` examples from
+                ``trainset``. If ``False``, take the first ``k`` examples in
+                order. Defaults to ``True``.
+
+        Returns:
+            A compiled copy of ``student`` whose predictors have their ``demos``
+            field populated with labeled examples from ``trainset``.
+        """
         self.student = student.reset_copy()
         self.trainset = trainset
 


### PR DESCRIPTION
## Summary

Contributes to #8926 — adds missing Google-style docstrings to two
optimizer classes in `dspy/teleprompt/`:

| File | What was added |
|------|---------------|
| `vanilla.py` | Class docstring for `LabeledFewShot` (with Args + Examples); method docstring for `compile` (with Args + Returns) |
| `ensemble.py` | Class docstring for `Ensemble` (with Args + Examples); method docstring for `compile` (with Args + Returns); one-line docstring for `EnsembledProgram.forward` |

All docstrings follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) as required by CONTRIBUTING.md, include correct Args/Returns/Examples sections, and describe only behavior that is verified directly from the source code.

## Checklist
- [x] Docstrings are 100% accurate (verified against implementation)
- [x] Google Python Style Guide format
- [x] Code examples included for the two public-facing classes
- [x] `ruff check` passes on both changed files

resolve #8926

https://claude.ai/code/session_01C4NGqpY8LisAhZmz1aSA1y