### PR TITLE
[codex] Isolate DSPy cache in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 import copy
 import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -8,16 +11,31 @@ from tests.test_utils.server import litellm_test_server, read_litellm_test_serve
 SKIP_DEFAULT_FLAGS = ["reliability", "extra", "llm_call", "deno"]
 
 
+def _close_cache(cache: Any) -> None:
+    disk_cache = getattr(cache, "disk_cache", None)
+    if hasattr(disk_cache, "close"):
+        disk_cache.close()
+
+
 @pytest.fixture(autouse=True)
-def clear_settings():
-    """Ensures that the settings are cleared after each test."""
-
-    yield
-
+def clear_settings(tmp_path: Path) -> Iterator[None]:
+    """Ensure each test gets fresh DSPy settings and an isolated cache."""
     import dspy
-    from dspy.dsp.utils.settings import DEFAULT_CONFIG
 
-    dspy.configure(**copy.deepcopy(DEFAULT_CONFIG), inherit_config=False)
+    original_cache = dspy.cache
+    dspy.configure_cache(disk_cache_dir=tmp_path / ".dspy_cache")
+    try:
+        yield
+    finally:
+        from dspy.dsp.utils.settings import DEFAULT_CONFIG
+
+        try:
+            dspy.configure(**copy.deepcopy(DEFAULT_CONFIG), inherit_config=False)
+        finally:
+            try:
+                _close_cache(dspy.cache)
+            finally:
+                dspy.cache = original_cache
 
 
 @pytest.fixture


### PR DESCRIPTION
## What changed

- Configure `dspy.cache` to use a per-test pytest `tmp_path` cache directory in the autouse test fixture.
- Close the per-test disk cache and restore the original cache object during teardown.

## Why

Tests were reading from the default persistent `~/.dspy_cache`. A stale cached LM response can bypass mocked LiteLLM calls, which made `test_retry_number_set_correctly` fail with `mock_completion.call_args is None`.

## Validation

- `uv run --frozen ruff check tests/conftest.py`
- `uv run --frozen pytest --deno -q tests/clients`

Reproduced the failure before the fix with `uv run pytest --deno -q tests/clients/test_lm.py::test_retry_number_set_correctly`; it passes after cache isolation.