### PR TITLE
fix(evaluate): expose timeout and straggler_limit in Evaluate

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -81,6 +81,8 @@ class Evaluate:
         failure_score: float = 0.0,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int = 120,
+        straggler_limit: int = 3,
         **kwargs,
     ):
         """
@@ -97,6 +99,10 @@ class Evaluate:
             failure_score (float): The default score to use if evaluation fails due to an exception.
             save_as_csv (Optional[str]): The file name where the csv will be saved.
             save_as_json (Optional[str]): The file name where the json will be saved.
+            timeout (int): Seconds before a straggler task is resubmitted. Set to 0 to disable straggler
+                detection. Defaults to 120.
+            straggler_limit (int): Straggler detection only activates when at most this many tasks remain
+                outstanding. Defaults to 3.
 
         """
         self.devset = devset
@@ -109,6 +115,8 @@ class Evaluate:
         self.failure_score = failure_score
         self.save_as_csv = save_as_csv
         self.save_as_json = save_as_json
+        self.timeout = timeout
+        self.straggler_limit = straggler_limit
 
         if "return_outputs" in kwargs:
             raise ValueError("`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object.")
@@ -165,6 +173,8 @@ class Evaluate:
             max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
             provide_traceback=self.provide_traceback,
             compare_results=True,
+            timeout=self.timeout,
+            straggler_limit=self.straggler_limit,
         )
 
         def process_item(example):

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -33,6 +33,20 @@ def test_evaluate_initialization():
     assert ev.metric == answer_exact_match
     assert ev.num_threads is None
     assert not ev.display_progress
+    assert ev.timeout == 120
+    assert ev.straggler_limit == 3
+
+
+def test_evaluate_custom_timeout():
+    devset = [new_example("What is 1+1?", "2")]
+    ev = Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        timeout=0,
+        straggler_limit=1,
+    )
+    assert ev.timeout == 0
+    assert ev.straggler_limit == 1
 
 
 def test_evaluate_call():


### PR DESCRIPTION
## Summary

`dspy.Parallel` already accepts `timeout` and `straggler_limit` arguments and forwards them to `ParallelExecutor`, but `dspy.Evaluate` hard-wires the 120-second straggler threshold with no way to override it. When individual evaluation examples routinely take longer than 120 seconds (e.g. multi-step ReAct programs, slow external tools, or large-context reasoning chains), `ParallelExecutor`'s straggler logic fires unnecessarily: still-running tasks get resubmitted, which can race against `executor.shutdown(wait=False)` and raise a `RuntimeError: cannot schedule new futures after shutdown`.

This PR adds `timeout` (default `120`) and `straggler_limit` (default `3`) to `Evaluate.__init__` and passes them through to `ParallelExecutor`, mirroring exactly what `Parallel` already does. Setting `timeout=0` disables straggler detection entirely for use cases where all examples are expected to be slow. All existing defaults are preserved, making the change fully backwards-compatible.

## Issue

Fixes #9574

## Local verification

```
cd /tmp/dspy
ruff check dspy/evaluate/evaluate.py tests/evaluate/test_evaluate.py
python -m pytest tests/evaluate/ -v -x
```

```
ruff: All checks passed!

tests/evaluate/test_evaluate.py::test_evaluate_initialization PASSED
tests/evaluate/test_evaluate.py::test_evaluate_custom_timeout PASSED
tests/evaluate/test_evaluate.py::test_evaluate_call PASSED
tests/evaluate/test_evaluate.py::test_evaluate_single_thread_runs_in_main_thread PASSED
tests/evaluate/test_evaluate.py::test_construct_result_df PASSED
tests/evaluate/test_evaluate.py::test_multithread_evaluate_call PASSED
tests/evaluate/test_evaluate.py::test_multi_thread_evaluate_call_cancelled PASSED
tests/evaluate/test_evaluate.py::test_evaluate_call_wrong_answer PASSED
tests/evaluate/test_evaluate.py::test_evaluate_display_table[False-False-False] PASSED
tests/evaluate/test_evaluate.py::test_evaluate_display_table[5-False-False] PASSED
tests/evaluate/test_evaluate.py::test_evaluate_display_table[True-False-False] PASSED
...
20 passed, 25 skipped in 1.93s
```

=== LOCAL_TEST_PASSED ===

## Risk

Fully additive; the two new keyword-only arguments default to the same values `ParallelExecutor` already uses, so no existing behaviour changes. Users who pass `timeout=0` disable the straggler-resubmission path, which could leave permanently-hung threads alive, but that is an explicit opt-in that callers would choose when they know their tasks are slow-but-not-hung.