### PR TITLE
docs: fix FAQ learn guide link

### DIFF
--- a/docs/docs/faqs.md
+++ b/docs/docs/faqs.md
@@ -19,7 +19,7 @@ The **DSPy** philosophy and abstraction differ significantly from other librarie
 
 ## Basic Usage
 
-**How should I use DSPy for my task?** We wrote a [eight-step guide](learn/index.md) on this. In short, using DSPy is an iterative process. You first define your task and the metrics you want to maximize, and prepare a few example inputs — typically without labels (or only with labels for the final outputs, if your metric requires them). Then, you build your pipeline by selecting built-in layers (`modules`) to use, giving each layer a `signature` (input/output spec), and then calling your modules freely in your Python code. Lastly, you use a DSPy `optimizer` to compile your code into high-quality instructions, automatic few-shot examples, or updated LM weights for your LM.
+**How should I use DSPy for my task?** We wrote an [eight-step guide](/learn/) on this. In short, using DSPy is an iterative process. You first define your task and the metrics you want to maximize, and prepare a few example inputs — typically without labels (or only with labels for the final outputs, if your metric requires them). Then, you build your pipeline by selecting built-in layers (`modules`) to use, giving each layer a `signature` (input/output spec), and then calling your modules freely in your Python code. Lastly, you use a DSPy `optimizer` to compile your code into high-quality instructions, automatic few-shot examples, or updated LM weights for your LM.
 
 **How do I convert my complex prompt into a DSPy pipeline?** See the same answer above.
 


### PR DESCRIPTION
## Problem

Issue #7765 reports that the FAQ's "eight-step guide" link leads to a dead path. In the current docs source, the FAQ links to `learn/index.md` from `docs/docs/faqs.md`; on the published site this can resolve under the FAQ path instead of the existing Learn page.

## Solution

- Point the FAQ link to the site-root Learn page (`/learn/`).
- Fix the adjacent grammar from "a eight-step" to "an eight-step".

## Validation

- `git diff --check`
- Verified `docs/docs/learn/index.md` exists.
- Verified `docs/docs/faqs.md` no longer references `learn/index.md` and now references `/learn/`.

## Confidence

85/100 — docs/broken-link + typo fix. The replacement target exists in the docs tree and matches the issue's reported dead FAQ link.

Fixes #7765
