### PR TITLE
fix: parse inline ChatAdapter field headers

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -209,19 +209,15 @@ class ChatAdapter(Adapter):
         return assistant_message_content
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
-        sections = [(None, [])]
-
-        for line in completion.splitlines():
-            match = field_header_pattern.match(line.strip())
-            if match:
-                # If the header pattern is found, split the rest of the line as content
+        sections = [(None, completion)]
+        matches = list(field_header_pattern.finditer(completion))
+        if matches:
+            sections = [(None, completion[: matches[0].start()].strip())]
+            for idx, match in enumerate(matches):
                 header = match.group(1)
-                remaining_content = line[match.end() :].strip()
-                sections.append((header, [remaining_content] if remaining_content else []))
-            else:
-                sections[-1][1].append(line)
-
-        sections = [(k, "\n".join(v).strip()) for k, v in sections]
+                start = match.end()
+                end = matches[idx + 1].start() if idx + 1 < len(matches) else len(completion)
+                sections.append((header, completion[start:end].strip()))
 
         fields = {}
         for k, v in sections:

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -92,6 +92,24 @@ def test_chat_adapter_sync_call():
     assert result == [{"answer": "Paris"}]
 
 
+def test_chat_adapter_parse_inline_field_headers():
+    signature = dspy.make_signature("question->next_thought, next_tool_name, next_tool_args")
+    adapter = dspy.ChatAdapter()
+    completion = """[[ ## next_thought ## ]]
+Need to search transactions.[[ ## next_tool_name ## ]]
+search[[ ## next_tool_args ## ]]
+{"query": "transactions"}
+[[ ## completed ## ]]"""
+
+    result = adapter.parse(signature, completion)
+
+    assert result == {
+        "next_thought": "Need to search transactions.",
+        "next_tool_name": "search",
+        "next_tool_args": '{"query": "transactions"}',
+    }
+
+
 @pytest.mark.asyncio
 async def test_chat_adapter_async_call():
     signature = dspy.make_signature("question->answer")


### PR DESCRIPTION
﻿## What
- parse ChatAdapter field headers wherever they appear in the completion, not only at the start of a line
- add a regression test for a model response that glues the next field marker onto the previous field text

## To verify
- `python -m pytest tests\adapters\test_chat_adapter.py -q -k "inline_field_headers or sync_call"`
- `python -m pytest tests\adapters\test_chat_adapter.py -q`
- `python -m ruff check dspy\adapters\chat_adapter.py tests\adapters\test_chat_adapter.py`
- `python -m py_compile dspy\adapters\chat_adapter.py tests\adapters\test_chat_adapter.py`
- `git diff --check -- dspy\adapters\chat_adapter.py tests\adapters\test_chat_adapter.py`

Fixes #8379
