### PR TITLE
Update versions for 3.2.1

### DIFF
--- a/.github/.internal_dspyai/pyproject.toml
+++ b/.github/.internal_dspyai/pyproject.toml
@@ -2,7 +2,7 @@
 #replace_package_name_marker
 name="dspy-ai"  
 #replace_package_version_marker
-version="3.2.0"  
+version="3.2.1"  
 description = "DSPy"  
 readme = {text = "`dspy-ai` is a compatibility alias for the [dspy](https://pypi.org/project/dspy/) package. Install `dspy` instead: `pip install dspy`.", content-type = "text/markdown"}  
 authors = [  
@@ -11,7 +11,7 @@ authors = [
 license = { text = "MIT License" }  
 requires-python = ">=3.9" 
 #replace_dspy_version_marker 
-dependencies = ["dspy>=3.2.0"]  
+dependencies = ["dspy>=3.2.1"]  
 urls = { "Homepage" = "https://github.com/stanfordnlp/dsp" }  
   
 [build-system]  

--- a/dspy/__metadata__.py
+++ b/dspy/__metadata__.py
@@ -1,7 +1,7 @@
 #replace_package_name_marker
 __name__="dspy"
 #replace_package_version_marker
-__version__="3.2.0"
+__version__="3.2.1"
 __description__="DSPy"
 __url__="https://github.com/stanfordnlp/dspy"
 __author__="Omar Khattab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 #replace_package_name_marker
 name="dspy"
 #replace_package_version_marker
-version="3.2.0"
+version="3.2.1"
 description = "DSPy"
 readme = "README.md"
 authors = [{ name = "Omar Khattab", email = "okhattab@stanford.edu" }]

--- a/uv.lock
+++ b/uv.lock
@@ -749,7 +749,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "3.2.0"
+version = "3.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Updates main version metadata after publishing 3.2.1.

Changes mirror the release workflow's main version bump step:
- Bump dspy package version to 3.2.1
- Bump dspy runtime metadata version to 3.2.1
- Bump dspy-ai alias package version and dspy dependency to 3.2.1
- Update uv.lock to 3.2.1

Validation:
- uv lock --check
- uv run pytest -q tests/metadata/test_metadata.py
- uv run python version assertions
- uv run python -m build --wheel