### PR TITLE
fix: handle cached native tool calls

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -2,8 +2,6 @@ import json
 import logging
 from typing import Any, get_origin
 
-import json_repair
-
 from dspy.adapters._legacy_type_markers import (
     _expand_legacy_custom_type_markers_in_chat_message,
     _expand_legacy_custom_type_markers_in_lm_message,
@@ -722,29 +720,6 @@ class Adapter:
             A dictionary of the output fields.
         """
         raise NotImplementedError
-
-
-def _provider_value(value: Any, key: str, default: Any = None) -> Any:
-    if isinstance(value, dict):
-        return value.get(key, default)
-    return getattr(value, key, default)
-
-
-def _provider_tool_call_to_tool_call_dict(tool_call: Any) -> dict[str, Any]:
-    function = _provider_value(tool_call, "function", {}) or {}
-    arguments = _provider_value(function, "arguments", {})
-    if isinstance(arguments, str):
-        parsed_arguments = json_repair.loads(arguments)
-    elif isinstance(arguments, dict):
-        parsed_arguments = arguments
-    else:
-        parsed_arguments = {}
-
-    return {
-        "id": _provider_value(tool_call, "id") or _provider_value(tool_call, "call_id"),
-        "name": _provider_value(function, "name") or _provider_value(tool_call, "name"),
-        "args": parsed_arguments,
-    }
 
 
 def _tool_calls_from_message(message: dict[str, Any]) -> tuple[str | None, ToolCalls | None]:

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -181,8 +181,7 @@ class Adapter:
                 value.setdefault(field_name, None)
 
             if tool_calls and tool_call_output_field_name:
-                tool_calls = [_provider_tool_call_to_tool_call_dict(tool_call) for tool_call in tool_calls]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
+                value[tool_call_output_field_name] = ToolCalls.from_openai_tool_calls(tool_calls)
 
             # TODO(adapter-types): Once `Type.parse_lm_output(context, output)` is
             # the real normalized hook, this should not call the legacy

--- a/dspy/adapters/two_step_adapter.py
+++ b/dspy/adapters/two_step_adapter.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-import json_repair
-
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.types import ToolCalls
@@ -160,14 +158,7 @@ class TwoStepAdapter(Adapter):
                 ) from e
 
             if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
+                value[tool_call_output_field_name] = ToolCalls.from_openai_tool_calls(tool_calls)
 
             if output_logprobs is not None:
                 value["logprobs"] = output_logprobs

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Callable, get_origin, get_type_hints
 
 import json_repair
@@ -318,7 +319,9 @@ class ToolCalls(Type):
                         break
 
             if func is None:
-                raise ValueError(f"Tool function '{self.name}' not found. Please pass the tool functions to the `execute` method.")
+                raise ValueError(
+                    f"Tool function '{self.name}' not found. Please pass the tool functions to the `execute` method."
+                )
 
             try:
                 args = self.args or {}
@@ -363,6 +366,11 @@ class ToolCalls(Type):
         """
         tool_calls = [cls.ToolCall(**_normalize_tool_call_dict(item)) for item in tool_calls_dicts]
         return cls(tool_calls=tool_calls)
+
+    @classmethod
+    def from_openai_tool_calls(cls, tool_calls: list[Any]) -> "ToolCalls":
+        tool_call_dicts = [_normalize_openai_tool_call(item) for item in tool_calls]
+        return cls.from_dict_list(tool_call_dicts)
 
     @classmethod
     def description(cls) -> str:
@@ -496,6 +504,43 @@ def _normalize_tool_call_dict(data: dict[str, Any]) -> dict[str, Any]:
 
     return {
         "id": data.get("id") or data.get("call_id"),
+        "name": name,
+        "args": arguments,
+    }
+
+
+def _get_tool_call_field(item: Any, field: str) -> Any:
+    if isinstance(item, Mapping):
+        return item.get(field)
+    return getattr(item, field, None)
+
+
+def _normalize_openai_tool_call(tool_call: Any) -> dict[str, Any]:
+    if isinstance(tool_call, Mapping) and "name" in tool_call and "args" in tool_call:
+        return {
+            "id": tool_call.get("id") or tool_call.get("call_id"),
+            "name": tool_call["name"],
+            "args": tool_call["args"],
+        }
+
+    function = _get_tool_call_field(tool_call, "function")
+    if function is None:
+        raise ValueError(f"Received invalid tool call value: {tool_call}")
+
+    name = _get_tool_call_field(function, "name")
+    arguments = _get_tool_call_field(function, "arguments")
+    if name is None:
+        raise ValueError(f"Received tool call without a function name: {tool_call}")
+
+    if isinstance(arguments, str):
+        arguments = json_repair.loads(arguments)
+    elif arguments is None:
+        arguments = {}
+    elif not isinstance(arguments, dict):
+        arguments = {}
+
+    return {
+        "id": _get_tool_call_field(tool_call, "id") or _get_tool_call_field(tool_call, "call_id"),
         "name": name,
         "args": arguments,
     }

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -480,9 +480,7 @@ def test_tool_calls_can_carry_results_without_formatting_them_for_lm():
 
     assert "tool_call_results" not in tool_calls.format()
     assert tool_calls.model_dump(mode="json")["tool_call_results"] == {
-        "tool_call_results": [
-            {"call_id": "call_1", "name": "search", "value": {"answer": "world"}, "is_error": False}
-        ]
+        "tool_call_results": [{"call_id": "call_1", "name": "search", "value": {"answer": "world"}, "is_error": False}]
     }
 
 
@@ -524,9 +522,7 @@ def test_tool_call_results_history_serialization_round_trip():
         "messages": [
             {
                 "tool_calls": {
-                    "tool_calls": [
-                        {"name": "search", "args": {"query": "hello"}}
-                    ],
+                    "tool_calls": [{"name": "search", "args": {"query": "hello"}}],
                     "tool_call_results": {
                         "tool_call_results": [
                             {"call_id": "call_1", "name": "search", "value": {"answer": "world"}, "is_error": False}
@@ -556,6 +552,26 @@ def test_tool_call_results_can_round_trip_as_native_tool_result_message():
     assert to_openai_chat_request(request)["messages"] == [
         {"role": "tool", "content": '{"items": ["cat"]}', "tool_call_id": "call_1", "name": "search"}
     ]
+
+
+def test_tool_calls_from_openai_tool_calls_avoids_model_dump():
+    class CachedFunction:
+        name = "search"
+        arguments = '{"query": "hello"}'
+
+        def model_dump(self):
+            raise TypeError("'MockValSer' object cannot be converted to 'SchemaSerializer'")
+
+    class CachedToolCall:
+        function = CachedFunction()
+
+        def model_dump(self):
+            raise TypeError("'MockValSer' object cannot be converted to 'SchemaSerializer'")
+
+    tool_calls = ToolCalls.from_openai_tool_calls([CachedToolCall()])
+
+    assert tool_calls.tool_calls[0].name == "search"
+    assert tool_calls.tool_calls[0].args == {"query": "hello"}
 
 
 def test_toolcalls_vague_match():
@@ -621,9 +637,7 @@ def test_toolcalls_vague_match():
     assert tc.tool_calls[0].args == {"query": "hello"}
 
     # Provider-style nested function.arguments should accept dict and JSON-string values.
-    tc = ToolCalls.model_validate(
-        {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}
-    )
+    tc = ToolCalls.model_validate({"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}})
     assert len(tc.tool_calls) == 1
     assert tc.tool_calls[0].args == {"query": "hello"}
 
@@ -687,8 +701,6 @@ def test_tool_convert_input_schema_to_tool_args_lang_chain():
     }
 
 
-
-
 def test_tool_call_execute():
     def get_weather(city: str) -> str:
         return f"The weather in {city} is sunny"
@@ -696,10 +708,7 @@ def test_tool_call_execute():
     def add_numbers(a: int, b: int) -> int:
         return a + b
 
-    tools = [
-        dspy.Tool(get_weather),
-        dspy.Tool(add_numbers)
-    ]
+    tools = [dspy.Tool(get_weather), dspy.Tool(add_numbers)]
 
     tool_call = dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Berlin"})
     result = tool_call.execute(functions=tools)


### PR DESCRIPTION
﻿## Summary
- normalize native OpenAI/LiteLLM tool-call objects in one `ToolCalls` helper
- avoid calling `model_dump()` on cached Pydantic objects whose serializer may be a stale `MockValSer`
- reuse the helper from both adapter paths and cover the cached-object case in tests

Fixes #9737.

## To verify
- `.venv\Scripts\python.exe -m py_compile dspy\adapters\types\tool.py dspy\adapters\base.py dspy\adapters\two_step_adapter.py tests\adapters\test_tool.py`
- `.venv\Scripts\python.exe -m ruff check dspy\adapters\types\tool.py dspy\adapters\base.py dspy\adapters\two_step_adapter.py`
- `.venv\Scripts\python.exe -m pytest tests\adapters\test_tool.py::test_tool_calls_from_openai_tool_calls_avoids_model_dump tests\adapters\test_tool.py::test_tool_calls_format_from_dict_list tests\adapters\test_chat_adapter.py::test_tool_call_with_null_content_does_not_raise -q --basetemp .tmp\pytest -p no:cacheprovider`
- `git diff --check`

Note: checking all of `tests/adapters/test_tool.py` with ruff currently reports an existing `B011` on an older `assert False` in the file. I left that unrelated cleanup out of this fix.
