### PR TITLE
feat(inspect_history): render tool_calls and tool-role messages

### DIFF
--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -22,6 +22,27 @@ def _blue(text: str, end: str = "\n", *, use_colors: bool = True) -> str:
     return str(text) + end
 
 
+def _get(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def _format_tool_call(tool_call: Any) -> str:
+    # OpenAI Chat Completions wire shape: {"function": {"name", "arguments"}}.
+    function = _get(tool_call, "function")
+    if function is not None:
+        name = _get(function, "name", "")
+        arguments = _get(function, "arguments", "")
+        return f"{name}: {arguments}"
+    # DSPy-native ToolCall / OpenAI Responses API shape: name+args on the item itself.
+    name = _get(tool_call, "name", "")
+    arguments = _get(tool_call, "args")
+    if arguments is None:
+        arguments = _get(tool_call, "arguments", "")
+    return f"{name}: {arguments}"
+
+
 def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO | None = None) -> None:
     """Print the last n prompts and their completions.
 
@@ -44,10 +65,13 @@ def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO
         print(_blue(f"[{timestamp}]", use_colors=use_colors), file=out)
 
         for msg in messages:
-            print(_red(f"{msg['role'].capitalize()} message:", use_colors=use_colors), file=out)
-            if isinstance(msg["content"], str):
+            role_label = f"{msg['role'].capitalize()} message:"
+            if msg["role"] == "tool" and msg.get("tool_call_id"):
+                role_label = f"Tool message: (tool_call_id={msg['tool_call_id']})"
+            print(_red(role_label, use_colors=use_colors), file=out)
+            if isinstance(msg.get("content"), str):
                 print(msg["content"].strip(), file=out)
-            else:
+            elif msg.get("content") is not None:
                 if isinstance(msg["content"], list):
                     for c in msg["content"]:
                         if c["type"] == "text":
@@ -75,6 +99,10 @@ def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO
                             file_data = file_info.get("file_data", "")
                             file_str = f"<file: name:{filename}, id:{file_id}, data_length:{len(file_data)}>"
                             print(_blue(file_str.strip(), use_colors=use_colors), file=out)
+            if msg.get("tool_calls"):
+                print(_red("Tool calls:", use_colors=use_colors), file=out)
+                for tool_call in msg["tool_calls"]:
+                    print(_green(_format_tool_call(tool_call), use_colors=use_colors), file=out)
             print("\n", file=out)
 
         if isinstance(outputs[0], dict):
@@ -85,7 +113,7 @@ def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO
             if outputs[0].get("tool_calls"):
                 print(_red("Tool calls:", use_colors=use_colors), file=out)
                 for tool_call in outputs[0]["tool_calls"]:
-                    print(_green(f"{tool_call['function']['name']}: {tool_call['function']['arguments']}", use_colors=use_colors), file=out)
+                    print(_green(_format_tool_call(tool_call), use_colors=use_colors), file=out)
         else:
             print(_red("Response:", use_colors=use_colors), file=out)
             print(_green(outputs[0].strip(), use_colors=use_colors), file=out)

--- a/tests/utils/test_inspect_history.py
+++ b/tests/utils/test_inspect_history.py
@@ -43,3 +43,71 @@ def test_pretty_print_history_renders_dspy_native_tool_call():
     output = buf.getvalue()
     assert "lookup" in output
     assert "val" in output
+
+
+def test_pretty_print_history_renders_assistant_message_tool_calls():
+    """An assistant message in the messages list with `tool_calls` (and typically
+    `content=None`) must render the calls under a `Tool calls:` header. Without
+    coverage here, a regression in the messages-loop tool_calls rendering branch
+    would go undetected."""
+    history = [
+        {
+            "timestamp": "now",
+            "messages": [
+                {"role": "user", "content": "search for it"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc",
+                            "type": "function",
+                            "function": {"name": "web_search", "arguments": '{"q":"dspy"}'},
+                        }
+                    ],
+                },
+            ],
+            "outputs": [{"text": "done", "tool_calls": None}],
+        }
+    ]
+    buf = io.StringIO()
+    pretty_print_history(history, n=1, file=buf)
+    output = buf.getvalue()
+    assert "Tool calls:" in output
+    assert "web_search" in output
+    assert '{"q":"dspy"}' in output
+
+
+def test_pretty_print_history_renders_tool_role_message_with_tool_call_id():
+    """A `tool` role message must render with its `tool_call_id` in the role label
+    so the user can match each tool result back to the call that produced it."""
+    history = [
+        {
+            "timestamp": "now",
+            "messages": [
+                {"role": "user", "content": "search"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_xyz",
+                            "type": "function",
+                            "function": {"name": "web_search", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_xyz",
+                    "content": "search result body",
+                },
+            ],
+            "outputs": [{"text": "final answer", "tool_calls": None}],
+        }
+    ]
+    buf = io.StringIO()
+    pretty_print_history(history, n=1, file=buf)
+    output = buf.getvalue()
+    assert "tool_call_id=call_xyz" in output
+    assert "search result body" in output

--- a/tests/utils/test_inspect_history.py
+++ b/tests/utils/test_inspect_history.py
@@ -1,0 +1,45 @@
+import io
+
+from dspy.adapters.types.tool import ToolCalls
+from dspy.utils.inspect_history import _format_tool_call, pretty_print_history
+
+
+def test_format_tool_call_openai_chat_completions_shape():
+    """OpenAI Chat Completions wire format: {'function': {'name', 'arguments'}}."""
+    item = {"function": {"name": "search", "arguments": '{"q":"x"}'}}
+    assert _format_tool_call(item) == 'search: {"q":"x"}'
+
+
+def test_format_tool_call_openai_responses_api_shape():
+    """OpenAI Responses API shape: name + arguments on the item itself."""
+    item = {"name": "search", "arguments": '{"q":"y"}'}
+    assert _format_tool_call(item) == 'search: {"q":"y"}'
+
+
+def test_format_tool_call_dspy_native_toolcall_shape():
+    """DSPy-native ToolCall pydantic object uses `args` (dict), not `function.arguments`."""
+    tc = ToolCalls.ToolCall(name="lookup", args={"key": "val"})
+    result = _format_tool_call(tc)
+    assert "lookup" in result and "val" in result
+
+
+def test_pretty_print_history_renders_dspy_native_tool_call():
+    """A history entry whose tool_calls contain DSPy-native ToolCall objects should
+    render the name and args, not produce empty `: ` output."""
+    history = [
+        {
+            "timestamp": "now",
+            "messages": [{"role": "user", "content": "hi"}],
+            "outputs": [
+                {
+                    "text": "",
+                    "tool_calls": [ToolCalls.ToolCall(name="lookup", args={"key": "val"})],
+                }
+            ],
+        }
+    ]
+    buf = io.StringIO()
+    pretty_print_history(history, n=1, file=buf)
+    output = buf.getvalue()
+    assert "lookup" in output
+    assert "val" in output


### PR DESCRIPTION
## What

`pretty_print_history` previously dropped any `tool_calls` array on assistant messages and could not render `tool` role messages at all, making debugging native-function-calling traces impossible. This PR adds rendering for both.

## Changes

- **`_get(obj, key, default)`** helper accepts both dicts and pydantic objects so the renderer works with raw OpenAI wire-format payloads *and* DSPy-native `ToolCall` instances.
- **`_format_tool_call`** handles both wire shapes:
  - OpenAI Chat Completions: `{function: {name, arguments}}`
  - Flat: `{name, args}` (DSPy-native) and `{name, arguments}` (Responses API)
- **Assistant messages with `tool_calls`** now render the calls under a `Tool calls:` header (both inside the messages loop and on the response side of the entry).
- **`tool` role messages** render with their `tool_call_id` so it is obvious which call a tool result corresponds to.

## Tests

`tests/utils/test_inspect_history.py` — 6 new tests covering:
- OpenAI Chat Completions wire shape (`{function: {name, arguments}}`)
- OpenAI Responses API wire shape (`{name, arguments}`)
- DSPy-native `ToolCall` pydantic object (uses `args` dict)
- `pretty_print_history` end-to-end with a DSPy-native ToolCall on the response side
- `pretty_print_history` end-to-end with an assistant message carrying `tool_calls` in the messages list (`{role: "assistant", content: None, tool_calls: [...]}`)
- `pretty_print_history` end-to-end with a `tool` role message and `tool_call_id` in the role label