### PR TITLE
fix: correct mismatched closing code fence in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To install the very latest from `main`:
 
 ```bash
 pip install git+https://github.com/stanfordnlp/dspy.git
-````
+```
 
 
 


### PR DESCRIPTION
### What
Replace the four-backtick closing fence (` ```` `) with the correct three-backtick fence (` ``` `) in the "Install from `main`" code block.

### Why
The opening fence uses three backticks but the closing fence uses four, which breaks Markdown rendering and leaves the code block unclosed in some renderers.

Small, scoped fix from kcolbchain contrib-bot.