### PR TITLE
ci(release): remove git-auto-commit-action from release workflow

### DIFF
--- a/.github/.internal_dspyai/internals/build-and-release.md
+++ b/.github/.internal_dspyai/internals/build-and-release.md
@@ -11,7 +11,8 @@ At a high level, the workflow works as follows:
 3. Builds and publishes a release on [test-pypi](https://test.pypi.org/project/dspy-ai-test/)
 4. Uses the test-pypi release to run build_utils/tests/intro.py with the new release as an integration test. Note intro.py is a copy of the intro notebook.
 5. Assuming the test runs successfully, it pushes a release to [pypi](https://pypi.org/project/dspy-ai/). If not, the user can delete the tag, make the fixes and then push the tag again. Versioning for multiple releases to test-pypi with the same tag version is taken care of by the workflow by appending a pre-release identifier, so the user only needs to consider the version for pypi. 
-6. (Currently manual) the user creates a release and includes release notes, as described in docs/docs/release-checklist.md
+6. A PR is automatically opened to bump version metadata on `main`.
+7. (Currently manual) the user creates a release and includes release notes, as described in docs/docs/release-checklist.md
 
 ## Implementation Details
 
@@ -20,6 +21,7 @@ The workflow executes a series of jobs in sequence:
 - build-and-publish-test-pypi
 - test-intro-script
 - build-and-publish-pypi
+- open-main-version-bump-pr
 
 #### extract-tag
 Extracts the tag pushed to the commit. This tag is expected to be the version of the new deployment. 
@@ -55,5 +57,7 @@ Builds and publishes the package to pypi.
 1. Builds the binary wheel
 1. Publishes the package to pypi.
 
+#### open-main-version-bump-pr
+Opens a PR against `main` to update version metadata after a successful publish. This ensures that `pyproject.toml`, `__metadata__.py`, and the `dspy-ai` wrapper package all reflect the latest published version on the default branch.
 
 \* The package name is updated by the workflow to allow the same files to be used to build both the pypi and test-pypi packages.

--- a/.github/.internal_dspyai/internals/release-checklist.md
+++ b/.github/.internal_dspyai/internals/release-checklist.md
@@ -7,6 +7,7 @@
       ```
     * This will trigger the github action to build and release the package.
 * [ ] Confirm the tests pass and the package has been published to pypi.
+* [ ] Merge the auto-generated version bump PR that is opened against `main`.
     * If the tests fail, you can remove the tag from your local and github repo using:
     ```bash
     git push origin --delete X.Y.Z # Delete on GitHub

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -88,10 +88,12 @@ jobs:
     environment:
       name: pypi
     permissions:
+      contents: read
       id-token: write # IMPORTANT: mandatory for trusted publishing
-      contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked] -- git-auto-commit-action needs persisted credentials
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -154,12 +156,6 @@ jobs:
         with:
           attestations: false
           packages-dir: .github/.internal_dspyai/dist/
-      - uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v5 # auto commit changes to release branch
-        with:
-          commit_message: Update versions
-          create_branch: true
-          branch: release-${{ needs.extract-tag.outputs.version }}
-
   open-main-version-bump-pr:
     needs: [extract-tag, build-and-publish-pypi]
     if: github.repository_owner == 'stanfordnlp'


### PR DESCRIPTION
Removes the `stefanzweifel/git-auto-commit-action` step from the `build-and-publish-pypi` job. This step created `release-X.Y.Z` snapshot branches during publishing, which is redundant since `open-main-version-bump-pr` already handles propagating version bumps to main via PR.

**Root cause of 3.2.1 release failure:** the `release-3.2.1` branch already existed from a prior failed attempt, so the auto-commit push was rejected as non-fast-forward. This cascaded to skip the version bump PR creation entirely since `open-main-version-bump-pr` depends on `build-and-publish-pypi`.

Also:
- Adds `persist-credentials: false` to the `build-and-publish-pypi` checkout (no longer needs credentials)
- Downgrades job permissions from `contents: write` to `contents: read`
- Updates release documentation to reflect the current workflow