### PR TITLE
fix(adapter): preserve config in ChatAdapter JSON fallback

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any, get_origin
 
-import json_repair
-
 from dspy.adapters.types import History, Type
 from dspy.adapters.types.base_type import split_message_content_for_custom_types
 from dspy.adapters.types.reasoning import Reasoning
@@ -16,6 +14,13 @@ from dspy.utils.exceptions import AdapterParseError
 logger = logging.getLogger(__name__)
 
 _DEFAULT_NATIVE_RESPONSE_TYPES = [Citations, Reasoning]
+
+
+def _native_tool_call_instruction(field_name: str) -> str:
+    return (
+        "When tool use is needed, call the available tools through the native tool-call interface. "
+        f"Do not emit `{field_name}` as a text or JSON output field."
+    )
 
 
 class Adapter:
@@ -40,6 +45,7 @@ class Adapter:
         callbacks: list[BaseCallback] | None = None,
         use_native_function_calling: bool = False,
         native_response_types: list[type[Type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
     ):
         """
         Args:
@@ -51,10 +57,15 @@ class Adapter:
             native_response_types: List of output field types that should be handled by native LM features rather than
                 adapter parsing. For example, `dspy.Citations` can be populated directly by citation APIs
                 (e.g., Anthropic's citation feature). Defaults to `[Citations]`.
+            allow_parallel_tool_calls: Whether to request provider-side parallel tool calls when native function calling
+                is active. If `None`, leaves the provider default unchanged. Defaults to None.
         """
         self.callbacks = callbacks or []
         self.use_native_function_calling = use_native_function_calling
-        self.native_response_types = native_response_types or _DEFAULT_NATIVE_RESPONSE_TYPES
+        self.native_response_types = list(native_response_types or _DEFAULT_NATIVE_RESPONSE_TYPES)
+        if ToolCalls not in self.native_response_types:
+            self.native_response_types.append(ToolCalls)
+        self.allow_parallel_tool_calls = allow_parallel_tool_calls
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
@@ -70,42 +81,52 @@ class Adapter:
         signature: type[Signature],
         inputs: dict[str, Any],
     ) -> type[Signature]:
-        if self.use_native_function_calling:
-            tool_call_input_field_name = self._get_tool_call_input_field_name(signature)
-            tool_call_output_field_name = self._get_tool_call_output_field_name(signature)
-
-            if tool_call_output_field_name and tool_call_input_field_name is None:
-                raise ValueError(
-                    f"You provided an output field {tool_call_output_field_name} to receive the tool calls information, "
-                    "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
-                    "input field with type `list[dspy.Tool]`."
-                )
-
-            if tool_call_output_field_name and lm.supports_function_calling:
-                tools = inputs[tool_call_input_field_name]
-                tools = tools if isinstance(tools, list) else [tools]
-
-                lm_tools = [tool.format_as_litellm_function_call() for tool in tools]
-
-                lm_kwargs["tools"] = lm_tools
-
-                signature_for_native_function_calling = signature.delete(tool_call_output_field_name)
-                signature_for_native_function_calling = signature_for_native_function_calling.delete(
-                    tool_call_input_field_name
-                )
-
-                return signature_for_native_function_calling
-
-        # Handle custom types that use native LM features, e.g., reasoning, citations, etc.
-        for name, field in signature.output_fields.items():
+        adapter_options = {
+            "use_native_function_calling": self.use_native_function_calling,
+            "allow_parallel_tool_calls": self.allow_parallel_tool_calls,
+        }
+        original_signature = signature
+        native_feature_instructions = []
+        for name, field in list(signature.output_fields.items()):
             if (
                 isinstance(field.annotation, type)
                 and field.annotation in self.native_response_types
                 and issubclass(field.annotation, Type)
             ):
-                signature = field.annotation.adapt_to_native_lm_feature(signature, name, lm, lm_kwargs)
+                signature_before_adaptation = signature
+                signature = field.annotation._call_adapt_to_native_lm_feature(
+                    signature,
+                    name,
+                    lm,
+                    lm_kwargs,
+                    inputs=inputs,
+                    adapter_options=adapter_options,
+                )
+                if signature is not signature_before_adaptation:
+                    if field.annotation is ToolCalls:
+                        native_feature_instructions.append(_native_tool_call_instruction(name))
 
+        if native_feature_instructions:
+            signature = self._with_native_feature_instructions(
+                original_signature,
+                signature,
+                native_feature_instructions,
+            )
         return signature
+
+    def _with_native_feature_instructions(
+        self,
+        original_signature: type[Signature],
+        processed_signature: type[Signature],
+        native_feature_instructions: list[str],
+    ) -> type[Signature]:
+        original_default_instructions = Signature(original_signature.fields).instructions
+        processed_default_instructions = Signature(processed_signature.fields).instructions
+        if original_signature.instructions == original_default_instructions:
+            instructions = processed_default_instructions
+        else:
+            instructions = processed_signature.instructions
+        return processed_signature.with_instructions("\n".join([instructions, *native_feature_instructions]))
 
     def _call_postprocess(
         self,
@@ -117,17 +138,15 @@ class Adapter:
     ) -> list[dict[str, Any]]:
         values = []
 
-        tool_call_output_field_name = self._get_tool_call_output_field_name(original_signature)
-
         for output in outputs:
             output_logprobs = None
-            tool_calls = None
             text = output
 
             if isinstance(output, dict):
-                text = output["text"]
+                text = output.get("text")
                 output_logprobs = output.get("logprobs")
-                tool_calls = output.get("tool_calls")
+
+            parsed_native_values = self._parse_native_lm_response(original_signature, output)
 
             if text:
                 value = self.parse(processed_signature, text)
@@ -135,10 +154,8 @@ class Adapter:
                     if field_name not in value:
                         # We need to set the field not present in the processed signature to None for consistency.
                         value[field_name] = None
-            elif tool_calls and tool_call_output_field_name:
-                value = {}
-                for field_name in original_signature.output_fields.keys():
-                    value[field_name] = None
+            elif parsed_native_values:
+                value = dict.fromkeys(original_signature.output_fields.keys())
             else:
                 raise AdapterParseError(
                     adapter_name=type(self).__name__,
@@ -147,26 +164,7 @@ class Adapter:
                     message="The LM returned an empty or null response.",
                 )
 
-            if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
-
-            # Parse custom types that does not rely on the `Adapter.parse()` method
-            for name, field in original_signature.output_fields.items():
-                if (
-                    isinstance(field.annotation, type)
-                    and field.annotation in self.native_response_types
-                    and issubclass(field.annotation, Type)
-                ):
-                    parsed_value = field.annotation.parse_lm_response(output)
-                    if parsed_value is not None:
-                        value[name] = parsed_value
+            value.update(parsed_native_values)
 
             if output_logprobs:
                 value["logprobs"] = output_logprobs
@@ -174,6 +172,19 @@ class Adapter:
             values.append(value)
 
         return values
+
+    def _parse_native_lm_response(self, signature: type[Signature], output: dict[str, Any] | str) -> dict[str, Any]:
+        value = {}
+        for name, field in signature.output_fields.items():
+            if (
+                isinstance(field.annotation, type)
+                and field.annotation in self.native_response_types
+                and issubclass(field.annotation, Type)
+            ):
+                parsed_value = field.annotation.parse_lm_response(output)
+                if parsed_value is not None:
+                    value[name] = parsed_value
+        return value
 
     def __call__(
         self,

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -86,7 +86,12 @@ class ChatAdapter(Adapter):
                 # On context window exceeded error, already using JSONAdapter, or use_json_adapter_fallback is False
                 # we don't want to retry with a different adapter. Raise the original error instead of the fallback error.
                 raise e
-            return JSONAdapter()(lm, lm_kwargs, signature, demos, inputs)
+            return JSONAdapter(
+                callbacks=self.callbacks,
+                use_native_function_calling=self.use_native_function_calling,
+                native_response_types=self.native_response_types,
+                allow_parallel_tool_calls=self.allow_parallel_tool_calls,
+            )(lm, lm_kwargs, signature, demos, inputs)
 
     async def acall(
         self,
@@ -110,7 +115,12 @@ class ChatAdapter(Adapter):
                 # On context window exceeded error, already using JSONAdapter, or use_json_adapter_fallback is False
                 # we don't want to retry with a different adapter. Raise the original error instead of the fallback error.
                 raise e
-            return await JSONAdapter().acall(lm, lm_kwargs, signature, demos, inputs)
+            return await JSONAdapter(
+                callbacks=self.callbacks,
+                use_native_function_calling=self.use_native_function_calling,
+                native_response_types=self.native_response_types,
+                allow_parallel_tool_calls=self.allow_parallel_tool_calls,
+            ).acall(lm, lm_kwargs, signature, demos, inputs)
 
     def format_field_description(self, signature: type[Signature]) -> str:
         return (

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -42,6 +42,7 @@ class ChatAdapter(Adapter):
         callbacks: list[BaseCallback] | None = None,
         use_native_function_calling: bool = False,
         native_response_types: list[type[type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
         use_json_adapter_fallback: bool = True,
     ):
         """
@@ -49,6 +50,8 @@ class ChatAdapter(Adapter):
             callbacks: List of callback functions to execute during adapter methods.
             use_native_function_calling: Whether to enable native function calling capabilities.
             native_response_types: List of output field types handled by native LM features.
+            allow_parallel_tool_calls: Whether to request provider-side parallel tool calls when native function calling
+                is active. If `None`, leaves the provider default unchanged.
             use_json_adapter_fallback: Whether to automatically fallback to JSONAdapter if the ChatAdapter fails.
                 If True, when an error occurs (except ContextWindowExceededError), the adapter will retry using
                 JSONAdapter. Defaults to True.
@@ -57,6 +60,7 @@ class ChatAdapter(Adapter):
             callbacks=callbacks,
             use_native_function_calling=use_native_function_calling,
             native_response_types=native_response_types,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
         )
         self.use_json_adapter_fallback = use_json_adapter_fallback
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -8,7 +8,7 @@ import regex
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
-from dspy.adapters.types.tool import ToolCalls
+from dspy.adapters.types import Type
 from dspy.adapters.utils import (
     format_field_value,
     get_annotation_name,
@@ -37,19 +37,43 @@ def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
     return False
 
 
+def _has_output_type_without_structured_output_schema(signature: SignatureMeta) -> bool:
+    for field in signature.output_fields.values():
+        annotation = field.annotation
+        if isinstance(annotation, type) and issubclass(annotation, Type):
+            if not annotation.supports_structured_output_schema():
+                return True
+    return False
+
+
 class JSONAdapter(ChatAdapter):
-    def __init__(self, callbacks: list[BaseCallback] | None = None, use_native_function_calling: bool = True):
+    def __init__(
+        self,
+        callbacks: list[BaseCallback] | None = None,
+        use_native_function_calling: bool = True,
+        native_response_types: list[type[type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
+    ):
         # JSONAdapter uses native function calling by default.
-        super().__init__(callbacks=callbacks, use_native_function_calling=use_native_function_calling)
+        super().__init__(
+            callbacks=callbacks,
+            use_native_function_calling=use_native_function_calling,
+            native_response_types=native_response_types,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
+        )
 
     def _json_adapter_call_common(self, lm, lm_kwargs, signature, demos, inputs, call_fn):
         """Common call logic to be used for both sync and async calls."""
         if "response_format" not in lm.supported_params:
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 
-        has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
-
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
+        effective_native_function_calling = self.use_native_function_calling and lm.supports_function_calling
+        has_unsupported_structured_output_type = _has_output_type_without_structured_output_schema(signature)
+        if (
+            _has_open_ended_mapping(signature)
+            or (not effective_native_function_calling and has_unsupported_structured_output_type)
+            or not lm.supports_response_schema
+        ):
             # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
             # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -68,11 +92,12 @@ class JSONAdapter(ChatAdapter):
             return result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
+            processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+            structured_output_model = _get_structured_outputs_response_format(processed_signature)
             lm_kwargs["response_format"] = structured_output_model
-            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+            messages = self.format(processed_signature, demos, inputs)
+            outputs = lm(messages=messages, **lm_kwargs)
+            return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -91,11 +116,12 @@ class JSONAdapter(ChatAdapter):
             return await result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
+            processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+            structured_output_model = _get_structured_outputs_response_format(processed_signature)
             lm_kwargs["response_format"] = structured_output_model
-            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+            messages = self.format(processed_signature, demos, inputs)
+            outputs = await lm.acall(messages=messages, **lm_kwargs)
+            return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -211,7 +237,6 @@ class JSONAdapter(ChatAdapter):
 
 def _get_structured_outputs_response_format(
     signature: SignatureMeta,
-    use_native_function_calling: bool = True,
 ) -> type[pydantic.BaseModel]:
     """
     Builds a Pydantic model from a DSPy signature's output_fields and ensures the generated JSON schema
@@ -233,9 +258,9 @@ def _get_structured_outputs_response_format(
     fields = {}
     for name, field in signature.output_fields.items():
         annotation = field.annotation
-        if use_native_function_calling and annotation == ToolCalls:
-            # Skip ToolCalls field if native function calling is enabled.
-            continue
+        if isinstance(annotation, type) and issubclass(annotation, Type):
+            if not annotation.supports_structured_output_schema():
+                raise ValueError(f"Field '{name}' does not support Structured Outputs.")
         default = field.default if hasattr(field, "default") else ...
         fields[name] = (annotation, default)
 

--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import re
 from typing import TYPE_CHECKING, Any, Optional, get_args, get_origin
@@ -83,6 +84,8 @@ class Type(pydantic.BaseModel):
         field_name: str,
         lm: BaseLM,
         lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
     ) -> type["Signature"]:
         """Adapt the custom type to the native LM feature if possible.
 
@@ -94,6 +97,8 @@ class Type(pydantic.BaseModel):
             field_name: The name of the field in the signature to adapt to the native LM feature.
             lm: The LM instance.
             lm_kwargs: The keyword arguments for the LM call, subject to in-place updates if adaptation if required.
+            inputs: The input values for this LM call.
+            adapter_options: Adapter configuration relevant to native LM feature adaptation.
 
         Returns:
             The adapted signature. If the custom type is not natively supported by the LM, return the original
@@ -102,9 +107,34 @@ class Type(pydantic.BaseModel):
         return signature
 
     @classmethod
+    def _call_adapt_to_native_lm_feature(
+        cls,
+        signature: type["Signature"],
+        field_name: str,
+        lm: BaseLM,
+        lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
+    ) -> type["Signature"]:
+        """Call `adapt_to_native_lm_feature` while preserving compatibility with old custom type hooks."""
+        method = cls.adapt_to_native_lm_feature
+        params = inspect.signature(method).parameters
+        kwargs = {}
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()) or "inputs" in params:
+            kwargs["inputs"] = inputs
+        if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()) or "adapter_options" in params:
+            kwargs["adapter_options"] = adapter_options
+        return method(signature, field_name, lm, lm_kwargs, **kwargs)
+
+    @classmethod
     def is_streamable(cls) -> bool:
         """Whether the custom type is streamable."""
         return False
+
+    @classmethod
+    def supports_structured_output_schema(cls) -> bool:
+        """Whether this type should be included in provider structured output schemas."""
+        return True
 
     @classmethod
     def parse_stream_chunk(cls, chunk: "ModelResponseStream") -> Optional["Type"]:

--- a/dspy/adapters/types/citation.py
+++ b/dspy/adapters/types/citation.py
@@ -168,7 +168,7 @@ class Citations(Type):
         return self.citations[index]
 
     @classmethod
-    def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs) -> bool:
+    def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs):
         if lm.model.startswith("anthropic/"):
             return signature.delete(field_name)
         return signature

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -1,7 +1,8 @@
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, get_args, get_origin, get_type_hints
 
+import json_repair
 import pydantic
 from jsonschema import ValidationError, validate
 from pydantic import BaseModel, TypeAdapter, create_model
@@ -321,6 +322,83 @@ class ToolCalls(Type):
     tool_calls: list[ToolCall]
 
     @classmethod
+    def _get_tool_call_input_field_name(cls, signature: type[Any]) -> str | None:
+        for name, field in signature.input_fields.items():
+            origin = get_origin(field.annotation)
+            args = get_args(field.annotation)
+            if origin is list and args and args[0] == Tool:
+                return name
+            if field.annotation == Tool:
+                return name
+        return None
+
+    @classmethod
+    def adapt_to_native_lm_feature(
+        cls,
+        signature: type[Any],
+        field_name: str,
+        lm,
+        lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
+    ) -> type[Any]:
+        adapter_options = adapter_options or {}
+        if not adapter_options.get("use_native_function_calling"):
+            return signature
+
+        tool_call_input_field_name = cls._get_tool_call_input_field_name(signature)
+        if tool_call_input_field_name is None:
+            raise ValueError(
+                f"You provided an output field {field_name} to receive the tool calls information, "
+                "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
+                "input field with type `list[dspy.Tool]`."
+            )
+
+        if not lm.supports_function_calling:
+            return signature
+
+        tools = (inputs or {})[tool_call_input_field_name]
+        tools = tools if isinstance(tools, list) else [tools]
+        lm_kwargs["tools"] = [tool.format_as_litellm_function_call() for tool in tools]
+
+        allow_parallel_tool_calls = adapter_options.get("allow_parallel_tool_calls")
+        if allow_parallel_tool_calls is not None:
+            lm_kwargs["parallel_tool_calls"] = allow_parallel_tool_calls
+
+        return signature.delete(field_name).delete(tool_call_input_field_name)
+
+    @classmethod
+    def parse_lm_response(cls, response: str | dict[str, Any]) -> "ToolCalls | None":
+        if not isinstance(response, dict):
+            return None
+        tool_calls = response.get("tool_calls")
+        if not tool_calls:
+            return None
+        return cls(tool_calls=[cls._parse_native_tool_call(tool_call) for tool_call in tool_calls])
+
+    @classmethod
+    def _parse_native_tool_call(cls, tool_call: Any) -> ToolCall:
+        if hasattr(tool_call, "model_dump"):
+            tool_call = tool_call.model_dump()
+
+        function = tool_call.get("function") if isinstance(tool_call, dict) else None
+        if function is not None:
+            if hasattr(function, "model_dump"):
+                function = function.model_dump()
+            name = function["name"]
+            arguments = function["arguments"]
+        else:
+            name = tool_call["name"]
+            arguments = tool_call["arguments"]
+
+        args = json_repair.loads(arguments) if isinstance(arguments, str) else arguments
+        return cls.ToolCall(name=name, args=args)
+
+    @classmethod
+    def supports_structured_output_schema(cls) -> bool:
+        return False
+
+    @classmethod
     def from_dict_list(cls, tool_calls_dicts: list[dict[str, Any]]) -> "ToolCalls":
         """Convert a list of dictionaries to a ToolCalls instance.
 
@@ -346,7 +424,7 @@ class ToolCalls(Type):
     @classmethod
     def description(cls) -> str:
         return (
-            "Tool calls information, including the name of the tools and the arguments to be passed to it. "
+            "One or more tool calls, including the name of each tool and the arguments to be passed to it. "
             "Arguments must be provided in JSON format."
         )
 

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -7,6 +7,7 @@ from litellm.utils import ChatCompletionMessageToolCall, Choices, Function, Mess
 
 import dspy
 from dspy.experimental import Citations
+from dspy.utils.callback import BaseCallback
 
 
 @pytest.mark.parametrize(
@@ -492,6 +493,87 @@ def test_chat_adapter_respects_use_json_adapter_fallback_flag():
             with pytest.raises(dspy.utils.exceptions.AdapterParseError):
                 adapter(lm, {}, signature, [], {"question": "What is the capital of France?"})
         mock_json_adapter_call.assert_not_called()
+
+
+def test_chat_adapter_fallback_preserves_adapter_configuration():
+    class CustomType(dspy.Type):
+        value: str
+
+    callback = BaseCallback()
+    adapter = dspy.ChatAdapter(
+        callbacks=[callback],
+        use_native_function_calling=True,
+        native_response_types=[CustomType],
+        allow_parallel_tool_calls=False,
+    )
+    signature = dspy.make_signature("question->answer")
+
+    with (
+        mock.patch.object(dspy.ChatAdapter, "parse", side_effect=ValueError("bad")),
+        mock.patch(
+            "dspy.adapters.json_adapter.JSONAdapter.__call__",
+            autospec=True,
+            return_value=[{"answer": "Paris"}],
+        ) as mock_json_adapter_call,
+    ):
+        result = adapter(
+            lm=mock.Mock(return_value=["bad"]),
+            lm_kwargs={},
+            signature=signature,
+            demos=[],
+            inputs={"question": "What is the capital of France?"},
+        )
+
+    assert result == [{"answer": "Paris"}]
+    fallback_adapter = mock_json_adapter_call.call_args.args[0]
+    assert fallback_adapter.callbacks == [callback]
+    assert fallback_adapter.use_native_function_calling is True
+    assert CustomType in fallback_adapter.native_response_types
+    assert dspy.ToolCalls in fallback_adapter.native_response_types
+    assert fallback_adapter.allow_parallel_tool_calls is False
+
+
+@pytest.mark.asyncio
+async def test_chat_adapter_async_fallback_preserves_adapter_configuration():
+    class CustomType(dspy.Type):
+        value: str
+
+    callback = BaseCallback()
+    adapter = dspy.ChatAdapter(
+        callbacks=[callback],
+        use_native_function_calling=True,
+        native_response_types=[CustomType],
+        allow_parallel_tool_calls=False,
+    )
+    signature = dspy.make_signature("question->answer")
+
+    class FakeLM:
+        async def acall(self, messages, **kwargs):
+            return ["bad"]
+
+    with (
+        mock.patch.object(dspy.ChatAdapter, "parse", side_effect=ValueError("bad")),
+        mock.patch(
+            "dspy.adapters.json_adapter.JSONAdapter.acall",
+            autospec=True,
+            return_value=[{"answer": "Paris"}],
+        ) as mock_json_adapter_acall,
+    ):
+        result = await adapter.acall(
+            lm=FakeLM(),
+            lm_kwargs={},
+            signature=signature,
+            demos=[],
+            inputs={"question": "What is the capital of France?"},
+        )
+
+    assert result == [{"answer": "Paris"}]
+    fallback_adapter = mock_json_adapter_acall.call_args.args[0]
+    assert fallback_adapter.callbacks == [callback]
+    assert fallback_adapter.use_native_function_calling is True
+    assert CustomType in fallback_adapter.native_response_types
+    assert dspy.ToolCalls in fallback_adapter.native_response_types
+    assert fallback_adapter.allow_parallel_tool_calls is False
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_parallel_tool_calls.py
+++ b/tests/adapters/test_parallel_tool_calls.py
@@ -1,0 +1,202 @@
+import pytest
+
+import dspy
+
+
+class RecordingLM:
+    supports_reasoning = False
+    supports_response_schema = True
+
+    def __init__(self, outputs, supported_params=None):
+        self.outputs = outputs
+        self.supported_params = set(supported_params or [])
+        self.supports_function_calling = True
+        self.calls = []
+
+    def __call__(self, messages, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        return self.outputs
+
+    async def acall(self, messages, **kwargs):
+        return self(messages, **kwargs)
+
+
+class ToolSignature(dspy.Signature):
+    question: str = dspy.InputField()
+    tools: list[dspy.Tool] = dspy.InputField()
+    answer: str = dspy.OutputField()
+    tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+
+def get_weather(city: str) -> str:
+    return f"The weather in {city} is sunny"
+
+
+def get_timezone(city: str) -> str:
+    return f"The timezone in {city} is CET"
+
+
+TOOLS = [dspy.Tool(get_weather), dspy.Tool(get_timezone)]
+EXPECTED_TOOL_CALLS = dspy.ToolCalls(
+    tool_calls=[
+        dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"}),
+        dspy.ToolCalls.ToolCall(name="get_timezone", args={"city": "Paris"}),
+    ]
+)
+
+
+def _supported_params(adapter_cls):
+    return {"response_format"} if adapter_cls is dspy.JSONAdapter else set()
+
+
+def _completion(adapter_cls, *, tool_calls=None):
+    if adapter_cls is dspy.JSONAdapter:
+        if tool_calls is None:
+            return '{"answer": "ok"}'
+        return f'{{"answer": "Need tools", "tool_calls": {tool_calls}}}'
+
+    if tool_calls is None:
+        return "[[ ## answer ## ]]\nok\n\n[[ ## completed ## ]]"
+    return f"[[ ## answer ## ]]\nNeed tools\n\n[[ ## tool_calls ## ]]\n{tool_calls}\n\n[[ ## completed ## ]]"
+
+
+def _run(adapter, lm):
+    return adapter(
+        lm,
+        {},
+        ToolSignature,
+        [],
+        {"question": "What is the weather in Paris?", "tools": TOOLS},
+    )
+
+
+@pytest.mark.parametrize("adapter_cls", [dspy.ChatAdapter, dspy.JSONAdapter])
+@pytest.mark.parametrize("allow_parallel_tool_calls", [None, False, True])
+def test_native_tool_call_request_uses_native_surface(adapter_cls, allow_parallel_tool_calls):
+    adapter = adapter_cls(
+        use_native_function_calling=True,
+        allow_parallel_tool_calls=allow_parallel_tool_calls,
+    )
+    lm = RecordingLM([_completion(adapter_cls)], supported_params=_supported_params(adapter_cls))
+
+    result = _run(adapter, lm)
+    call = lm.calls[0]
+    system_message = call["messages"][0]["content"]
+
+    assert result[0]["answer"] == "ok"
+    assert result[0]["tool_calls"] is None
+    assert "tools" in call["kwargs"]
+    assert "native tool-call interface" in system_message
+    assert "[[ ## tools ## ]]" not in system_message
+    assert "[[ ## tool_calls ## ]]" not in system_message
+    if allow_parallel_tool_calls is None:
+        assert "parallel_tool_calls" not in call["kwargs"]
+    else:
+        assert call["kwargs"]["parallel_tool_calls"] is allow_parallel_tool_calls
+    if adapter_cls is dspy.JSONAdapter:
+        assert set(call["kwargs"]["response_format"].model_json_schema()["properties"]) == {"answer"}
+
+
+@pytest.mark.parametrize("adapter_cls", [dspy.ChatAdapter, dspy.JSONAdapter])
+def test_non_native_tool_calls_parse_multiple_calls(adapter_cls):
+    adapter = adapter_cls(use_native_function_calling=False, allow_parallel_tool_calls=True)
+    tool_calls = """
+[
+  {"name": "get_weather", "args": {"city": "Paris"}},
+  {"name": "get_timezone", "args": {"city": "Paris"}}
+]
+    """
+    lm = RecordingLM([_completion(adapter_cls, tool_calls=tool_calls)], supported_params=_supported_params(adapter_cls))
+
+    result = _run(adapter, lm)[0]
+    call = lm.calls[0]
+
+    assert result["answer"] == "Need tools"
+    assert result["tool_calls"] == EXPECTED_TOOL_CALLS
+    assert "tools" not in call["kwargs"]
+    assert "parallel_tool_calls" not in call["kwargs"]
+    assert "tool_calls" in call["messages"][0]["content"]
+    if adapter_cls is dspy.JSONAdapter:
+        assert call["kwargs"]["response_format"] == {"type": "json_object"}
+
+
+def test_native_function_calling_preserves_multiple_chat_tool_calls():
+    lm = RecordingLM(
+        [
+            {
+                "text": None,
+                "tool_calls": [
+                    {
+                        "function": {"arguments": '{"city":"Paris"}', "name": "get_weather"},
+                        "id": "call_weather",
+                        "type": "function",
+                    },
+                    {
+                        "function": {"arguments": '{"city":"Paris"}', "name": "get_timezone"},
+                        "id": "call_timezone",
+                        "type": "function",
+                    },
+                ],
+            }
+        ]
+    )
+
+    result = _run(dspy.ChatAdapter(use_native_function_calling=True), lm)[0]
+
+    assert result["answer"] is None
+    assert result["tool_calls"] == EXPECTED_TOOL_CALLS
+
+
+def test_native_function_calling_parses_responses_api_tool_call_shape():
+    lm = RecordingLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "type": "function_call",
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    }
+                ]
+            }
+        ]
+    )
+
+    result = _run(dspy.ChatAdapter(use_native_function_calling=True), lm)[0]
+
+    assert result["answer"] is None
+    assert result["tool_calls"] == dspy.ToolCalls(
+        tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"})]
+    )
+
+
+def test_legacy_custom_type_native_hook_signature_still_works():
+    class CustomType(dspy.Type):
+        value: str
+
+        @classmethod
+        def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs):
+            lm_kwargs["legacy_hook_called"] = True
+            return signature.delete(field_name)
+
+        @classmethod
+        def parse_lm_response(cls, response):
+            if isinstance(response, dict) and "custom_value" in response:
+                return cls(value=response["custom_value"])
+            return None
+
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: CustomType = dspy.OutputField()
+
+    lm = RecordingLM([{"text": None, "custom_value": "ok"}])
+    result = dspy.ChatAdapter(native_response_types=[CustomType])(
+        lm,
+        {},
+        MySignature,
+        [],
+        {"question": "hello"},
+    )
+
+    assert result[0]["answer"] == CustomType(value="ok")
+    assert lm.calls[0]["kwargs"]["legacy_hook_called"] is True


### PR DESCRIPTION
When ChatAdapter falls back to JSONAdapter on parse failure, forward `callbacks`, `native_response_types`, `use_native_function_calling`, and `allow_parallel_tool_calls` so the fallback adapter behaves consistently.

Stacked on #9773.