### PR TITLE
fix(predict): create fresh PythonInterpreter per forward() call to fix thread-safety in ProgramOfThought and CodeAct

### DIFF
--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -11,12 +11,19 @@ from dspy.signatures.signature import Signature, ensure_signature
 
 logger = logging.getLogger(__name__)
 
+
 class CodeAct(ReAct, ProgramOfThought):
     """
     CodeAct is a module that utilizes the Code Interpreter and predefined tools to solve the problem.
     """
 
-    def __init__(self, signature: str | type[Signature], tools: list[Callable], max_iters: int = 5, interpreter: PythonInterpreter | None = None):
+    def __init__(
+        self,
+        signature: str | type[Signature],
+        tools: list[Callable],
+        max_iters: int = 5,
+        interpreter: PythonInterpreter | None = None,
+    ):
         """
         Initializes the CodeAct class with the specified model, temperature, and max tokens.
 
@@ -42,9 +49,7 @@ class CodeAct(ReAct, ProgramOfThought):
         self.history = []
 
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
-        if any(
-            not inspect.isfunction(tool.func) for tool in tools
-        ):
+        if any(not inspect.isfunction(tool.func) for tool in tools):
             raise ValueError("CodeAct only accepts functions and not callable objects.")
         tools = {tool.name: tool for tool in tools}
 
@@ -53,7 +58,13 @@ class CodeAct(ReAct, ProgramOfThought):
         codeact_signature = (
             dspy.Signature({**self.signature.input_fields}, "\n".join(instructions))
             .append("trajectory", dspy.InputField(), type_=str)
-            .append("generated_code", dspy.OutputField(desc="Python code that when executed, produces output relevant to answering the question"), type_=str)
+            .append(
+                "generated_code",
+                dspy.OutputField(
+                    desc="Python code that when executed, produces output relevant to answering the question"
+                ),
+                type_=str,
+            )
             .append("finished", dspy.OutputField(desc="a boolean flag to determine if the process is done"), type_=bool)
         )
 
@@ -65,8 +76,10 @@ class CodeAct(ReAct, ProgramOfThought):
         self.tools: dict[str, Tool] = tools
         self.codeact = dspy.Predict(codeact_signature)
         self.extractor = dspy.ChainOfThought(extract_signature)
-        # It will raises exception when dspy cannot find available deno instance by now.
-        self.interpreter = interpreter or PythonInterpreter()
+        # Store user-provided interpreter; if None, a fresh one is created per forward() call
+        # to avoid sharing a single interpreter across concurrent threads.
+        self._user_interpreter = interpreter
+        self.interpreter = interpreter
 
     def _build_instructions(self, signature, tools):
         instructions = [f"{signature.instructions}\n"] if signature.instructions else []
@@ -88,32 +101,37 @@ class CodeAct(ReAct, ProgramOfThought):
         return instructions
 
     def forward(self, **kwargs):
-        # Define the tool functions in the interpreter
-        for tool in self.tools.values():
-            self.interpreter(inspect.getsource(tool.func))
+        interp = self._get_fresh_interpreter()
+        try:
+            # Define the tool functions in the interpreter
+            for tool in self.tools.values():
+                interp(inspect.getsource(tool.func))
 
-        trajectory = {}
-        max_iters = kwargs.pop("max_iters", self.max_iters)
-        for idx in range(max_iters):
-            code_data = self.codeact(trajectory=trajectory, **kwargs)
-            output = None
-            code, error = self._parse_code(code_data)
+            trajectory = {}
+            max_iters = kwargs.pop("max_iters", self.max_iters)
+            for idx in range(max_iters):
+                code_data = self.codeact(trajectory=trajectory, **kwargs)
+                output = None
+                code, error = self._parse_code(code_data)
 
-            if error:
-                trajectory[f"observation_{idx}"] = f"Failed to parse the generated code: {error}"
-                continue
+                if error:
+                    trajectory[f"observation_{idx}"] = f"Failed to parse the generated code: {error}"
+                    continue
 
-            trajectory[f"generated_code_{idx}"] = code
-            output, error = self._execute_code(code)
+                trajectory[f"generated_code_{idx}"] = code
+                output, error = self._execute_code(code, interp)
 
-            if not error:
-                trajectory[f"code_output_{idx}"] = output
-            else:
-                trajectory[f"observation_{idx}"] = f"Failed to execute the generated code: {error}"
+                if not error:
+                    trajectory[f"code_output_{idx}"] = output
+                else:
+                    trajectory[f"observation_{idx}"] = f"Failed to execute the generated code: {error}"
 
-            if code_data.finished:
-                break
+                if code_data.finished:
+                    break
 
-        extract = self._call_with_potential_trajectory_truncation(self.extractor, trajectory, **kwargs)
-        self.interpreter.shutdown()
-        return dspy.Prediction(trajectory=trajectory, **extract)
+            extract = self._call_with_potential_trajectory_truncation(self.extractor, trajectory, **kwargs)
+            return dspy.Prediction(trajectory=trajectory, **extract)
+        finally:
+            if self._user_interpreter is None:
+                interp.shutdown()
+            self.interpreter = interp  # expose for post-call inspection (e.g., tests)

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -27,7 +27,9 @@ class ProgramOfThought(Module):
     ```
     """
 
-    def __init__(self, signature: str | type[Signature], max_iters: int = 3, interpreter: PythonInterpreter | None = None):
+    def __init__(
+        self, signature: str | type[Signature], max_iters: int = 3, interpreter: PythonInterpreter | None = None
+    ):
         """
         Args:
             signature: The signature of the module.
@@ -59,8 +61,11 @@ class ProgramOfThought(Module):
                 self._generate_instruction("answer"),
             ),
         )
-        # It will raises exception when dspy cannot find available deno instance by now.
-        self.interpreter = interpreter or PythonInterpreter()
+        # Store user-provided interpreter; if None, a fresh one is created per forward() call
+        # to avoid sharing a single interpreter across concurrent threads (e.g., dspy.Evaluate
+        # with num_threads > 1), which causes "I/O operation on closed file" errors.
+        self._user_interpreter = interpreter
+        self.interpreter = interpreter
 
     def _generate_signature(self, mode):
         signature_dict = dict(self.input_fields)
@@ -123,6 +128,10 @@ class ProgramOfThought(Module):
 
         return "\n".join(instr)
 
+    def _get_fresh_interpreter(self) -> PythonInterpreter:
+        """Return user-provided interpreter, or create a new one for this forward() call."""
+        return self._user_interpreter if self._user_interpreter is not None else PythonInterpreter()
+
     def _parse_code(self, code_data):
         code = code_data.get("generated_code", "").split("---", 1)[0].split("\n\n\n", 1)[0]
         code_match = re.search(r"```python[ \n](.*?)[ \n]```?", code, re.DOTALL)
@@ -137,15 +146,16 @@ class ProgramOfThought(Module):
             code_block += "\n" + last_line_match.group(1)
         return code_block, None
 
-    def _execute_code(self, code):
+    def _execute_code(self, code, interpreter: PythonInterpreter | None = None):
         """
         Execute the code using PythonInterpreter and return the output or error.
         """
         if not code:
             return None, "Error: Empty code before execution."
 
+        interp = interpreter if interpreter is not None else self.interpreter
         try:
-            result = self.interpreter.execute(code)
+            result = interp.execute(code)
             if isinstance(result, FinalOutput):
                 result = result.output
             # Since it's more complex structure now, just blindly use json to represents all.
@@ -155,26 +165,30 @@ class ProgramOfThought(Module):
             return None, str(e)
 
     def forward(self, **kwargs):
-        input_kwargs = {field_name: kwargs[field_name] for field_name in self.input_fields}
-        code_data = self.code_generate(**input_kwargs)
-        output = None
-        code, error = self._parse_code(code_data)
-        if not error:
-            output, error = self._execute_code(code)
-        hop = 1
-        # Retying code generation and execution until no error or reach max_iters
-        while error is not None:
-            logger.error(f"Error in code execution: {error}")
-            if hop == self.max_iters:
-                self.interpreter.shutdown()
-                raise RuntimeError(f"Max hops reached. Failed to run ProgramOfThought: {error}")
-            input_kwargs.update({"previous_code": code, "error": error})
-            code_data = self.code_regenerate(**input_kwargs)
+        interp = self._get_fresh_interpreter()
+        try:
+            input_kwargs = {field_name: kwargs[field_name] for field_name in self.input_fields}
+            code_data = self.code_generate(**input_kwargs)
+            output = None
             code, error = self._parse_code(code_data)
             if not error:
-                output, error = self._execute_code(code)
-            hop += 1
-        input_kwargs.update({"final_generated_code": code, "code_output": output})
-        output_gen_result = self.generate_output(**input_kwargs)
-        self.interpreter.shutdown()
-        return output_gen_result
+                output, error = self._execute_code(code, interp)
+            hop = 1
+            # Retying code generation and execution until no error or reach max_iters
+            while error is not None:
+                logger.error(f"Error in code execution: {error}")
+                if hop == self.max_iters:
+                    raise RuntimeError(f"Max hops reached. Failed to run ProgramOfThought: {error}")
+                input_kwargs.update({"previous_code": code, "error": error})
+                code_data = self.code_regenerate(**input_kwargs)
+                code, error = self._parse_code(code_data)
+                if not error:
+                    output, error = self._execute_code(code, interp)
+                hop += 1
+            input_kwargs.update({"final_generated_code": code, "code_output": output})
+            output_gen_result = self.generate_output(**input_kwargs)
+            return output_gen_result
+        finally:
+            if self._user_interpreter is None:
+                interp.shutdown()
+            self.interpreter = interp  # expose for post-call inspection (e.g., tests)

--- a/tests/predict/test_program_of_thought.py
+++ b/tests/predict/test_program_of_thought.py
@@ -1,9 +1,12 @@
-from unittest.mock import patch
+import threading
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import dspy
 from dspy import ProgramOfThought, Signature
+from dspy.primitives.code_interpreter import FinalOutput
+from dspy.primitives.python_interpreter import PythonInterpreter
 from dspy.utils import DummyLM
 
 
@@ -110,6 +113,79 @@ def test_pot_code_generation_persistent_errors():
     pot = ProgramOfThought(BasicQA, max_iters=max_iters)
     with pytest.raises(RuntimeError, match="Max hops reached. Failed to run ProgramOfThought: ZeroDivisionError:"):
         pot(question="What is 1+1?")
+
+
+def test_pot_creates_fresh_interpreter_per_forward():
+    """Each forward() creates an independent PythonInterpreter (fixes thread-safety for num_threads > 1)."""
+    lm = DummyLM(
+        [
+            {"reasoning": "R1", "generated_code": "```python\nresult = 1+1\n```"},
+            {"reasoning": "R2", "answer": "2"},
+            {"reasoning": "R3", "generated_code": "```python\nresult = 2+2\n```"},
+            {"reasoning": "R4", "answer": "4"},
+        ]
+    )
+    dspy.configure(lm=lm)
+
+    created_interpreters = []
+
+    def make_mock_interp():
+        m = MagicMock(spec=PythonInterpreter)
+        m.execute.return_value = FinalOutput({"answer": "2"})
+        created_interpreters.append(m)
+        return m
+
+    with patch("dspy.predict.program_of_thought.PythonInterpreter", side_effect=make_mock_interp):
+        pot = ProgramOfThought(BasicQA)
+        assert pot.interpreter is None  # no interpreter allocated until forward()
+
+        pot(question="What is 1+1?")
+        assert len(created_interpreters) == 1
+        assert created_interpreters[0].shutdown.called
+
+        pot(question="What is 2+2?")
+        assert len(created_interpreters) == 2  # second call gets a new interpreter
+        assert created_interpreters[1].shutdown.called
+
+
+def test_pot_thread_safe_concurrent_forward():
+    """Concurrent forward() calls each get an independent interpreter (issue #9082)."""
+    errors: list[str] = []
+    created_interpreters: list[MagicMock] = []
+
+    def make_mock_interp():
+        m = MagicMock(spec=PythonInterpreter)
+        m.execute.return_value = FinalOutput({"answer": "1"})
+        created_interpreters.append(m)
+        return m
+
+    with patch("dspy.predict.program_of_thought.PythonInterpreter", side_effect=make_mock_interp):
+        pot = ProgramOfThought(BasicQA)
+
+        def run():
+            # Each thread uses its own DummyLM to avoid shared-state contention
+            thread_lm = DummyLM(
+                [
+                    {"reasoning": "R", "generated_code": "```python\nresult = 1\n```"},
+                    {"reasoning": "R", "answer": "1"},
+                ]
+            )
+            try:
+                with dspy.context(lm=thread_lm):
+                    pot(question="What is 1+1?")
+            except Exception as exc:
+                errors.append(str(exc))
+
+        threads = [threading.Thread(target=run) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert not errors, f"Errors in concurrent forward(): {errors}"
+    assert len(created_interpreters) == 3  # one interpreter per thread
+    for m in created_interpreters:
+        assert m.shutdown.called  # each interpreter was properly closed
 
 
 def test_pot_code_parse_error():


### PR DESCRIPTION
## 📝 Changes Description

Fixes #9082 — `ProgramOfThought` and `CodeAct` fail with `"I/O operation on closed file"` (or `RuntimeError: PythonInterpreter is not thread-safe`) when used with `dspy.Evaluate(num_threads > 1)`.

**Root cause:** Both modules stored a single `PythonInterpreter` on `self.interpreter` and called `shutdown()` at the end of every `forward()` call. Under concurrent execution, one thread's `shutdown()` closes the subprocess stdin/stdout pipes while sibling threads are still writing to them.

**Fix:**
- `_get_fresh_interpreter()` returns the caller-supplied interpreter unchanged, or creates a new `PythonInterpreter()` at the start of each `forward()` call.
- A `try/finally` block guarantees the fresh interpreter is shut down after each call.
- `_execute_code` accepts an optional `interpreter` kwarg so `forward()` can pass its local instance without touching `self.interpreter`.
- `self.interpreter` is updated in the `finally` block so existing assertions like `pot.interpreter.deno_process is None` continue to pass.
- Callers who pass a custom `interpreter=...` at construction time are unaffected; their interpreter is reused as before.

Two new unit tests (no Deno required) verify the fix:
- `test_pot_creates_fresh_interpreter_per_forward` — asserts that no interpreter is allocated at init and that each `forward()` call gets a separate instance.
- `test_pot_thread_safe_concurrent_forward` — runs 3 threads concurrently, asserts no errors and that each thread received its own interpreter.

```
=== LOCAL_TEST_PASSED ===
```

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

The `@pytest.mark.deno` tests (`test_pot_code_generation`, `test_pot_support_multiple_fields`, etc.) still assert `pot.interpreter.deno_process is None` after a forward call. This continues to hold because `self.interpreter` is updated to the (now-shut-down) interpreter in the `finally` block.