### PR TITLE
fix(interpreter): transport Pydantic models as JSON

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -19,6 +19,9 @@ import threading
 from os import PathLike
 from typing import Any, Callable, NoReturn
 
+from pydantic import BaseModel
+from pydantic_core import PydanticSerializationError
+
 from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeExecutionError, CodeInterpreterError, FinalOutput
 
 __all__ = ["PythonInterpreter", "FinalOutput", "CodeExecutionError", "CodeInterpreterError"]
@@ -93,6 +96,27 @@ def _await_in_sync(coroutine: Any) -> Any:
     if loop is None:
         return asyncio.run(coroutine)
     return loop.run_until_complete(coroutine)
+
+
+def _dump_pydantic(value: BaseModel) -> Any:
+    """Dump a Pydantic model to JSON-compatible values."""
+    try:
+        return value.model_dump(mode="json")
+    except PydanticSerializationError as e:
+        raise CodeInterpreterError(f"Unable to serialize {type(value).__name__} as JSON: {e}") from e
+
+
+def _coerce_pydantic(value: Any) -> Any:
+    """Recursively convert Pydantic ``BaseModel`` instances to JSON-compatible values."""
+    if isinstance(value, BaseModel):
+        return _coerce_pydantic(_dump_pydantic(value))
+    if isinstance(value, dict):
+        return {k: _coerce_pydantic(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_coerce_pydantic(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_coerce_pydantic(v) for v in value)
+    return value
 
 
 class PythonInterpreter:
@@ -359,6 +383,7 @@ class PythonInterpreter:
             result = self.tools[tool_name](**kwargs)
             if asyncio.iscoroutine(result):
                 result = _await_in_sync(result)
+            result = _coerce_pydantic(result)
             if result is None or isinstance(result, str):
                 response = _jsonrpc_result({"value": str(result) if result is not None else "", "type": "string"}, request_id)
             else:
@@ -478,6 +503,8 @@ class PythonInterpreter:
         """Recursively convert Python values to JSON-compatible types."""
         if value is None or isinstance(value, (str, int, float, bool)):
             return value
+        elif isinstance(value, BaseModel):
+            return self._to_json_compatible(_dump_pydantic(value))
         elif isinstance(value, dict):
             return {k: self._to_json_compatible(v) for k, v in value.items()}
         elif isinstance(value, (list, tuple)):
@@ -534,6 +561,8 @@ class PythonInterpreter:
             return f"float('{value}')"
         elif isinstance(value, (int, float)):
             return str(value)
+        elif isinstance(value, BaseModel):
+            return self._serialize_value(_dump_pydantic(value))
         elif isinstance(value, (list, tuple)):
             # Tuples become lists for JSON compatibility
             items = ", ".join(self._serialize_value(item) for item in value)

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -1,11 +1,34 @@
 import asyncio
+import json
 import os
 import random
+from datetime import datetime
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
 from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreterError, FinalOutput
 from dspy.primitives.python_interpreter import PythonInterpreter
+
+
+class _Hit(BaseModel):
+    document_id: int
+    title: str
+
+
+class _TimestampedHit(_Hit):
+    created_at: datetime
+
+
+class _UnserializableValue:
+    pass
+
+
+class _UnserializableModel(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    value: _UnserializableValue
+
 
 pytestmark = pytest.mark.deno
 
@@ -261,6 +284,70 @@ def test_serialize_set_mixed_types():
         result = interpreter.execute("x", variables={"x": {1, "a"}})
         assert isinstance(result, list)
         assert set(result) == {1, "a"}
+
+
+def test_serialize_pydantic_variable():
+    """Pydantic instances passed via variables= should arrive in the sandbox as dicts."""
+    with PythonInterpreter() as interpreter:
+        result = interpreter.execute(
+            "hit['document_id']",
+            variables={"hit": _Hit(document_id=7, title="abc")},
+        )
+        assert result == 7
+
+
+def test_serialize_pydantic_nested_in_dict():
+    """Pydantic instances nested inside list/dict variables should be coerced too."""
+    with PythonInterpreter() as interpreter:
+        result = interpreter.execute(
+            "(data['hit']['document_id'], data['hit']['title'])",
+            variables={"data": {"hit": _Hit(document_id=11, title="nested")}},
+        )
+        assert result == [11, "nested"]
+
+
+def test_serialize_pydantic_in_list_variable():
+    """A list variable whose elements are Pydantic instances should be coerced too."""
+    with PythonInterpreter() as interpreter:
+        result = interpreter.execute(
+            "sum(h['document_id'] for h in hits)",
+            variables={"hits": [_Hit(document_id=1, title="a"), _Hit(document_id=2, title="b")]},
+        )
+        assert result == 3
+
+
+def test_pydantic_json_values_are_compatible_with_large_variable_injection(monkeypatch):
+    """The large-variable path should serialize Pydantic's JSON-mode values."""
+    value = _TimestampedHit(
+        document_id=7,
+        title="dated",
+        created_at=datetime(2026, 5, 14, 8, 7, 27),
+    )
+    expected = {
+        "document_id": 7,
+        "title": "dated",
+        "created_at": "2026-05-14T08:07:27",
+    }
+    interpreter = PythonInterpreter()
+
+    assert interpreter._to_json_compatible(value) == expected
+
+    monkeypatch.setattr("dspy.primitives.python_interpreter.LARGE_VAR_THRESHOLD", 0)
+    code = interpreter._inject_variables("hit", {"hit": value})
+    assert "hit = json.loads" in code
+    assert json.loads(interpreter._pending_large_vars["hit"]) == expected
+
+
+def test_unserializable_pydantic_variable_raises_code_interpreter_error():
+    """Invalid host variables should fail before the interpreter process starts."""
+    interpreter = PythonInterpreter()
+    value = _UnserializableModel(value=_UnserializableValue())
+
+    with pytest.raises(CodeInterpreterError, match="Unable to serialize _UnserializableModel as JSON") as exc_info:
+        interpreter.execute("value", variables={"value": value})
+
+    assert type(exc_info.value) is CodeInterpreterError
+    assert interpreter.deno_process is None
 
 
 def test_deno_command_dict_raises_type_error():
@@ -613,6 +700,48 @@ def test_tool_returning_nan_falls_back_to_string():
         )
         assert "str" in result
         assert "inf" in result
+
+
+def test_tool_returns_pydantic_model():
+    """Pydantic models returned from a tool should arrive in the sandbox as dicts."""
+
+    def search() -> _TimestampedHit:
+        return _TimestampedHit(
+            document_id=42,
+            title="example",
+            created_at=datetime(2026, 5, 14, 8, 7, 27),
+        )
+
+    with PythonInterpreter(tools={"search": search}) as sandbox:
+        result = sandbox.execute("r = search()\n(r['document_id'], r['title'], r['created_at'])")
+        assert result == [42, "example", "2026-05-14T08:07:27"]
+
+
+def test_tool_returns_list_of_pydantic_models():
+    """Lists of Pydantic models from a tool should round-trip as lists of dicts."""
+
+    def search_many() -> list[_Hit]:
+        return [_Hit(document_id=1, title="a"), _Hit(document_id=2, title="b")]
+
+    with PythonInterpreter(tools={"search_many": search_many}) as sandbox:
+        result = sandbox.execute(
+            "hits = search_many()\nsum(h['document_id'] for h in hits)"
+        )
+        assert result == 3
+
+
+def test_tool_returning_unserializable_pydantic_model_raises_execution_error():
+    """A BaseModel that cannot honor JSON transport should remain a visible tool error."""
+
+    def get_value() -> _UnserializableModel:
+        return _UnserializableModel(value=_UnserializableValue())
+
+    with PythonInterpreter(tools={"get_value": get_value}) as sandbox:
+        with pytest.raises(
+            CodeExecutionError,
+            match="CodeInterpreterError.*Unable to serialize _UnserializableModel as JSON",
+        ):
+            sandbox.execute("get_value()")
 
 
 # =============================================================================


### PR DESCRIPTION
## Issue / repro

`PythonInterpreter` accepts host variables and host-side tool results over a JSON boundary, but a Pydantic `BaseModel` does not currently cross that boundary structurally.

```python
class Hit(BaseModel):
    document_id: int
    title: str

def search() -> Hit:
    return Hit(document_id=42, title="example")

with PythonInterpreter(tools={"search": search}) as interp:
    interp.execute("hit = search()\nhit['document_id']")
```

On current `main`, `json.dumps(Hit(...))` raises `TypeError`, so the existing arbitrary-object fallback sends `"document_id=42 title='example'"` into the sandbox. Indexing it then fails because `hit` is a string.

The opposite direction fails earlier:

```python
interp.execute("hit['document_id']", variables={"hit": Hit(document_id=7, title="abc")})
# CodeInterpreterError: Unsupported value type: Hit
```

## Root cause

The interpreter's wire format is JSON, but `BaseModel` requires an explicit Pydantic dump before ordinary JSON encoding.

The tool path intentionally stringifies arbitrary non-JSON objects:

```python
try:
    payload = json.dumps(result, allow_nan=False)
except (TypeError, ValueError):
    payload = str(result)
```

That fallback is useful for unknown host objects, but it accidentally makes a first-class structured DSPy type look successful while losing its shape. The small- and large-variable serializers reject the same model instead, so the three host boundaries disagree.

## Why this fixes the root cause

`BaseModel` now opts into one explicit conversion before the existing JSON transport:

```python
value.model_dump(mode="json")
```

JSON mode matters: Pydantic converts values such as `datetime` and `UUID` to their JSON representations before DSPy's existing container handling continues. Models nested in the supported dict/list/tuple paths therefore use the same wire shape as top-level models.

If `model_dump(mode="json")` raises Pydantic's specific `PydanticSerializationError`, it becomes `CodeInterpreterError`. Invalid injected variables fail before Deno starts; invalid tool results follow the existing tool-error RPC path and surface as recoverable `CodeExecutionError`.

## Why this is the concise boundary

- Only `BaseModel` gains new behavior; arbitrary host objects retain the existing string fallback.
- One dump helper owns Pydantic's JSON/error contract.
- A narrow recursive helper adapts tool results without changing their existing scalar, tuple, async, or fallback behavior.
- No generic serialization protocol, provider branch, retry, schema generation, or broad exception catch is added.

## What changes

| Boundary | Before | After |
|---|---|---|
| Small injected variable | `CodeInterpreterError` | sandbox dict/list/scalar |
| Large injected variable | unsupported type | JSON-mode value through the existing file path |
| Tool result | model repr string | sandbox dict/list/scalar |
| Invalid Pydantic serialization | inconsistent fallback/error | explicit interpreter error contract |

## Review map

This is one focused contributor-authored commit over current `main`.

- `dspy/primitives/python_interpreter.py`: 29 production lines define the three BaseModel boundaries.
- `tests/primitives/test_python_interpreter.py`: direct, nested, list, large-value, tool, datetime, and error-contract proofs.

## Compatibility boundaries / downsides

- A tool-returned `BaseModel` now arrives as its JSON-mode structure instead of its repr string. Code that deliberately parsed the old repr must migrate to dict/list access; that repr transport was the bug.
- Pydantic's model dump contract is authoritative. Custom field serializers are honored, and JSON-native types such as datetime become strings.
- A model whose Pydantic JSON dump raises is no longer silently stringified. Variables raise `CodeInterpreterError` before startup; tool calls produce recoverable `CodeExecutionError` feedback.
- Values produced successfully by the dump continue through the existing transport rules. In particular, non-finite numbers and other downstream non-JSON tool payloads retain the existing string fallback; this PR does not redefine those semantics.
- Non-Pydantic values are unchanged: async tools are awaited, JSON scalars keep their type, arbitrary non-JSON tool results retain the existing string fallback, and interpreter failures remain terminal.
- This does not add support for dataclasses or arbitrary model protocols.
- This does not reconstruct typed RLM output fields or implement bidirectional `SandboxSerializable` outputs; it only makes the existing PythonInterpreter host boundary structurally correct.
- `model_dump(mode="json")` and `PydanticSerializationError` are available at DSPy's declared Pydantic 2.0 floor.

## Verification

- `uv run --frozen pytest --deno -q tests/primitives/test_python_interpreter.py` — `64 passed`
- focused compatibility/error selection — `13 passed`
- changed-file pre-commit hooks — passed
- lower-bound API checked against Pydantic 2.0 / pydantic-core 2.0.1

## AI assistance disclosure

The contributor used Claude Code while analyzing and drafting the original fix and tests, then reproduced both failures against DSPy 3.2.1 and reviewed the patch. This repair preserves that disclosure and contributor authorship.
