### PR TITLE
fix: allow finish tool to accept kwargs from structured output

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -60,7 +60,7 @@ class ReAct(Module):
         )
 
         tools["finish"] = Tool(
-            func=lambda: "Completed.",
+            func=lambda **kwargs: "Completed.",
             name="finish",
             desc=f"Marks the task as complete. That is, signals that all information for producing the outputs, i.e. {outputs}, are now available to be extracted.",
             args={},


### PR DESCRIPTION
## Summary

When using structured output signatures in `ReAct`, models pass output fields as `next_tool_args` on the finish call. The finish tool was defined as `lambda: "Completed."` with no parameters, so calling `tools["finish"](**pred.next_tool_args)` raised a `TypeError` and logged a spurious execution error in the trajectory (the run still completed, but the error polluted the logs).

**Root cause:** `react.py` line 63:
```python
# before
func=lambda: "Completed.",
# after
func=lambda **kwargs: "Completed.",
```

The fix absorbs any extra keyword arguments silently, matching how a real tool with defined args would behave when called with its expected schema.

## Test plan

- [ ] Run existing ReAct tests: `pytest tests/predict/test_react.py`
- [ ] Verify no `TypeError` in trajectory when a structured output signature is used with `ReAct` and the model passes output fields on the finish call

Fixes #9424