### PR TITLE
refactor(tool-call): route native handling through types

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Any, get_origin
 
-import json_repair
-
 from dspy.adapters.types import History, Type
 from dspy.adapters.types.base_type import split_message_content_for_custom_types
 from dspy.adapters.types.reasoning import Reasoning
@@ -15,7 +13,14 @@ from dspy.utils.exceptions import AdapterParseError
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_NATIVE_RESPONSE_TYPES = [Citations, Reasoning]
+_DEFAULT_NATIVE_RESPONSE_TYPES = [Citations, Reasoning, ToolCalls]
+
+
+def _native_tool_call_instruction(field_name: str) -> str:
+    return (
+        "When tool use is needed, call the available tools through the native tool-call interface. "
+        f"Do not emit `{field_name}` as a text or JSON output field."
+    )
 
 
 class Adapter:
@@ -40,6 +45,7 @@ class Adapter:
         callbacks: list[BaseCallback] | None = None,
         use_native_function_calling: bool = False,
         native_response_types: list[type[Type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
     ):
         """
         Args:
@@ -50,11 +56,16 @@ class Adapter:
                 or `list[dspy.Tool]` types. Defaults to False.
             native_response_types: List of output field types that should be handled by native LM features rather than
                 adapter parsing. For example, `dspy.Citations` can be populated directly by citation APIs
-                (e.g., Anthropic's citation feature). Defaults to `[Citations]`.
+                (e.g., Anthropic's citation feature). Defaults to `[Citations, Reasoning, ToolCalls]`.
+            allow_parallel_tool_calls: Whether to request provider-side parallel tool calls when native function calling
+                is active. If `None`, leaves the provider default unchanged. Defaults to None.
         """
         self.callbacks = callbacks or []
         self.use_native_function_calling = use_native_function_calling
-        self.native_response_types = native_response_types or _DEFAULT_NATIVE_RESPONSE_TYPES
+        self.native_response_types = list(
+            _DEFAULT_NATIVE_RESPONSE_TYPES if native_response_types is None else native_response_types
+        )
+        self.allow_parallel_tool_calls = allow_parallel_tool_calls
 
     def __init_subclass__(cls, **kwargs) -> None:
         super().__init_subclass__(**kwargs)
@@ -70,42 +81,52 @@ class Adapter:
         signature: type[Signature],
         inputs: dict[str, Any],
     ) -> type[Signature]:
-        if self.use_native_function_calling:
-            tool_call_input_field_name = self._get_tool_call_input_field_name(signature)
-            tool_call_output_field_name = self._get_tool_call_output_field_name(signature)
-
-            if tool_call_output_field_name and tool_call_input_field_name is None:
-                raise ValueError(
-                    f"You provided an output field {tool_call_output_field_name} to receive the tool calls information, "
-                    "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
-                    "input field with type `list[dspy.Tool]`."
-                )
-
-            if tool_call_output_field_name and lm.supports_function_calling:
-                tools = inputs[tool_call_input_field_name]
-                tools = tools if isinstance(tools, list) else [tools]
-
-                lm_tools = [tool.format_as_litellm_function_call() for tool in tools]
-
-                lm_kwargs["tools"] = lm_tools
-
-                signature_for_native_function_calling = signature.delete(tool_call_output_field_name)
-                signature_for_native_function_calling = signature_for_native_function_calling.delete(
-                    tool_call_input_field_name
-                )
-
-                return signature_for_native_function_calling
-
-        # Handle custom types that use native LM features, e.g., reasoning, citations, etc.
-        for name, field in signature.output_fields.items():
+        adapter_options = {
+            "use_native_function_calling": self.use_native_function_calling,
+            "allow_parallel_tool_calls": self.allow_parallel_tool_calls,
+        }
+        original_signature = signature
+        native_feature_instructions = []
+        for name, field in list(signature.output_fields.items()):
             if (
                 isinstance(field.annotation, type)
                 and field.annotation in self.native_response_types
                 and issubclass(field.annotation, Type)
             ):
-                signature = field.annotation.adapt_to_native_lm_feature(signature, name, lm, lm_kwargs)
+                signature_before_adaptation = signature
+                signature = field.annotation.adapt_to_native_lm_feature(
+                    signature,
+                    name,
+                    lm,
+                    lm_kwargs,
+                    inputs=inputs,
+                    adapter_options=adapter_options,
+                )
+                if signature is not signature_before_adaptation:
+                    if field.annotation is ToolCalls:
+                        native_feature_instructions.append(_native_tool_call_instruction(name))
 
+        if native_feature_instructions:
+            signature = self._with_native_feature_instructions(
+                original_signature,
+                signature,
+                native_feature_instructions,
+            )
         return signature
+
+    def _with_native_feature_instructions(
+        self,
+        original_signature: type[Signature],
+        processed_signature: type[Signature],
+        native_feature_instructions: list[str],
+    ) -> type[Signature]:
+        original_default_instructions = Signature(original_signature.fields).instructions
+        processed_default_instructions = Signature(processed_signature.fields).instructions
+        if original_signature.instructions == original_default_instructions:
+            instructions = processed_default_instructions
+        else:
+            instructions = processed_signature.instructions
+        return processed_signature.with_instructions("\n".join([instructions, *native_feature_instructions]))
 
     def _call_postprocess(
         self,
@@ -117,17 +138,15 @@ class Adapter:
     ) -> list[dict[str, Any]]:
         values = []
 
-        tool_call_output_field_name = self._get_tool_call_output_field_name(original_signature)
-
         for output in outputs:
             output_logprobs = None
-            tool_calls = None
             text = output
 
             if isinstance(output, dict):
-                text = output["text"]
+                text = output.get("text")
                 output_logprobs = output.get("logprobs")
-                tool_calls = output.get("tool_calls")
+
+            parsed_native_values = self._parse_native_lm_response(original_signature, output)
 
             if text:
                 value = self.parse(processed_signature, text)
@@ -135,10 +154,8 @@ class Adapter:
                     if field_name not in value:
                         # We need to set the field not present in the processed signature to None for consistency.
                         value[field_name] = None
-            elif tool_calls and tool_call_output_field_name:
-                value = {}
-                for field_name in original_signature.output_fields.keys():
-                    value[field_name] = None
+            elif parsed_native_values:
+                value = dict.fromkeys(original_signature.output_fields.keys())
             else:
                 raise AdapterParseError(
                     adapter_name=type(self).__name__,
@@ -147,26 +164,7 @@ class Adapter:
                     message="The LM returned an empty or null response.",
                 )
 
-            if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
-
-            # Parse custom types that does not rely on the `Adapter.parse()` method
-            for name, field in original_signature.output_fields.items():
-                if (
-                    isinstance(field.annotation, type)
-                    and field.annotation in self.native_response_types
-                    and issubclass(field.annotation, Type)
-                ):
-                    parsed_value = field.annotation.parse_lm_response(output)
-                    if parsed_value is not None:
-                        value[name] = parsed_value
+            value.update(parsed_native_values)
 
             if output_logprobs:
                 value["logprobs"] = output_logprobs
@@ -174,6 +172,19 @@ class Adapter:
             values.append(value)
 
         return values
+
+    def _parse_native_lm_response(self, signature: type[Signature], output: dict[str, Any] | str) -> dict[str, Any]:
+        value = {}
+        for name, field in signature.output_fields.items():
+            if (
+                isinstance(field.annotation, type)
+                and field.annotation in self.native_response_types
+                and issubclass(field.annotation, Type)
+            ):
+                parsed_value = field.annotation.parse_lm_response(output)
+                if parsed_value is not None:
+                    value[name] = parsed_value
+        return value
 
     def __call__(
         self,

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -42,6 +42,7 @@ class ChatAdapter(Adapter):
         callbacks: list[BaseCallback] | None = None,
         use_native_function_calling: bool = False,
         native_response_types: list[type[type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
         use_json_adapter_fallback: bool = True,
     ):
         """
@@ -49,6 +50,8 @@ class ChatAdapter(Adapter):
             callbacks: List of callback functions to execute during adapter methods.
             use_native_function_calling: Whether to enable native function calling capabilities.
             native_response_types: List of output field types handled by native LM features.
+            allow_parallel_tool_calls: Whether to request provider-side parallel tool calls when native function calling
+                is active. If `None`, leaves the provider default unchanged.
             use_json_adapter_fallback: Whether to automatically fallback to JSONAdapter if the ChatAdapter fails.
                 If True, when an error occurs (except ContextWindowExceededError), the adapter will retry using
                 JSONAdapter. Defaults to True.
@@ -57,6 +60,7 @@ class ChatAdapter(Adapter):
             callbacks=callbacks,
             use_native_function_calling=use_native_function_calling,
             native_response_types=native_response_types,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
         )
         self.use_json_adapter_fallback = use_json_adapter_fallback
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -8,7 +8,7 @@ import regex
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
-from dspy.adapters.types.tool import ToolCalls
+from dspy.adapters.types import Type
 from dspy.adapters.utils import (
     format_field_value,
     get_annotation_name,
@@ -37,19 +37,43 @@ def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
     return False
 
 
+def _has_output_type_without_structured_output_schema(signature: SignatureMeta) -> bool:
+    for field in signature.output_fields.values():
+        annotation = field.annotation
+        if isinstance(annotation, type) and issubclass(annotation, Type):
+            if not annotation.supports_structured_output_schema():
+                return True
+    return False
+
+
 class JSONAdapter(ChatAdapter):
-    def __init__(self, callbacks: list[BaseCallback] | None = None, use_native_function_calling: bool = True):
+    def __init__(
+        self,
+        callbacks: list[BaseCallback] | None = None,
+        use_native_function_calling: bool = True,
+        native_response_types: list[type[type]] | None = None,
+        allow_parallel_tool_calls: bool | None = None,
+    ):
         # JSONAdapter uses native function calling by default.
-        super().__init__(callbacks=callbacks, use_native_function_calling=use_native_function_calling)
+        super().__init__(
+            callbacks=callbacks,
+            use_native_function_calling=use_native_function_calling,
+            native_response_types=native_response_types,
+            allow_parallel_tool_calls=allow_parallel_tool_calls,
+        )
 
     def _json_adapter_call_common(self, lm, lm_kwargs, signature, demos, inputs, call_fn):
         """Common call logic to be used for both sync and async calls."""
         if "response_format" not in lm.supported_params:
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 
-        has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
-
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
+        effective_native_function_calling = self.use_native_function_calling and lm.supports_function_calling
+        has_unsupported_structured_output_type = _has_output_type_without_structured_output_schema(signature)
+        if (
+            _has_open_ended_mapping(signature)
+            or (not effective_native_function_calling and has_unsupported_structured_output_type)
+            or not lm.supports_response_schema
+        ):
             # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
             # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -68,11 +92,12 @@ class JSONAdapter(ChatAdapter):
             return result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
+            processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+            structured_output_model = _get_structured_outputs_response_format(processed_signature)
             lm_kwargs["response_format"] = structured_output_model
-            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+            messages = self.format(processed_signature, demos, inputs)
+            outputs = lm(messages=messages, **lm_kwargs)
+            return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -91,11 +116,12 @@ class JSONAdapter(ChatAdapter):
             return await result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
+            processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+            structured_output_model = _get_structured_outputs_response_format(processed_signature)
             lm_kwargs["response_format"] = structured_output_model
-            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+            messages = self.format(processed_signature, demos, inputs)
+            outputs = await lm.acall(messages=messages, **lm_kwargs)
+            return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -211,7 +237,6 @@ class JSONAdapter(ChatAdapter):
 
 def _get_structured_outputs_response_format(
     signature: SignatureMeta,
-    use_native_function_calling: bool = True,
 ) -> type[pydantic.BaseModel]:
     """
     Builds a Pydantic model from a DSPy signature's output_fields and ensures the generated JSON schema
@@ -233,9 +258,9 @@ def _get_structured_outputs_response_format(
     fields = {}
     for name, field in signature.output_fields.items():
         annotation = field.annotation
-        if use_native_function_calling and annotation == ToolCalls:
-            # Skip ToolCalls field if native function calling is enabled.
-            continue
+        if isinstance(annotation, type) and issubclass(annotation, Type):
+            if not annotation.supports_structured_output_schema():
+                raise ValueError(f"Field '{name}' does not support Structured Outputs.")
         default = field.default if hasattr(field, "default") else ...
         fields[name] = (annotation, default)
 

--- a/dspy/adapters/types/citation.py
+++ b/dspy/adapters/types/citation.py
@@ -168,7 +168,15 @@ class Citations(Type):
         return self.citations[index]
 
     @classmethod
-    def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs) -> bool:
+    def adapt_to_native_lm_feature(
+        cls,
+        signature,
+        field_name,
+        lm,
+        lm_kwargs,
+        inputs=None,
+        adapter_options=None,
+    ) -> bool:
         if lm.model.startswith("anthropic/"):
             return signature.delete(field_name)
         return signature

--- a/dspy/adapters/types/reasoning.py
+++ b/dspy/adapters/types/reasoning.py
@@ -49,6 +49,8 @@ class Reasoning(Type):
         field_name: str,
         lm: BaseLM,
         lm_kwargs: dict[str, Any],
+        inputs: dict[str, Any] | None = None,
+        adapter_options: dict[str, Any] | None = None,
     ) -> type["Signature"]:
         if "reasoning_effort" in lm_kwargs:
             # `lm_kwargs` overrides `lm.kwargs`.

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -195,7 +195,7 @@ def test_chat_adapter_exception_raised_on_failure():
     signature = dspy.make_signature("question->answer")
     adapter = dspy.ChatAdapter()
     invalid_completion = "{'output':'mismatched value'}"
-    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="Adapter ChatAdapter failed to parse*"):
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="Adapter ChatAdapter failed to parse"):
         adapter.parse(signature, invalid_completion)
 
 
@@ -401,8 +401,10 @@ def test_chat_adapter_with_code():
 
 def test_code_output_field_omits_json_schema_in_prompt():
     """Regression test for #9251: dspy.Code should avoid duplicating large JSON schema text."""
+
     class CodeGeneration(dspy.Signature):
         """Generate code to answer the question"""
+
         question: str = dspy.InputField()
         code: dspy.Code = dspy.OutputField()
 
@@ -562,7 +564,13 @@ def test_chat_adapter_toolcalls_native_function_calling():
         )
 
         assert result[0]["tool_calls"] == dspy.ToolCalls(
-            tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"})]
+            tool_calls=[
+                dspy.ToolCalls.ToolCall(
+                    name="get_weather",
+                    args={"city": "Paris"},
+                    id="call_pQm8ajtSMxgA0nrzK2ivFmxG",
+                )
+            ]
         )
         # `answer` is not present, so we set it to None
         assert result[0]["answer"] is None
@@ -723,25 +731,23 @@ def test_format_system_message():
 
     adapter = dspy.ChatAdapter()
     system_message = adapter.format_system_message(MySignature)
-    expected_system_message = """Your input fields are:
-1. `question` (str):
-Your output fields are:
-1. `answers` (list[str]): 
-2. `scores` (list[float]):
-All interactions will be structured in the following way, with the appropriate values filled in.
-
-[[ ## question ## ]]
-{question}
-
-[[ ## answers ## ]]
-{answers}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "string"}}
-
-[[ ## scores ## ]]
-{scores}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "number"}}
-
-[[ ## completed ## ]]
-In adhering to this structure, your objective is: 
-        Answer the question with multiple answers and scores"""
+    expected_system_message = (
+        "Your input fields are:\n"
+        "1. `question` (str):\n"
+        "Your output fields are:\n"
+        "1. `answers` (list[str]): \n"
+        "2. `scores` (list[float]):\n"
+        "All interactions will be structured in the following way, with the appropriate values filled in.\n\n"
+        "[[ ## question ## ]]\n"
+        "{question}\n\n"
+        "[[ ## answers ## ]]\n"
+        '{answers}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "string"}}\n\n'
+        "[[ ## scores ## ]]\n"
+        '{scores}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "number"}}\n\n'
+        "[[ ## completed ## ]]\n"
+        "In adhering to this structure, your objective is: \n"
+        "        Answer the question with multiple answers and scores"
+    )
     assert system_message == expected_system_message
 
 
@@ -786,9 +792,14 @@ def test_tool_call_with_null_content_does_not_raise():
     adapter = dspy.ChatAdapter(use_native_function_calling=True)
     sig_cls = dspy.Signature("question, tools: list[dspy.Tool] -> answer, tool_calls: dspy.ToolCalls")
 
-    outputs = [{"text": None, "tool_calls": [
-        {"function": {"name": "search", "arguments": '{"query": "test"}'}, "id": "call_1", "type": "function"}
-    ]}]
+    outputs = [
+        {
+            "text": None,
+            "tool_calls": [
+                {"function": {"name": "search", "arguments": '{"query": "test"}'}, "id": "call_1", "type": "function"}
+            ],
+        }
+    ]
 
     result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
     assert result is not None

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -833,7 +833,13 @@ def test_json_adapter_toolcalls_native_function_calling():
         )
 
         assert result[0]["tool_calls"] == dspy.ToolCalls(
-            tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"})]
+            tool_calls=[
+                dspy.ToolCalls.ToolCall(
+                    name="get_weather",
+                    args={"city": "Paris"},
+                    id="call_pQm8ajtSMxgA0nrzK2ivFmxG",
+                )
+            ]
         )
         # `answer` is not present, so we set it to None
         assert result[0]["answer"] is None
@@ -995,24 +1001,22 @@ def test_format_system_message():
 
     adapter = dspy.JSONAdapter()
     system_message = adapter.format_system_message(MySignature)
-    expected_system_message = """Your input fields are:
-1. `question` (str):
-Your output fields are:
-1. `answers` (list[str]): 
-2. `scores` (list[float]):
-All interactions will be structured in the following way, with the appropriate values filled in.
-
-Inputs will have the following structure:
-
-[[ ## question ## ]]
-{question}
-
-Outputs will be a JSON object with the following fields.
-
-{
-  "answers": "{answers}        # note: the value you produce must adhere to the JSON schema: {\\"type\\": \\"array\\", \\"items\\": {\\"type\\": \\"string\\"}}",
-  "scores": "{scores}        # note: the value you produce must adhere to the JSON schema: {\\"type\\": \\"array\\", \\"items\\": {\\"type\\": \\"number\\"}}"
-}
-In adhering to this structure, your objective is: 
-        Answer the question with multiple answers and scores"""
+    expected_system_message = (
+        "Your input fields are:\n"
+        "1. `question` (str):\n"
+        "Your output fields are:\n"
+        "1. `answers` (list[str]): \n"
+        "2. `scores` (list[float]):\n"
+        "All interactions will be structured in the following way, with the appropriate values filled in.\n\n"
+        "Inputs will have the following structure:\n\n"
+        "[[ ## question ## ]]\n"
+        "{question}\n\n"
+        "Outputs will be a JSON object with the following fields.\n\n"
+        "{\n"
+        '  "answers": "{answers}        # note: the value you produce must adhere to the JSON schema: {\\"type\\": \\"array\\", \\"items\\": {\\"type\\": \\"string\\"}}",\n'
+        '  "scores": "{scores}        # note: the value you produce must adhere to the JSON schema: {\\"type\\": \\"array\\", \\"items\\": {\\"type\\": \\"number\\"}}"\n'
+        "}\n"
+        "In adhering to this structure, your objective is: \n"
+        "        Answer the question with multiple answers and scores"
+    )
     assert system_message == expected_system_message

--- a/tests/adapters/test_parallel_tool_calls.py
+++ b/tests/adapters/test_parallel_tool_calls.py
@@ -1,0 +1,217 @@
+import pytest
+
+import dspy
+
+
+class RecordingLM:
+    supports_reasoning = False
+    supports_response_schema = True
+
+    def __init__(self, outputs, supported_params=None):
+        self.outputs = outputs
+        self.supported_params = set(supported_params or [])
+        self.supports_function_calling = True
+        self.calls = []
+
+    def __call__(self, messages, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        return self.outputs
+
+    async def acall(self, messages, **kwargs):
+        return self(messages, **kwargs)
+
+
+class ToolSignature(dspy.Signature):
+    question: str = dspy.InputField()
+    tools: list[dspy.Tool] = dspy.InputField()
+    answer: str = dspy.OutputField()
+    tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+
+def get_weather(city: str) -> str:
+    return f"The weather in {city} is sunny"
+
+
+def get_timezone(city: str) -> str:
+    return f"The timezone in {city} is CET"
+
+
+TOOLS = [dspy.Tool(get_weather), dspy.Tool(get_timezone)]
+EXPECTED_TOOL_CALLS = dspy.ToolCalls(
+    tool_calls=[
+        dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"}),
+        dspy.ToolCalls.ToolCall(name="get_timezone", args={"city": "Paris"}),
+    ]
+)
+EXPECTED_NATIVE_TOOL_CALLS = dspy.ToolCalls(
+    tool_calls=[
+        dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"}, id="call_weather"),
+        dspy.ToolCalls.ToolCall(name="get_timezone", args={"city": "Paris"}, id="call_timezone"),
+    ]
+)
+
+
+def _supported_params(adapter_cls):
+    return {"response_format"} if adapter_cls is dspy.JSONAdapter else set()
+
+
+def _completion(adapter_cls, *, tool_calls=None):
+    if adapter_cls is dspy.JSONAdapter:
+        if tool_calls is None:
+            return '{"answer": "ok"}'
+        return f'{{"answer": "Need tools", "tool_calls": {tool_calls}}}'
+
+    if tool_calls is None:
+        return "[[ ## answer ## ]]\nok\n\n[[ ## completed ## ]]"
+    return f"[[ ## answer ## ]]\nNeed tools\n\n[[ ## tool_calls ## ]]\n{tool_calls}\n\n[[ ## completed ## ]]"
+
+
+def _run(adapter, lm):
+    return adapter(
+        lm,
+        {},
+        ToolSignature,
+        [],
+        {"question": "What is the weather in Paris?", "tools": TOOLS},
+    )
+
+
+@pytest.mark.parametrize("adapter_cls", [dspy.ChatAdapter, dspy.JSONAdapter])
+@pytest.mark.parametrize("allow_parallel_tool_calls", [None, False, True])
+def test_native_tool_call_request_uses_native_surface(adapter_cls, allow_parallel_tool_calls):
+    adapter = adapter_cls(
+        use_native_function_calling=True,
+        allow_parallel_tool_calls=allow_parallel_tool_calls,
+    )
+    lm = RecordingLM([_completion(adapter_cls)], supported_params=_supported_params(adapter_cls))
+
+    result = _run(adapter, lm)
+    call = lm.calls[0]
+    system_message = call["messages"][0]["content"]
+
+    assert result[0]["answer"] == "ok"
+    assert result[0]["tool_calls"] is None
+    assert "tools" in call["kwargs"]
+    assert "native tool-call interface" in system_message
+    assert "[[ ## tools ## ]]" not in system_message
+    assert "[[ ## tool_calls ## ]]" not in system_message
+    if allow_parallel_tool_calls is None:
+        assert "parallel_tool_calls" not in call["kwargs"]
+    else:
+        assert call["kwargs"]["parallel_tool_calls"] is allow_parallel_tool_calls
+    if adapter_cls is dspy.JSONAdapter:
+        assert set(call["kwargs"]["response_format"].model_json_schema()["properties"]) == {"answer"}
+
+
+@pytest.mark.parametrize("adapter_cls", [dspy.ChatAdapter, dspy.JSONAdapter])
+def test_non_native_tool_calls_parse_multiple_calls(adapter_cls):
+    adapter = adapter_cls(use_native_function_calling=False, allow_parallel_tool_calls=True)
+    tool_calls = """
+[
+  {"name": "get_weather", "args": {"city": "Paris"}},
+  {"name": "get_timezone", "args": {"city": "Paris"}}
+]
+    """
+    lm = RecordingLM([_completion(adapter_cls, tool_calls=tool_calls)], supported_params=_supported_params(adapter_cls))
+
+    result = _run(adapter, lm)[0]
+    call = lm.calls[0]
+
+    assert result["answer"] == "Need tools"
+    assert result["tool_calls"] == EXPECTED_TOOL_CALLS
+    assert "tools" not in call["kwargs"]
+    assert "parallel_tool_calls" not in call["kwargs"]
+    assert "tool_calls" in call["messages"][0]["content"]
+    if adapter_cls is dspy.JSONAdapter:
+        assert call["kwargs"]["response_format"] == {"type": "json_object"}
+
+
+def test_native_function_calling_preserves_multiple_chat_tool_calls():
+    lm = RecordingLM(
+        [
+            {
+                "text": None,
+                "tool_calls": [
+                    {
+                        "function": {"arguments": '{"city":"Paris"}', "name": "get_weather"},
+                        "id": "call_weather",
+                        "type": "function",
+                    },
+                    {
+                        "function": {"arguments": '{"city":"Paris"}', "name": "get_timezone"},
+                        "id": "call_timezone",
+                        "type": "function",
+                    },
+                ],
+            }
+        ]
+    )
+
+    result = _run(dspy.ChatAdapter(use_native_function_calling=True), lm)[0]
+
+    assert result["answer"] is None
+    assert result["tool_calls"] == EXPECTED_NATIVE_TOOL_CALLS
+
+
+def test_native_function_calling_parses_responses_api_tool_call_shape():
+    lm = RecordingLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "type": "function_call",
+                        "call_id": "call_weather",
+                        "name": "get_weather",
+                        "arguments": '{"city":"Paris"}',
+                    }
+                ]
+            }
+        ]
+    )
+
+    result = _run(dspy.ChatAdapter(use_native_function_calling=True), lm)[0]
+
+    assert result["answer"] is None
+    assert result["tool_calls"] == dspy.ToolCalls(
+        tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"}, id="call_weather")]
+    )
+
+
+def test_custom_type_native_hook_receives_adapter_context():
+    class CustomType(dspy.Type):
+        value: str
+
+        @classmethod
+        def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs, inputs=None, adapter_options=None):
+            lm_kwargs["hook_inputs"] = inputs
+            lm_kwargs["hook_adapter_options"] = adapter_options
+            return signature.delete(field_name)
+
+        @classmethod
+        def parse_lm_response(cls, response):
+            if isinstance(response, dict) and "custom_value" in response:
+                return cls(value=response["custom_value"])
+            return None
+
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: CustomType = dspy.OutputField()
+
+    lm = RecordingLM([{"text": None, "custom_value": "ok"}])
+    adapter = dspy.ChatAdapter(native_response_types=[CustomType])
+    result = adapter(
+        lm,
+        {},
+        MySignature,
+        [],
+        {"question": "hello"},
+    )
+
+    assert adapter.native_response_types == [CustomType]
+    assert dspy.ChatAdapter(native_response_types=[]).native_response_types == []
+    assert result[0]["answer"] == CustomType(value="ok")
+    assert lm.calls[0]["kwargs"]["hook_inputs"] == {"question": "hello"}
+    assert lm.calls[0]["kwargs"]["hook_adapter_options"] == {
+        "use_native_function_calling": False,
+        "allow_parallel_tool_calls": None,
+    }

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -1059,7 +1059,7 @@ async def test_streaming_allows_custom_streamable_type():
             return True
 
         @classmethod
-        def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs):
+        def adapt_to_native_lm_feature(cls, signature, field_name, lm, lm_kwargs, inputs=None, adapter_options=None):
             return signature.delete(field_name)
 
         @classmethod
@@ -1305,9 +1305,7 @@ async def test_chat_adapter_with_generic_type_annotation():
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="[[ ##"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" response"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ## ]]\n\n"))])
-        yield ModelResponseStream(
-            model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="1"))]
-        )
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="1"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="\n\n[[ ##"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" completed"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ## ]]"))])


### PR DESCRIPTION
## Summary
- Route native adapter setup/parsing through `Type.adapt_to_native_lm_feature` and `Type.parse_lm_response` for ChatAdapter and JSONAdapter.
- Add `allow_parallel_tool_calls` plumbing across ChatAdapter and JSONAdapter.
- Update JSON structured-output setup to preprocess native-only fields before building schemas.

## Design note
- TwoStepAdapter is intentionally excluded from native tool-call support in this PR. It remains a text-first extraction adapter; native tool execution should stay in agents/adapters that explicitly model tool calls end-to-end.

## Stack
- Depends on #9777.

## Testing
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr2-native-toolcalls-adapters run pytest tests --deno`
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr2-native-toolcalls-adapters run pytest tests/streaming/test_streaming.py::test_streaming_allows_custom_streamable_type --deno -q`
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr2-native-toolcalls-adapters run ruff check tests/streaming/test_streaming.py`
- `uv --directory /Users/isaac/projects/dspy-worktrees/isaac/react-v2-pr2-native-toolcalls-adapters run ruff format --check tests/streaming/test_streaming.py`
- Prior PR2 adapter validators: `tests/adapters/test_parallel_tool_calls.py --deno`, `tests/adapters --deno`, and changed-file ruff checks.