### PR TITLE
feat(tool-call): support parallel tool call requests

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any, get_origin
 
-import json_repair
-
 from dspy.adapters.types import History, Type
 from dspy.adapters.types.base_type import split_message_content_for_custom_types
 from dspy.adapters.types.reasoning import Reasoning
@@ -15,7 +13,14 @@ from dspy.utils.exceptions import AdapterParseError
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_NATIVE_RESPONSE_TYPES = [Citations, Reasoning]
+_DEFAULT_NATIVE_RESPONSE_TYPES = [Citations, Reasoning, ToolCalls]
+
+
+def _native_tool_call_instruction(field_name: str) -> str:
+    return (
+        "When tool use is needed, call the available tools through the native tool-call interface. "
+        f"Do not emit `{field_name}` as a text or JSON output field."
+    )
 
 
 class Adapter:
@@ -40,6 +45,7 @@ class Adapter:
         callbacks: list[BaseCallback] | None = None,
         use_native_function_calling: bool = False,
         native_response_types: list[type[Type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
     ):
         """
         Args:
@@ -50,11 +56,16 @@ class Adapter:
                 or `list[dspy.Tool]` types. Defaults to False.
             native_response_types: List of output field types that should be handled by native LM features rather than
                 adapter parsing. For example, `dspy.Citations` can be populated directly by citation APIs
-                (e.g., Anthropic's citation feature). Defaults to `[Citations]`.
+                (e.g., Anthropic's citation feature). Defaults to `[Citations, Reasoning, ToolCalls]`.
+            allow_parallel_tool_calls: Whether to request provider-side parallel tool calls when native function calling
+                is active. If `None`, leaves the provider default unchanged. Defaults to None.
         """
         self.callbacks = callbacks or []
         self.use_native_function_calling = use_native_function_calling
-        self.native_response_types = native_response_types or _DEFAULT_NATIVE_RESPONSE_TYPES
+        self.native_response_types = list(
+            _DEFAULT_NATIVE_RESPONSE_TYPES if native_response_types is None else native_response_types
+        )
+        self.allow_parallel_tool_calls = allow_parallel_tool_calls
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
@@ -70,42 +81,52 @@ class Adapter:
         signature: type[Signature],
         inputs: dict[str, Any],
     ) -> type[Signature]:
-        if self.use_native_function_calling:
-            tool_call_input_field_name = self._get_tool_call_input_field_name(signature)
-            tool_call_output_field_name = self._get_tool_call_output_field_name(signature)
-
-            if tool_call_output_field_name and tool_call_input_field_name is None:
-                raise ValueError(
-                    f"You provided an output field {tool_call_output_field_name} to receive the tool calls information, "
-                    "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
-                    "input field with type `list[dspy.Tool]`."
-                )
-
-            if tool_call_output_field_name and lm.supports_function_calling:
-                tools = inputs[tool_call_input_field_name]
-                tools = tools if isinstance(tools, list) else [tools]
-
-                lm_tools = [tool.format_as_litellm_function_call() for tool in tools]
-
-                lm_kwargs["tools"] = lm_tools
-
-                signature_for_native_function_calling = signature.delete(tool_call_output_field_name)
-                signature_for_native_function_calling = signature_for_native_function_calling.delete(
-                    tool_call_input_field_name
-                )
-
-                return signature_for_native_function_calling
-
-        # Handle custom types that use native LM features, e.g., reasoning, citations, etc.
-        for name, field in signature.output_fields.items():
+        adapter_options = {
+            "use_native_function_calling": self.use_native_function_calling,
+            "allow_parallel_tool_calls": self.allow_parallel_tool_calls,
+        }
+        original_signature = signature
+        native_feature_instructions = []
+        for name, field in list(signature.output_fields.items()):
             if (
                 isinstance(field.annotation, type)
                 and field.annotation in self.native_response_types
                 and issubclass(field.annotation, Type)
             ):
-                signature = field.annotation.adapt_to_native_lm_feature(signature, name, lm, lm_kwargs)
+                signature_before_adaptation = signature
+                signature = field.annotation._call_adapt_to_native_lm_feature(
+                    signature,
+                    name,
+                    lm,
+                    lm_kwargs,
+                    inputs=inputs,
+                    adapter_options=adapter_options,
+                )
+                if signature is not signature_before_adaptation:
+                    if field.annotation is ToolCalls:
+                        native_feature_instructions.append(_native_tool_call_instruction(name))
 
+        if native_feature_instructions:
+            signature = self._with_native_feature_instructions(
+                original_signature,
+                signature,
+                native_feature_instructions,
+            )
         return signature
+
+    def _with_native_feature_instructions(
+        self,
+        original_signature: type[Signature],
+        processed_signature: type[Signature],
+        native_feature_instructions: list[str],
+    ) -> type[Signature]:
+        original_default_instructions = Signature(original_signature.fields).instructions
+        processed_default_instructions = Signature(processed_signature.fields).instructions
+        if original_signature.instructions == original_default_instructions:
+            instructions = processed_default_instructions
+        else:
+            instructions = processed_signature.instructions
+        return processed_signature.with_instructions("\n".join([instructions, *native_feature_instructions]))
 
     def _call_postprocess(
         self,
@@ -117,17 +138,15 @@ class Adapter:
     ) -> list[dict[str, Any]]:
         values = []
 
-        tool_call_output_field_name = self._get_tool_call_output_field_name(original_signature)
-
         for output in outputs:
             output_logprobs = None
-            tool_calls = None
             text = output
 
             if isinstance(output, dict):
-                text = output["text"]
+                text = output.get("text")
                 output_logprobs = output.get("logprobs")
-                tool_calls = output.get("tool_calls")
+
+            parsed_native_values = self._parse_native_lm_response(original_signature, output)
 
             if text:
                 value = self.parse(processed_signature, text)
@@ -135,10 +154,8 @@ class Adapter:
                     if field_name not in value:
                         # We need to set the field not present in the processed signature to None for consistency.
                         value[field_name] = None
-            elif tool_calls and tool_call_output_field_name:
-                value = {}
-                for field_name in original_signature.output_fields.keys():
-                    value[field_name] = None
+            elif parsed_native_values:
+                value = dict.fromkeys(original_signature.output_fields.keys())
             else:
                 raise AdapterParseError(
                     adapter_name=type(self).__name__,
@@ -147,26 +164,7 @@ class Adapter:
                     message="The LM returned an empty or null response.",
                 )
 
-            if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
-
-            # Parse custom types that does not rely on the `Adapter.parse()` method
-            for name, field in original_signature.output_fields.items():
-                if (
-                    isinstance(field.annotation, type)
-                    and field.annotation in self.native_response_types
-                    and issubclass(field.annotation, Type)
-                ):
-                    parsed_value = field.annotation.parse_lm_response(output)
-                    if parsed_value is not None:
-                        value[name] = parsed_value
+            value.update(parsed_native_values)
 
             if output_logprobs:
                 value["logprobs"] = output_logprobs
@@ -174,6 +172,19 @@ class Adapter:
             values.append(value)
 
         return values
+
+    def _parse_native_lm_response(self, signature: type[Signature], output: dict[str, Any] | str) -> dict[str, Any]:
+        value = {}
+        for name, field in signature.output_fields.items():
+            if (
+                isinstance(field.annotation, type)
+                and field.annotation in self.native_response_types
+                and issubclass(field.annotation, Type)
+            ):
+                parsed_value = field.annotation.parse_lm_response(output)
+                if parsed_value is not None:
+                    value[name] = parsed_value
+        return value
 
     def __call__(
         self,

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -42,6 +42,7 @@ class ChatAdapter(Adapter):
         callbacks: list[BaseCallback] | None = None,
         use_native_function_calling: bool = False,
         native_response_types: list[type[type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
         use_json_adapter_fallback: bool = True,
     ):
         """
@@ -49,6 +50,8 @@ class ChatAdapter(Adapter):
             callbacks: List of callback functions to execute during adapter methods.
             use_native_function_calling: Whether to enable native function calling capabilities.
             native_response_types: List of output field types handled by native LM features.
+            allow_parallel_tool_calls: Whether to request provider-side parallel tool calls when native function calling
+                is active. If `None`, leaves the provider default unchanged.
             use_json_adapter_fallback: Whether to automatically fallback to JSONAdapter if the ChatAdapter fails.
                 If True, when an error occurs (except ContextWindowExceededError), the adapter will retry using
                 JSONAdapter. Defaults to True.
@@ -57,6 +60,7 @@ class ChatAdapter(Adapter):
             callbacks=callbacks,
             use_native_function_calling=use_native_function_calling,
             native_response_types=native_response_types,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
         )
         self.use_json_adapter_fallback = use_json_adapter_fallback
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -8,7 +8,7 @@ import regex
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
-from dspy.adapters.types.tool import ToolCalls
+from dspy.adapters.types import Type
 from dspy.adapters.utils import (
     format_field_value,
     get_annotation_name,
@@ -37,19 +37,43 @@ def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
     return False
 
 
+def _has_output_type_without_structured_output_schema(signature: SignatureMeta) -> bool:
+    for field in signature.output_fields.values():
+        annotation = field.annotation
+        if isinstance(annotation, type) and issubclass(annotation, Type):
+            if not annotation.supports_structured_output_schema():
+                return True
+    return False
+
+
 class JSONAdapter(ChatAdapter):
-    def __init__(self, callbacks: list[BaseCallback] | None = None, use_native_function_calling: bool = True):
+    def __init__(
+        self,
+        callbacks: list[BaseCallback] | None = None,
+        use_native_function_calling: bool = True,
+        native_response_types: list[type[type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
+    ):
         # JSONAdapter uses native function calling by default.
-        super().__init__(callbacks=callbacks, use_native_function_calling=use_native_function_calling)
+        super().__init__(
+            callbacks=callbacks,
+            use_native_function_calling=use_native_function_calling,
+            native_response_types=native_response_types,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
+        )
 
     def _json_adapter_call_common(self, lm, lm_kwargs, signature, demos, inputs, call_fn):
         """Common call logic to be used for both sync and async calls."""
         if "response_format" not in lm.supported_params:
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 
-        has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
-
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
+        effective_native_function_calling = self.use_native_function_calling and lm.supports_function_calling
+        has_unsupported_structured_output_type = _has_output_type_without_structured_output_schema(signature)
+        if (
+            _has_open_ended_mapping(signature)
+            or (not effective_native_function_calling and has_unsupported_structured_output_type)
+            or not lm.supports_response_schema
+        ):
             # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
             # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -68,11 +92,12 @@ class JSONAdapter(ChatAdapter):
             return result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
+            processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+            structured_output_model = _get_structured_outputs_response_format(processed_signature)
             lm_kwargs["response_format"] = structured_output_model
-            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+            messages = self.format(processed_signature, demos, inputs)
+            outputs = lm(messages=messages, **lm_kwargs)
+            return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -91,11 +116,12 @@ class JSONAdapter(ChatAdapter):
             return await result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
+            processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+            structured_output_model = _get_structured_outputs_response_format(processed_signature)
             lm_kwargs["response_format"] = structured_output_model
-            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+            messages = self.format(processed_signature, demos, inputs)
+            outputs = await lm.acall(messages=messages, **lm_kwargs)
+            return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -211,7 +237,6 @@ class JSONAdapter(ChatAdapter):
 
 def _get_structured_outputs_response_format(
     signature: SignatureMeta,
-    use_native_function_calling: bool = True,
 ) -> type[pydantic.BaseModel]:
     """
     Builds a Pydantic model from a DSPy signature's output_fields and ensures the generated JSON schema
@@ -233,9 +258,9 @@ def _get_structured_outputs_response_format(
     fields = {}
     for name, field in signature.output_fields.items():
         annotation = field.annotation
-        if use_native_function_calling and annotation == ToolCalls:
-            # Skip ToolCalls field if native function calling is enabled.
-            continue
+        if isinstance(annotation, type) and issubclass(annotation, Type):
+            if not annotation.supports_structured_output_schema():
+                raise ValueError(f"Field '{name}' does not support Structured Outputs.")
         default = field.default if hasattr(field, "default") else ...
         fields[name] = (annotation, default)
 

--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import re
 from typing import TYPE_CHECKING, Any, Optional, get_args, get_origin
@@ -83,6 +84,8 @@ class Type(pydantic.BaseModel):
         field_name: str,
         lm: BaseLM,
         lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
     ) -> type["Signature"]:
         """Adapt the custom type to the native LM feature if possible.
 
@@ -94,6 +97,8 @@ class Type(pydantic.BaseModel):
             field_name: The name of the field in the signature to adapt to the native LM feature.
             lm: The LM instance.
             lm_kwargs: The keyword arguments for the LM call, subject to in-place updates if adaptation if required.
+            inputs: The input values for this LM call.
+            adapter_options: Adapter configuration relevant to native LM feature adaptation.
 
         Returns:
             The adapted signature. If the custom type is not natively supported by the LM, return the original
@@ -102,9 +107,34 @@ class Type(pydantic.BaseModel):
         return signature
 
     @classmethod
+    def _call_adapt_to_native_lm_feature(
+        cls,
+        signature: type["Signature"],
+        field_name: str,
+        lm: BaseLM,
+        lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
+    ) -> type["Signature"]:
+        """Call `adapt_to_native_lm_feature` while preserving compatibility with old custom type hooks."""
+        method = cls.adapt_to_native_lm_feature
+        params = inspect.signature(method).parameters
+        kwargs = {}
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()) or "inputs" in params:
+            kwargs["inputs"] = inputs
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()) or "adapter_options" in params:
+            kwargs["adapter_options"] = adapter_options
+        return method(signature, field_name, lm, lm_kwargs, **kwargs)
+
+    @classmethod
     def is_streamable(cls) -> bool:
         """Whether the custom type is streamable."""
         return False
+
+    @classmethod
+    def supports_structured_output_schema(cls) -> bool:
+        """Whether this type should be included in provider structured output schemas."""
+        return True
 
     @classmethod
     def parse_stream_chunk(cls, chunk: "ModelResponseStream") -> Optional["Type"]:

--- a/dspy/adapters/types/citation.py
+++ b/dspy/adapters/types/citation.py
@@ -168,7 +168,7 @@ class Citations(Type):
         return self.citations[index]
 
     @classmethod
-    def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs) -> bool:
+    def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs):
         if lm.model.startswith("anthropic/"):
             return signature.delete(field_name)
         return signature

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -1,7 +1,8 @@
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, get_args, get_origin, get_type_hints
 
+import json_repair
 import pydantic
 from jsonschema import ValidationError, validate
 from pydantic import BaseModel, TypeAdapter, create_model
@@ -263,15 +264,19 @@ class ToolCalls(Type):
     class ToolCall(Type):
         name: str
         args: dict[str, Any]
+        id: str | None = None
 
         def format(self):
-            return {
+            formatted = {
                 "type": "function",
                 "function": {
                     "name": self.name,
                     "arguments": self.args,
                 },
             }
+            if self.id is not None:
+                formatted["id"] = self.id
+            return formatted
 
         def execute(self, functions: dict[str, Any] | list[Tool] | None = None) -> Any:
             """Execute this individual tool call and return its result.
@@ -310,7 +315,9 @@ class ToolCalls(Type):
                         break
 
             if func is None:
-                raise ValueError(f"Tool function '{self.name}' not found. Please pass the tool functions to the `execute` method.")
+                raise ValueError(
+                    f"Tool function '{self.name}' not found. Please pass the tool functions to the `execute` method."
+                )
 
             try:
                 args = self.args or {}
@@ -319,6 +326,65 @@ class ToolCalls(Type):
                 raise RuntimeError(f"Error executing tool '{self.name}': {e}") from e
 
     tool_calls: list[ToolCall]
+
+    @classmethod
+    def _get_tool_call_input_field_name(cls, signature: type[Any]) -> str | None:
+        for name, field in signature.input_fields.items():
+            origin = get_origin(field.annotation)
+            args = get_args(field.annotation)
+            if origin is list and args and args[0] == Tool:
+                return name
+            if field.annotation == Tool:
+                return name
+        return None
+
+    @classmethod
+    def adapt_to_native_lm_feature(
+        cls,
+        signature: type[Any],
+        field_name: str,
+        lm,
+        lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
+    ) -> type[Any]:
+        adapter_options = adapter_options or {}
+        if not adapter_options.get("use_native_function_calling"):
+            return signature
+
+        tool_call_input_field_name = cls._get_tool_call_input_field_name(signature)
+        if tool_call_input_field_name is None:
+            raise ValueError(
+                f"You provided an output field {field_name} to receive the tool calls information, "
+                "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
+                "input field with type `list[dspy.Tool]`."
+            )
+
+        if not lm.supports_function_calling:
+            return signature
+
+        tools = (inputs or {})[tool_call_input_field_name]
+        tools = tools if isinstance(tools, list) else [tools]
+        lm_kwargs["tools"] = [tool.format_as_litellm_function_call() for tool in tools]
+
+        allow_parallel_tool_calls = adapter_options.get("allow_parallel_tool_calls")
+        if allow_parallel_tool_calls is not None:
+            lm_kwargs["parallel_tool_calls"] = allow_parallel_tool_calls
+
+        return signature.delete(field_name).delete(tool_call_input_field_name)
+
+    @classmethod
+    def parse_lm_response(cls, response: str | dict[str, Any]) -> "ToolCalls | None":
+        if not isinstance(response, dict):
+            return None
+        tool_calls = response.get("tool_calls")
+        if not tool_calls:
+            return None
+        return cls.model_validate(tool_calls)
+
+    @classmethod
+    def supports_structured_output_schema(cls) -> bool:
+        return False
 
     @classmethod
     def from_dict_list(cls, tool_calls_dicts: list[dict[str, Any]]) -> "ToolCalls":
@@ -340,21 +406,78 @@ class ToolCalls(Type):
             tool_calls = ToolCalls.from_dict_list(tool_calls_dict)
             ```
         """
-        tool_calls = [cls.ToolCall(**item) for item in tool_calls_dicts]
-        return cls(tool_calls=tool_calls)
+        return cls.model_validate(tool_calls_dicts)
 
     @classmethod
     def description(cls) -> str:
         return (
-            "Tool calls information, including the name of the tools and the arguments to be passed to it. "
+            "One or more tool calls, including the name of each tool and the arguments to be passed to it. "
             "Arguments must be provided in JSON format."
         )
 
-    def format(self) -> list[dict[str, Any]]:
+    def format(self) -> dict[str, list[dict[str, Any]]]:
         # The tool_call field is compatible with OpenAI's tool calls schema.
         return {
             "tool_calls": [tool_call.format() for tool_call in self.tool_calls],
         }
+
+    @staticmethod
+    def _get_tool_call_value(item: Any, key: str, default: Any = None) -> Any:
+        if isinstance(item, dict):
+            return item.get(key, default)
+        return getattr(item, key, default)
+
+    @staticmethod
+    def _parse_tool_call_args(args: Any) -> Any:
+        if isinstance(args, str):
+            return json_repair.loads(args)
+        return args
+
+    @classmethod
+    def _normalized_tool_call(cls, name: Any, args: Any, tool_call_id: Any = None) -> dict[str, Any] | None:
+        if name is None:
+            return None
+        normalized = {"name": name, "args": cls._parse_tool_call_args(args)}
+        if tool_call_id:
+            normalized["id"] = tool_call_id
+        return normalized
+
+    @classmethod
+    def _normalize_native_tool_call(cls, item: Any) -> Any:
+        if not isinstance(item, dict) and hasattr(item, "model_dump"):
+            try:
+                dumped_item = item.model_dump()
+            except TypeError:
+                dumped_item = None
+            if isinstance(dumped_item, dict):
+                item = dumped_item
+
+        function = cls._get_tool_call_value(item, "function")
+        if function is not None:
+            name = cls._get_tool_call_value(function, "name")
+            arguments = cls._get_tool_call_value(function, "arguments", {})
+            normalized = cls._normalized_tool_call(name, arguments, cls._get_tool_call_value(item, "id"))
+            if normalized is not None:
+                return normalized
+
+        name = cls._get_tool_call_value(item, "name")
+        if cls._get_tool_call_value(item, "type") == "function_call" and name is not None:
+            arguments = cls._get_tool_call_value(item, "arguments", {})
+            normalized = cls._normalized_tool_call(
+                name,
+                arguments,
+                cls._get_tool_call_value(item, "call_id") or cls._get_tool_call_value(item, "id"),
+            )
+            if normalized is not None:
+                return normalized
+
+        args = cls._get_tool_call_value(item, "args")
+        if args is not None:
+            normalized = cls._normalized_tool_call(name, args, cls._get_tool_call_value(item, "id"))
+            if normalized is not None:
+                return normalized
+
+        return item
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -362,25 +485,21 @@ class ToolCalls(Type):
         if isinstance(data, cls):
             return data
 
-        # Handle case where data is a list of dicts with "name" and "args" keys
-        if isinstance(data, list) and all(
-            isinstance(item, dict) and "name" in item and "args" in item for item in data
-        ):
-            return {"tool_calls": [cls.ToolCall(**item) for item in data]}
-        # Handle case where data is a dict
+        tool_calls_data = None
+        if isinstance(data, list):
+            tool_calls_data = data
         elif isinstance(data, dict):
             if "tool_calls" in data:
-                # Handle case where data is a dict with "tool_calls" key
                 tool_calls_data = data["tool_calls"]
-                if isinstance(tool_calls_data, list):
-                    return {
-                        "tool_calls": [
-                            cls.ToolCall(**item) if isinstance(item, dict) else item for item in tool_calls_data
-                        ]
-                    }
-            elif "name" in data and "args" in data:
-                # Handle case where data is a dict with "name" and "args" keys
-                return {"tool_calls": [cls.ToolCall(**data)]}
+            else:
+                normalized = cls._normalize_native_tool_call(data)
+                if isinstance(normalized, dict) and "name" in normalized and "args" in normalized:
+                    return {"tool_calls": [normalized]}
+
+        if isinstance(tool_calls_data, list):
+            normalized = [cls._normalize_native_tool_call(item) for item in tool_calls_data]
+            if all(isinstance(item, dict) and "name" in item and "args" in item for item in normalized):
+                return {"tool_calls": normalized}
 
         raise ValueError(f"Received invalid value for `dspy.ToolCalls`: {data}")
 
@@ -393,7 +512,7 @@ def _resolve_json_schema_reference(schema: dict) -> dict:
         return schema
 
     def resolve_refs(obj: Any) -> Any:
-        if not isinstance(obj, (dict, list)):
+        if not isinstance(obj, dict | list):
             return obj
         if isinstance(obj, dict):
             if "$ref" in obj:

--- a/tests/adapters/test_parallel_tool_calls.py
+++ b/tests/adapters/test_parallel_tool_calls.py
@@ -1,0 +1,212 @@
+import pytest
+
+import dspy
+
+
+class RecordingLM:
+    supports_reasoning = False
+    supports_response_schema = True
+
+    def __init__(self, outputs, supported_params=None):
+        self.outputs = outputs
+        self.supported_params = set(supported_params or [])
+        self.supports_function_calling = True
+        self.calls = []
+
+    def __call__(self, messages, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        return self.outputs
+
+    async def acall(self, messages, **kwargs):
+        return self(messages, **kwargs)
+
+
+class ToolSignature(dspy.Signature):
+    question: str = dspy.InputField()
+    tools: list[dspy.Tool] = dspy.InputField()
+    answer: str = dspy.OutputField()
+    tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+
+def get_weather(city: str) -> str:
+    return f"The weather in {city} is sunny"
+
+
+def get_timezone(city: str) -> str:
+    return f"The timezone in {city} is CET"
+
+
+TOOLS = [dspy.Tool(get_weather), dspy.Tool(get_timezone)]
+EXPECTED_TOOL_CALLS = dspy.ToolCalls(
+    tool_calls=[
+        dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"}),
+        dspy.ToolCalls.ToolCall(name="get_timezone", args={"city": "Paris"}),
+    ]
+)
+EXPECTED_NATIVE_TOOL_CALLS = dspy.ToolCalls(
+    tool_calls=[
+        dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"}, id="call_weather"),
+        dspy.ToolCalls.ToolCall(name="get_timezone", args={"city": "Paris"}, id="call_timezone"),
+    ]
+)
+
+
+def _supported_params(adapter_cls):
+    return {"response_format"} if adapter_cls is dspy.JSONAdapter else set()
+
+
+def _completion(adapter_cls, *, tool_calls=None):
+    if adapter_cls is dspy.JSONAdapter:
+        if tool_calls is None:
+            return '{"answer": "ok"}'
+        return f'{{"answer": "Need tools", "tool_calls": {tool_calls}}}'
+
+    if tool_calls is None:
+        return "[[ ## answer ## ]]\nok\n\n[[ ## completed ## ]]"
+    return f"[[ ## answer ## ]]\nNeed tools\n\n[[ ## tool_calls ## ]]\n{tool_calls}\n\n[[ ## completed ## ]]"
+
+
+def _run(adapter, lm):
+    return adapter(
+        lm,
+        {},
+        ToolSignature,
+        [],
+        {"question": "What is the weather in Paris?", "tools": TOOLS},
+    )
+
+
+@pytest.mark.parametrize("adapter_cls", [dspy.ChatAdapter, dspy.JSONAdapter])
+@pytest.mark.parametrize("allow_parallel_tool_calls", [None, False, True])
+def test_native_tool_call_request_uses_native_surface(adapter_cls, allow_parallel_tool_calls):
+    adapter = adapter_cls(
+        use_native_function_calling=True,
+        allow_parallel_tool_calls=allow_parallel_tool_calls,
+    )
+    lm = RecordingLM([_completion(adapter_cls)], supported_params=_supported_params(adapter_cls))
+
+    result = _run(adapter, lm)
+    call = lm.calls[0]
+    system_message = call["messages"][0]["content"]
+
+    assert result[0]["answer"] == "ok"
+    assert result[0]["tool_calls"] is None
+    assert "tools" in call["kwargs"]
+    assert "native tool-call interface" in system_message
+    assert "[[ ## tools ## ]]" not in system_message
+    assert "[[ ## tool_calls ## ]]" not in system_message
+    if allow_parallel_tool_calls is None:
+        assert "parallel_tool_calls" not in call["kwargs"]
+    else:
+        assert call["kwargs"]["parallel_tool_calls"] is allow_parallel_tool_calls
+    if adapter_cls is dspy.JSONAdapter:
+        assert set(call["kwargs"]["response_format"].model_json_schema()["properties"]) == {"answer"}
+
+
+@pytest.mark.parametrize("adapter_cls", [dspy.ChatAdapter, dspy.JSONAdapter])
+def test_non_native_tool_calls_parse_multiple_calls(adapter_cls):
+    adapter = adapter_cls(use_native_function_calling=False, allow_parallel_tool_calls=True)
+    tool_calls = """
+[
+  {"name": "get_weather", "args": {"city": "Paris"}},
+  {"name": "get_timezone", "args": {"city": "Paris"}}
+]
+    """
+    lm = RecordingLM([_completion(adapter_cls, tool_calls=tool_calls)], supported_params=_supported_params(adapter_cls))
+
+    result = _run(adapter, lm)[0]
+    call = lm.calls[0]
+
+    assert result["answer"] == "Need tools"
+    assert result["tool_calls"] == EXPECTED_TOOL_CALLS
+    assert "tools" not in call["kwargs"]
+    assert "parallel_tool_calls" not in call["kwargs"]
+    assert "tool_calls" in call["messages"][0]["content"]
+    if adapter_cls is dspy.JSONAdapter:
+        assert call["kwargs"]["response_format"] == {"type": "json_object"}
+
+
+def test_native_function_calling_preserves_multiple_chat_tool_calls():
+    lm = RecordingLM(
+        [
+            {
+                "text": None,
+                "tool_calls": [
+                    {
+                        "function": {"arguments": '{"city":"Paris"}', "name": "get_weather"},
+                        "id": "call_weather",
+                        "type": "function",
+                    },
+                    {
+                        "function": {"arguments": '{"city":"Paris"}', "name": "get_timezone"},
+                        "id": "call_timezone",
+                        "type": "function",
+                    },
+                ],
+            }
+        ]
+    )
+
+    result = _run(dspy.ChatAdapter(use_native_function_calling=True), lm)[0]
+
+    assert result["answer"] is None
+    assert result["tool_calls"] == EXPECTED_NATIVE_TOOL_CALLS
+
+
+def test_native_function_calling_parses_responses_api_tool_call_shape():
+    lm = RecordingLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_weather",
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    }
+                ]
+            }
+        ]
+    )
+
+    result = _run(dspy.ChatAdapter(use_native_function_calling=True), lm)[0]
+
+    assert result["answer"] is None
+    assert result["tool_calls"] == dspy.ToolCalls(
+        tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"}, id="call_weather")]
+    )
+
+
+def test_legacy_custom_type_native_hook_signature_still_works():
+    class CustomType(dspy.Type):
+        value: str
+
+        @classmethod
+        def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs):
+            lm_kwargs["legacy_hook_called"] = True
+            return signature.delete(field_name)
+
+        @classmethod
+        def parse_lm_response(cls, response):
+            if isinstance(response, dict) and "custom_value" in response:
+                return cls(value=response["custom_value"])
+            return None
+
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: CustomType = dspy.OutputField()
+
+    lm = RecordingLM([{"text": None, "custom_value": "ok"}])
+    adapter = dspy.ChatAdapter(native_response_types=[CustomType])
+    result = adapter(
+        lm,
+        {},
+        MySignature,
+        [],
+        {"question": "hello"},
+    )
+
+    assert adapter.native_response_types == [CustomType]
+    assert dspy.ChatAdapter(native_response_types=[]).native_response_types == []
+    assert result[0]["answer"] == CustomType(value="ok")
+    assert lm.calls[0]["kwargs"]["legacy_hook_called"] is True

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -497,6 +497,27 @@ def test_toolcalls_vague_match():
         ToolCalls.model_validate([{"foo": "bar"}])
 
 
+def test_toolcalls_normalizes_cached_litellm_tool_call_object():
+    class Function:
+        name = "search"
+        arguments = '{"query": "hello", "k": 5}'
+
+    class CachedToolCall:
+        id = "call_123"
+        type = "function"
+        function = Function()
+
+        def model_dump(self):
+            raise TypeError("'MockValSer' object cannot be converted to 'SchemaSerializer'")
+
+    tc = ToolCalls.model_validate([CachedToolCall()])
+
+    assert len(tc.tool_calls) == 1
+    assert tc.tool_calls[0].name == "search"
+    assert tc.tool_calls[0].args == {"query": "hello", "k": 5}
+    assert tc.tool_calls[0].id == "call_123"
+
+
 def test_tool_convert_input_schema_to_tool_args_no_input_params():
     args, arg_types, arg_desc = convert_input_schema_to_tool_args(schema={"properties": {}})
     assert args == {}
@@ -542,8 +563,6 @@ def test_tool_convert_input_schema_to_tool_args_lang_chain():
     }
 
 
-
-
 def test_tool_call_execute():
     def get_weather(city: str) -> str:
         return f"The weather in {city} is sunny"
@@ -551,10 +570,7 @@ def test_tool_call_execute():
     def add_numbers(a: int, b: int) -> int:
         return a + b
 
-    tools = [
-        dspy.Tool(get_weather),
-        dspy.Tool(add_numbers)
-    ]
+    tools = [dspy.Tool(get_weather), dspy.Tool(add_numbers)]
 
     tool_call = dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Berlin"})
     result = tool_call.execute(functions=tools)
@@ -577,7 +593,7 @@ def test_tool_call_execute():
     tool_call4 = dspy.ToolCalls.ToolCall(name="nonexistent", args={})
     try:
         tool_call4.execute(functions=tools)
-        assert False, "Should have raised ValueError"
+        raise AssertionError("Should have raised ValueError")
     except ValueError as e:
         assert "not found" in str(e)
 


### PR DESCRIPTION
## Summary

Encapsulates native `ToolCalls` handling inside the `ToolCalls` type and makes adapter native-response handling generic across `dspy.Type` subclasses.

## What changed

- Added `ToolCalls` to the default native response types while preserving explicit `native_response_types` as an exact override.
- Moved native tool-call setup/parsing into `ToolCalls.adapt_to_native_lm_feature()` and `ToolCalls.parse_lm_response()`.
- Added ToolCalls normalization for:
  - OpenAI chat-completions-style `function` tool calls
  - OpenAI Responses API `function_call` items
  - cached LiteLLM tool-call objects
  - multiple / parallel tool calls
- Added `allow_parallel_tool_calls` adapter option and forwards it as `parallel_tool_calls` when explicitly set.
- Updated `JSONAdapter` structured-output handling so unsupported native-output types like `ToolCalls` are excluded from structured schemas when native function calling is active.
- Preserved compatibility for existing custom `Type.adapt_to_native_lm_feature()` hooks.
- Added tests covering native/non-native ToolCalls behavior across `ChatAdapter` and `JSONAdapter`.

## Why

Native tool-call behavior was previously a special side channel in `Adapter`. This change makes `ToolCalls` own its native adaptation/parsing logic, aligning it with the existing native `Type` pattern used by reasoning/citations and making adapter behavior cleaner and easier to extend.

## Validation

- `uv run pytest --deno tests/adapters/test_parallel_tool_calls.py tests/adapters/test_tool.py -q`
  - `43 passed`

## Review notes / boundaries

- This PR is focused on native ToolCalls encapsulation, ToolCalls parsing/normalization, structured-output compatibility, and parallel tool-call request wiring.
- It does not change broader adapter fallback semantics beyond what is needed for native ToolCalls and JSON structured-output behavior.
