### PR TITLE
fix(settings): close context across async contexts

### DIFF
--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -50,6 +50,10 @@ _CONTEXT_ACTIVE_ATTR = "__dspy_context_active__"
 _CONTEXT_PARENT_ATTR = "__dspy_context_parent__"
 
 
+def _copy_overrides(overrides):
+    return dotdict(overrides.copy())
+
+
 def _active_overrides(overrides):
     # Async generator finalization can happen in a different contextvars.Context from entry.
     # In that case the original token cannot be reset there, so readers skip deactivated override snapshots.
@@ -59,6 +63,10 @@ def _active_overrides(overrides):
     while getattr(overrides, _CONTEXT_ACTIVE_ATTR, True) is False:
         overrides = getattr(overrides, _CONTEXT_PARENT_ATTR, dotdict())
     return overrides
+
+
+def _is_token_from_different_context_error(error):
+    return "was created in a different Context" in str(error)
 
 
 class Settings:
@@ -261,10 +269,10 @@ class Settings:
         # `dspy.context` is documented manually in docs/docs/api/utils/context.md
         # changes here should be reflected there as well.
         parent_overrides = _active_overrides(thread_local_overrides.get())
-        original_overrides = parent_overrides.copy()
+        original_overrides = _copy_overrides(parent_overrides)
         new_overrides = dotdict({**main_thread_config, **original_overrides, **kwargs})
         setattr(new_overrides, _CONTEXT_ACTIVE_ATTR, True)
-        setattr(new_overrides, _CONTEXT_PARENT_ATTR, parent_overrides)
+        setattr(new_overrides, _CONTEXT_PARENT_ATTR, _copy_overrides(parent_overrides))
         token = thread_local_overrides.set(new_overrides)
 
         try:
@@ -273,8 +281,9 @@ class Settings:
             setattr(new_overrides, _CONTEXT_ACTIVE_ATTR, False)
             try:
                 thread_local_overrides.reset(token)
-            except ValueError:
-                thread_local_overrides.set(parent_overrides)
+            except ValueError as exc:
+                if not _is_token_from_different_context_error(exc):
+                    raise
 
     def __repr__(self):
         overrides = _active_overrides(thread_local_overrides.get())
@@ -282,7 +291,8 @@ class Settings:
         return repr(combined_config)
 
     def save(
-        self, path: str,
+        self,
+        path: str,
         modules_to_serialize: list[str] | None = None,
         exclude_keys: list[str] | None = None,
     ):

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -45,7 +45,20 @@ config_owner_async_task = None
 # Global lock for settings configuration
 global_lock = threading.Lock()
 
-thread_local_overrides = contextvars.ContextVar("context_overrides", default=dotdict())
+thread_local_overrides = contextvars.ContextVar("context_overrides", default=dotdict())  # noqa: B039
+_CONTEXT_ACTIVE_ATTR = "__dspy_context_active__"
+_CONTEXT_PARENT_ATTR = "__dspy_context_parent__"
+
+
+def _active_overrides(overrides):
+    # Async generator finalization can happen in a different contextvars.Context from entry.
+    # In that case the original token cannot be reset there, so readers skip deactivated override snapshots.
+    if overrides is None:
+        return dotdict()
+
+    while getattr(overrides, _CONTEXT_ACTIVE_ATTR, True) is False:
+        overrides = getattr(overrides, _CONTEXT_PARENT_ATTR, dotdict())
+    return overrides
 
 
 class Settings:
@@ -76,7 +89,7 @@ class Settings:
         return global_lock
 
     def __getattr__(self, name):
-        overrides = thread_local_overrides.get()
+        overrides = _active_overrides(thread_local_overrides.get())
         if name in overrides:
             return overrides[name]
         elif name in main_thread_config:
@@ -97,7 +110,7 @@ class Settings:
         self.__setattr__(key, value)
 
     def __contains__(self, key):
-        overrides = thread_local_overrides.get()
+        overrides = _active_overrides(thread_local_overrides.get())
         return key in overrides or key in main_thread_config
 
     def get(self, key, default=None):
@@ -107,7 +120,7 @@ class Settings:
             return default
 
     def copy(self):
-        overrides = thread_local_overrides.get()
+        overrides = _active_overrides(thread_local_overrides.get())
         return dotdict({**main_thread_config, **overrides})
 
     @property
@@ -247,17 +260,24 @@ class Settings:
         """
         # `dspy.context` is documented manually in docs/docs/api/utils/context.md
         # changes here should be reflected there as well.
-        original_overrides = thread_local_overrides.get().copy()
+        parent_overrides = _active_overrides(thread_local_overrides.get())
+        original_overrides = parent_overrides.copy()
         new_overrides = dotdict({**main_thread_config, **original_overrides, **kwargs})
+        setattr(new_overrides, _CONTEXT_ACTIVE_ATTR, True)
+        setattr(new_overrides, _CONTEXT_PARENT_ATTR, parent_overrides)
         token = thread_local_overrides.set(new_overrides)
 
         try:
             yield
         finally:
-            thread_local_overrides.reset(token)
+            setattr(new_overrides, _CONTEXT_ACTIVE_ATTR, False)
+            try:
+                thread_local_overrides.reset(token)
+            except ValueError:
+                thread_local_overrides.set(parent_overrides)
 
     def __repr__(self):
-        overrides = thread_local_overrides.get()
+        overrides = _active_overrides(thread_local_overrides.get())
         combined_config = {**main_thread_config, **overrides}
         return repr(combined_config)
 

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -92,14 +92,14 @@ class Module(BaseModule, metaclass=ProgramMeta):
 
     @with_callbacks
     def __call__(self, *args, **kwargs) -> Prediction:
-        from dspy.dsp.utils.settings import thread_local_overrides
+        from dspy.dsp.utils.settings import _active_overrides, thread_local_overrides
 
         caller_modules = settings.caller_modules or []
         caller_modules = list(caller_modules)
         caller_modules.append(self)
 
         with settings.context(caller_modules=caller_modules):
-            if settings.track_usage and thread_local_overrides.get().get("usage_tracker") is None:
+            if settings.track_usage and _active_overrides(thread_local_overrides.get()).get("usage_tracker") is None:
                 with track_usage() as usage_tracker:
                     output = self.forward(*args, **kwargs)
                 tokens = usage_tracker.get_total_tokens()
@@ -111,14 +111,14 @@ class Module(BaseModule, metaclass=ProgramMeta):
 
     @with_callbacks
     async def acall(self, *args, **kwargs) -> Prediction:
-        from dspy.dsp.utils.settings import thread_local_overrides
+        from dspy.dsp.utils.settings import _active_overrides, thread_local_overrides
 
         caller_modules = settings.caller_modules or []
         caller_modules = list(caller_modules)
         caller_modules.append(self)
 
         with settings.context(caller_modules=caller_modules):
-            if settings.track_usage and thread_local_overrides.get().get("usage_tracker") is None:
+            if settings.track_usage and _active_overrides(thread_local_overrides.get()).get("usage_tracker") is None:
                 with track_usage() as usage_tracker:
                     output = await self.aforward(*args, **kwargs)
                     tokens = usage_tracker.get_total_tokens()

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -329,8 +329,9 @@ class Module(BaseModule, metaclass=ProgramMeta):
         if prediction_in_output:
             prediction_in_output.set_lm_usage(tokens)
         else:
-            logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking.")
-
+            logger.warning(
+                "Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking."
+            )
 
     def __getattribute__(self, name):
         attr = super().__getattribute__(name)

--- a/dspy/utils/asyncify.py
+++ b/dspy/utils/asyncify.py
@@ -45,14 +45,14 @@ def asyncify(program: "Module") -> Callable[[Any, Any], Awaitable[Any]]:
 
     async def async_program(*args, **kwargs) -> Any:
         # Capture the current overrides at call-time.
-        from dspy.dsp.utils.settings import thread_local_overrides
+        from dspy.dsp.utils.settings import _active_overrides, thread_local_overrides
 
-        parent_overrides = thread_local_overrides.get().copy()
+        parent_overrides = _active_overrides(thread_local_overrides.get()).copy()
 
         def wrapped_program(*a, **kw):
-            from dspy.dsp.utils.settings import thread_local_overrides
+            from dspy.dsp.utils.settings import _active_overrides, thread_local_overrides
 
-            original_overrides = thread_local_overrides.get()
+            original_overrides = _active_overrides(thread_local_overrides.get())
             token = thread_local_overrides.set({**original_overrides, **parent_overrides.copy()})
             try:
                 return program(*a, **kw)

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -120,9 +120,9 @@ class ParallelExecutor:
                 start_time_map[submission_id] = time.time()
 
             # Apply parent's thread-local overrides
-            from dspy.dsp.utils.settings import thread_local_overrides
+            from dspy.dsp.utils.settings import _active_overrides, thread_local_overrides
 
-            original = thread_local_overrides.get()
+            original = _active_overrides(thread_local_overrides.get())
             new_overrides = {**original, **parent_overrides.copy()}
             if new_overrides.get("usage_tracker"):
                 # Usage tracker needs to be deep copied across threads so that each thread tracks its own usage
@@ -156,9 +156,9 @@ class ParallelExecutor:
         executor = ThreadPoolExecutor(max_workers=self.num_threads)
         try:
             with interrupt_manager():
-                from dspy.dsp.utils.settings import thread_local_overrides
+                from dspy.dsp.utils.settings import _active_overrides, thread_local_overrides
 
-                parent_overrides = thread_local_overrides.get().copy()
+                parent_overrides = _active_overrides(thread_local_overrides.get()).copy()
 
                 futures_map = {}
                 futures_set = set()

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+import importlib
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -9,6 +10,9 @@ import pytest
 from litellm import Choices, Message, ModelResponse
 
 import dspy
+from dspy.dsp.utils.utils import dotdict
+
+settings_utils = importlib.import_module("dspy.dsp.utils.settings")
 
 
 def test_basic_dspy_settings():
@@ -42,6 +46,7 @@ def test_dspy_context():
 @pytest.mark.asyncio
 async def test_dspy_context_closes_async_generator_in_different_context():
     with dspy.context(lm="outer"):
+
         async def stream():
             with dspy.context(lm="inner"):
                 yield dspy.settings.lm
@@ -53,6 +58,39 @@ async def test_dspy_context_closes_async_generator_in_different_context():
         await close_task
 
         assert dspy.settings.lm == "outer"
+
+
+def test_dspy_context_parent_snapshot_is_stable():
+    with dspy.context(lm="outer"):
+        parent_overrides = settings_utils.thread_local_overrides.get()
+        with dspy.context(lm="inner"):
+            inner_overrides = settings_utils.thread_local_overrides.get()
+            parent_snapshot = getattr(inner_overrides, settings_utils._CONTEXT_PARENT_ATTR)
+
+    assert parent_snapshot == parent_overrides
+    assert parent_snapshot is not parent_overrides
+
+
+def test_dspy_context_reraises_non_context_token_value_error(monkeypatch):
+    class RaisingResetContextVar:
+        def __init__(self):
+            self.current = dotdict()
+
+        def get(self):
+            return self.current
+
+        def set(self, value):
+            self.current = value
+            return object()
+
+        def reset(self, token):
+            raise ValueError("Token was created by a different ContextVar")
+
+    monkeypatch.setattr(settings_utils, "thread_local_overrides", RaisingResetContextVar())
+
+    with pytest.raises(ValueError, match="different ContextVar"):
+        with dspy.context(lm="inner"):
+            pass
 
 
 def test_dspy_context_parallel():
@@ -235,7 +273,6 @@ def test_dspy_settings_save_exclude_keys(tmp_path):
     assert dspy.settings.lm.model == "openai/gpt-4o"
     assert dspy.settings.adapter is None
     assert not dspy.settings.track_usage
-
 
 
 def test_settings_save_with_extra_modules(tmp_path):

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -21,7 +22,7 @@ def test_forbid_configure_call_in_child_thread():
     dspy.configure(lm=dspy.LM("openai/gpt-4o"), adapter=dspy.JSONAdapter(), callbacks=[lambda x: x])
 
     def worker():
-        with pytest.raises(RuntimeError, match="Cannot call dspy.configure"):
+        with pytest.raises(RuntimeError, match=r"dspy\.settings can only be changed"):
             dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"), callbacks=[])
 
     with ThreadPoolExecutor(max_workers=1) as executor:
@@ -36,6 +37,22 @@ def test_dspy_context():
 
     assert dspy.settings.lm.model == "openai/gpt-4o"
     assert len(dspy.settings.callbacks) == 1
+
+
+@pytest.mark.asyncio
+async def test_dspy_context_closes_async_generator_in_different_context():
+    with dspy.context(lm="outer"):
+        async def stream():
+            with dspy.context(lm="inner"):
+                yield dspy.settings.lm
+
+        generator = stream()
+        assert await generator.__anext__() == "inner"
+
+        close_task = contextvars.Context().run(asyncio.create_task, generator.aclose())
+        await close_task
+
+        assert dspy.settings.lm == "outer"
 
 
 def test_dspy_context_parallel():


### PR DESCRIPTION
## Summary

Fixes #8797.

- Make `dspy.context()` override snapshots deactivatable so async generator finalization from a different `contextvars.Context` does not crash while resetting the token.
- Resolve only active overrides when reading settings and when propagating settings into worker threads/tasks, preventing stale inner context values from leaking after cross-context close.
- Add a regression test that closes an async generator running inside `dspy.context()` from a separate context.

## Testing

- `uv run pytest tests/utils/test_settings.py tests/utils/test_parallelizer.py tests/utils/test_asyncify.py -q`
- `uv run ruff check dspy/dsp/utils/settings.py dspy/utils/parallelizer.py dspy/utils/asyncify.py dspy/primitives/module.py tests/utils/test_settings.py`
- `uv run python -m py_compile dspy/dsp/utils/settings.py dspy/utils/parallelizer.py dspy/utils/asyncify.py dspy/primitives/module.py tests/utils/test_settings.py`
- `uv run pre-commit run --files dspy/dsp/utils/settings.py dspy/utils/parallelizer.py dspy/utils/asyncify.py dspy/primitives/module.py tests/utils/test_settings.py`

## AI assistance disclosure

Prepared with OpenAI Codex at Pragnyan's request. I reproduced the bug locally, implemented and reviewed the patch, and ran the checks above.

Prompt summary: make one high-quality OSS contribution to `stanfordnlp/dspy`, avoid duplicate upstream work, keep the patch small, validate it, and open a draft PR if credible.