### PR TITLE
fix(rlm): protect history from nested fences

### DIFF
--- a/dspy/primitives/repl_types.py
+++ b/dspy/primitives/repl_types.py
@@ -23,6 +23,23 @@ if TYPE_CHECKING:
 __all__ = ["REPLVariable", "REPLEntry", "REPLHistory"]
 
 
+def _longest_backtick_run(text: str) -> int:
+    longest = 0
+    current = 0
+    for char in text:
+        if char == "`":
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _markdown_block(text: str, language: str = "") -> str:
+    fence = "`" * max(3, _longest_backtick_run(text) + 1)
+    return f"{fence}{language}\n{text}\n{fence}"
+
+
 class REPLVariable(pydantic.BaseModel):
     """Metadata about a variable available in the REPL environment."""
 
@@ -95,7 +112,7 @@ class REPLVariable(pydantic.BaseModel):
         if self.constraints:
             lines.append(f"Constraints: {self.constraints}")
         lines.append(f"Total length: {self.total_length:,} characters")
-        lines.append(f"Preview:\n```\n{self.preview}\n```")
+        lines.append(f"Preview:\n{_markdown_block(self.preview)}")
         return "\n".join(lines)
 
     @pydantic.model_serializer()
@@ -124,12 +141,12 @@ class REPLEntry(pydantic.BaseModel):
             tail_chars = max_output_chars - head_chars
             omitted = raw_len - max_output_chars
             output = output[:head_chars] + f"\n\n... ({omitted:,} characters omitted) ...\n\n" + output[-tail_chars:]
-        return f"Output ({raw_len:,} chars):\n{output}"
+        return f"Output ({raw_len:,} chars):\n{_markdown_block(output)}"
 
     def format(self, index: int, max_output_chars: int = 10_000) -> str:
         """Format this entry for inclusion in prompts."""
         reasoning_line = f"Reasoning: {self.reasoning}\n" if self.reasoning else ""
-        code_block = f"```python\n{self.code}\n```"
+        code_block = _markdown_block(self.code, "python")
         return f"=== Step {index + 1} ===\n{reasoning_line}Code:\n{code_block}\n{self.format_output(self.output, max_output_chars)}"
 
 

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -540,6 +540,19 @@ class TestREPLTypes:
         assert "print(1)" in formatted
         assert "1" in formatted
 
+    def test_repl_entry_format_handles_nested_code_fences(self):
+        """History formatting should not let prior markdown fences close the current block."""
+        entry = REPLEntry(
+            reasoning="inspect previous model output",
+            code='print("""```python\nx = 1\n```""")',
+            output="Code:\n```python\nprint(1)\n```\nOutput: ok",
+        )
+        formatted = entry.format(index=0)
+
+        assert "````python\n" in formatted
+        assert "\n````\nOutput" in formatted
+        assert "Code:\n```python\nprint(1)\n```" in formatted
+
     def test_repl_entry_format_truncation(self):
         """Test REPLEntry.format() truncates with head+tail and shows true length."""
         output = "a" * 100 + "b" * 100
@@ -559,7 +572,15 @@ class TestREPLTypes:
     def test_repl_entry_truncation_preserves_exact_odd_limit(self, limit, head, tail):
         formatted = REPLEntry.format_output("abcdef", max_output_chars=limit)
 
-        assert formatted == f"Output (6 chars):\n{head}\n\n... ({6 - limit} characters omitted) ...\n\n{tail}"
+        truncated = f"{head}\n\n... ({6 - limit} characters omitted) ...\n\n{tail}"
+        assert formatted == f"Output (6 chars):\n```\n{truncated}\n```"
+
+    def test_repl_entry_truncation_uses_a_fence_longer_than_retained_backticks(self):
+        formatted = REPLEntry.format_output("````abcdef````", max_output_chars=9)
+
+        assert formatted == (
+            "Output (14 chars):\n`````\n````\n\n... (5 characters omitted) ...\n\nf````\n`````"
+        )
 
     @pytest.mark.parametrize("limit", [0, -1])
     def test_repl_entry_rejects_non_positive_limit(self, limit):
@@ -590,6 +611,14 @@ class TestREPLTypes:
         assert var.type_name == "str"
         assert var.total_length == 11
         assert "hello world" in var.preview
+
+    def test_repl_variable_format_handles_nested_code_fences(self):
+        """Variable previews can contain markdown copied from prior traces."""
+        var = REPLVariable.from_value("context", "before\n```python\nx = 1\n```\nafter")
+        formatted = var.format()
+
+        assert "Preview:\n````\n" in formatted
+        assert "```python\nx = 1\n```" in formatted
 
     def test_repl_variable_truncation(self):
         """Test REPLVariable preview shows head and tail."""


### PR DESCRIPTION
> **Stack:** one contributor-authored commit on top of #10019. That parent owns exact source-character truncation; this PR owns only how the retained text is delimited in the RLM prompt.

Fixes #9573.

## 1. Issue / repro

RLM copies generated code, interpreter output, and input previews into later prompts using fixed triple-backtick fences. Those values can themselves contain Markdown code blocks:

```python
entry = REPLEntry(
    code='print("""```python\nx = 1\n```""")',
    output="Code:\n```python\nprint(1)\n```\nOutput: ok",
)
```

The inner ` ``` ` sequence can terminate the outer code block early. In #9573, a prior REPL output containing fenced code corrupted the next action prompt and the adapter could no longer parse the model's `reasoning`/`code` fields.

## 2. Why this is the root cause

The formatter currently assumes its payload never contains its delimiter:

```python
code_block = f"```python\n{self.code}\n```"
lines.append(f"Preview:\n```\n{self.preview}\n```")
```

`code`, `output`, and `preview` are derived from user/model/interpreter data, so that assumption is false. The adapter failure is downstream: once the transcript's Markdown structure is ambiguous, the next LM response can stop following the action signature.

## 3. How we know the fix addresses the root cause

The regression reproduces the reported connection directly: code and output contain their own ` ```python ` blocks, then the formatted history is inspected to prove the outer delimiter is four backticks and the inner block is unchanged.

A second exact regression combines truncation with a retained four-backtick run:

```text
raw output: ````abcdef````
limit:      9 source characters
outer fence: ````` (five backticks)
```

That proves the formatter chooses the delimiter from the text that actually reaches the prompt, after #10019's truncation step.

## 4. Why this is the concise fix

One helper finds the longest consecutive backtick run, and one helper chooses a fence exactly one character longer (with three as the Markdown minimum):

```python
fence = "`" * max(3, _longest_backtick_run(text) + 1)
return f"{fence}{language}\n{text}\n{fence}"
```

The same helper replaces the three delimiter-owning call sites. There is no escaping table, parser, retry, provider branch, or content mutation. The payload remains byte-for-byte intact inside an unambiguous fence.

## 5. Context needed to validate the change

Markdown permits a fenced block to use more than three backticks. A closing fence must be at least as long as the opening fence, so choosing `longest inner run + 1` guarantees that no retained payload sequence can close the outer block.

Truncation and fencing are separate contracts:

1. #10019 selects exactly the configured number of source characters;
2. this PR selects a safe delimiter for those retained characters.

The delimiter and omission marker are formatting overhead, not part of the source-character budget.

## 6. What the fix does in the code

- Dynamically fences generated code while preserving the `python` language tag.
- Wraps REPL output in a dynamically sized literal block.
- Replaces fixed preview fences with the same safe delimiter.
- Tests nested triple-backtick blocks, retained four-backtick runs, and truncation composition.

## Compatibility boundaries and downsides

- **REPL output is now always fenced.** This intentionally changes prompt text, snapshots, token counts, and cache keys even when the output contains no backticks.
- **Existing code and preview formatting is unchanged for ordinary payloads.** With no run of three backticks, both still use a three-backtick fence.
- **Longer runs produce longer delimiters without a fixed cap.** The delimiter is always one character longer than the longest retained run.
- **Truncation semantics are unchanged.** Original length, omitted count, head/tail allocation, and positive-limit validation remain owned by #10019.
- **Reasoning remains plain text.** This PR fixes the delimiter-owning code/output/preview paths from the reported failure; changing reasoning presentation would be a separate prompt-format decision.
- **No adapter, LM provider, interpreter, tool, lifecycle, retry, or fallback behavior changes.**

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — `134 passed, 2 skipped`
- repository pre-commit hooks on both changed files — passed
- `git diff --check` — passed
- review diff over #10019 is one commit and two files
