### PR TITLE
ci(workflows): fix zizmor and actionlint findings across all workflows

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -4,13 +4,18 @@ on:
   push:
     tags:
       - "*"
+permissions: {}
 jobs:
   extract-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.extract_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - id: extract_tag
         name: Extract tag name
         run: echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
@@ -21,9 +26,12 @@ jobs:
     environment:
       name: testpypi
     permissions:
+      contents: read
       id-token: write # IMPORTANT: mandatory for trusted publishing
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -36,15 +44,18 @@ jobs:
           deno-version: v2.7.7
       - name: Get correct version for TestPyPI release
         id: check_version
+        env:
+          VERSION: ${{ needs.extract-tag.outputs.version }}
         run: |
-          VERSION=${{ needs.extract-tag.outputs.version }}  
           PACKAGE_NAME="dspy-ai-test-isaac"
           echo "Checking if $VERSION for $PACKAGE_NAME exists on TestPyPI"  
-          NEW_VERSION=$(python3 .github/workflows/build_utils/test_version.py $PACKAGE_NAME $VERSION)  
+          NEW_VERSION=$(python3 .github/workflows/build_utils/test_version.py "$PACKAGE_NAME" "$VERSION")  
           echo "Version to be used for TestPyPI release: $NEW_VERSION"  
           echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
       - name: Update version in pyproject.toml
-        run: sed -i '/#replace_package_version_marker/{n;s/version="[^"]*"/version="${{ steps.check_version.outputs.version }}"/;}' pyproject.toml
+        env:
+          VERSION: ${{ steps.check_version.outputs.version }}
+        run: sed -i "/#replace_package_version_marker/{n;s/version=\"[^\"]*\"/version=\"$VERSION\"/;}" pyproject.toml
       - name: Update package name in pyproject.toml
         run: sed -i '/#replace_package_name_marker/{n;s/name="[^"]*"/name="dspy-ai-test-isaac"/;}' pyproject.toml
       - name: Build a binary wheel
@@ -80,7 +91,7 @@ jobs:
       id-token: write # IMPORTANT: mandatory for trusted publishing
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] -- git-auto-commit-action needs persisted credentials
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -92,9 +103,13 @@ jobs:
         with:
           deno-version: v2.7.7
       - name: Update version in pyproject.toml
-        run: sed -i '/#replace_package_version_marker/{n;s/version *= *"[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' pyproject.toml
+        env:
+          VERSION: ${{ needs.extract-tag.outputs.version }}
+        run: sed -i "/#replace_package_version_marker/{n;s/version *= *\"[^\"]*\"/version=\"$VERSION\"/;}" pyproject.toml
       - name: Update version in __metadata__.py
-        run: sed -i '/#replace_package_version_marker/{n;s/__version__ *= *"[^"]*"/__version__="${{ needs.extract-tag.outputs.version }}"/;}' ./dspy/__metadata__.py
+        env:
+          VERSION: ${{ needs.extract-tag.outputs.version }}
+        run: sed -i "/#replace_package_version_marker/{n;s/__version__ *= *\"[^\"]*\"/__version__=\"$VERSION\"/;}" ./dspy/__metadata__.py
       # Publish to dspy
       - name: Update package name in pyproject.toml
         run: sed -i '/#replace_package_name_marker/{n;s/name *= *"[^"]*"/name="dspy"/;}' pyproject.toml
@@ -123,10 +138,13 @@ jobs:
       - name: Update package name in pyproject.toml
         run: sed -i '/#replace_package_name_marker/{n;s/name *= *"[^"]*"/name="dspy-ai"/;}' .github/.internal_dspyai/pyproject.toml
       - name: Update version for dspy-ai release
-        run: sed -i '/#replace_package_version_marker/{n;s/version *= *"[^"]*"/version="${{ needs.extract-tag.outputs.version }}"/;}' .github/.internal_dspyai/pyproject.toml
+        env:
+          VERSION: ${{ needs.extract-tag.outputs.version }}
+        run: sed -i "/#replace_package_version_marker/{n;s/version *= *\"[^\"]*\"/version=\"$VERSION\"/;}" .github/.internal_dspyai/pyproject.toml
       - name: Update dspy dependency for dspy-ai release
-        run: |
-          sed -i '/#replace_dspy_version_marker/{n;s/dspy>=[^"]*/dspy>=${{ needs.extract-tag.outputs.version }}/;}' .github/.internal_dspyai/pyproject.toml
+        env:
+          VERSION: ${{ needs.extract-tag.outputs.version }}
+        run: sed -i "/#replace_dspy_version_marker/{n;s/dspy>=[^\"]*/dspy>=$VERSION/;}" .github/.internal_dspyai/pyproject.toml
       - name: Build a binary wheel (dspy-ai)
         run: python3 -m build .github/.internal_dspyai/
       - name: Validate built distributions (dspy-ai)
@@ -152,6 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: main
       - name: Apply version bump for main
         env:

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -10,13 +10,19 @@ on:
     paths:
       - "docs/**"
 
+permissions: {}
+
 jobs:
   build-test:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install dependencies and build
         run: |
           cd docs
@@ -26,14 +32,17 @@ jobs:
   update-docs-subtree:
     if: github.event_name == 'push' && github.repository == 'stanfordnlp/dspy'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Push docs to separate repo
         uses: cpina/github-action-push-to-another-repository@55306faa4ed53b815ae49e564af8cfb359d32ae2 # main
         env:
-          API_TOKEN_GITHUB: ${{ secrets.GH_PAT }}
+          API_TOKEN_GITHUB: ${{ secrets.GH_PAT }} # zizmor: ignore[secrets-outside-env]
         with:
           source-directory: "docs"
           destination-github-username: "krypticmouse"

--- a/.github/workflows/precommits_check.yml
+++ b/.github/workflows/precommits_check.yml
@@ -2,11 +2,17 @@ name: Pre-commit checks
 on:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   pre-commit-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -20,17 +26,22 @@ jobs:
         id: files
         uses: jitterbit/get-changed-files@b17fbb00bdc0c0f63fcf166580804b4d2cdc2a42 # v1
       - name: Checking changed files
+        env:
+          CHANGED_FILES: ${{ steps.files.outputs.all }}
         shell: bash
         run: |
           echo "Changed files"
-          echo ${{ steps.files.outputs.all }}
+          echo "$CHANGED_FILES"
           echo "GitHub Client version"
-          echo $(gh --version)
+          gh --version
       - name: Pre-Commit Checks
+        env:
+          CHANGED_FILES: ${{ steps.files.outputs.all }}
         run: |
           python -m pip install --upgrade pip
           pip install pre-commit
           echo "Running pre-commit scans:"
           # adding log display in case of pre-commit errors
-          pre-commit run -v --files ${{ steps.files.outputs.all }}
+          # shellcheck disable=SC2086
+          pre-commit run -v --files $CHANGED_FILES
         shell: bash

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions: {}
+
 jobs:
   fix:
     name: Check Ruff Fix
@@ -15,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
@@ -28,7 +32,7 @@ jobs:
       - name: Create and activate virtual environment
         run: |
           uv venv .venv
-          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: uv sync --dev -p .venv --extra dev
       - name: Ruff Check
@@ -47,11 +51,15 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -71,7 +79,7 @@ jobs:
       - name: Create and activate virtual environment
         run: |
           uv venv .venv
-          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: |
           uv sync --dev -p .venv --extra dev
@@ -90,8 +98,12 @@ jobs:
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
@@ -105,7 +117,7 @@ jobs:
       - name: Create and activate virtual environment
         run: |
           uv venv .venv
-          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: |
           uv sync --dev -p .venv --extra dev
@@ -128,12 +140,12 @@ jobs:
         if: steps.cache-ollama.outputs.cache-hit != 'true'
         run: docker exec ollama ollama pull llama3.2:3b
       - name: Set LM environment variable
-        run: echo "LM_FOR_TEST=ollama/llama3.2:3b" >> $GITHUB_ENV
+        run: echo "LM_FOR_TEST=ollama/llama3.2:3b" >> "$GITHUB_ENV"
       - name: Run tests
         run: uv run -p .venv pytest -m llm_call --llm_call -vv --durations=5 tests/
       - name: Fix permissions for cache
         if: always()
-        run: sudo chown -R $USER:$USER ollama-data || true
+        run: sudo chown -R "$USER":"$USER" ollama-data || true
       - name: Stop Ollama service
         if: always()
         run: docker stop ollama && docker rm ollama
@@ -141,11 +153,15 @@ jobs:
   build_package:
     name: Build Package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -159,7 +175,7 @@ jobs:
       - name: Create and activate virtual environment
         run: |
           uv venv .venv
-          echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+          echo "${{ github.workspace }}/.venv/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
         run: uv sync --dev -p .venv --extra dev
       - name: Build


### PR DESCRIPTION
Fixes all existing zizmor and actionlint findings across all 4 GitHub Actions workflow files, preparing a clean baseline for adding workflow linting to CI (#9742).

**zizmor fixes:**
- Added restrictive `permissions: {}` at workflow level with explicit per-job `contents: read`
- Added `persist-credentials: false` to all `actions/checkout` steps (suppressed where `git-auto-commit-action` needs credentials)
- Fixed template-injection by moving `${{ }}` expressions to `env:` blocks in `build_and_release.yml`
- Suppressed `secrets-outside-env` on `docs-push.yml` (requires org-level environment setup)

**actionlint/shellcheck fixes:**
- Quoted `$GITHUB_PATH`, `$GITHUB_ENV`, `$USER` variables
- Fixed script injection in `precommits_check.yml` (`steps.files.outputs.all` moved to env var)
- Replaced useless `echo $(gh --version)` with direct `gh --version`