### PR TITLE
fix(lm): reject unsupported model types early

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -71,6 +71,11 @@ class LM(BaseLM):
                 stripped before sending requests to the provider.
         """
         # Remember to update LM.copy() if you modify the constructor!
+        if model_type not in {"chat", "text", "responses"}:
+            raise ValueError(
+                f"Unsupported model_type={model_type!r}. Expected one of: 'chat', 'text', 'responses'."
+            )
+
         self.model = model
         self.model_type = model_type
         self.cache = cache

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tempfile
 import time
 import warnings
@@ -44,6 +45,11 @@ def make_response(output_blocks):
         usage=ResponseAPIUsage(input_tokens=1, output_tokens=1, total_tokens=2),
         user=None,
     )
+
+
+def test_lm_rejects_unsupported_model_type():
+    with pytest.raises(ValueError, match="Unsupported model_type='invalid'"):
+        dspy.LM(model="openai/dspy-test-model", model_type="invalid")
 
 
 def test_chat_lms_can_be_queried(litellm_test_server):
@@ -339,7 +345,9 @@ def test_reasoning_model_requirements(model_name):
     # Should raise assertion error if temperature or max_tokens requirements not met
     with pytest.raises(
         ValueError,
-        match="reasoning models require passing temperature=1.0 or None and max_tokens >= 16000 or None",
+        match=re.escape(
+            "reasoning models require passing temperature=1.0 or None and max_tokens >= 16000 or None"
+        ),
     ):
         dspy.LM(
             model=model_name,


### PR DESCRIPTION
## Summary
- Validate `dspy.LM(model_type=...)` at construction time.
- Raise a clear `ValueError` for unsupported model types instead of letting calls fail later with an unclear completion-path error.
- Clean up an existing regex lint warning in the same test file so focused lint passes.

## Verification
- `uv run pytest tests/clients/test_lm.py -q -k "model_type or chat_lms_can_be_queried or reasoning_model_requirements"`
- `uv run ruff check dspy/clients/lm.py tests/clients/test_lm.py`

## PR overlap check
- Searched open PRs for `LM model_type unsupported validation`; no existing open PR covers this specific fix.