### PR TITLE
fix: reject comma paths for PythonInterpreter

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -94,6 +94,15 @@ def _await_in_sync(coroutine: Any) -> Any:
     return loop.run_until_complete(coroutine)
 
 
+def _reject_comma_paths(option: str, paths: list[PathLike | str]) -> None:
+    for path in paths:
+        if "," in str(path):
+            raise ValueError(
+                f"{option} contains a path with a comma, which Deno cannot represent "
+                f"in comma-separated permission flags: {path!r}"
+            )
+
+
 class PythonInterpreter:
     """Local interpreter for secure Python execution using Deno and Pyodide.
 
@@ -150,6 +159,8 @@ class PythonInterpreter:
 
         self.enable_read_paths = enable_read_paths or []
         self.enable_write_paths = enable_write_paths or []
+        _reject_comma_paths("enable_read_paths", self.enable_read_paths)
+        _reject_comma_paths("enable_write_paths", self.enable_write_paths)
         self.enable_env_vars = enable_env_vars or []
         self.enable_network_access = enable_network_access or []
         self.sync_files = sync_files

--- a/tests/primitives/test_python_interpreter_flags.py
+++ b/tests/primitives/test_python_interpreter_flags.py
@@ -1,0 +1,17 @@
+import pytest
+
+from dspy.primitives.python_interpreter import PythonInterpreter
+
+
+def test_enable_read_paths_reject_comma(tmp_path):
+    path = tmp_path / "sales,2025.csv"
+
+    with pytest.raises(ValueError, match=r"enable_read_paths.*comma"):
+        PythonInterpreter(enable_read_paths=[path])
+
+
+def test_enable_write_paths_reject_comma(tmp_path):
+    path = tmp_path / "report,final.txt"
+
+    with pytest.raises(ValueError, match=r"enable_write_paths.*comma"):
+        PythonInterpreter(enable_write_paths=[path])


### PR DESCRIPTION
﻿## Changes Description

Fixes #9749.

`PythonInterpreter` currently joins `enable_read_paths` and `enable_write_paths` with commas when building Deno permission flags. Deno has no escaping for commas in those allow lists, so a path like `sales,2025.csv` is split into two unrelated entries and the sandbox later denies access to the real file.

This patch rejects comma-containing read/write paths when the interpreter is constructed. That fails early with a clear error instead of launching Deno with a permission set that cannot work.

## Contributor Checklist

- [x] Title of the PR follows the repo's existing fix-style convention
- [x] Commit message follows the repo's existing fix-style convention

## Tested

- `python -m pytest tests\primitives\test_python_interpreter_flags.py -q --basetemp .tmp\pytest -p no:cacheprovider`
- `ruff check dspy\primitives\python_interpreter.py tests\primitives\test_python_interpreter_flags.py`
- `ruff format --check tests\primitives\test_python_interpreter_flags.py`
- `python -m py_compile dspy\primitives\python_interpreter.py tests\primitives\test_python_interpreter_flags.py`
- `git diff --check`

Note: `ruff format --check dspy\primitives\python_interpreter.py` would reformat unrelated existing lines in that file, so I did not run formatting over the whole file for this small fix.
