### PR TITLE
fix: await async tool functions in PythonInterpreter

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -6,6 +6,7 @@ WASM environment using Deno and Pyodide. It implements the Interpreter
 protocol defined in interpreter.py.
 """
 
+import asyncio
 import functools
 import inspect
 import json
@@ -70,6 +71,17 @@ def _jsonrpc_error(code: int, message: str, id: int | str, data: dict | None = N
     if data:
         err["data"] = data
     return json.dumps({"jsonrpc": "2.0", "error": err, "id": id})
+
+
+def _await_in_sync(coroutine: Any) -> Any:
+    """Run a coroutine to completion from a sync caller."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+    if loop is None:
+        return asyncio.run(coroutine)
+    return loop.run_until_complete(coroutine)
 
 
 class PythonInterpreter:
@@ -300,6 +312,8 @@ class PythonInterpreter:
             if tool_name not in self.tools:
                 raise CodeInterpreterError(f"Unknown tool: {tool_name}")
             result = self.tools[tool_name](**kwargs)
+            if asyncio.iscoroutine(result):
+                result = _await_in_sync(result)
             is_json = isinstance(result, (list, dict))
             response = _jsonrpc_result(
                 {"value": json.dumps(result) if is_json else (str(result) if result is not None else ""), "type": "json" if is_json else "string"},

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import random
 
@@ -374,6 +375,38 @@ def test_tool_error_surfaces_as_runtime_error():
         )
         assert "ValueError" in result
         assert "bad value: 42" in result
+
+
+def test_tool_async_def_function():
+    """async def tools should be awaited so the sandbox sees the resolved value."""
+
+    async def slow_search(query: str) -> str:
+        await asyncio.sleep(0)
+        return f"answer:{query}"
+
+    with PythonInterpreter(tools={"slow_search": slow_search}) as sandbox:
+        result = sandbox.execute("slow_search(query='hello')")
+        assert result == "answer:hello"
+
+
+def test_tool_async_def_raises_propagates():
+    """Exceptions raised inside an async tool should surface as RuntimeError in the sandbox."""
+
+    async def failing_async(x: int) -> str:
+        await asyncio.sleep(0)
+        raise ValueError(f"boom:{x}")
+
+    with PythonInterpreter(tools={"failing_async": failing_async}) as sandbox:
+        result = sandbox.execute(
+            "try:\n"
+            "    failing_async(7)\n"
+            "    output = 'no error'\n"
+            "except RuntimeError as e:\n"
+            "    output = str(e)\n"
+            "output"
+        )
+        assert "ValueError" in result
+        assert "boom:7" in result
 
 
 


### PR DESCRIPTION
## Summary

`PythonInterpreter._handle_tool_call` invokes host-side tools with a plain sync call.  If the tool is `async def`, the returned coroutine slips straight through to the sandbox response path and gets stringified as `"<coroutine object … at 0x…>"`. 
The agent reads the repr as the answer, and CPython emits `RuntimeWarning: coroutine '…' was never awaited` on stderr. Silent data corruption, no exception.

  ## What's broken on `main`

  ```python
  import asyncio
  from dspy.primitives.python_interpreter import PythonInterpreter

  async def slow_search(query: str) -> str:
      await asyncio.sleep(0)
      return f"answer:{query}"

  with PythonInterpreter(tools={"slow_search": slow_search}) as interp:
      out = interp("print(slow_search(query='hello'))")
  # Before: out is "<coroutine object slow_search at 0x…>\n"
  #         + stderr: RuntimeWarning: coroutine 'slow_search' was never awaited
  # After:  out is "answer:hello\n"
  ```

  ## Change

  - New private helper `_await_in_sync(coroutine)` in
  `dspy/primitives/python_interpreter.py` — copies the idiom from
  `Tool._run_async_in_sync`: `asyncio.run` when no loop is running,
  `loop.run_until_complete` when one is.
  - In `_handle_tool_call`, after invoking the tool, check `asyncio.iscoroutine(result)`
  and run it through `_await_in_sync` before any further handling. Exceptions raised
  inside the coroutine flow through `asyncio.run` and land in the existing `except
  Exception` block, so async tool errors surface as `RuntimeError` exactly like sync tool
   errors today.

## Testing

  - [x] `uv run pytest tests/primitives/test_python_interpreter.py --deno` → 43 passed
  (41 existing + 2 new)
  - [x] `uv run pre-commit run --files dspy/primitives/python_interpreter.py
  tests/primitives/test_python_interpreter.py` → clean
  - [x] Out-of-tree repro confirmed: before/after stdout matches the snippet above,
  `RuntimeWarning` is gone

## AI assistance disclosure

 I ran into this while making a tools for RLM agent. Every backend call I wanted to expose to the agent was `async def`, and the sandbox was silently feeding the agent coroutine repr strings instead of real values. 
I used Claude Code (Opus 4.7) to analyze the failure path and draft the fix and tests against the precedent in `dspy.Tool`. I reproduced the bug against a clean 3.2.1 install before and after and reviewed this PR