### PR TITLE
fix(adapter): preserve empty JSON fallback results

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -88,7 +88,7 @@ class JSONAdapter(ChatAdapter):
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().__call__)
-        if result:
+        if result is not None:
             return result
 
         try:
@@ -112,7 +112,7 @@ class JSONAdapter(ChatAdapter):
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().acall)
-        if result:
+        if result is not None:
             return await result
 
         try:

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -115,6 +115,27 @@ def test_json_adapter_sync_call():
     assert result == [{"answer": "Paris"}]
 
 
+def test_json_adapter_empty_early_fallback_result_does_not_call_lm_again():
+    class EmptyResultLM:
+        def __init__(self):
+            self.supported_params = set()
+            self.calls = []
+
+        def __call__(self, messages, **kwargs):
+            self.calls.append({"messages": messages, "kwargs": kwargs})
+            return []
+
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.JSONAdapter()
+    lm = EmptyResultLM()
+
+    result = adapter(lm, {}, signature, [], {"question": "What is the capital of France?"})
+
+    assert result == []
+    assert len(lm.calls) == 1
+    assert "response_format" not in lm.calls[0]["kwargs"]
+
+
 @pytest.mark.asyncio
 async def test_json_adapter_async_call():
     signature = dspy.make_signature("question->answer")


### PR DESCRIPTION
Change `if result:` to `if result is not None:` in JSONAdapter's `__call__` and `acall` so that an empty list from the common fallback path is returned directly instead of triggering an unnecessary second LM call.

Stacked on #9773 -> fix(adapter): preserve config in ChatAdapter JSON fallback.