### PR TITLE
fix(json_adapter): wrap per-field parse errors in AdapterParseError

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -187,7 +187,15 @@ class JSONAdapter(ChatAdapter):
         # Attempt to cast each value to type signature.output_fields[k].annotation.
         for k, v in fields.items():
             if k in signature.output_fields:
-                fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                try:
+                    fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                except Exception as e:
+                    raise AdapterParseError(
+                        adapter_name="JSONAdapter",
+                        signature=signature,
+                        lm_response=completion,
+                        message=f"Failed to parse field {k} with value {v} from the LM response. Error message: {e}",
+                    )
 
         if fields.keys() != signature.output_fields.keys():
             raise AdapterParseError(

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -936,6 +936,45 @@ def test_json_adapter_parse_raise_error_on_mismatch_fields():
     )
 
 
+def test_json_adapter_parse_wraps_field_type_cast_errors():
+    # Per-field type-cast failures should surface as AdapterParseError,
+    # matching ChatAdapter's behavior (test_chat_adapter_exception_raised_on_failure).
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        count: int = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter()
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="Failed to parse field count"):
+        adapter.parse(Sig, '{"count": "not_a_number"}')
+
+
+def test_json_adapter_parse_wraps_literal_validation_errors():
+    from typing import Literal
+
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        sentiment: Literal["pos", "neg"] = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter()
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="Failed to parse field sentiment"):
+        adapter.parse(Sig, '{"sentiment": "happy"}')
+
+
+def test_json_adapter_parse_wraps_pydantic_validation_errors():
+    class Person(pydantic.BaseModel):
+        name: str
+        age: int
+
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        person: Person = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter()
+    # Missing required nested field "age" must surface as AdapterParseError, not pydantic.ValidationError.
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="Failed to parse field person"):
+        adapter.parse(Sig, '{"person": {"name": "Alice"}}')
+
+
 def test_json_adapter_formats_image():
     # Test basic image formatting
     image = dspy.Image(url="https://example.com/image.jpg")


### PR DESCRIPTION
## Summary

`JSONAdapter.parse` calls `parse_value()` outside a `try/except`, so when the LM returns a value that can't be cast to the field's annotated type (bad `int`, invalid `Literal`, missing required nested Pydantic field, etc.), the raw `pydantic.ValidationError` or `ValueError` propagates up instead of being wrapped in `dspy.utils.exceptions.AdapterParseError`.

The sister `ChatAdapter` already wraps the same call in `try/except` and re-raises as `AdapterParseError` ([`chat_adapter.py:229-237`](https://github.com/stanfordnlp/dspy/blob/main/dspy/adapters/chat_adapter.py#L229-L237)). This PR mirrors that pattern in `JSONAdapter` so both adapters report parse failures consistently.

## Why this matters

Users following the documented `try: ... except dspy.AdapterParseError:` pattern silently miss most parse failure modes when `JSONAdapter` is active.

Asymmetry, before this PR (verified locally with dspy 3.2.1 against the same signatures and inputs):

| Failure mode                       | `ChatAdapter`              | `JSONAdapter`         |
| ---                                | ---                        | ---                   |
| bad int value (`\"count\": \"x\"`)     | `AdapterParseError` ✓      | `ValidationError` ✗   |
| invalid `Literal` value            | `AdapterParseError` ✓      | `ValueError` ✗        |
| missing required nested field      | `AdapterParseError` ✓      | `ValidationError` ✗   |

After this PR, all rows produce `AdapterParseError` for both adapters.

## Repro (before)

```python
from typing import Literal
import dspy

class Sig(dspy.Signature):
    q: str = dspy.InputField()
    sentiment: Literal[\"pos\", \"neg\"] = dspy.OutputField()

dspy.JSONAdapter().parse(Sig, '{\"sentiment\": \"happy\"}')
# Raises ValueError, not dspy.utils.exceptions.AdapterParseError.
```

## Changes

- `dspy/adapters/json_adapter.py`: wrap the `parse_value()` call in `try/except` and re-raise as `AdapterParseError`, mirroring the message format used by `ChatAdapter`.
- `tests/adapters/test_json_adapter.py`: three new regression tests covering type-cast, `Literal`, and nested Pydantic validation failures.

## Test plan

- [x] `pytest tests/adapters/test_json_adapter.py -k parse -v` → 4 passed (3 new + the existing mismatch test)
- [x] `pytest tests/adapters/test_json_adapter.py tests/adapters/test_chat_adapter.py` → 61 passed, no regressions
- [x] `ruff check` clean on changed lines (pre-existing W291 warnings in `test_json_adapter.py:1040,1055` are unrelated)
- [x] Verified the repro above raises `AdapterParseError` after the patch

## Related

Existing issue #7693 discusses retry-on-validation-error behavior; this PR is orthogonal — it changes the *exception type* reaching the user, not whether the framework retries.

## AI disclosure

Bug found and fix drafted with the help of an AI coding assistant; I read every line of the diff, verified the reproduction in a local install, and confirmed the existing adapter test suite still passes.