### PR TITLE
feat(tool-call): normalize native ToolCalls type shapes

### DIFF
--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -83,6 +83,8 @@ class Type(pydantic.BaseModel):
         field_name: str,
         lm: BaseLM,
         lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
     ) -> type["Signature"]:
         """Adapt the custom type to the native LM feature if possible.
 
@@ -94,6 +96,8 @@ class Type(pydantic.BaseModel):
             field_name: The name of the field in the signature to adapt to the native LM feature.
             lm: The LM instance.
             lm_kwargs: The keyword arguments for the LM call, subject to in-place updates if adaptation if required.
+            inputs: The input values for this LM call.
+            adapter_options: Adapter configuration relevant to native LM feature adaptation.
 
         Returns:
             The adapted signature. If the custom type is not natively supported by the LM, return the original
@@ -105,6 +109,11 @@ class Type(pydantic.BaseModel):
     def is_streamable(cls) -> bool:
         """Whether the custom type is streamable."""
         return False
+
+    @classmethod
+    def supports_structured_output_schema(cls) -> bool:
+        """Whether this type should be included in provider structured output schemas."""
+        return True
 
     @classmethod
     def parse_stream_chunk(cls, chunk: "ModelResponseStream") -> Optional["Type"]:

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -1,7 +1,8 @@
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, get_args, get_origin, get_type_hints
 
+import json_repair
 import pydantic
 from jsonschema import ValidationError, validate
 from pydantic import BaseModel, TypeAdapter, create_model
@@ -263,15 +264,20 @@ class ToolCalls(Type):
     class ToolCall(Type):
         name: str
         args: dict[str, Any]
+        id: str | None = None
 
         def format(self):
-            return {
+            """Format this tool call using the OpenAI-compatible native tool-call schema."""
+            formatted = {
                 "type": "function",
                 "function": {
                     "name": self.name,
                     "arguments": self.args,
                 },
             }
+            if self.id is not None:
+                formatted["id"] = self.id
+            return formatted
 
         def execute(self, functions: dict[str, Any] | list[Tool] | None = None) -> Any:
             """Execute this individual tool call and return its result.
@@ -310,7 +316,9 @@ class ToolCalls(Type):
                         break
 
             if func is None:
-                raise ValueError(f"Tool function '{self.name}' not found. Please pass the tool functions to the `execute` method.")
+                raise ValueError(
+                    f"Tool function '{self.name}' not found. Please pass the tool functions to the `execute` method."
+                )
 
             try:
                 args = self.args or {}
@@ -319,6 +327,74 @@ class ToolCalls(Type):
                 raise RuntimeError(f"Error executing tool '{self.name}': {e}") from e
 
     tool_calls: list[ToolCall]
+
+    @classmethod
+    def _get_tool_call_input_field_name(cls, signature: type[Any]) -> str | None:
+        for name, field in signature.input_fields.items():
+            origin = get_origin(field.annotation)
+            args = get_args(field.annotation)
+            if origin is list and args and args[0] == Tool:
+                return name
+            if field.annotation == Tool:
+                return name
+        return None
+
+    @classmethod
+    def adapt_to_native_lm_feature(
+        cls,
+        signature: type[Any],
+        field_name: str,
+        lm,
+        lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
+    ) -> type[Any]:
+        """Adapt a ToolCalls output field to native function-calling parameters when enabled."""
+        adapter_options = adapter_options or {}
+        if not adapter_options.get("use_native_function_calling"):
+            return signature
+
+        tool_call_input_field_name = cls._get_tool_call_input_field_name(signature)
+        if tool_call_input_field_name is None:
+            raise ValueError(
+                f"You provided an output field {field_name} to receive the tool calls information, "
+                "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
+                "input field with type `list[dspy.Tool]`."
+            )
+
+        if not lm.supports_function_calling:
+            return signature
+
+        if inputs is None or tool_call_input_field_name not in inputs or inputs[tool_call_input_field_name] is None:
+            raise ValueError(
+                f"You provided an output field {field_name} to receive the tool calls information, "
+                f"but did not provide a value for the tools input field `{tool_call_input_field_name}`."
+            )
+
+        tools = inputs[tool_call_input_field_name]
+        tools = tools if isinstance(tools, list) else [tools]
+        lm_kwargs["tools"] = [tool.format_as_litellm_function_call() for tool in tools]
+
+        allow_parallel_tool_calls = adapter_options.get("allow_parallel_tool_calls")
+        if allow_parallel_tool_calls is not None:
+            lm_kwargs["parallel_tool_calls"] = allow_parallel_tool_calls
+
+        return signature.delete(field_name).delete(tool_call_input_field_name)
+
+    @classmethod
+    def parse_lm_response(cls, response: str | dict[str, Any]) -> "ToolCalls | None":
+        """Parse native LM tool-call payloads into a ToolCalls value."""
+        if not isinstance(response, dict):
+            return None
+        tool_calls = response.get("tool_calls")
+        if not tool_calls:
+            return None
+        return cls.model_validate(tool_calls)
+
+    @classmethod
+    def supports_structured_output_schema(cls) -> bool:
+        """Return whether ToolCalls can be represented in provider structured-output schemas."""
+        return False
 
     @classmethod
     def from_dict_list(cls, tool_calls_dicts: list[dict[str, Any]]) -> "ToolCalls":
@@ -340,47 +416,105 @@ class ToolCalls(Type):
             tool_calls = ToolCalls.from_dict_list(tool_calls_dict)
             ```
         """
-        tool_calls = [cls.ToolCall(**item) for item in tool_calls_dicts]
-        return cls(tool_calls=tool_calls)
+        return cls.model_validate(tool_calls_dicts)
 
     @classmethod
     def description(cls) -> str:
+        """Describe the expected tool-call payload for prompt-based formatting."""
         return (
-            "Tool calls information, including the name of the tools and the arguments to be passed to it. "
+            "One or more tool calls, including the name of each tool and the arguments to be passed to it. "
             "Arguments must be provided in JSON format."
         )
 
-    def format(self) -> list[dict[str, Any]]:
+    def format(self) -> dict[str, list[dict[str, Any]]]:
+        """Format this collection using the OpenAI-compatible native tool-call schema."""
         # The tool_call field is compatible with OpenAI's tool calls schema.
         return {
             "tool_calls": [tool_call.format() for tool_call in self.tool_calls],
         }
 
+    @staticmethod
+    def _get_tool_call_value(item: Any, key: str, default: Any = None) -> Any:
+        if isinstance(item, dict):
+            return item.get(key, default)
+        return getattr(item, key, default)
+
+    @staticmethod
+    def _parse_tool_call_args(args: Any) -> Any:
+        if isinstance(args, str):
+            return json_repair.loads(args)
+        return args
+
+    @classmethod
+    def _normalized_tool_call(cls, name: Any, args: Any, tool_call_id: Any = None) -> dict[str, Any] | None:
+        if name is None:
+            return None
+        normalized = {"name": name, "args": cls._parse_tool_call_args(args)}
+        if tool_call_id is not None:
+            normalized["id"] = tool_call_id
+        return normalized
+
+    @classmethod
+    def _normalize_native_tool_call(cls, item: Any) -> Any:
+        if not isinstance(item, dict) and hasattr(item, "model_dump"):
+            try:
+                dumped_item = item.model_dump()
+            except TypeError:
+                dumped_item = None
+            if isinstance(dumped_item, dict):
+                item = dumped_item
+
+        function = cls._get_tool_call_value(item, "function")
+        if function is not None:
+            name = cls._get_tool_call_value(function, "name")
+            arguments = cls._get_tool_call_value(function, "arguments", {})
+            normalized = cls._normalized_tool_call(name, arguments, cls._get_tool_call_value(item, "id"))
+            if normalized is not None:
+                return normalized
+
+        name = cls._get_tool_call_value(item, "name")
+        if cls._get_tool_call_value(item, "type") == "function_call" and name is not None:
+            arguments = cls._get_tool_call_value(item, "arguments", {})
+            call_id = cls._get_tool_call_value(item, "call_id")
+            tool_call_id = call_id if call_id is not None else cls._get_tool_call_value(item, "id")
+            normalized = cls._normalized_tool_call(
+                name,
+                arguments,
+                tool_call_id,
+            )
+            if normalized is not None:
+                return normalized
+
+        args = cls._get_tool_call_value(item, "args")
+        if args is not None:
+            normalized = cls._normalized_tool_call(name, args, cls._get_tool_call_value(item, "id"))
+            if normalized is not None:
+                return normalized
+
+        return item
+
     @pydantic.model_validator(mode="before")
     @classmethod
     def validate_input(cls, data: Any):
+        """Normalize supported DSPy and provider-native tool-call shapes before validation."""
         if isinstance(data, cls):
             return data
 
-        # Handle case where data is a list of dicts with "name" and "args" keys
-        if isinstance(data, list) and all(
-            isinstance(item, dict) and "name" in item and "args" in item for item in data
-        ):
-            return {"tool_calls": [cls.ToolCall(**item) for item in data]}
-        # Handle case where data is a dict
+        tool_calls_data = None
+        if isinstance(data, list):
+            tool_calls_data = data
         elif isinstance(data, dict):
             if "tool_calls" in data:
-                # Handle case where data is a dict with "tool_calls" key
                 tool_calls_data = data["tool_calls"]
-                if isinstance(tool_calls_data, list):
-                    return {
-                        "tool_calls": [
-                            cls.ToolCall(**item) if isinstance(item, dict) else item for item in tool_calls_data
-                        ]
-                    }
-            elif "name" in data and "args" in data:
-                # Handle case where data is a dict with "name" and "args" keys
-                return {"tool_calls": [cls.ToolCall(**data)]}
+            else:
+                normalized = cls._normalize_native_tool_call(data)
+                if isinstance(normalized, dict) and "name" in normalized and "args" in normalized:
+                    return {"tool_calls": [normalized]}
+
+        if isinstance(tool_calls_data, list):
+            normalized = [cls._normalize_native_tool_call(item) for item in tool_calls_data]
+            if all(isinstance(item, dict) and "name" in item and "args" in item for item in normalized):
+                return {"tool_calls": normalized}
 
         raise ValueError(f"Received invalid value for `dspy.ToolCalls`: {data}")
 

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -497,6 +497,140 @@ def test_toolcalls_vague_match():
         ToolCalls.model_validate([{"foo": "bar"}])
 
 
+def test_toolcalls_normalizes_native_tool_call_shapes():
+    data = [
+        {
+            "id": "call_chat",
+            "type": "function",
+            "function": {"name": "search", "arguments": '{"query": "hello", "k": 5}'},
+        },
+        {
+            "type": "function_call",
+            "call_id": "call_responses",
+            "name": "lookup",
+            "arguments": '{"key": "value"}',
+        },
+        {"id": "call_dspy", "name": "translate", "args": {"text": "world", "lang": "fr"}},
+    ]
+
+    tc = ToolCalls.model_validate(data)
+
+    assert [(call.name, call.args, call.id) for call in tc.tool_calls] == [
+        ("search", {"query": "hello", "k": 5}, "call_chat"),
+        ("lookup", {"key": "value"}, "call_responses"),
+        ("translate", {"text": "world", "lang": "fr"}, "call_dspy"),
+    ]
+    assert tc.tool_calls[0].format()["id"] == "call_chat"
+
+
+def test_toolcalls_preserves_falsy_native_tool_call_ids():
+    data = [
+        {
+            "id": "",
+            "type": "function",
+            "function": {"name": "search", "arguments": '{"query": "hello"}'},
+        },
+        {
+            "type": "function_call",
+            "call_id": "",
+            "id": "fallback_id",
+            "name": "lookup",
+            "arguments": '{"key": "value"}',
+        },
+    ]
+
+    tc = ToolCalls.model_validate(data)
+
+    assert [call.id for call in tc.tool_calls] == ["", ""]
+    assert tc.tool_calls[0].format()["id"] == ""
+
+
+def test_toolcalls_normalizes_cached_litellm_tool_call_object():
+    class Function:
+        name = "search"
+        arguments = '{"query": "hello", "k": 5}'
+
+    class CachedToolCall:
+        id = "call_123"
+        type = "function"
+        function = Function()
+
+        def model_dump(self):
+            raise TypeError("'MockValSer' object cannot be converted to 'SchemaSerializer'")
+
+    tc = ToolCalls.model_validate([CachedToolCall()])
+
+    assert len(tc.tool_calls) == 1
+    assert tc.tool_calls[0].name == "search"
+    assert tc.tool_calls[0].args == {"query": "hello", "k": 5}
+    assert tc.tool_calls[0].id == "call_123"
+
+
+def test_toolcalls_parse_lm_response():
+    response = {
+        "text": None,
+        "tool_calls": [
+            {
+                "id": "call_123",
+                "type": "function",
+                "function": {"name": "search", "arguments": '{"query": "hello"}'},
+            }
+        ],
+    }
+
+    parsed = ToolCalls.parse_lm_response(response)
+
+    assert parsed == ToolCalls(tool_calls=[ToolCalls.ToolCall(name="search", args={"query": "hello"}, id="call_123")])
+    assert ToolCalls.parse_lm_response("[[ ## answer ## ]]") is None
+    assert ToolCalls.parse_lm_response({"text": "done"}) is None
+
+
+def test_toolcalls_native_adapt_configures_tools_without_adapter():
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    class NativeLM:
+        supports_function_calling = True
+
+    lm_kwargs = {}
+    processed = ToolCalls.adapt_to_native_lm_feature(
+        ToolSignature,
+        "tool_calls",
+        NativeLM(),
+        lm_kwargs,
+        inputs={"question": "hi", "tools": [dspy.Tool(dummy_function)]},
+        adapter_options={"use_native_function_calling": True, "allow_parallel_tool_calls": False},
+    )
+
+    assert "tools" not in processed.input_fields
+    assert "tool_calls" not in processed.output_fields
+    assert len(lm_kwargs["tools"]) == 1
+    assert lm_kwargs["parallel_tool_calls"] is False
+    assert ToolCalls.supports_structured_output_schema() is False
+
+
+def test_toolcalls_native_adapt_requires_tool_input_values():
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    class NativeLM:
+        supports_function_calling = True
+
+    with pytest.raises(ValueError, match="did not provide a value for the tools input field `tools`"):
+        ToolCalls.adapt_to_native_lm_feature(
+            ToolSignature,
+            "tool_calls",
+            NativeLM(),
+            {},
+            inputs=None,
+            adapter_options={"use_native_function_calling": True},
+        )
+
+
 def test_tool_convert_input_schema_to_tool_args_no_input_params():
     args, arg_types, arg_desc = convert_input_schema_to_tool_args(schema={"properties": {}})
     assert args == {}
@@ -542,8 +676,6 @@ def test_tool_convert_input_schema_to_tool_args_lang_chain():
     }
 
 
-
-
 def test_tool_call_execute():
     def get_weather(city: str) -> str:
         return f"The weather in {city} is sunny"
@@ -551,10 +683,7 @@ def test_tool_call_execute():
     def add_numbers(a: int, b: int) -> int:
         return a + b
 
-    tools = [
-        dspy.Tool(get_weather),
-        dspy.Tool(add_numbers)
-    ]
+    tools = [dspy.Tool(get_weather), dspy.Tool(add_numbers)]
 
     tool_call = dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Berlin"})
     result = tool_call.execute(functions=tools)
@@ -577,7 +706,7 @@ def test_tool_call_execute():
     tool_call4 = dspy.ToolCalls.ToolCall(name="nonexistent", args={})
     try:
         tool_call4.execute(functions=tools)
-        assert False, "Should have raised ValueError"
+        raise AssertionError("Should have raised ValueError")
     except ValueError as e:
         assert "not found" in str(e)
 


### PR DESCRIPTION
## Summary
- Add type-layer support for native ToolCalls normalization across provider shapes.
- Add optional `inputs` and `adapter_options` parameters to `Type.adapt_to_native_lm_feature` for future native adapter integration.
- Mark ToolCalls as unsupported for provider structured-output schemas and add focused tests.
- Add regressions for missing tool input values and falsy native tool-call IDs.

## Compatibility note
Future adapter wiring will call `Type.adapt_to_native_lm_feature` with the new optional parameters. Custom `Type` subclasses that override this hook with the old 4-argument signature will need to accept the new optional parameters or `**kwargs`.

## Testing
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr1-toolcalls-type run pytest tests/adapters/test_tool.py --deno`
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr1-toolcalls-type run pytest tests/adapters --deno`
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr1-toolcalls-type run ruff check dspy/adapters/types/base_type.py dspy/adapters/types/tool.py tests/adapters/test_tool.py`
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr1-toolcalls-type run ruff format --check dspy/adapters/types/base_type.py dspy/adapters/types/tool.py tests/adapters/test_tool.py`