### PR TITLE
fix: resolve Deno read permission paths

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -15,6 +15,7 @@ import os
 import subprocess
 import threading
 from os import PathLike
+from pathlib import Path
 from typing import Any, Callable
 
 from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeInterpreterError, FinalOutput
@@ -44,6 +45,14 @@ JSONRPC_APP_ERRORS = {
     "CodeInterpreterError": -32008,
     "Unknown": -32099,
 }
+
+
+def _append_deno_permission_path(paths: list[str], path: PathLike | str) -> None:
+    raw_path = os.fspath(path)
+    resolved_path = str(Path(raw_path).expanduser().resolve(strict=False))
+    for candidate in (raw_path, resolved_path):
+        if candidate and candidate not in paths:
+            paths.append(candidate)
 
 
 def _jsonrpc_request(method: str, params: dict, id: int | str) -> str:
@@ -147,12 +156,14 @@ class PythonInterpreter:
             # Also allow reading Deno's cache directory so Pyodide can load its files
             deno_dir = self._get_deno_dir()
             if deno_dir:
-                allowed_read_paths.append(deno_dir)
+                _append_deno_permission_path(allowed_read_paths, deno_dir)
 
             if self.enable_read_paths:
-                allowed_read_paths.extend(str(p) for p in self.enable_read_paths)
+                for path in self.enable_read_paths:
+                    _append_deno_permission_path(allowed_read_paths, path)
             if self.enable_write_paths:
-                allowed_read_paths.extend(str(p) for p in self.enable_write_paths)
+                for path in self.enable_write_paths:
+                    _append_deno_permission_path(allowed_read_paths, path)
             args.append(f"--allow-read={','.join(allowed_read_paths)}")
 
             self._env_arg = ""

--- a/tests/primitives/test_python_interpreter_permissions.py
+++ b/tests/primitives/test_python_interpreter_permissions.py
@@ -1,0 +1,27 @@
+import os
+
+import pytest
+
+from dspy.primitives.python_interpreter import PythonInterpreter
+
+
+def _allow_read_paths(interpreter: PythonInterpreter) -> list[str]:
+    allow_read_arg = next(arg for arg in interpreter.deno_command if arg.startswith("--allow-read="))
+    return allow_read_arg.removeprefix("--allow-read=").split(",")
+
+
+def test_deno_read_permissions_include_resolved_symlink_paths(tmp_path, monkeypatch):
+    real_dir = tmp_path / "real"
+    link_dir = tmp_path / "link"
+    real_dir.mkdir()
+    try:
+        os.symlink(real_dir, link_dir, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink unavailable: {exc}")
+
+    monkeypatch.setattr(PythonInterpreter, "_get_deno_dir", staticmethod(lambda: str(link_dir)))
+    interpreter = PythonInterpreter(enable_read_paths=[str(link_dir)])
+
+    allow_read_paths = _allow_read_paths(interpreter)
+    assert str(link_dir) in allow_read_paths
+    assert str(real_dir.resolve()) in allow_read_paths


### PR DESCRIPTION
## Changes Description

Fixes #9501.

Deno checks read permissions against path strings and does not resolve symlinks. `PythonInterpreter` can pass a symlinked Deno cache path, read path, or write path to `--allow-read`, while Deno/Pyodide later tries to read the resolved target path.

This patch keeps the original path and also adds the resolved path when building `--allow-read`. That covers symlinked `DENO_DIR`, `enable_read_paths`, and `enable_write_paths` without changing how files are mounted in the sandbox.

## Contributor Checklist

- [x] Pre-Commit checks are passing locally
- [x] Title of the PR follows the repo's existing fix-style convention
- [x] Commit message follows the repo's existing fix-style convention

## Tested

- `python -m py_compile dspy/primitives/python_interpreter.py tests/primitives/test_python_interpreter_permissions.py`
- `pytest tests/primitives/test_python_interpreter_permissions.py -q`
- `ruff check --no-cache dspy/primitives/python_interpreter.py tests/primitives/test_python_interpreter_permissions.py`
- `pre-commit run --files dspy/primitives/python_interpreter.py tests/primitives/test_python_interpreter_permissions.py`
- `git diff --check`
- `git fsck --no-progress`

## Warnings

AI assistance: Codex helped prepare the patch and run checks.