### PR TITLE
fix(dspy): unwrap nested JSON adapter outputs

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -24,6 +24,38 @@ from dspy.utils.exceptions import AdapterParseError
 logger = logging.getLogger(__name__)
 
 
+def _parse_json_object(value: str) -> Any:
+    parsed = json_repair.loads(value)
+
+    if isinstance(parsed, dict):
+        return parsed
+
+    pattern = r"\{(?:[^{}]|(?R))*\}"
+    match = regex.search(pattern, value, regex.DOTALL)
+    if match:
+        return json_repair.loads(match.group(0))
+
+    return parsed
+
+
+def _find_single_nested_output_fields(fields: dict[str, Any], signature: type[Signature]) -> dict[str, Any]:
+    candidates = []
+
+    for value in fields.values():
+        nested_fields = value
+        if isinstance(value, str):
+            nested_fields = _parse_json_object(value)
+
+        if not isinstance(nested_fields, dict):
+            continue
+
+        output_fields = {k: v for k, v in nested_fields.items() if k in signature.output_fields}
+        if output_fields.keys() == signature.output_fields.keys():
+            candidates.append(output_fields)
+
+    return candidates[0] if len(candidates) == 1 else {}
+
+
 def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
     """
     Check whether any output field in the signature has an open-ended mapping type,
@@ -49,7 +81,11 @@ class JSONAdapter(ChatAdapter):
 
         has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
 
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
+        if (
+            _has_open_ended_mapping(signature)
+            or (not self.use_native_function_calling and has_tool_calls)
+            or not lm.supports_response_schema
+        ):
             # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
             # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -146,16 +182,9 @@ class JSONAdapter(ChatAdapter):
         return self.format_field_with_value(fields_with_values, role="assistant")
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
-        fields = json_repair.loads(completion)
+        parsed_fields = _parse_json_object(completion)
 
-        if not isinstance(fields, dict):
-            pattern = r"\{(?:[^{}]|(?R))*\}"
-            match = regex.search(pattern, completion, regex.DOTALL)
-            if match:
-                completion = match.group(0)
-                fields = json_repair.loads(completion)
-
-        if not isinstance(fields, dict):
+        if not isinstance(parsed_fields, dict):
             raise AdapterParseError(
                 adapter_name="JSONAdapter",
                 signature=signature,
@@ -163,7 +192,9 @@ class JSONAdapter(ChatAdapter):
                 message="LM response cannot be serialized to a JSON object.",
             )
 
-        fields = {k: v for k, v in fields.items() if k in signature.output_fields}
+        fields = {k: v for k, v in parsed_fields.items() if k in signature.output_fields}
+        if not fields:
+            fields = _find_single_nested_output_fields(parsed_fields, signature)
 
         # Attempt to cast each value to type signature.output_fields[k].annotation.
         for k, v in fields.items():

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -193,6 +193,8 @@ class JSONAdapter(ChatAdapter):
             )
 
         fields = {k: v for k, v in parsed_fields.items() if k in signature.output_fields}
+        # Only unwrap when the top level has no output fields. Partial top-level matches should remain parse errors
+        # instead of mixing fields from two potentially conflicting response shapes.
         if not fields:
             fields = _find_single_nested_output_fields(parsed_fields, signature)
 

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -906,6 +906,50 @@ def test_json_adapter_parse_raise_error_on_mismatch_fields():
     )
 
 
+@pytest.mark.parametrize(
+    "completion",
+    [
+        '{"json_input": {"reasoning": "general analysis", "actors": ["EntityA"], "details": "scenario details"}}',
+        '{"json_object": {"reasoning": "internal process", "actors": ["EntityD", "EntityE"], "details": "procedural details"}}',
+        '{"json": "{\\n\\"reasoning\\": \\"interaction analysis\\",\\n\\"actors\\": [\\"EntityB\\", \\"EntityC\\"],\\n\\"details\\": \\"possible behavior\\"\\n}\\n</invoke>"}',
+    ],
+)
+def test_json_adapter_parse_unwraps_nested_json_output_fields(completion):
+    class AnalysisSignature(dspy.Signature):
+        prompt: str = dspy.InputField()
+        reasoning: str = dspy.OutputField()
+        actors: list[str] = dspy.OutputField()
+        details: str = dspy.OutputField()
+
+    result = dspy.JSONAdapter().parse(AnalysisSignature, completion)
+
+    assert set(result.keys()) == {"reasoning", "actors", "details"}
+    assert isinstance(result["reasoning"], str)
+    assert isinstance(result["actors"], list)
+    assert isinstance(result["details"], str)
+
+
+def test_json_adapter_parse_keeps_top_level_output_fields_when_nested_json_is_present():
+    class AnalysisSignature(dspy.Signature):
+        prompt: str = dspy.InputField()
+        reasoning: str = dspy.OutputField()
+        actors: list[str] = dspy.OutputField()
+        details: str = dspy.OutputField()
+
+    completion = (
+        '{"reasoning": "top-level analysis", "actors": ["Top"], "details": "top-level details", '
+        '"json_input": {"reasoning": "nested analysis", "actors": ["Nested"], "details": "nested details"}}'
+    )
+
+    result = dspy.JSONAdapter().parse(AnalysisSignature, completion)
+
+    assert result == {
+        "reasoning": "top-level analysis",
+        "actors": ["Top"],
+        "details": "top-level details",
+    }
+
+
 def test_json_adapter_formats_image():
     # Test basic image formatting
     image = dspy.Image(url="https://example.com/image.jpg")

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -950,6 +950,24 @@ def test_json_adapter_parse_keeps_top_level_output_fields_when_nested_json_is_pr
     }
 
 
+def test_json_adapter_parse_rejects_ambiguous_nested_output_fields():
+    class AnalysisSignature(dspy.Signature):
+        prompt: str = dspy.InputField()
+        reasoning: str = dspy.OutputField()
+        actors: list[str] = dspy.OutputField()
+        details: str = dspy.OutputField()
+
+    completion = (
+        '{"json_input": {"reasoning": "first", "actors": ["EntityA"], "details": "first details"}, '
+        '"json_object": {"reasoning": "second", "actors": ["EntityB"], "details": "second details"}}'
+    )
+
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError) as e:
+        dspy.JSONAdapter().parse(AnalysisSignature, completion)
+
+    assert e.value.parsed_result == {}
+
+
 def test_json_adapter_formats_image():
     # Test basic image formatting
     image = dspy.Image(url="https://example.com/image.jpg")


### PR DESCRIPTION
## Changes Description

This PR fixes #8539 by making `JSONAdapter.parse` recover from model responses that wrap the requested output object inside a single top-level JSON field such as `json_input`, `json_object`, or a JSON string under `json`.

The unwrap is intentionally conservative: top-level output fields still win, and nested data is used only when the outer object has no output fields and exactly one nested object contains the complete expected output field set.

## Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## Validation

- `uv run pytest tests/adapters/test_json_adapter.py -q`
- `uv run ruff check dspy/adapters/json_adapter.py tests/adapters/test_json_adapter.py`
- `git diff --check`

## Warnings

None.