### PR TITLE
docs: fix two duplicate-word typos missed by #9641

### DIFF
--- a/docs/docs/deep-dive/data-handling/loading-custom-data.md
+++ b/docs/docs/deep-dive/data-handling/loading-custom-data.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Creating a Custom Dataset
 
-We've seen how to work with with `Example` objects and use the `HotPotQA` class to load the HuggingFace HotPotQA dataset as a list of `Example` objects. But in production, such structured datasets are rare. Instead, you'll find yourself working on a custom dataset and might question: how do I create my own dataset or what format should it be?
+We've seen how to work with `Example` objects and use the `HotPotQA` class to load the HuggingFace HotPotQA dataset as a list of `Example` objects. But in production, such structured datasets are rare. Instead, you'll find yourself working on a custom dataset and might question: how do I create my own dataset or what format should it be?
 
 In DSPy, your dataset is a list of `Examples`, which we can accomplish in two ways:
 

--- a/dspy/teleprompt/bootstrap_finetune.py
+++ b/dspy/teleprompt/bootstrap_finetune.py
@@ -269,7 +269,7 @@ def prepare_teacher(student: Module, teacher: Module | None = None) -> Module:
     if teacher is None:
         return student
 
-    # Ensuring that the student and teacher are are structurally equivalent
+    # Ensuring that the student and teacher are structurally equivalent
     assert_structural_equivalency(student, teacher)
 
     # Ensuring that the student and teacher programs do not share predictors


### PR DESCRIPTION
## Summary

Fixes two cases of accidentally-duplicated stop words that were missed by the recently merged PR #9641 ("docs: fix duplicate 'the the' typos across docs, source, and tests"):

| File | Before | After |
|------|--------|-------|
| `dspy/teleprompt/bootstrap_finetune.py` (line 272, comment) | `the student and teacher are are structurally equivalent` | `the student and teacher are structurally equivalent` |
| `docs/docs/deep-dive/data-handling/loading-custom-data.md` (line 9) | `how to work with with \`Example\` objects` | `how to work with \`Example\` objects` |

Both are pure prose-quality fixes — comment text in one Python module and a sentence in one Markdown doc. No functional, API, or behavior change.

## Why

PR #9641 caught the most common dup pattern (`the the`) but a broader regex over `\b(\w+)\s+\1\b` for short stop words still surfaces these two leftovers on `upstream/main`. Cleaning them keeps the repo consistent with the recently-merged style fix.

## How to test

```bash
grep -rn -E "\b(are are|with with)\b" docs/ dspy/ tests/
# returns no matches after this PR
```

No tests, builds, or runtime behavior are affected.