### PR TITLE
Fix dspy.Module.__call__ failing to propagate usage to Predictions in list/dict returns

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -317,17 +317,18 @@ class Module(BaseModule, metaclass=ProgramMeta):
             return results
 
     def _set_lm_usage(self, tokens: dict[str, Any], output: Any):
-        # Some optimizers (e.g., GEPA bootstrap tracing) temporarily patch
-        # module.forward to return a tuple: (prediction, trace).
-        # When usage tracking is enabled, ensure we attach usage to the
-        # prediction object if present.
-        prediction_in_output = None
-        if isinstance(output, Prediction):
-            prediction_in_output = output
-        elif isinstance(output, tuple) and len(output) > 0 and isinstance(output[0], Prediction):
-            prediction_in_output = output[0]
-        if prediction_in_output:
-            prediction_in_output.set_lm_usage(tokens)
+        # Walk the output structure and attach usage to every Prediction
+        # found. This handles common containers used by modules:
+        #   - A single Prediction (the typical case).
+        #   - A tuple, e.g. (prediction, trace) from optimizers such as
+        #     GEPA bootstrap tracing.
+        #   - A list of Predictions, e.g. when ``forward`` returns the
+        #     result of ``dspy.Parallel``.
+        #   - Dicts whose values contain any of the above.
+        predictions = _collect_predictions(output)
+        if predictions:
+            for prediction in predictions:
+                prediction.set_lm_usage(tokens)
         else:
             logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking.")
 
@@ -347,6 +348,29 @@ class Module(BaseModule, metaclass=ProgramMeta):
                 )
 
         return attr
+
+
+def _collect_predictions(output: Any) -> list[Prediction]:
+    """Recursively collect ``Prediction`` objects from a module's output.
+
+    Walks lists, tuples, and dicts so that usage can be attached to every
+    ``Prediction`` returned by ``Module.forward``, regardless of how the
+    user nests them in the return value.
+    """
+    predictions: list[Prediction] = []
+
+    def _walk(obj: Any) -> None:
+        if isinstance(obj, Prediction):
+            predictions.append(obj)
+        elif isinstance(obj, (list, tuple)):
+            for item in obj:
+                _walk(item)
+        elif isinstance(obj, dict):
+            for value in obj.values():
+                _walk(value)
+
+    _walk(output)
+    return predictions
 
 
 def set_attribute_by_name(obj, name, value):

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -325,6 +325,15 @@ class Module(BaseModule, metaclass=ProgramMeta):
         #   - A list of Predictions, e.g. when ``forward`` returns the
         #     result of ``dspy.Parallel``.
         #   - Dicts whose values contain any of the above.
+        #
+        # NOTE on aggregate-vs-per-prediction semantics: when ``forward``
+        # returns N Predictions (e.g. from ``dspy.Parallel``), each one
+        # receives a reference to the same ``tokens`` dict, which holds
+        # the *aggregate* usage across all LM calls made during this
+        # outer module invocation, not the per-call usage. Callers that
+        # need a per-call breakdown should track usage inside each
+        # sub-call rather than summing ``p.get_lm_usage()`` over the
+        # returned list (that would over-count by a factor of N).
         predictions = _collect_predictions(output)
         if predictions:
             for prediction in predictions:

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -6,7 +6,8 @@ import pytest
 
 import dspy
 from dspy.primitives.example import Example
-from dspy.primitives.module import Module, set_attribute_by_name
+from dspy.primitives.module import Module, _collect_predictions, set_attribute_by_name
+from dspy.primitives.prediction import Prediction
 from dspy.utils import DummyLM
 
 
@@ -243,3 +244,144 @@ def test_load_state_is_transactional():
         assert template.a.predict.demos == [], (
             "load_state partially mutated module before failing"
         )
+
+
+def test_collect_predictions_single():
+    pred = Prediction(answer="hi")
+    assert _collect_predictions(pred) == [pred]
+
+
+def test_collect_predictions_tuple_with_trace():
+    # Mirrors the (prediction, trace) shape used by GEPA bootstrap tracing.
+    pred = Prediction(answer="hi")
+    assert _collect_predictions((pred, {"trace": "data"})) == [pred]
+
+
+def test_collect_predictions_list():
+    p1 = Prediction(answer="a")
+    p2 = Prediction(answer="b")
+    assert _collect_predictions([p1, p2]) == [p1, p2]
+
+
+def test_collect_predictions_nested_dict_and_list():
+    p1 = Prediction(answer="a")
+    p2 = Prediction(answer="b")
+    p3 = Prediction(answer="c")
+    output = {"main": p1, "others": [p2, [p3]]}
+    collected = _collect_predictions(output)
+    assert set(map(id, collected)) == {id(p1), id(p2), id(p3)}
+
+
+def test_collect_predictions_no_predictions():
+    assert _collect_predictions("just a string") == []
+    assert _collect_predictions({"a": 1, "b": [2, 3]}) == []
+    assert _collect_predictions(None) == []
+
+
+def test_set_lm_usage_attaches_to_list_of_predictions():
+    # Regression test for the dspy.Parallel-inside-Module case from #9201.
+    # The forward returns a list of Predictions (as dspy.Parallel does) and
+    # usage must be attached to every Prediction in the list.
+    class ParallelModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.pred = dspy.Predict("q -> a")
+
+        def forward(self, qs):
+            return dspy.Parallel(num_threads=2).forward(
+                [(self.pred, dspy.Example(q=q).with_inputs("q")) for q in qs]
+            )
+
+    lm = DummyLM([{"a": "1"}, {"a": "2"}])
+    with dspy.context(lm=lm, track_usage=True):
+        results = ParallelModule()(["x", "y"])
+
+    assert len(results) == 2
+    assert all(isinstance(r, Prediction) for r in results)
+    assert all(r.get_lm_usage() is not None for r in results)
+
+
+def test_set_lm_usage_attaches_to_nested_structure():
+    class NestedModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.pred = dspy.Predict("q -> a")
+
+        def forward(self):
+            return {
+                "main": self.pred(q="x"),
+                "others": [self.pred(q="y"), self.pred(q="z")],
+            }
+
+    lm = DummyLM([{"a": "1"}, {"a": "2"}, {"a": "3"}])
+    with dspy.context(lm=lm, track_usage=True):
+        result = NestedModule()()
+
+    assert isinstance(result, dict)
+    predictions = [result["main"], *result["others"]]
+    assert all(isinstance(p, Prediction) for p in predictions)
+    assert all(p.get_lm_usage() is not None for p in predictions)
+
+
+def test_set_lm_usage_preserves_single_prediction_behavior():
+    # The most common case must continue to work unchanged.
+    class SimpleModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.pred = dspy.Predict("q -> a")
+
+        def forward(self, q):
+            return self.pred(q=q)
+
+    lm = DummyLM([{"a": "1"}])
+    with dspy.context(lm=lm, track_usage=True):
+        result = SimpleModule()(q="x")
+
+    assert isinstance(result, Prediction)
+    assert result.get_lm_usage() is not None
+
+
+def test_set_lm_usage_no_warning_for_non_prediction_when_track_usage_disabled(monkeypatch):
+    # When the user does not enable track_usage, _set_lm_usage is never
+    # invoked and modules can return any type without warnings.
+    warnings = []
+    import dspy.primitives.module as module_mod
+
+    monkeypatch.setattr(module_mod.logger, "warning", lambda msg, *a, **kw: warnings.append(msg))
+
+    class StringModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.pred = dspy.Predict("q -> a")
+
+        def forward(self, q):
+            return self.pred(q=q).a
+
+    with dspy.context(lm=DummyLM([{"a": "ok"}])):
+        result = StringModule()(q="x")
+
+    assert result == "ok"
+    assert not any("Failed to set LM usage" in w for w in warnings)
+
+
+def test_set_lm_usage_warns_when_no_prediction_found_with_track_usage(monkeypatch):
+    # When track_usage is on but the module returns a container with no
+    # Predictions, the warning must still fire so users notice the misuse.
+    warnings = []
+    import dspy.primitives.module as module_mod
+
+    monkeypatch.setattr(module_mod.logger, "warning", lambda msg, *a, **kw: warnings.append(msg))
+
+    class NoPredictionModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.pred = dspy.Predict("q -> a")
+
+        def forward(self, q):
+            return {"answer": self.pred(q=q).a}  # plain dict, no Prediction
+
+    with dspy.context(lm=DummyLM([{"a": "ok"}]), track_usage=True):
+        result = NoPredictionModule()(q="x")
+
+    assert result == {"answer": "ok"}
+    assert any("Failed to set LM usage" in w for w in warnings)


### PR DESCRIPTION
# What does this PR do?

Fixes #9201.

`Module.__call__` wraps the `forward` call in `_set_lm_usage`, which assumed the output is a single `Prediction` (or the `(Prediction, trace)` tuple used by GEPA bootstrap tracing). When the module returns a list, tuple, or dict (common when `forward` is implemented with `dspy.Parallel`), no `Prediction` is found and the wrapper emits a `"Failed to set LM usage"` warning while leaving usage unset on the contained predictions. Combined with `track_usage=True`, this is what the issue reports as the `[None, None]` / `AttributeError: 'NoneType' object has no attribute 'get_lm_usage'` symptom.

This PR replaces the type-specific check with a small recursive helper, `_collect_predictions`, that walks lists, tuples, and dicts and returns every `Prediction` found. Usage is then attached to each. The warning still fires when no `Prediction` is found anywhere in the output, so genuine misuse remains visible.

## Reviewer context

This was raised in the prior stale PR #9213, where @TomeHirata asked for "recursive Prediction discovery in output" rather than a fragile type ladder. This PR implements exactly that, scoped to just the `Module.__call__` wrapper change; the orthogonal parallel-worker tracker propagation concern is left to its sibling PR (#9360).

## Tests

Added cases in `tests/primitives/test_module.py` covering:

- `_collect_predictions` unit tests for: single `Prediction`, `(Prediction, trace)` tuple (GEPA shape), list of `Prediction`s, nested `{"main": Prediction, "others": [Prediction, [Prediction]]}`, and structures with no `Prediction`s.
- End-to-end `Module.__call__` with `track_usage=True`:
  - Single `Prediction` return (existing behavior preserved).
  - `dspy.Parallel(...).forward([...])` inside `forward` returning a list of `Prediction`s (the issue repro, verified with `DummyLM`).
  - Nested dict-of-list-of-`Prediction` return.
  - Non-`Prediction` return with `track_usage=True` still warns; the same return type without `track_usage` does not warn.

Existing `tests/primitives/`, `tests/predict/`, and `tests/utils/` suites continue to pass (339 passed, 101 skipped locally).