### PR TITLE
fix(lm): handle None usage from Responses API on truncated responses

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -106,7 +106,7 @@ class BaseLM:
             "kwargs": kwargs,
             "response": response,
             "outputs": outputs,
-            "usage": dict(getattr(response, "usage", {})),
+            "usage": dict(getattr(response, "usage", {}) or {}),
             "cost": getattr(response, "_hidden_params", {}).get("response_cost"),
             "timestamp": datetime.datetime.now().isoformat(),
             "uuid": str(uuid.uuid4()),

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -194,7 +194,7 @@ class LM(BaseLM):
         self._check_truncation(results)
 
         if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker:
-            settings.usage_tracker.add_usage(self.model, dict(getattr(results, "usage", {})))
+            settings.usage_tracker.add_usage(self.model, dict(getattr(results, "usage", {}) or {}))
         return results
 
     async def aforward(
@@ -235,7 +235,7 @@ class LM(BaseLM):
         self._check_truncation(results)
 
         if not getattr(results, "cache_hit", False) and dspy.settings.usage_tracker:
-            settings.usage_tracker.add_usage(self.model, dict(getattr(results, "usage", {})))
+            settings.usage_tracker.add_usage(self.model, dict(getattr(results, "usage", {}) or {}))
         return results
 
     def launch(self, launch_kwargs: dict[str, Any] | None = None):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1029,6 +1029,119 @@ def test_responses_api_with_pydantic_model_input():
     }
 
 
+def test_responses_api_with_none_usage():
+    """Responses API returns usage=None for incomplete/truncated responses (e.g. max_output_tokens hit)."""
+    api_response = ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0.0,
+        error=None,
+        incomplete_details={"reason": "max_output_tokens"},
+        instructions=None,
+        model="openai/gpt-5-mini",
+        object="response",
+        output=[
+            ResponseOutputMessage(
+                **{
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "incomplete",
+                    "content": [
+                        {"type": "output_text", "text": "Partial response that was truncated", "annotations": []}
+                    ],
+                },
+            ),
+        ],
+        metadata={},
+        parallel_tool_calls=False,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=100,
+        previous_response_id=None,
+        reasoning=None,
+        status="incomplete",
+        text=None,
+        truncation="disabled",
+        usage=None,
+        user=None,
+    )
+
+    with mock.patch("litellm.responses", autospec=True, return_value=api_response):
+        lm = dspy.LM(
+            model="openai/gpt-5-mini",
+            model_type="responses",
+            cache=False,
+            temperature=1.0,
+            max_tokens=16000,
+        )
+
+        with track_usage() as tracker:
+            result = lm("test query")
+
+        assert result == [{"text": "Partial response that was truncated"}]
+        assert lm.history[-1]["usage"] == {}
+        assert tracker.get_total_tokens() == {}
+
+
+@pytest.mark.asyncio
+async def test_responses_api_with_none_usage_async():
+    """Async path: Responses API returns usage=None for incomplete/truncated responses."""
+    api_response = ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0.0,
+        error=None,
+        incomplete_details={"reason": "max_output_tokens"},
+        instructions=None,
+        model="openai/gpt-5-mini",
+        object="response",
+        output=[
+            ResponseOutputMessage(
+                **{
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "status": "incomplete",
+                    "content": [
+                        {"type": "output_text", "text": "Partial async response", "annotations": []}
+                    ],
+                },
+            ),
+        ],
+        metadata={},
+        parallel_tool_calls=False,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=100,
+        previous_response_id=None,
+        reasoning=None,
+        status="incomplete",
+        text=None,
+        truncation="disabled",
+        usage=None,
+        user=None,
+    )
+
+    with mock.patch("litellm.aresponses", autospec=True, return_value=api_response):
+        lm = dspy.LM(
+            model="openai/gpt-5-mini",
+            model_type="responses",
+            cache=False,
+            temperature=1.0,
+            max_tokens=16000,
+        )
+
+        with track_usage() as tracker:
+            result = await lm.acall("test query")
+
+        assert result == [{"text": "Partial async response"}]
+        assert lm.history[-1]["usage"] == {}
+        assert tracker.get_total_tokens() == {}
+
+
 @pytest.mark.asyncio
 async def test_streaming_passes_headers_correctly():
     from dspy.clients.lm import _get_stream_completion_fn


### PR DESCRIPTION
## Problem

OpenAI's Responses API returns `usage=None` for incomplete/truncated responses (e.g. when `max_output_tokens` is hit or content filtering triggers). LiteLLM passes this through as-is across all supported versions (1.64.0–1.82.6).

The existing code `dict(getattr(response, "usage", {}))` only guards against the attribute being **absent** — not against it being explicitly `None`. Since `getattr` returns the attribute value when it exists (even if `None`), this becomes `dict(None)` and raises `TypeError: 'NoneType' object is not iterable`.

### Why `getattr` alone is insufficient

`getattr(obj, "usage", {})` returns the default `{}` only when the attribute **does not exist** on the object. Both `ModelResponse` (chat/text) and `ResponsesAPIResponse` (responses) always declare a `usage` attribute, so the default is never used for litellm types.

- **`ModelResponse`** (chat/text): `usage` always exists and defaults to a zeroed `Usage()` — never `None`, never absent.
- **`ResponsesAPIResponse`** (responses): `usage` always exists as a declared `Optional[ResponseAPIUsage]` field — present but set to `None` on truncated responses.

However, `getattr` with a default still serves a purpose: `BaseLM` subclasses can implement custom `forward()` methods returning arbitrary response objects (plain dicts, custom classes) that may not have a `usage` attribute at all. The `getattr` default catches that case.

So both guards are needed: `getattr(..., {})` handles a missing attribute (custom LMs), and `or {}` handles a `None` attribute (Responses API truncation).

## Fix

Add `or {}` to coerce `None` to an empty dict at all 3 call sites:

- `dspy/clients/base_lm.py:109` — history entry construction
- `dspy/clients/lm.py:197` — sync `forward()` usage tracking
- `dspy/clients/lm.py:238` — async `aforward()` usage tracking

## Tests

Added two new tests (`test_responses_api_with_none_usage` and `test_responses_api_with_none_usage_async`) that mock a truncated Responses API response with `usage=None` and verify the sync and async paths handle it gracefully.