### PR TITLE
docs: add Google-style docstrings to teleprompt/random_search.py

### DIFF
--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -25,6 +25,19 @@ from .vanilla import LabeledFewShot
 
 
 class BootstrapFewShotWithRandomSearch(Teleprompter):
+    """Randomly search over bootstrapped few-shot demonstration sets.
+
+    Generates multiple candidate programs by running ``BootstrapFewShot`` with
+    different random seeds and shuffled training sets, then evaluates each
+    candidate on a validation set and returns the best one.  Three special
+    seeds are always tried first: a zero-shot baseline (seed -3), a
+    labeled-only baseline (seed -2), and an unshuffled bootstrap (seed -1).
+
+    The returned program carries a ``candidate_programs`` attribute with all
+    evaluated candidates sorted by descending score, so callers can inspect
+    the full search history.
+    """
+
     def __init__(
         self,
         metric,
@@ -38,6 +51,29 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
         stop_at_score=None,
         metric_threshold=None,
     ):
+        """Initialize the random-search optimizer.
+
+        Args:
+            metric: Evaluation function used to score each candidate program.
+            teacher_settings: Optional dict of settings forwarded to the
+                teacher LM during bootstrapping.
+            max_bootstrapped_demos: Upper bound on bootstrapped demonstrations
+                per predictor.  Each candidate randomly samples between 1 and
+                this value.
+            max_labeled_demos: Maximum number of labeled demonstrations
+                included alongside bootstrapped ones.
+            max_rounds: Number of bootstrapping rounds passed to each
+                ``BootstrapFewShot`` run.
+            num_candidate_programs: How many random-seed candidates to
+                generate (in addition to the three special seeds).
+            num_threads: Thread count for the ``Evaluate`` calls.
+            max_errors: Maximum evaluation errors tolerated before aborting.
+                Falls back to ``dspy.settings.max_errors`` when *None*.
+            stop_at_score: If set, stop the search early once a candidate
+                reaches this score.
+            metric_threshold: Passed to ``BootstrapFewShot`` to filter
+                bootstrapped demos by quality.
+        """
         self.metric = metric
         self.teacher_settings = teacher_settings or {}
         self.max_rounds = max_rounds
@@ -55,6 +91,30 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
         print(f"Will attempt to bootstrap {self.num_candidate_sets} candidate sets.")
 
     def compile(self, student, *, teacher=None, trainset, valset=None, restrict=None, labeled_sample=True):
+        """Search for the best demonstration set and return the top program.
+
+        Iterates over the special seeds (-3, -2, -1) and then
+        ``num_candidate_programs`` random seeds.  For each seed the training
+        set is shuffled, a ``BootstrapFewShot`` optimizer produces a candidate
+        program, and that candidate is scored on *valset*.  The program with
+        the highest score is returned.
+
+        Args:
+            student: The ``dspy.Module`` to optimize.
+            teacher: Optional teacher module for bootstrapping.  When *None*,
+                the student acts as its own teacher.
+            trainset: Training examples used to bootstrap demonstrations.
+            valset: Validation examples for scoring candidates.  Defaults to
+                *trainset* when not provided.
+            restrict: Optional collection of seed values.  When given, only
+                seeds present in *restrict* are evaluated.
+            labeled_sample: Whether to sample labeled demos (forwarded to
+                ``LabeledFewShot.compile``).
+
+        Returns:
+            The best-scoring ``dspy.Module`` copy, with a
+            ``candidate_programs`` list attached (sorted by descending score).
+        """
         self.trainset = trainset
         self.valset = valset or trainset  # TODO: FIXME: Note this choice.
 


### PR DESCRIPTION
Add Google-style docstrings to `BootstrapFewShotWithRandomSearch` in `teleprompt/random_search.py` — class-level, `__init__`, and `compile`.

Part of #8926.