### PR TITLE
refactor: remove asyncer dependency, inline with direct anyio calls

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 import re
@@ -5,10 +6,10 @@ import threading
 import warnings
 from typing import Any, Literal, cast
 
+import anyio.from_thread
 import litellm
 import pydantic
 from anyio.streams.memory import MemoryObjectSendStream
-from asyncer import syncify
 from litellm import ContextWindowExceededError as LitellmContextWindowExceededError
 
 import dspy
@@ -370,8 +371,7 @@ def _get_stream_completion_fn(
         return litellm.stream_chunk_builder(chunks)
 
     def sync_stream_completion():
-        syncified_stream_completion = syncify(stream_completion)
-        return syncified_stream_completion(request, cache_kwargs)
+        return anyio.from_thread.run(functools.partial(stream_completion, request, cache_kwargs))
 
     async def async_stream_completion():
         return await stream_completion(request, cache_kwargs)

--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -3,7 +3,7 @@ import concurrent.futures
 from dataclasses import dataclass
 from typing import Any
 
-from asyncer import syncify
+import anyio.from_thread
 
 from dspy.dsp.utils.settings import settings
 from dspy.utils.callback import BaseCallback
@@ -47,7 +47,7 @@ def sync_send_to_stream(stream, message):
             return future.result()
     except RuntimeError:
         # Not in an event loop, safe to use a new event loop in this thread
-        return syncify(_send)()
+        return anyio.from_thread.run(_send)
 
 
 class StatusMessageProvider:

--- a/dspy/utils/asyncify.py
+++ b/dspy/utils/asyncify.py
@@ -1,6 +1,7 @@
+import functools
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
-import asyncer
+import anyio
 from anyio import CapacityLimiter
 
 if TYPE_CHECKING:
@@ -58,8 +59,7 @@ def asyncify(program: "Module") -> Callable[[Any, Any], Awaitable[Any]]:
             finally:
                 thread_local_overrides.reset(token)
 
-        # Create a fresh asyncified callable each time, ensuring the latest context is used.
-        call_async = asyncer.asyncify(wrapped_program, abandon_on_cancel=True, limiter=get_limiter())
-        return await call_async(*args, **kwargs)
+        partial_f = functools.partial(wrapped_program, *args, **kwargs)
+        return await anyio.to_thread.run_sync(partial_f, abandon_on_cancel=True, limiter=get_limiter())
 
     return async_program

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "json-repair>=0.54.2",
     "tenacity>=8.2.3",
     "anyio",
-    "asyncer==0.0.8",
     "cachetools>=5.5.0",
     "cloudpickle>=3.1.2",
     "numpy>=1.26.0",

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 from unittest import mock
 from unittest.mock import AsyncMock
 
+import anyio.from_thread
 import pydantic
 import pytest
-from asyncer import syncify
 from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
 
 import dspy
@@ -1035,8 +1035,7 @@ async def test_streaming_allows_custom_chunk_types():
                 chunk = CustomChunk(text="hello")
                 await dspy.settings.send_stream.send(chunk)
 
-            syncified_send_to_stream = syncify(send_to_stream)
-            syncified_send_to_stream()
+            anyio.from_thread.run(send_to_stream)
             return dspy.Prediction(answer="dummy output")
 
     program = dspy.streamify(MyProgram())

--- a/uv.lock
+++ b/uv.lock
@@ -244,18 +244,6 @@ wheels = [
 ]
 
 [[package]]
-name = "asyncer"
-version = "0.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/67/7ea59c3e69eaeee42e7fc91a5be67ca5849c8979acac2b920249760c6af2/asyncer-0.0.8.tar.gz", hash = "sha256:a589d980f57e20efb07ed91d0dbe67f1d2fd343e7142c66d3a099f05c620739c", size = 18217, upload-time = "2024-08-24T23:15:36.449Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/04/15b6ca6b7842eda2748bda0a0af73f2d054e9344320f8bba01f994294bcb/asyncer-0.0.8-py3-none-any.whl", hash = "sha256:5920d48fc99c8f8f0f1576e1882f5022885589c5fcbc46ce4224ec3e53776eeb", size = 9209, upload-time = "2024-08-24T23:15:35.317Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -753,7 +741,6 @@ version = "3.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
-    { name = "asyncer" },
     { name = "cachetools" },
     { name = "cloudpickle" },
     { name = "diskcache" },
@@ -817,7 +804,6 @@ weaviate = [
 requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.18.0,<1.0.0" },
     { name = "anyio" },
-    { name = "asyncer", specifier = "==0.0.8" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.3" },
     { name = "cachetools", specifier = ">=5.5.0" },
     { name = "cloudpickle", specifier = ">=3.1.2" },


### PR DESCRIPTION
Remove `asyncer==0.0.8` as a dependency. The library is a thin wrapper around `anyio` that adds kwargs support via `functools.partial`. DSPy already depends on `anyio` directly.

The entire runtime value of asyncer is two functions:

- [`asyncify`](https://github.com/fastapi/asyncer/blob/32fb323c9c4b097f84d52ff251fe88d0f79f85f0/asyncer/_main.py#L370-L377) -- `functools.partial(fn, *args, **kwargs)` then `await anyio.to_thread.run_sync(partial_f, ...)`
- [`syncify`](https://github.com/fastapi/asyncer/blob/32fb323c9c4b097f84d52ff251fe88d0f79f85f0/asyncer/_main.py#L297-L310) -- `functools.partial(fn, *args, **kwargs)` then `anyio.from_thread.run(partial_f)`

This also eliminates the exact-version pin (`==0.0.8`), which was a version conflict risk for downstream users.