### PR TITLE
rlm: treat None code from sub-LLM as empty

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -64,8 +64,10 @@ You have max {max_llm_calls} sub-LLM calls. When done, call SUBMIT() with your o
 _PYTHON_FENCE_LANGS = {"python", "py", "python3", "py3", ""}
 
 
-def _strip_code_fences(code: str) -> str:
+def _strip_code_fences(code: str | None) -> str:
     """Extract Python code from markdown fences, or return as-is if no fences."""
+    if not code:
+        return ""
     code = code.strip()
     if "```" not in code:
         return code


### PR DESCRIPTION
Closes #9632. Local models occasionally return `Reasoning: None / Code: None`; `.strip()` raises `AttributeError` and the iteration crashes. Coerce None to empty string.