### PR TITLE
fix(clients): honor caching=False per-call in dspy.Embedder

### DIFF
--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -93,7 +93,7 @@ class Embedder:
             raise ValueError("All inputs must be strings.")
 
         batch_size = batch_size or self.batch_size
-        caching = caching or self.caching
+        caching = caching if caching is not None else self.caching
         merged_kwargs = self.default_kwargs.copy()
         merged_kwargs.update(kwargs)
 

--- a/tests/clients/test_embedding.py
+++ b/tests/clients/test_embedding.py
@@ -151,3 +151,49 @@ async def test_async_embedding():
 
         assert len(result) == len(inputs)
         np.testing.assert_allclose(result, mock_embeddings)
+
+
+def test_call_caching_false_overrides_instance_true(cache):
+    model = "text-embedding-ada-002"
+    inputs = ["hello"]
+    with patch("litellm.embedding") as mock_litellm:
+        mock_litellm.return_value = MockEmbeddingResponse([[0.1, 0.2, 0.3]])
+        embedding = Embedder(model, caching=True)
+        embedding(inputs)
+        embedding(inputs, caching=False)
+        assert mock_litellm.call_count == 2
+
+
+def test_call_caching_true_overrides_instance_false(cache):
+    model = "text-embedding-ada-002"
+    inputs = ["hello"]
+    with patch("litellm.embedding") as mock_litellm:
+        mock_litellm.return_value = MockEmbeddingResponse([[0.1, 0.2, 0.3]])
+        embedding = Embedder(model, caching=False)
+        embedding(inputs, caching=True)
+        embedding(inputs, caching=True)
+        assert mock_litellm.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_acall_caching_false_overrides_instance_true(cache):
+    model = "text-embedding-ada-002"
+    inputs = ["hello"]
+    with patch("litellm.aembedding") as mock_litellm:
+        mock_litellm.return_value = MockEmbeddingResponse([[0.1, 0.2, 0.3]])
+        embedding = Embedder(model, caching=True)
+        await embedding.acall(inputs)
+        await embedding.acall(inputs, caching=False)
+        assert mock_litellm.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_acall_caching_true_overrides_instance_false(cache):
+    model = "text-embedding-ada-002"
+    inputs = ["hello"]
+    with patch("litellm.aembedding") as mock_litellm:
+        mock_litellm.return_value = MockEmbeddingResponse([[0.1, 0.2, 0.3]])
+        embedding = Embedder(model, caching=False)
+        await embedding.acall(inputs, caching=True)
+        await embedding.acall(inputs, caching=True)
+        assert mock_litellm.call_count == 1


### PR DESCRIPTION
`Embedder._preprocess` used `caching or self.caching`, silently
  ignoring `caching=False` when the instance default was True. Switched
   to an explicit None-sentinel check. Applies to both `__call__` and
  `acall`. Introduced incidentally in #8080.

  Added 4 tests for the override matrix; inherit cases already covered
  by `test_litellm_embedding`.

  ## Warnings
  Used Claude (Anthropic) for code archaeology and test scaffolding.
  Verified by running tests pre- and post-fix.