### PR TITLE
ci(workflows): add security-events permission for SARIF upload

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
The zizmor-action uploads SARIF results to GitHub Code Scanning via `codeql-action/upload-sarif`, which requires `security-events: write`. Without it, the upload fails with:

```
Resource not accessible by integration - https://docs.github.com/rest
```

This is the [standard permission](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions) for any workflow that uploads SARIF.

See failed run: https://github.com/stanfordnlp/dspy/actions/runs/25752222184/job/75631267428