### PR TITLE
Make LiteLLM imports lazy

### DIFF
--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -3,13 +3,14 @@ import os
 from pathlib import Path
 from typing import Any
 
-import litellm
-
 from dspy.clients.base_lm import BaseLM, inspect_history
 from dspy.clients.cache import Cache
 from dspy.clients.embedding import Embedder
 from dspy.clients.lm import LM
 from dspy.clients.provider import Provider, TrainingJob
+from dspy.utils.lazy_import import require
+
+litellm = require("litellm", extra="litellm", feature="LiteLLM logging")
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +57,6 @@ def configure_cache(
     dspy.cache = DSPY_CACHE
 
 
-litellm.telemetry = False
-litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
-
 
 def _get_dspy_cache():
     disk_cache_dir = os.environ.get("DSPY_CACHEDIR") or os.path.join(Path.home(), ".dspy_cache")
@@ -91,7 +89,7 @@ DSPY_CACHE = _get_dspy_cache()
 def configure_litellm_logging(level: str = "ERROR"):
     """Configure LiteLLM logging to the specified level."""
     # Litellm uses a global logger called `verbose_logger` to control all loggings.
-    from litellm._logging import verbose_logger
+    verbose_logger = litellm._logging.verbose_logger
 
     numeric_logging_level = getattr(logging, level)
 
@@ -102,16 +100,14 @@ def configure_litellm_logging(level: str = "ERROR"):
 
 def enable_litellm_logging():
     litellm.suppress_debug_info = False
+    litellm._dspy_logging_configured = True
     configure_litellm_logging("DEBUG")
 
 
 def disable_litellm_logging():
     litellm.suppress_debug_info = True
+    litellm._dspy_logging_configured = True
     configure_litellm_logging("ERROR")
-
-
-# By default, we disable LiteLLM logging for clean logging
-disable_litellm_logging()
 
 __all__ = [
     "BaseLM",

--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -3,14 +3,12 @@ import os
 from pathlib import Path
 from typing import Any
 
+from dspy.clients._litellm import get_litellm
 from dspy.clients.base_lm import BaseLM, inspect_history
 from dspy.clients.cache import Cache
 from dspy.clients.embedding import Embedder
 from dspy.clients.lm import LM
 from dspy.clients.provider import Provider, TrainingJob
-from dspy.utils.lazy_import import require
-
-litellm = require("litellm", extra="litellm", feature="LiteLLM logging")
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +87,7 @@ DSPY_CACHE = _get_dspy_cache()
 def configure_litellm_logging(level: str = "ERROR"):
     """Configure LiteLLM logging to the specified level."""
     # Litellm uses a global logger called `verbose_logger` to control all loggings.
+    litellm = get_litellm(feature="LiteLLM logging")
     verbose_logger = litellm._logging.verbose_logger
 
     numeric_logging_level = getattr(logging, level)
@@ -99,12 +98,14 @@ def configure_litellm_logging(level: str = "ERROR"):
 
 
 def enable_litellm_logging():
+    litellm = get_litellm(feature="LiteLLM logging")
     litellm.suppress_debug_info = False
     litellm._dspy_logging_configured = True
     configure_litellm_logging("DEBUG")
 
 
 def disable_litellm_logging():
+    litellm = get_litellm(feature="LiteLLM logging")
     litellm.suppress_debug_info = True
     litellm._dspy_logging_configured = True
     configure_litellm_logging("ERROR")

--- a/dspy/clients/_litellm.py
+++ b/dspy/clients/_litellm.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import functools
+import sys
+import types
+from typing import Any
+
+from dspy.utils.lazy_import import require
+
+
+@functools.cache
+def _configure_litellm_defaults(litellm: types.ModuleType) -> None:
+    """Apply DSPy's global LiteLLM defaults once when LiteLLM is first imported."""
+    litellm.telemetry = False
+    litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
+    if not getattr(litellm, "_dspy_logging_configured", False):
+        litellm.suppress_debug_info = True
+        litellm._dspy_logging_configured = True
+
+
+def _materialize_litellm(litellm: types.ModuleType) -> None:
+    """Force LiteLLM's lazy module to execute, or raise the missing dependency error."""
+    # `require()` returns either an importlib LazyLoader-backed module or a _MissingModule.
+    # Accessing a real LiteLLM attribute forces LazyLoader execution; on _MissingModule it raises
+    # the helpful install-hint ImportError immediately at the DSPy call site.
+    _completion = litellm.completion
+
+
+@functools.cache
+def get_litellm(*, feature: str) -> Any:
+    """Import LiteLLM, apply DSPy's defaults once, and return the module."""
+    litellm = require("litellm", extra="litellm", feature=feature)
+    _materialize_litellm(litellm)
+    _configure_litellm_defaults(litellm)
+    return litellm
+
+
+def is_litellm_context_window_error(error: Exception) -> bool:
+    """Return whether an exception is LiteLLM's context-window error, if LiteLLM is loaded."""
+    litellm_module = sys.modules.get("litellm")
+    context_window_error = getattr(litellm_module, "ContextWindowExceededError", None)
+    return context_window_error is not None and isinstance(error, context_window_error)

--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -2,12 +2,22 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
-import litellm
-
 from dspy.clients.cache import request_cache
 from dspy.utils.lazy_import import require
 
 np = require("numpy")
+
+
+def _configure_litellm_defaults(litellm):
+    litellm.telemetry = False
+    litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
+    if not getattr(litellm, "_dspy_logging_configured", False):
+        litellm.suppress_debug_info = True
+        litellm._dspy_logging_configured = True
+
+
+litellm = require("litellm", extra="litellm", feature="dspy.Embedder", on_load=_configure_litellm_defaults)
+
 
 class Embedder:
     """DSPy embedding class.

--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -2,21 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Callable
 
+from dspy.clients._litellm import get_litellm
 from dspy.clients.cache import request_cache
 from dspy.utils.lazy_import import require
 
 np = require("numpy")
 
 
-def _configure_litellm_defaults(litellm):
-    litellm.telemetry = False
-    litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
-    if not getattr(litellm, "_dspy_logging_configured", False):
-        litellm.suppress_debug_info = True
-        litellm._dspy_logging_configured = True
-
-
-litellm = require("litellm", extra="litellm", feature="dspy.Embedder", on_load=_configure_litellm_defaults)
+def _get_litellm():
+    return get_litellm(feature="dspy.Embedder")
 
 
 class Embedder:
@@ -162,8 +156,8 @@ class Embedder:
 
 def _compute_embeddings(model, batch_inputs, caching=False, **kwargs):
     if isinstance(model, str):
-        caching = caching and litellm.cache is not None
-        embedding_response = litellm.embedding(model=model, input=batch_inputs, caching=caching, **kwargs)
+        caching = caching and _get_litellm().cache is not None
+        embedding_response = _get_litellm().embedding(model=model, input=batch_inputs, caching=caching, **kwargs)
         return [data["embedding"] for data in embedding_response.data]
     elif callable(model):
         return model(batch_inputs, **kwargs)
@@ -178,8 +172,8 @@ def _cached_compute_embeddings(model, batch_inputs, caching=True, **kwargs):
 
 async def _acompute_embeddings(model, batch_inputs, caching=False, **kwargs):
     if isinstance(model, str):
-        caching = caching and litellm.cache is not None
-        embedding_response = await litellm.aembedding(model=model, input=batch_inputs, caching=caching, **kwargs)
+        caching = caching and _get_litellm().cache is not None
+        embedding_response = await _get_litellm().aembedding(model=model, input=batch_inputs, caching=caching, **kwargs)
         return [data["embedding"] for data in embedding_response.data]
     elif callable(model):
         return model(batch_inputs, **kwargs)

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -11,6 +11,7 @@ import pydantic
 from anyio.streams.memory import MemoryObjectSendStream
 
 import dspy
+from dspy.clients._litellm import get_litellm, is_litellm_context_window_error
 from dspy.clients.cache import request_cache
 from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, ReinforceJob, TrainingJob
@@ -18,27 +19,14 @@ from dspy.clients.utils_finetune import TrainDataFormat
 from dspy.dsp.utils.settings import settings
 from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import ContextWindowExceededError
-from dspy.utils.lazy_import import require
 
 from .base_lm import BaseLM
 
 logger = logging.getLogger(__name__)
 
 
-def _configure_litellm_defaults(litellm):
-    litellm.telemetry = False
-    litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
-    if not getattr(litellm, "_dspy_logging_configured", False):
-        litellm.suppress_debug_info = True
-        litellm._dspy_logging_configured = True
-
-
-litellm = require("litellm", extra="litellm", feature="dspy.LM", on_load=_configure_litellm_defaults)
-
-
-def _is_litellm_context_window_error(error: Exception) -> bool:
-    error_type = type(error)
-    return error_type.__module__.startswith("litellm") and "ContextWindowExceeded" in error_type.__name__
+def _get_litellm():
+    return get_litellm(feature="dspy.LM")
 
 
 class LM(BaseLM):
@@ -137,19 +125,19 @@ class LM(BaseLM):
 
     @property
     def supports_function_calling(self) -> bool:
-        return litellm.supports_function_calling(model=self.model)
+        return _get_litellm().supports_function_calling(model=self.model)
 
     @property
     def supports_reasoning(self) -> bool:
-        return litellm.supports_reasoning(self.model)
+        return _get_litellm().supports_reasoning(self.model)
 
     @property
     def supports_response_schema(self) -> bool:
-        return litellm.supports_response_schema(model=self.model, custom_llm_provider=self._provider_name)
+        return _get_litellm().supports_response_schema(model=self.model, custom_llm_provider=self._provider_name)
 
     @property
     def supported_params(self) -> set[str]:
-        params = litellm.get_supported_openai_params(model=self.model, custom_llm_provider=self._provider_name)
+        params = _get_litellm().get_supported_openai_params(model=self.model, custom_llm_provider=self._provider_name)
         return set(params) if params else set()
 
     def _warn_zero_temp_rollout(self, temperature: float | None, rollout_id):
@@ -205,7 +193,7 @@ class LM(BaseLM):
                 cache=litellm_cache_args,
             )
         except Exception as e:
-            if _is_litellm_context_window_error(e):
+            if is_litellm_context_window_error(e):
                 raise ContextWindowExceededError(model=self.model) from e
             raise
 
@@ -248,7 +236,7 @@ class LM(BaseLM):
                 cache=litellm_cache_args,
             )
         except Exception as e:
-            if _is_litellm_context_window_error(e):
+            if is_litellm_context_window_error(e):
                 raise ContextWindowExceededError(model=self.model) from e
             raise
 
@@ -374,7 +362,7 @@ def _get_stream_completion_fn(
         request["stream_options"] = {"include_usage": True}
 
     async def stream_completion(request: dict[str, Any], cache_kwargs: dict[str, Any]):
-        response = await litellm.acompletion(
+        response = await _get_litellm().acompletion(
             cache=cache_kwargs,
             stream=True,
             headers=headers,
@@ -387,7 +375,7 @@ def _get_stream_completion_fn(
                 chunk.predict_id = caller_predict_id
             chunks.append(chunk)
             await stream.send(chunk)
-        return litellm.stream_chunk_builder(chunks)
+        return _get_litellm().stream_chunk_builder(chunks)
 
     def sync_stream_completion():
         return anyio.from_thread.run(functools.partial(stream_completion, request, cache_kwargs))
@@ -408,7 +396,7 @@ def litellm_completion(request: dict[str, Any], num_retries: int, cache: dict[st
     headers = _add_dspy_identifier_to_headers(request.pop("headers", None))
     stream_completion = _get_stream_completion_fn(request, cache, sync=True, headers=headers)
     if stream_completion is None:
-        return litellm.completion(
+        return _get_litellm().completion(
             cache=cache,
             num_retries=num_retries,
             retry_strategy="exponential_backoff_retry",
@@ -436,7 +424,7 @@ def litellm_text_completion(request: dict[str, Any], num_retries: int, cache: di
     # Build the prompt from the messages.
     prompt = "\n\n".join([x["content"] for x in request.pop("messages")] + ["BEGIN RESPONSE:"])
 
-    return litellm.text_completion(
+    return _get_litellm().text_completion(
         cache=cache,
         model=f"text-completion-openai/{model}",
         api_key=api_key,
@@ -456,7 +444,7 @@ async def alitellm_completion(request: dict[str, Any], num_retries: int, cache: 
     headers = _add_dspy_identifier_to_headers(request.pop("headers", None))
     stream_completion = _get_stream_completion_fn(request, cache, sync=False, headers=headers)
     if stream_completion is None:
-        return await litellm.acompletion(
+        return await _get_litellm().acompletion(
             cache=cache,
             num_retries=num_retries,
             retry_strategy="exponential_backoff_retry",
@@ -482,7 +470,7 @@ async def alitellm_text_completion(request: dict[str, Any], num_retries: int, ca
     # Build the prompt from the messages.
     prompt = "\n\n".join([x["content"] for x in request.pop("messages")] + ["BEGIN RESPONSE:"])
 
-    return await litellm.atext_completion(
+    return await _get_litellm().atext_completion(
         cache=cache,
         model=f"text-completion-openai/{model}",
         api_key=api_key,
@@ -502,7 +490,7 @@ def litellm_responses_completion(request: dict[str, Any], num_retries: int, cach
     headers = request.pop("headers", None)
     request = _convert_chat_request_to_responses_request(request)
 
-    return litellm.responses(
+    return _get_litellm().responses(
         cache=cache,
         num_retries=num_retries,
         retry_strategy="exponential_backoff_retry",
@@ -518,7 +506,7 @@ async def alitellm_responses_completion(request: dict[str, Any], num_retries: in
     headers = request.pop("headers", None)
     request = _convert_chat_request_to_responses_request(request)
 
-    return await litellm.aresponses(
+    return await _get_litellm().aresponses(
         cache=cache,
         num_retries=num_retries,
         retry_strategy="exponential_backoff_retry",

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -7,10 +7,8 @@ import warnings
 from typing import Any, Literal, cast
 
 import anyio.from_thread
-import litellm
 import pydantic
 from anyio.streams.memory import MemoryObjectSendStream
-from litellm import ContextWindowExceededError as LitellmContextWindowExceededError
 
 import dspy
 from dspy.clients.cache import request_cache
@@ -20,10 +18,27 @@ from dspy.clients.utils_finetune import TrainDataFormat
 from dspy.dsp.utils.settings import settings
 from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import ContextWindowExceededError
+from dspy.utils.lazy_import import require
 
 from .base_lm import BaseLM
 
 logger = logging.getLogger(__name__)
+
+
+def _configure_litellm_defaults(litellm):
+    litellm.telemetry = False
+    litellm.cache = None  # By default we disable LiteLLM cache and use DSPy on-disk cache.
+    if not getattr(litellm, "_dspy_logging_configured", False):
+        litellm.suppress_debug_info = True
+        litellm._dspy_logging_configured = True
+
+
+litellm = require("litellm", extra="litellm", feature="dspy.LM", on_load=_configure_litellm_defaults)
+
+
+def _is_litellm_context_window_error(error: Exception) -> bool:
+    error_type = type(error)
+    return error_type.__module__.startswith("litellm") and "ContextWindowExceeded" in error_type.__name__
 
 
 class LM(BaseLM):
@@ -189,8 +204,10 @@ class LM(BaseLM):
                 num_retries=self.num_retries,
                 cache=litellm_cache_args,
             )
-        except LitellmContextWindowExceededError as e:
-            raise ContextWindowExceededError(model=self.model) from e
+        except Exception as e:
+            if _is_litellm_context_window_error(e):
+                raise ContextWindowExceededError(model=self.model) from e
+            raise
 
         self._check_truncation(results)
 
@@ -230,8 +247,10 @@ class LM(BaseLM):
                 num_retries=self.num_retries,
                 cache=litellm_cache_args,
             )
-        except LitellmContextWindowExceededError as e:
-            raise ContextWindowExceededError(model=self.model) from e
+        except Exception as e:
+            if _is_litellm_context_window_error(e):
+                raise ContextWindowExceededError(model=self.model) from e
+            raise
 
         self._check_truncation(results)
 

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -6,11 +6,9 @@ from asyncio import iscoroutinefunction
 from queue import Queue
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator
 
-import litellm
 import orjson
 from anyio import create_memory_object_stream, create_task_group
 from anyio.streams.memory import MemoryObjectSendStream
-from litellm import ModelResponseStream
 
 from dspy.dsp.utils.settings import settings
 from dspy.primitives.prediction import Prediction
@@ -19,6 +17,12 @@ from dspy.streaming.streaming_listener import StreamListener, find_predictor_for
 from dspy.utils.asyncify import asyncify
 
 logger = logging.getLogger(__name__)
+
+
+def _is_litellm_model_response_stream(value: Any) -> bool:
+    cls = type(value)
+    return cls.__name__ == "ModelResponseStream" and cls.__module__.startswith("litellm")
+
 
 if TYPE_CHECKING:
     from dspy.primitives.module import Module
@@ -178,7 +182,7 @@ def streamify(
             tg.start_soon(generator, args, kwargs, send_stream)
 
             async for value in receive_stream:
-                if isinstance(value, ModelResponseStream):
+                if _is_litellm_model_response_stream(value):
                     if len(predict_id_to_listener) == 0:
                         # No listeners are configured, yield the chunk directly for backwards compatibility.
                         yield value
@@ -271,7 +275,7 @@ async def streaming_response(streamer: AsyncGenerator) -> AsyncGenerator:
         if isinstance(value, Prediction):
             data = {"prediction": dict(value.items(include_dspy=False))}
             yield f"data: {orjson.dumps(data).decode()}\n\n"
-        elif isinstance(value, litellm.ModelResponseStream):
+        elif _is_litellm_model_response_stream(value):
             data = {"chunk": value.json()}
             yield f"data: {orjson.dumps(data).decode()}\n\n"
         elif isinstance(value, str) and value.startswith("data:"):

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -5,7 +5,6 @@ from queue import Queue
 from typing import TYPE_CHECKING, Any
 
 import jiter
-from litellm import ModelResponseStream
 
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
@@ -15,6 +14,8 @@ from dspy.dsp.utils.settings import settings
 from dspy.streaming.messages import StreamResponse
 
 if TYPE_CHECKING:
+    from litellm import ModelResponseStream
+
     from dspy.primitives.module import Module
 
 ADAPTER_SUPPORT_STREAMING = [ChatAdapter, XMLAdapter, JSONAdapter]
@@ -112,7 +113,7 @@ class StreamListener:
 
         return False
 
-    def receive(self, chunk: ModelResponseStream):
+    def receive(self, chunk: "ModelResponseStream"):
         adapter_name = settings.adapter.__class__.__name__ if settings.adapter else "ChatAdapter"
         if adapter_name not in self.adapter_identifiers:
             raise ValueError(

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import re
 from collections import defaultdict
@@ -113,7 +115,7 @@ class StreamListener:
 
         return False
 
-    def receive(self, chunk: "ModelResponseStream"):
+    def receive(self, chunk: ModelResponseStream):
         adapter_name = settings.adapter.__class__.__name__ if settings.adapter else "ChatAdapter"
         if adapter_name not in self.adapter_identifiers:
             raise ValueError(
@@ -369,7 +371,7 @@ class StreamListener:
 
 
 def find_predictor_for_stream_listeners(
-    program: "Module", stream_listeners: list[StreamListener]
+    program: Module, stream_listeners: list[StreamListener]
 ) -> dict[int, list[StreamListener]]:
     """Find the predictor for each stream listener.
 
@@ -386,7 +388,7 @@ def find_predictor_for_stream_listeners(
         field_name_to_named_predictor[listener.signature_field_name] = None
 
     for name, predictor in predictors:
-        for field_name, field_info in predictor.signature.output_fields.items():
+        for field_name in predictor.signature.output_fields:
             if field_name not in field_name_to_named_predictor:
                 continue
 

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -23,7 +23,6 @@ import importlib.util
 import inspect
 import sys
 import types
-from collections.abc import Callable
 from typing import Any
 
 
@@ -45,28 +44,6 @@ _INSTALL_HINTS: dict[str, str] = {
     "numpy": "numpy",
     "litellm": "litellm",
 }
-_ON_LOAD_CALLBACKS: dict[str, list[Callable[[types.ModuleType], None]]] = {}
-_LAZY_MODULES: set[str] = set()
-
-
-class _OnLoadLoader:
-    def __init__(self, module: str, loader):
-        self.module = module
-        self.loader = loader
-
-    def create_module(self, spec):
-        if hasattr(self.loader, "create_module"):
-            return self.loader.create_module(spec)
-        return None
-
-    def exec_module(self, module: types.ModuleType):
-        self.loader.exec_module(module)
-        _LAZY_MODULES.discard(self.module)
-        for callback in _ON_LOAD_CALLBACKS.pop(self.module, []):
-            callback(module)
-
-    def __getattr__(self, name: str):
-        return getattr(self.loader, name)
 
 
 class _MissingModule(types.ModuleType):
@@ -100,13 +77,7 @@ def is_available(module: str) -> bool:
         return False
 
 
-def require(
-    module: str,
-    *,
-    extra: str | None = None,
-    feature: str | None = None,
-    on_load: Callable[[types.ModuleType], None] | None = None,
-) -> Any:
+def require(module: str, *, extra: str | None = None, feature: str | None = None) -> Any:
     """Return a lazily-loaded module, or a stub that raises on access.
 
     Safe to call at module level:
@@ -124,16 +95,9 @@ def require(
         module: Dotted module path (e.g. `"numpy"`).
         extra: Name of the dspy extra that provides this dep.
         feature: Label shown in the error (e.g. `"dspy.Embeddings"`).
-        on_load: Optional callback run once with the real module after it is loaded.
     """
     if module in sys.modules:
-        mod = sys.modules[module]
-        if on_load is not None:
-            if module in _LAZY_MODULES:
-                _ON_LOAD_CALLBACKS.setdefault(module, []).append(on_load)
-            else:
-                on_load(mod)
-        return mod
+        return sys.modules[module]
 
     spec = importlib.util.find_spec(module)
     if spec is None or spec.loader is None:
@@ -155,14 +119,9 @@ def require(
         del parent
         return _MissingModule(module, message, frame_data)
 
-    if on_load is not None:
-        _ON_LOAD_CALLBACKS.setdefault(module, []).append(on_load)
-    spec.loader = _OnLoadLoader(module, spec.loader)
-
     loader = importlib.util.LazyLoader(spec.loader)
     spec.loader = loader
     mod = importlib.util.module_from_spec(spec)
     sys.modules[module] = mod
-    _LAZY_MODULES.add(module)
     loader.exec_module(mod)
     return mod

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -23,6 +23,7 @@ import importlib.util
 import inspect
 import sys
 import types
+from collections.abc import Callable
 from typing import Any
 
 
@@ -42,7 +43,30 @@ _INSTALL_HINTS: dict[str, str] = {
     "weaviate": "weaviate",
     "anthropic": "anthropic",
     "numpy": "numpy",
+    "litellm": "litellm",
 }
+_ON_LOAD_CALLBACKS: dict[str, list[Callable[[types.ModuleType], None]]] = {}
+_LAZY_MODULES: set[str] = set()
+
+
+class _OnLoadLoader:
+    def __init__(self, module: str, loader):
+        self.module = module
+        self.loader = loader
+
+    def create_module(self, spec):
+        if hasattr(self.loader, "create_module"):
+            return self.loader.create_module(spec)
+        return None
+
+    def exec_module(self, module: types.ModuleType):
+        self.loader.exec_module(module)
+        _LAZY_MODULES.discard(self.module)
+        for callback in _ON_LOAD_CALLBACKS.pop(self.module, []):
+            callback(module)
+
+    def __getattr__(self, name: str):
+        return getattr(self.loader, name)
 
 
 class _MissingModule(types.ModuleType):
@@ -76,7 +100,13 @@ def is_available(module: str) -> bool:
         return False
 
 
-def require(module: str, *, extra: str | None = None, feature: str | None = None) -> Any:
+def require(
+    module: str,
+    *,
+    extra: str | None = None,
+    feature: str | None = None,
+    on_load: Callable[[types.ModuleType], None] | None = None,
+) -> Any:
     """Return a lazily-loaded module, or a stub that raises on access.
 
     Safe to call at module level:
@@ -94,9 +124,16 @@ def require(module: str, *, extra: str | None = None, feature: str | None = None
         module: Dotted module path (e.g. `"numpy"`).
         extra: Name of the dspy extra that provides this dep.
         feature: Label shown in the error (e.g. `"dspy.Embeddings"`).
+        on_load: Optional callback run once with the real module after it is loaded.
     """
     if module in sys.modules:
-        return sys.modules[module]
+        mod = sys.modules[module]
+        if on_load is not None:
+            if module in _LAZY_MODULES:
+                _ON_LOAD_CALLBACKS.setdefault(module, []).append(on_load)
+            else:
+                on_load(mod)
+        return mod
 
     spec = importlib.util.find_spec(module)
     if spec is None or spec.loader is None:
@@ -118,9 +155,14 @@ def require(module: str, *, extra: str | None = None, feature: str | None = None
         del parent
         return _MissingModule(module, message, frame_data)
 
+    if on_load is not None:
+        _ON_LOAD_CALLBACKS.setdefault(module, []).append(on_load)
+    spec.loader = _OnLoadLoader(module, spec.loader)
+
     loader = importlib.util.LazyLoader(spec.loader)
     spec.loader = loader
     mod = importlib.util.module_from_spec(spec)
     sys.modules[module] = mod
+    _LAZY_MODULES.add(module)
     loader.exec_module(mod)
     return mod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ mcp = ["mcp; python_version >= '3.10'"]
 langchain = ["langchain_core"]
 optuna = ["optuna>=3.4.0"]
 numpy = ["numpy>=1.26.0"]
+litellm = ["litellm>=1.64.0"]
 dev = [
     "pytest>=6.2.5",
     "pytest-mock>=3.12.0",

--- a/tests/clients/test_lazy_litellm_import.py
+++ b/tests/clients/test_lazy_litellm_import.py
@@ -1,97 +1,58 @@
-import subprocess
+import importlib.util
 import sys
-import textwrap
+
+import pytest
 
 
-def run_python(code: str) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(code)],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+def _hide_litellm(monkeypatch):
+    real_find_spec = importlib.util.find_spec
+
+    def find_spec(name, *args, **kwargs):
+        if name == "litellm" or name.startswith("litellm."):
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+    monkeypatch.delitem(sys.modules, "litellm", raising=False)
+
+    from dspy.clients._litellm import get_litellm
+
+    get_litellm.cache_clear()
 
 
-def test_import_dspy_succeeds_without_litellm():
-    run_python(
-        """
-        import importlib.util
-        import sys
+def test_import_dspy_does_not_import_litellm(monkeypatch):
+    monkeypatch.delitem(sys.modules, "litellm", raising=False)
 
-        real_find_spec = importlib.util.find_spec
+    import dspy
 
-        def find_spec(name, *args, **kwargs):
-            if name == "litellm" or name.startswith("litellm."):
-                return None
-            return real_find_spec(name, *args, **kwargs)
+    _ = dspy.LM
+    _ = dspy.Embedder
+    _ = dspy.streamify
 
-        importlib.util.find_spec = find_spec
-        sys.modules.pop("litellm", None)
-
-        import dspy
-
-        _ = dspy.LM
-        _ = dspy.Embedder
-        _ = dspy.streamify
-        """
-    )
+    assert "litellm" not in sys.modules
 
 
-def test_lm_litellm_use_raises_helpful_error_without_litellm():
-    run_python(
-        """
-        import importlib.util
-        import sys
+def test_lm_litellm_use_raises_helpful_error_without_litellm(monkeypatch):
+    import dspy
 
-        real_find_spec = importlib.util.find_spec
+    _hide_litellm(monkeypatch)
 
-        def find_spec(name, *args, **kwargs):
-            if name == "litellm" or name.startswith("litellm."):
-                return None
-            return real_find_spec(name, *args, **kwargs)
+    with pytest.raises(ImportError) as exc_info:
+        _ = dspy.LM("openai/gpt-4o-mini").supports_function_calling
 
-        importlib.util.find_spec = find_spec
-        sys.modules.pop("litellm", None)
-
-        import dspy
-
-        try:
-            _ = dspy.LM("openai/gpt-4o-mini").supports_function_calling
-        except ImportError as e:
-            msg = str(e)
-            assert "[litellm]" in msg
-            assert "dspy.LM" in msg
-        else:
-            raise AssertionError("Expected ImportError")
-        """
-    )
+    msg = str(exc_info.value)
+    assert "[litellm]" in msg
+    assert "dspy.LM" in msg
 
 
-def test_embedder_litellm_use_raises_helpful_error_without_litellm():
-    run_python(
-        """
-        import importlib.util
-        import sys
+def test_embedder_litellm_use_raises_helpful_error_without_litellm(monkeypatch):
+    import dspy
 
-        real_find_spec = importlib.util.find_spec
+    _hide_litellm(monkeypatch)
 
-        def find_spec(name, *args, **kwargs):
-            if name == "litellm" or name.startswith("litellm."):
-                return None
-            return real_find_spec(name, *args, **kwargs)
+    with pytest.raises(ImportError) as exc_info:
+        dspy.Embedder("openai/text-embedding-3-small")(["hello"])
 
-        importlib.util.find_spec = find_spec
-        sys.modules.pop("litellm", None)
-
-        import dspy
-
-        try:
-            dspy.Embedder("openai/text-embedding-3-small")(["hello"])
-        except ImportError as e:
-            msg = str(e)
-            assert "[litellm]" in msg
-            assert "dspy.Embedder" in msg
-        else:
-            raise AssertionError("Expected ImportError")
-        """
-    )
+    msg = str(exc_info.value)
+    assert "[litellm]" in msg
+    assert "dspy.Embedder" in msg

--- a/tests/clients/test_lazy_litellm_import.py
+++ b/tests/clients/test_lazy_litellm_import.py
@@ -1,0 +1,97 @@
+import subprocess
+import sys
+import textwrap
+
+
+def run_python(code: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_import_dspy_succeeds_without_litellm():
+    run_python(
+        """
+        import importlib.util
+        import sys
+
+        real_find_spec = importlib.util.find_spec
+
+        def find_spec(name, *args, **kwargs):
+            if name == "litellm" or name.startswith("litellm."):
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        importlib.util.find_spec = find_spec
+        sys.modules.pop("litellm", None)
+
+        import dspy
+
+        _ = dspy.LM
+        _ = dspy.Embedder
+        _ = dspy.streamify
+        """
+    )
+
+
+def test_lm_litellm_use_raises_helpful_error_without_litellm():
+    run_python(
+        """
+        import importlib.util
+        import sys
+
+        real_find_spec = importlib.util.find_spec
+
+        def find_spec(name, *args, **kwargs):
+            if name == "litellm" or name.startswith("litellm."):
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        importlib.util.find_spec = find_spec
+        sys.modules.pop("litellm", None)
+
+        import dspy
+
+        try:
+            _ = dspy.LM("openai/gpt-4o-mini").supports_function_calling
+        except ImportError as e:
+            msg = str(e)
+            assert "[litellm]" in msg
+            assert "dspy.LM" in msg
+        else:
+            raise AssertionError("Expected ImportError")
+        """
+    )
+
+
+def test_embedder_litellm_use_raises_helpful_error_without_litellm():
+    run_python(
+        """
+        import importlib.util
+        import sys
+
+        real_find_spec = importlib.util.find_spec
+
+        def find_spec(name, *args, **kwargs):
+            if name == "litellm" or name.startswith("litellm."):
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        importlib.util.find_spec = find_spec
+        sys.modules.pop("litellm", None)
+
+        import dspy
+
+        try:
+            dspy.Embedder("openai/text-embedding-3-small")(["hello"])
+        except ImportError as e:
+            msg = str(e)
+            assert "[litellm]" in msg
+            assert "dspy.Embedder" in msg
+        else:
+            raise AssertionError("Expected ImportError")
+        """
+    )

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -42,50 +42,6 @@ def test_require_returns_stub_when_missing():
     assert isinstance(stub, _MissingModule)
 
 
-def test_require_on_load_runs_once_on_first_access(tmp_path, monkeypatch):
-    import importlib
-    import sys
-
-    module = "lazy_import_test_module"
-    (tmp_path / f"{module}.py").write_text("VALUE = 41\n")
-    monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.delitem(sys.modules, module, raising=False)
-    importlib.invalidate_caches()
-
-    calls = []
-
-    def configure(mod):
-        calls.append(mod.__name__)
-        mod.CONFIGURED = True
-
-    mod = require(module, on_load=configure)
-    assert calls == []
-
-    assert mod.VALUE == 41
-    assert mod.CONFIGURED is True
-    assert calls == [module]
-
-
-def test_require_collects_on_load_callbacks_before_first_access(tmp_path, monkeypatch):
-    import importlib
-    import sys
-
-    module = "lazy_import_test_module_multi"
-    (tmp_path / f"{module}.py").write_text("VALUE = 42\n")
-    monkeypatch.syspath_prepend(str(tmp_path))
-    monkeypatch.delitem(sys.modules, module, raising=False)
-    importlib.invalidate_caches()
-
-    calls = []
-    mod = require(module, on_load=lambda _: calls.append("first"))
-    same_mod = require(module, on_load=lambda _: calls.append("second"))
-
-    assert same_mod is mod
-    assert calls == []
-    assert mod.VALUE == 42
-    assert calls == ["first", "second"]
-
-
 def test_require_stub_raises_on_access_with_install_hint():
     dist = _detect_dspy_dist()
     stub = require("nonexistent_abc", feature="dspy.Test")

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -42,21 +42,80 @@ def test_require_returns_stub_when_missing():
     assert isinstance(stub, _MissingModule)
 
 
+def test_require_on_load_runs_once_on_first_access(tmp_path, monkeypatch):
+    import importlib
+    import sys
+
+    module = "lazy_import_test_module"
+    (tmp_path / f"{module}.py").write_text("VALUE = 41\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, module, raising=False)
+    importlib.invalidate_caches()
+
+    calls = []
+
+    def configure(mod):
+        calls.append(mod.__name__)
+        mod.CONFIGURED = True
+
+    mod = require(module, on_load=configure)
+    assert calls == []
+
+    assert mod.VALUE == 41
+    assert mod.CONFIGURED is True
+    assert calls == [module]
+
+
+def test_require_collects_on_load_callbacks_before_first_access(tmp_path, monkeypatch):
+    import importlib
+    import sys
+
+    module = "lazy_import_test_module_multi"
+    (tmp_path / f"{module}.py").write_text("VALUE = 42\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.delitem(sys.modules, module, raising=False)
+    importlib.invalidate_caches()
+
+    calls = []
+    mod = require(module, on_load=lambda _: calls.append("first"))
+    same_mod = require(module, on_load=lambda _: calls.append("second"))
+
+    assert same_mod is mod
+    assert calls == []
+    assert mod.VALUE == 42
+    assert calls == ["first", "second"]
+
+
 def test_require_stub_raises_on_access_with_install_hint():
     dist = _detect_dspy_dist()
     stub = require("nonexistent_abc", feature="dspy.Test")
     with pytest.raises(ImportError) as exc_info:
-        stub.something
+        _ = stub.something
     msg = str(exc_info.value)
     assert f"{dist}[nonexistent_abc]" in msg, msg
     assert "dspy.Test" in msg
+
+
+def test_require_stub_uses_install_hint_for_litellm(monkeypatch):
+    import importlib.util
+    import sys
+
+    dist = _detect_dspy_dist()
+    find_spec = importlib.util.find_spec
+    monkeypatch.delitem(sys.modules, "litellm", raising=False)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda module: None if module == "litellm" else find_spec(module))
+
+    stub = require("litellm", feature="dspy.LM")
+    with pytest.raises(ImportError) as exc_info:
+        _ = stub.something
+    assert f"{dist}[litellm]" in str(exc_info.value)
 
 
 def test_require_stub_uses_explicit_extra():
     dist = _detect_dspy_dist()
     stub = require("nonexistent_xyz", extra="custom", feature="dspy.X")
     with pytest.raises(ImportError) as exc_info:
-        stub.something
+        _ = stub.something
     assert f"{dist}[custom]" in str(exc_info.value)
 
 
@@ -64,7 +123,7 @@ def test_require_stub_falls_back_to_module_name():
     dist = _detect_dspy_dist()
     stub = require("nonexistent_xyz", feature="dspy.X")
     with pytest.raises(ImportError) as exc_info:
-        stub.something
+        _ = stub.something
     assert f"{dist}[nonexistent_xyz]" in str(exc_info.value)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -778,6 +778,10 @@ dev = [
 langchain = [
     { name = "langchain-core" },
 ]
+litellm = [
+    { name = "litellm", version = "1.68.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
+    { name = "litellm", version = "1.72.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
+]
 mcp = [
     { name = "mcp", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "mcp", version = "1.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
@@ -819,6 +823,7 @@ requires-dist = [
     { name = "langchain-core", marker = "extra == 'test-extras'" },
     { name = "litellm", specifier = ">=1.64.0" },
     { name = "litellm", marker = "(python_full_version == '3.14.*' and extra == 'dev') or (sys_platform == 'win32' and extra == 'dev')", specifier = ">=1.64.0" },
+    { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.64.0" },
     { name = "litellm", extras = ["proxy"], marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = ">=1.64.0" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'mcp'" },
     { name = "mcp", marker = "python_full_version >= '3.10' and extra == 'test-extras'" },
@@ -843,7 +848,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.1" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = "~=4.5.4" },
 ]
-provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "numpy", "dev", "test-extras"]
+provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "numpy", "litellm", "dev", "test-extras"]
 
 [[package]]
 name = "email-validator"


### PR DESCRIPTION
## Summary
- lazy-load LiteLLM so importing DSPy works without importing the dependency
- configure LiteLLM defaults on first actual use via lazy import on-load hooks
- avoid LiteLLM imports in streaming type checks and annotations
- add tests for lazy import callbacks and DSPy import behavior without LiteLLM

## Tests
- python3 -m pytest tests/clients/test_lazy_litellm_import.py tests/utils/test_lazy_import.py -q