### PR TITLE
docs: add Google-style docstrings to MultiChainComparison

### DIFF
--- a/dspy/predict/multi_chain_comparison.py
+++ b/dspy/predict/multi_chain_comparison.py
@@ -5,7 +5,33 @@ from dspy.signatures.signature import ensure_signature
 
 
 class MultiChainComparison(Module):
+    """Compares multiple chain-of-thought reasoning attempts and produces a refined answer.
+
+    Given ``M`` reasoning attempts (typically from ``ChainOfThought`` with high
+    temperature), this module asks the LM to review all attempts holistically
+    and produce a corrected rationale and final answer. This is useful for
+    self-consistency style pipelines where you generate several candidate
+    solutions and want the model to pick or synthesize the best one.
+
+    Example:
+        >>> import dspy
+        >>> cot = dspy.ChainOfThought("question -> answer", temperature=0.7, n=3)
+        >>> compare = dspy.MultiChainComparison("question -> answer", M=3)
+        >>> completions = cot(question="What is 12 * 15?").completions
+        >>> result = compare(completions, question="What is 12 * 15?")
+    """
+
     def __init__(self, signature, M=3, temperature=0.7, **config):  # noqa: N803
+        """Initializes the MultiChainComparison module.
+
+        Args:
+            signature: The task signature defining input and output fields.
+            M: The number of reasoning attempts to compare. Must match the
+                number of completions passed to ``forward``.
+            temperature: Sampling temperature for the comparison LM call.
+            **config: Additional configuration passed to the underlying
+                ``Predict`` module.
+        """
         super().__init__()
 
         self.M = M
@@ -33,6 +59,24 @@ class MultiChainComparison(Module):
         self.predict = Predict(signature, temperature=temperature, **config)
 
     def forward(self, completions, **kwargs):
+        """Compares reasoning attempts and returns a refined prediction.
+
+        Extracts the rationale and answer from each completion, formats them
+        as numbered "student attempts", and asks the LM to synthesize a
+        corrected rationale and final answer.
+
+        Args:
+            completions: A list of ``M`` completion dicts, each containing
+                a ``rationale`` (or ``reasoning``) key and the output field.
+            **kwargs: Additional input field values for the signature.
+
+        Returns:
+            A ``Prediction`` with a ``rationale`` field containing the
+            corrected reasoning and the original output field.
+
+        Raises:
+            AssertionError: If ``len(completions)`` does not equal ``M``.
+        """
         attempts = []
 
         for c in completions:


### PR DESCRIPTION
Adds docstrings to `dspy/predict/multi_chain_comparison.py` — class, `__init__`, and `forward`.

Follows the Google Python style guide as specified in #8926.

This file had zero docstrings. Now all public APIs are documented with descriptions, args, returns, and a class-level usage example.