### PR TITLE
fix(avatar): remove deprecated prefix args from internal signatures

### DIFF
--- a/dspy/predict/avatar/signatures.py
+++ b/dspy/predict/avatar/signatures.py
@@ -10,14 +10,11 @@ class Actor(dspy.Signature):
     Note: You can opt to use no tools and provide the final answer directly. You can also one tool multiple times with different input queries if applicable."""
 
     goal: str = dspy.InputField(
-        prefix="Goal:",
         desc="Task to be accomplished.",
     )
     tools: list[str] = dspy.InputField(
-        prefix="Tools:",
         desc="list of tools to use",
     )
     action_1: Action = dspy.OutputField(
-        prefix="Action 1:",
         desc="1st action to take.",
     )

--- a/dspy/teleprompt/avatar_optimizer.py
+++ b/dspy/teleprompt/avatar_optimizer.py
@@ -28,23 +28,18 @@ Task:
 (3) Lastly, specify the modification in tools used that can lead to improved performance on the negative inputs."""
 
     instruction: str = dspy.InputField(
-        prefix="Instruction: ",
         desc="Instruction for the actor to execute the task",
     )
     actions: list[str] = dspy.InputField(
-        prefix="Actions: ",
         desc="Actions actor can take to complete the task",
     )
     pos_input_with_metrics: list[EvalResult] = dspy.InputField(
-        prefix="Positive Inputs: ",
         desc="Positive inputs along with their score on a evaluation metric and actions taken",
     )
     neg_input_with_metrics: list[EvalResult] = dspy.InputField(
-        prefix="Negative Inputs: ",
         desc="Negative inputs along with their score on a evaluation metric and actions taken",
     )
     feedback: str = dspy.OutputField(
-        prefix="Feedback: ",
         desc="Feedback for the actor to improve the performance of negative inputs",
     )
 
@@ -59,15 +54,12 @@ Your task is to incorporate the feedback and generate a detailed instruction for
 Make sure that the new instruction talks about how to use the tools effectively and should be no more than 3 paragraphs long. The previous instruction contains general guidelines that you must retain in the new instruction."""
 
     previous_instruction: str = dspy.InputField(
-        prefix="Previous Instruction: ",
         desc="Previous instruction for the actor to execute the task",
     )
     feedback: str = dspy.InputField(
-        prefix="Feedback: ",
         desc="Feedback for the actor to improve the performance of negative inputs",
     )
     new_instruction: str = dspy.OutputField(
-        prefix="New Instruction: ",
         desc="New instruction for the actor to execute the task",
     )
 


### PR DESCRIPTION
### Summary
Remove `prefix=` from `InputField`/`OutputField` calls in two avatar-related files that still use the deprecated argument. The `prefix` kwarg is a no-op in the adapter-based architecture and produces 11 `DeprecationWarning`s on every `import dspy`.

### Affected files
- `dspy/predict/avatar/signatures.py` — `Actor` class (3 occurrences)
- `dspy/teleprompt/avatar_optimizer.py` — `Comparator` and `FeedbackBasedInstruction` classes (8 occurrences)

### Verification
```
import warnings
warnings.filterwarnings("default", category=DeprecationWarning)
import dspy  # no warnings after this change
```