### PR TITLE
fix: skip mount_file for directories in enable_read_paths

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -124,8 +124,14 @@ class PythonInterpreter:
         Args:
             deno_command: command list to launch Deno.
             enable_read_paths: Files or directories to allow reading from in the sandbox.
+                Files are mounted under ``/sandbox/<basename>``; directories are accessible at
+                their host path via Deno's ``--allow-read=<dir>`` and are not mounted under
+                ``/sandbox/``.
             enable_write_paths: Files or directories to allow writing to in the sandbox.
-                All write paths will also be able to be read from for mounting.
+                All write paths are also readable for mounting. Files are mounted under
+                ``/sandbox/<basename>`` and synced back to the host on exit; directories are
+                accessible at the host path via ``--allow-write=<dir>`` and are not mounted
+                under ``/sandbox/`` (no write-back sync).
             enable_env_vars: Environment variable names to allow in the sandbox.
             enable_network_access: Domains or IPs to allow network access in the sandbox.
             sync_files: If set, syncs changes within the sandbox back to original files after execution.
@@ -238,6 +244,13 @@ class PythonInterpreter:
             return
         for path in paths_to_mount:
             if not path:
+                continue
+            if os.path.isdir(path):
+                logger.debug(
+                    "Skipping mount_file for directory %s; sandbox access is granted via "
+                    "--allow-read/--allow-write at the host path.",
+                    path,
+                )
                 continue
             if not os.path.exists(path):
                 if self.enable_write_paths and path in self.enable_write_paths:

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -666,3 +666,56 @@ def test_enable_read_paths_multiple_files(tmp_path):
         assert contents["test1.txt"] == "Content 1"
         assert contents["test2.txt"] == "Content 2"
         assert contents["test3.txt"] == "Content 3"
+
+
+def test_enable_read_paths_accepts_directory(tmp_path):
+    """Directories in enable_read_paths should not crash the sandbox at mount time.
+
+    Files inside the directory are reachable at their host path via Deno's
+    --allow-read=<dir> (using the js.Deno API from inside Pyodide); the directory
+    itself is not mirrored under /sandbox/.
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    secret = data_dir / "secret.txt"
+    secret.write_text("from-host-dir")
+
+    with PythonInterpreter(enable_read_paths=[str(data_dir)]) as interpreter:
+        assert interpreter.execute("print('ok')") == "ok\n"
+
+        output = interpreter(
+            "import js\n"
+            f"print(js.Deno.readTextFileSync({str(secret)!r}))"
+        )
+        assert "from-host-dir" in output
+
+        assert interpreter.execute(
+            f"import os\nos.path.exists('/sandbox/{data_dir.name}')"
+        ) is False
+
+
+def test_enable_read_paths_mixed_file_and_directory(tmp_path):
+    """A list mixing files and directories should mount files and skip directories."""
+    file1 = tmp_path / "alpha.txt"
+    file1.write_text("alpha-content")
+
+    data_dir = tmp_path / "extras"
+    data_dir.mkdir()
+    inside = data_dir / "inside.txt"
+    inside.write_text("inside-content")
+
+    with PythonInterpreter(enable_read_paths=[str(file1), str(data_dir)]) as interpreter:
+        mounted = interpreter.execute(
+            "with open('/sandbox/alpha.txt', 'r') as f:\n    data = f.read()\ndata"
+        )
+        assert mounted == "alpha-content"
+
+        host_read = interpreter(
+            "import js\n"
+            f"print(js.Deno.readTextFileSync({str(inside)!r}))"
+        )
+        assert "inside-content" in host_read
+
+        assert interpreter.execute(
+            f"import os\nos.path.exists('/sandbox/{data_dir.name}')"
+        ) is False


### PR DESCRIPTION
## Summary

If you pass a directory to `PythonInterpreter(enable_read_paths=[...])`, the first
  `execute()` call crashes:

  ```
  CodeInterpreterError: Error mounting /srv/agent/node_modules:
  Failed to mount file: Is a directory (os error 21)
  ```

  `_mount_files` sends a `mount_file` JSON-RPC for every entry, and the sandbox-side handler in `runner.js` does `Deno.readFile(hostPath)`, which doesn't work on directories. The docstring says "Files or directories", and the Deno CLI side already cooperates — `--allow-read=<dir>` is emitted so the sandbox has read access to the whole tree at the host path. 

## Where I ran into it

  ```python
  import dspy
  from dspy.primitives.python_interpreter import PythonInterpreter

  interp = PythonInterpreter(enable_read_paths=["/srv/agent/node_modules"])
  rlm = dspy.RLM("context, query -> answer", interpreter=interp)

  rlm(context="...", query="...")
  # Before: first call crashes with "Is a directory (os error 21)"
  # After:  works; files inside the dir are reachable at host path via
  #         js.Deno.readTextFileSync(...) or the usual Deno APIs.
  ```
## Change

  - `dspy/primitives/python_interpreter.py` — in `_mount_files`, skip directory entries
  with a `logger.debug` before the `mount_file` call. Applies to both `enable_read_paths`
   and `enable_write_paths` (same crash, same fix).
  - Update the `enable_read_paths` / `enable_write_paths` docstrings so the
  file-vs-directory contract is spelled out: files mount at `/sandbox/<basename>`;
  directories stay accessible at their host path via Deno's `--allow-read=<dir>` and
  aren't mirrored under `/sandbox/`.

## Testing

  - [x] `uv run pytest tests/primitives/test_python_interpreter.py --deno` → 43 passed
  (41 existing + 2 new)
  - [x] `uv run pre-commit run --files dspy/primitives/python_interpreter.py
  tests/primitives/test_python_interpreter.py` → clean
  - [x] Verified end-to-end against a clean 3.2.1 install — same
  `enable_read_paths=[<dir>]` snippet goes from crash to `print('ok')` returning normally

New tests (under the existing `pytest.mark.deno`):

  - `test_enable_read_paths_accepts_directory` — a directory in `enable_read_paths`
  doesn't crash, files inside it are reachable via `js.Deno.readTextFileSync`, and the
  directory isn't mirrored under `/sandbox/`.
  - `test_enable_read_paths_mixed_file_and_directory` — a list with both a file and a
  directory: the file still mounts under `/sandbox/<basename>` and the directory is
  skipped.

