### PR TITLE
refactor: replace typeguard with stdlib type checking

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,10 +1,10 @@
 import logging
 import random
-from typing import Any, Literal, get_args, get_origin
+import types
+from typing import Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
-from typeguard import TypeCheckError, check_type
 
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.clients.base_lm import BaseLM
@@ -304,16 +304,72 @@ def _get_type_name(type_annotation) -> str:
 
 def _is_value_compatible_with_type(value: Any, expected: type) -> bool:
     """Return True if the value matches the expected type hint."""
-    try:
-        # Special handle list[str] because we allow setting input type to str, however, invoking with a list thereof.
-        if expected is str and isinstance(value, list):
-            if all(isinstance(item, str) for item in value):
-                return True
+    # Special handle list[str] because we allow setting input type to str, however, invoking with a list thereof.
+    if expected is str and isinstance(value, list):
+        if all(isinstance(item, str) for item in value):
+            return True
 
-        check_type(value, expected)
+    return _check_type(value, expected)
+
+
+def _check_type(value: Any, expected: type) -> bool:
+    """Stdlib replacement for typeguard.check_type."""
+    if expected is Any:
         return True
-    except TypeCheckError:
-        return False
+
+    origin = get_origin(expected)
+    args = get_args(expected)
+
+    # Union / Optional (X | None)
+    if origin is Union or origin is types.UnionType:
+        return any(_check_type(value, arg) for arg in args)
+
+    # Literal
+    if origin is Literal:
+        return value in args
+
+    # list
+    if origin is list:
+        if not isinstance(value, list):
+            return False
+        if args:
+            return all(_check_type(item, args[0]) for item in value)
+        return True
+
+    # dict
+    if origin is dict:
+        if not isinstance(value, dict):
+            return False
+        if args:
+            key_type, val_type = args
+            return all(_check_type(k, key_type) and _check_type(v, val_type) for k, v in value.items())
+        return True
+
+    # tuple
+    if origin is tuple:
+        if not isinstance(value, tuple):
+            return False
+        if args:
+            if len(args) == 2 and args[1] is Ellipsis:
+                return all(_check_type(item, args[0]) for item in value)
+            if len(value) != len(args):
+                return False
+            return all(_check_type(item, arg) for item, arg in zip(value, args))
+        return True
+
+    # set / frozenset
+    if origin is set or origin is frozenset:
+        if not isinstance(value, origin):
+            return False
+        if args:
+            return all(_check_type(item, args[0]) for item in value)
+        return True
+
+    # Plain type (int, str, BaseModel subclass, etc.)
+    if isinstance(expected, type):
+        return isinstance(value, expected)
+
+    return False
 
 def serialize_object(obj):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "cloudpickle>=3.1.2",
     "numpy>=1.26.0",
     "gepa[dspy]==0.1.1",
-    "typeguard==4.5.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,6 @@ dependencies = [
     { name = "requests" },
     { name = "tenacity" },
     { name = "tqdm" },
-    { name = "typeguard" },
 ]
 
 [package.optional-dependencies]
@@ -834,7 +833,6 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
     { name = "tenacity", specifier = ">=8.2.3" },
     { name = "tqdm", specifier = ">=4.66.1" },
-    { name = "typeguard", specifier = "==4.5.1" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = "~=4.5.4" },
 ]
 provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "dev", "test-extras"]


### PR DESCRIPTION
## Summary

Remove `typeguard==4.5.1` by replacing its single call site with a ~40-line stdlib `_check_type()` function.

## Context

typeguard was used in exactly one place: `_is_value_compatible_with_type()` in `dspy/predict/predict.py`, which emits a warning when input field types don't match the signature. It used `check_type()` and caught `TypeCheckError`.

## Changes

- **`dspy/predict/predict.py`**: Replace `typeguard.check_type` with `_check_type()` using `get_origin`/`get_args` from `typing`. Handles:
  - `Union` / `X | None` (Optional)
  - `Literal[...]`
  - `list[T]` with element checking
  - `dict[K, V]` with key/value checking
  - `tuple[T1, T2, ...]` (fixed-length) and `tuple[T, ...]` (variadic)
  - `set[T]` / `frozenset[T]`
  - Plain types (`int`, `str`, BaseModel subclasses, etc.)
  - `Any` (always passes)
- **`pyproject.toml`**: Remove `typeguard==4.5.1` from dependencies

## Testing

All 75 predict tests pass, including all 21 type-validation tests covering: basic types, `list[str]`, `list[int]`, `dict[str, int]`, `tuple[str, int, bool]`, `tuple[int, ...]`, `Literal`, `Literal | None`, string signatures.