### PR TITLE
fix(evaluate): expose timeout param and fix straggler shutdown race (#9574)

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -81,6 +81,7 @@ class Evaluate:
         failure_score: float = 0.0,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int | None = None,
         **kwargs,
     ):
         """
@@ -97,6 +98,9 @@ class Evaluate:
             failure_score (float): The default score to use if evaluation fails due to an exception.
             save_as_csv (Optional[str]): The file name where the csv will be saved.
             save_as_json (Optional[str]): The file name where the json will be saved.
+            timeout (Optional[int]): Straggler timeout in seconds. A task running longer than this
+                is resubmitted on a separate thread to guard against indefinite hangs.
+                If ``None`` (default), ParallelExecutor's built-in 120s timeout is used.
 
         """
         self.devset = devset
@@ -109,6 +113,7 @@ class Evaluate:
         self.failure_score = failure_score
         self.save_as_csv = save_as_csv
         self.save_as_json = save_as_json
+        self.timeout = timeout
 
         if "return_outputs" in kwargs:
             raise ValueError("`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object.")
@@ -125,6 +130,7 @@ class Evaluate:
         callback_metadata: dict[str, Any] | None = None,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int | None = None,
     ) -> EvaluationResult:
         """
         Args:
@@ -138,6 +144,8 @@ class Evaluate:
             display_table (Union[bool, int]): Whether to display the evaluation results in a table. if not provided, use
                 `self.display_table`. If a number is passed, the evaluation results will be truncated to that number before displayed.
             callback_metadata (dict): Metadata to be used for evaluate callback handlers.
+            timeout (Optional[int]): Straggler timeout in seconds. Overrides the value set at
+                construction time. ``None`` falls back to ``self.timeout``.
 
         Returns:
             The evaluation results are returned as a dspy.EvaluationResult object containing the following attributes:
@@ -153,19 +161,23 @@ class Evaluate:
         display_table = display_table if display_table is not None else self.display_table
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
+        timeout = timeout if timeout is not None else self.timeout
 
         if callback_metadata:
             logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
 
         tqdm.tqdm._instances.clear()
 
-        executor = ParallelExecutor(
-            num_threads=num_threads,
-            disable_progress_bar=not display_progress,
-            max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
-            provide_traceback=self.provide_traceback,
-            compare_results=True,
-        )
+        executor_kwargs: dict[str, Any] = {
+            "num_threads": num_threads,
+            "disable_progress_bar": not display_progress,
+            "max_errors": (self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
+            "provide_traceback": self.provide_traceback,
+            "compare_results": True,
+        }
+        if timeout is not None:
+            executor_kwargs["timeout"] = timeout
+        executor = ParallelExecutor(**executor_kwargs)
 
         def process_item(example):
             prediction = program(**example.inputs())

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -200,7 +200,7 @@ class ParallelExecutor:
                         break
 
                     # Check stragglers if few remain
-                    if 0 < self.timeout and len(not_done) <= self.straggler_limit:
+                    if self.timeout is not None and 0 < self.timeout and len(not_done) <= self.straggler_limit:
                         now = time.time()
                         for f in list(not_done):
                             if f not in resubmitted:
@@ -209,13 +209,19 @@ class ParallelExecutor:
                                     st = start_time_map.get(sid, None)
                                 if st and (now - st) >= self.timeout:
                                     resubmitted.add(f)
-                                    nf = executor.submit(
-                                        worker,
-                                        parent_overrides,
-                                        submission_counter,
-                                        idx,
-                                        item,
-                                    )
+                                    try:
+                                        nf = executor.submit(
+                                            worker,
+                                            parent_overrides,
+                                            submission_counter,
+                                            idx,
+                                            item,
+                                        )
+                                    except RuntimeError:
+                                        # Executor is shutting down (e.g. after
+                                        # KeyboardInterrupt). The original future
+                                        # will eventually complete or be cancelled.
+                                        continue
                                     futures_map[nf] = (submission_counter, idx, item)
                                     futures_set.add(nf)
                                     submission_counter += 1

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -423,3 +423,32 @@ def test_evaluate_save_as_csv_with_history():
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
 
+
+def test_evaluate_with_custom_timeout():
+    """Evaluate respects straggler timeout parameter."""
+    dspy.configure(lm=DummyLM({"test": {"answer": "ok"}}))
+    devset = [new_example("test", "ok")]
+    ev = Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        display_progress=False,
+        timeout=300,
+    )
+    assert ev.timeout == 300
+    result = ev(program=Predict("question -> answer"))
+    assert result.score == 100.0
+
+
+def test_evaluate_call_with_timeout_override():
+    """__call__ timeout overrides constructor timeout."""
+    dspy.configure(lm=DummyLM({"test": {"answer": "ok"}}))
+    devset = [new_example("test", "ok")]
+    ev = Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        display_progress=False,
+        timeout=300,
+    )
+    result = ev(program=Predict("question -> answer"), timeout=600)
+    assert result.score == 100.0
+

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -166,3 +166,25 @@ def test_sequential_compare_results():
     results = executor.execute(task, data)
 
     assert results == [(1, False), (2, False), (3, True), (4, True), (5, True)]
+
+
+def test_timeout_disables_straggler_resubmission():
+    """timeout=None should skip straggler resubmission entirely."""
+    def task(item):
+        return item
+
+    data = [1, 2, 3]
+    executor = ParallelExecutor(num_threads=3, timeout=None)
+    results = executor.execute(task, data)
+    assert results == [1, 2, 3]
+
+
+def test_zero_timeout_disables_straggler_resubmission():
+    """timeout=0 should skip straggler resubmission."""
+    def task(item):
+        return item
+
+    data = [1, 2, 3]
+    executor = ParallelExecutor(num_threads=3, timeout=0)
+    results = executor.execute(task, data)
+    assert results == [1, 2, 3]


### PR DESCRIPTION
Closes #9574

## Summary

Two related fixes for DSPy's evaluation parallel executor:

### 1. Add `timeout` parameter to `Evaluate`

Users can now control the straggler timeout (previously hardcoded to 120s via `ParallelExecutor`'s default):

```python
ev = Evaluate(devset=..., metric=..., timeout=300)
ev(program, timeout=600)  # or override at call time
```

### 2. Fix RuntimeError on straggler resubmission after shutdown

`_execute_parallel`'s straggler resubmission calls `executor.submit()` while the executor might be shutting down (e.g. after `KeyboardInterrupt` or during long evals), producing:

> RuntimeError: cannot schedule new futures after shutdown

The fix wraps the resubmission in a try-except `RuntimeError` and skips gracefully when the executor is no longer accepting work.

Also guards the straggler check against `None`/zero `timeout` values to prevent `TypeError`.

## Tests

- `test_evaluate_with_custom_timeout` — timeout set at construction propagates correctly
- `test_evaluate_call_with_timeout_override` — per-call timeout overrides constructor value
- `test_timeout_disables_straggler_resubmission` — `timeout=None` skips straggler logic
- `test_zero_timeout_disables_straggler_resubmission` — `timeout=0` also skips

All 24 tests pass.