### PR TITLE
fix(python_interpreter): resolve symlinks for Deno --allow-read paths (#9501)

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -151,15 +151,15 @@ class PythonInterpreter:
         else:
             args = ["deno", "run"]
 
-            allowed_read_paths = [_canonicalize_path(self._get_runner_path())]
-
             # Also allow reading Deno's cache directory so Pyodide can load its files
             deno_dir = self._get_deno_dir()
-            if deno_dir:
-                allowed_read_paths.append(_canonicalize_path(deno_dir))
-
-            allowed_read_paths.extend(_canonicalize_path(p) for p in self.enable_read_paths)
-            allowed_read_paths.extend(_canonicalize_path(p) for p in self.enable_write_paths)
+            raw_read_paths = [
+                self._get_runner_path(),
+                *([deno_dir] if deno_dir else []),
+                *self.enable_read_paths,
+                *self.enable_write_paths,
+            ]
+            allowed_read_paths = [_canonicalize_path(p) for p in raw_read_paths]
             args.append(f"--allow-read={','.join(allowed_read_paths)}")
 
             self._env_arg = ""

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -46,6 +46,16 @@ JSONRPC_APP_ERRORS = {
 }
 
 
+def _canonicalize_path(path: PathLike | str) -> str:
+    """Resolve symlinks so the path matches what Deno's permission check sees.
+
+    Deno does string-prefix matching against the realpath of the accessed file
+    (denoland/deno#9607), so --allow-read / --allow-write entries must be
+    realpath'd or reads through a symlink (including DENO_DIR) are denied.
+    """
+    return os.path.realpath(os.path.expanduser(os.fspath(path)))
+
+
 def _jsonrpc_request(method: str, params: dict, id: int | str) -> str:
     """Create a JSON-RPC 2.0 request (expects response)."""
     return json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": id})
@@ -141,18 +151,15 @@ class PythonInterpreter:
         else:
             args = ["deno", "run"]
 
-            # Allow reading runner.js and explicitly enabled paths
-            allowed_read_paths = [self._get_runner_path()]
+            allowed_read_paths = [_canonicalize_path(self._get_runner_path())]
 
             # Also allow reading Deno's cache directory so Pyodide can load its files
             deno_dir = self._get_deno_dir()
             if deno_dir:
-                allowed_read_paths.append(deno_dir)
+                allowed_read_paths.append(_canonicalize_path(deno_dir))
 
-            if self.enable_read_paths:
-                allowed_read_paths.extend(str(p) for p in self.enable_read_paths)
-            if self.enable_write_paths:
-                allowed_read_paths.extend(str(p) for p in self.enable_write_paths)
+            allowed_read_paths.extend(_canonicalize_path(p) for p in self.enable_read_paths)
+            allowed_read_paths.extend(_canonicalize_path(p) for p in self.enable_write_paths)
             args.append(f"--allow-read={','.join(allowed_read_paths)}")
 
             self._env_arg = ""
@@ -163,9 +170,9 @@ class PythonInterpreter:
             if self.enable_network_access:
                 args.append(f"--allow-net={','.join(str(x) for x in self.enable_network_access)}")
             if self.enable_write_paths:
-                args.append(f"--allow-write={','.join(str(x) for x in self.enable_write_paths)}")
+                args.append(f"--allow-write={','.join(_canonicalize_path(x) for x in self.enable_write_paths)}")
 
-            args.append(self._get_runner_path())
+            args.append(_canonicalize_path(self._get_runner_path()))
 
             # For runner.js to load in env vars
             if self._env_arg:
@@ -232,16 +239,21 @@ class PythonInterpreter:
                     open(path, "a").close()
                 else:
                     raise FileNotFoundError(f"Cannot mount non-existent file: {path}")
-            virtual_path = f"/sandbox/{os.path.basename(path)}"
-            self._send_request("mount_file", {"host_path": str(path), "virtual_path": virtual_path}, f"mounting {path}")
+            # Virtual path keeps the user's basename so sandbox code refers to the
+            # file by the name passed in; host_path is realpath'd so Deno's
+            # permission check matches the canonical entries in --allow-read.
+            virtual_path = f"/sandbox/{os.path.basename(str(path))}"
+            host_path = _canonicalize_path(path)
+            self._send_request("mount_file", {"host_path": host_path, "virtual_path": virtual_path}, f"mounting {path}")
         self._mounted_files = True
 
     def _sync_files(self):
         if not self.enable_write_paths or not self.sync_files:
             return
         for path in self.enable_write_paths:
-            virtual_path = f"/sandbox/{os.path.basename(path)}"
-            sync_msg = _jsonrpc_notification("sync_file", {"virtual_path": virtual_path, "host_path": str(path)})
+            virtual_path = f"/sandbox/{os.path.basename(str(path))}"
+            host_path = _canonicalize_path(path)
+            sync_msg = _jsonrpc_notification("sync_file", {"virtual_path": virtual_path, "host_path": host_path})
             self.deno_process.stdin.write(sync_msg + "\n")
             self.deno_process.stdin.flush()
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -602,6 +602,29 @@ def test_large_variable_threshold_boundary():
     assert "x" in interpreter._pending_large_vars, "Serialized size over threshold should use filesystem"
 
 
+def test_enable_read_paths_symlink(tmp_path):
+    """Regression test for #9501: symlinked enable_read_paths must resolve so Deno
+    can read through them (denoland/deno#9607 — Deno prefix-matches against the
+    realpath of the file being read). The sandbox virtual path keeps the user's
+    original basename so user code refers to the file by the name passed in.
+    """
+    real_file = tmp_path / "real_name.txt"
+    real_file.write_text("through symlink")
+    link_file = tmp_path / "link_name.txt"
+    try:
+        link_file.symlink_to(real_file)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    with PythonInterpreter(enable_read_paths=[str(link_file)]) as interp:
+        allow_read = next(a for a in interp.deno_command if a.startswith("--allow-read=")).split(",")
+        assert os.path.realpath(str(real_file)) in allow_read
+        assert str(link_file) not in allow_read
+
+        result = interp.execute("with open('/sandbox/link_name.txt') as f:\n    data = f.read()\ndata")
+        assert result == "through symlink"
+
+
 def test_enable_read_paths_multiple_files(tmp_path):
     """Test that enable_read_paths works with multiple files in the same directory.
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -617,7 +617,8 @@ def test_enable_read_paths_symlink(tmp_path):
         pytest.skip(f"symlink creation unavailable: {exc}")
 
     with PythonInterpreter(enable_read_paths=[str(link_file)]) as interp:
-        allow_read = next(a for a in interp.deno_command if a.startswith("--allow-read=")).split(",")
+        allow_read_arg = next(a for a in interp.deno_command if a.startswith("--allow-read="))
+        allow_read = allow_read_arg[len("--allow-read="):].split(",")
         assert os.path.realpath(str(real_file)) in allow_read
         assert str(link_file) not in allow_read
 


### PR DESCRIPTION
Fixes #9501.

Deno's `--allow-read` does string-prefix matching against the realpath of the file being read (denoland/deno#9607). If `DENO_DIR` or any path in `enable_read_paths` goes through a symlink, the allow-list entry doesn't match and the read is denied — which is what breaks `PythonInterpreter()` on default Pyodide installs (`~/node_modules/pyodide` is a symlink).

Repro without DSPy:

```bash
D=/tmp/repro && rm -rf $D && mkdir -p $D/real && ln -s $D/real $D/link
echo hi > $D/real/data.txt
echo 'console.log(Deno.readTextFileSync(Deno.args[0]))' > $D/read.js

deno run --no-prompt --allow-read=$D/link $D/read.js $D/real/data.txt
# NotCapable: Requires read access to "/tmp/repro/real/data.txt"

deno run --no-prompt --allow-read=$(realpath $D/link) $D/read.js $D/real/data.txt
# hi
```

Fix is to `os.path.realpath()` everything we put into `--allow-read` / `--allow-write` and the `host_path` we hand to runner.js. The virtual path inside the sandbox keeps the user's original basename so user code still opens `/sandbox/<name>` by the name passed in.

Regression test added (`test_enable_read_paths_symlink`) — fails on main, passes here.