### PR TITLE
refactor: replace xxhash with stdlib hashlib.sha256

### DIFF
--- a/dspy/utils/hasher.py
+++ b/dspy/utils/hasher.py
@@ -1,7 +1,6 @@
+import hashlib
 from pickle import dumps
 from typing import Any
-
-import xxhash
 
 """
 The following class was pulled from the `datasets` package from Hugging Face.
@@ -12,6 +11,7 @@ License: Apache License 2.0
 Author: Hugging Face Inc.
 URL: https://github.com/huggingface/datasets/blob/fa73ab472eecf9136a3daf7a0fbff16a3dffa7a6/src/datasets/fingerprint.py#L170
 Changes: 2025-08-10 - Ran ruff to format the code to DSPy styles.
+         2026-05-07 - Replaced xxhash with hashlib.sha256 to remove C-extension dep.
 """
 class Hasher:
     """Hasher that accepts python objects as inputs."""
@@ -19,8 +19,7 @@ class Hasher:
     dispatch: dict = {}
 
     def __init__(self):
-        """Initialize an empty xxhash64 hasher state."""
-        self.m = xxhash.xxh64()
+        self.m = hashlib.sha256()
 
     @classmethod
     def hash_bytes(cls, value: bytes | list[bytes]) -> str:
@@ -30,10 +29,10 @@ class Hasher:
             value: A single bytes object or a list of bytes to hash in order.
 
         Returns:
-            The xxhash64 hexadecimal digest.
+            The hexadecimal digest.
         """
         value = [value] if isinstance(value, bytes) else value
-        m = xxhash.xxh64()
+        m = hashlib.sha256()
         for x in value:
             m.update(x)
         return m.hexdigest()
@@ -46,7 +45,7 @@ class Hasher:
             value: Any pickle-serializable Python object.
 
         Returns:
-            The xxhash64 hexadecimal digest of the serialized object.
+            The hexadecimal digest of the serialized object.
         """
         return cls.hash_bytes(dumps(value))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "cachetools>=5.5.0",
     "cloudpickle>=3.1.2",
     "numpy>=1.26.0",
-    "xxhash>=3.5.0",
     "gepa[dspy]==0.1.1",
     "typeguard==4.4.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -772,7 +772,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "tqdm" },
     { name = "typeguard" },
-    { name = "xxhash" },
 ]
 
 [package.optional-dependencies]
@@ -852,7 +851,6 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.1" },
     { name = "typeguard", specifier = "==4.4.3" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = "~=4.5.4" },
-    { name = "xxhash", specifier = ">=3.5.0" },
 ]
 provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "dev", "test-extras"]
 


### PR DESCRIPTION
Replace the `xxhash` C-extension dependency with stdlib `hashlib.sha256`. The `Hasher` class (vendored from HuggingFace `datasets`) uses only `xxh64()`, `.update()`, and `.hexdigest()` — all of which have identical API equivalents in `hashlib.sha256`.

Only 2 call sites in the codebase, both low-frequency:
- `bootstrap.py` — seeds an RNG for demo selection during optimization
- `utils_finetune.py` — generates a filename for finetuning data (once per job)

xxhash is ~4x faster than sha256, but at these call volumes (tens of calls per optimization run, not per LM call) the absolute difference is negligible.