### PR TITLE
chore(ci): remove unused setup-node step from docs-push workflow

### DIFF
--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -17,10 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: "18"
       - name: Install dependencies and build
         run: |
           cd docs


### PR DESCRIPTION
## Why

The `Set up Node.js` step in `.github/workflows/docs-push.yml` has been a no-op since [#1657](https://github.com/stanfordnlp/dspy/pull/1657) (Oct 2024) migrated the docs from a Node-based static site generator to MkDocs. That PR switched the build commands from `npm install && npm run build` to:

```yaml
cd docs
pip install -r requirements.txt
mkdocs build
```

…but left the `Set up Node.js` step in place. Nothing in `docs/requirements.txt` (`mkdocs`, `mkdocs-material[imaging]`, `mkdocs-jupyter`, `mkdocs-redirects`, `mkdocstrings(-python)`, `mkdocs-llmstxt`) shells out to `node` or `npm`, so installing Node 18 is pure cruft.

Discovered while reviewing the [`actions/setup-node` 6.3.0 → 6.4.0 dependabot bump](https://github.com/stanfordnlp/dspy/pull/9696) — every dependabot churn on `actions/setup-node` since Oct 2024 has been re-pinning a step whose output the build never consumes.

## Verification

Reproduced the docs build locally with `node`/`npm` stripped from `PATH`:

```
env -i PATH=<python-bin>:/usr/bin:/bin python3 -m mkdocs build
```

Build completed successfully (`Documentation built in 39.47 seconds`) and produced `docs/site/index.html`.

## Change

Drops the `Set up Node.js` step (and its associated SHA-pinned external action) from the `build-test` job. No other change.