### PR TITLE
Plan adapter calls with normalized responses

### DIFF
--- a/dspy/adapters/_signature_field_partition.py
+++ b/dspy/adapters/_signature_field_partition.py
@@ -1,0 +1,162 @@
+"""Separate DSPy signature fields between adapter formatting and native LM channels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import Any, get_origin
+
+from dspy.adapters.types import Type
+from dspy.adapters.types.tool import Tool, ToolCalls
+from dspy.clients.base_lm import BaseLM
+from dspy.core.types import LMToolSpec
+from dspy.signatures.signature import Signature
+
+
+@dataclass(frozen=True)
+class _NativeResponseField:
+    """A source signature output field filled from normalized LM response data."""
+
+    name: str
+    annotation: type[Type]
+
+
+@dataclass
+class _SignatureFieldPartition:
+    """Result of separating one DSPy signature execution across LM channels.
+
+    AI-engineering mental model:
+
+    A DSPy signature is a source-level interface: it describes the semantic
+    inputs and outputs of a module, not necessarily how every field should be
+    transported to or from a model. Modern LMs expose more than a text prompt
+    and a text completion: they have native tool specifications, tool-call
+    outputs, reasoning content, citations, and eventually media/document input
+    channels. Before rendering a request, DSPy must therefore separate the
+    source signature fields into two paths:
+
+    1. The remaining adapter format/parse path. These fields stay in
+       `remaining_signature` / `remaining_inputs` and are passed to the
+       adapter's ordinary `format()` method. Textual LM output for these fields
+       is parsed with the same `remaining_signature` via `parse()`.
+
+    2. Native LM request/response channels. These fields are removed from the
+       remaining signature and represented explicitly as normalized request data
+       (`tool_specs`, `request_kwargs`) or as source output fields that should be
+       filled from `LMResponse` (`native_response_fields`).
+
+    This object is not a planner or orchestrator. It is the value produced by a
+    field-separation pass for one concrete signature execution, including the
+    particular inputs and request kwargs for that execution. Keeping these
+    values together makes the invariant visible: any field consumed by a native
+    LM channel should no longer be rendered or parsed through the remaining
+    adapter format.
+    """
+
+    source_signature: type[Signature]
+    remaining_signature: type[Signature]
+    remaining_inputs: dict[str, Any]
+    request_kwargs: dict[str, Any]
+    tool_specs: list[LMToolSpec] = dataclass_field(default_factory=list)
+    native_response_fields: list[_NativeResponseField] = dataclass_field(default_factory=list)
+
+
+def _partition_signature_fields(
+    adapter: Any,
+    lm: BaseLM,
+    lm_kwargs: dict[str, Any],
+    signature: type[Signature],
+    inputs: dict[str, Any],
+) -> _SignatureFieldPartition:
+    """Separate signature fields between adapter format/parse and native LM channels."""
+    partition = _SignatureFieldPartition(
+        source_signature=signature,
+        remaining_signature=signature,
+        remaining_inputs=dict(inputs),
+        request_kwargs=dict(lm_kwargs),
+    )
+
+    _partition_native_tool_calling(adapter, lm, partition)
+    _partition_native_response_types(adapter, lm, partition)
+    return partition
+
+
+def _partition_native_tool_calling(adapter: Any, lm: BaseLM, partition: _SignatureFieldPartition) -> None:
+    if not adapter.use_native_function_calling:
+        return
+
+    tool_call_input_field_name = _get_tool_call_input_field_name(partition.remaining_signature)
+    tool_call_output_field_name = _get_tool_call_output_field_name(partition.remaining_signature)
+
+    if tool_call_output_field_name and tool_call_input_field_name is None:
+        raise ValueError(
+            f"You provided an output field {tool_call_output_field_name} to receive the tool calls information, "
+            "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
+            "input field with type `list[dspy.Tool]`."
+        )
+
+    if not (tool_call_output_field_name and lm.supports_function_calling):
+        return
+
+    tools = partition.remaining_inputs[tool_call_input_field_name]
+    tools = tools if isinstance(tools, list) else [tools]
+    partition.tool_specs.extend(_tool_to_lm_tool_spec(tool) for tool in tools)
+    partition.native_response_fields.append(_NativeResponseField(tool_call_output_field_name, ToolCalls))
+    partition.remaining_signature = partition.remaining_signature.delete(tool_call_output_field_name).delete(
+        tool_call_input_field_name
+    )
+    partition.remaining_inputs.pop(tool_call_input_field_name, None)
+
+
+def _partition_native_response_types(adapter: Any, lm: BaseLM, partition: _SignatureFieldPartition) -> None:
+    for name, field in list(partition.remaining_signature.output_fields.items()):
+        annotation = field.annotation
+        if not (isinstance(annotation, type) and annotation in adapter.native_response_types and issubclass(annotation, Type)):
+            continue
+        if annotation is ToolCalls:
+            continue
+
+        before = partition.remaining_signature
+        adapted = _adapt_native_response_type(annotation, partition.remaining_signature, name, lm, partition.request_kwargs)
+        if adapted is not before:
+            partition.native_response_fields.append(_NativeResponseField(name, annotation))
+            partition.remaining_signature = adapted
+
+
+def _adapt_native_response_type(
+    annotation: type[Type],
+    signature: type[Signature],
+    field_name: str,
+    lm: BaseLM,
+    lm_kwargs: dict[str, Any],
+) -> type[Signature]:
+    # Keep existing Type-owned compatibility hooks for now. Later changes can
+    # move built-in native behavior into explicit renderers/codecs while
+    # retaining this as a fallback for user custom types.
+    return annotation.adapt_to_native_lm_feature(signature, field_name, lm, lm_kwargs)
+
+
+def _tool_to_lm_tool_spec(tool: Tool) -> LMToolSpec:
+    args = tool.args or {}
+    return LMToolSpec(
+        name=tool.name or "",
+        description=tool.desc,
+        parameters={"type": "object", "properties": args, "required": list(args.keys())},
+    )
+
+
+def _get_tool_call_input_field_name(signature: type[Signature]) -> str | None:
+    for name, field in signature.input_fields.items():
+        origin = get_origin(field.annotation)
+        if origin is list and field.annotation.__args__[0] == Tool:
+            return name
+        if field.annotation == Tool:
+            return name
+    return None
+
+
+def _get_tool_call_output_field_name(signature: type[Signature]) -> str | None:
+    for name, field in signature.output_fields.items():
+        if field.annotation == ToolCalls:
+            return name
+    return None

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -2,22 +2,21 @@ import json
 import logging
 from typing import Any, get_origin
 
-import json_repair
-
 from dspy.adapters._legacy_type_markers import (
     _expand_legacy_custom_type_markers_in_chat_message,
     _expand_legacy_custom_type_markers_in_lm_message,
+)
+from dspy.adapters._signature_field_partition import (
+    _NativeResponseField,
+    _partition_signature_fields,
+    _SignatureFieldPartition,
 )
 from dspy.adapters.types import History, Type
 from dspy.adapters.types.reasoning import Reasoning
 from dspy.adapters.types.tool import Tool, ToolCalls
 from dspy.clients.base_lm import BaseLM
-from dspy.clients.openai_format import (
-    legacy_outputs_from_lm_response,
-    lm_response_from_legacy_outputs,
-    to_openai_chat_request,
-)
-from dspy.core.types import LMMessage, LMRequest, LMResponse
+from dspy.clients.openai_format import lm_response_from_legacy_outputs, to_openai_chat_request
+from dspy.core.types import LMMessage, LMOutput, LMRequest, LMResponse
 from dspy.experimental import Citations
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback, with_callbacks
@@ -73,151 +72,23 @@ class Adapter:
         cls.format = with_callbacks(cls.format)
         cls.parse = with_callbacks(cls.parse)
 
-    def _call_preprocess(
-        self,
-        lm: BaseLM,
-        lm_kwargs: dict[str, Any],
-        signature: type[Signature],
-        inputs: dict[str, Any],
-    ) -> type[Signature]:
-        # TODO(adapters-plan): This remains the pre-normalized planning hook. It
-        # mutates `lm_kwargs` and returns only the render signature, which loses
-        # information we will need for plan-driven rendering/parsing. The next
-        # stacked PR should replace this with an explicit `_AdapterPlan` that
-        # records deleted fields, native tools, native output fields, inserted
-        # messages/parts, and LM config patches.
-        if self.use_native_function_calling:
-            tool_call_input_field_name = self._get_tool_call_input_field_name(signature)
-            tool_call_output_field_name = self._get_tool_call_output_field_name(signature)
-
-            if tool_call_output_field_name and tool_call_input_field_name is None:
-                raise ValueError(
-                    f"You provided an output field {tool_call_output_field_name} to receive the tool calls information, "
-                    "but did not provide any tools as the input. Please provide a list of tools as the input by adding an "
-                    "input field with type `list[dspy.Tool]`."
-                )
-
-            if tool_call_output_field_name and lm.supports_function_calling:
-                tools = inputs[tool_call_input_field_name]
-                tools = tools if isinstance(tools, list) else [tools]
-
-                lm_tools = [tool.format_as_litellm_function_call() for tool in tools]
-
-                lm_kwargs["tools"] = lm_tools
-
-                signature_for_native_function_calling = signature.delete(tool_call_output_field_name)
-                signature_for_native_function_calling = signature_for_native_function_calling.delete(
-                    tool_call_input_field_name
-                )
-
-                return signature_for_native_function_calling
-
-        # TODO(adapters-plan): Built-in/native response planning should move out
-        # of `Type.adapt_to_native_lm_feature()` and into adapter-owned planning
-        # renderers. Keep this compatibility hook for this boundary-only PR.
-        # Handle custom types that use native LM features, e.g., reasoning, citations, etc.
-        for name, field in signature.output_fields.items():
-            if (
-                isinstance(field.annotation, type)
-                and field.annotation in self.native_response_types
-                and issubclass(field.annotation, Type)
-            ):
-                signature = field.annotation.adapt_to_native_lm_feature(signature, name, lm, lm_kwargs)
-
-        return signature
-
-    def _call_postprocess(
-        self,
-        processed_signature: type[Signature],
-        original_signature: type[Signature],
-        outputs: list[dict[str, Any] | str],
-        lm: BaseLM,
-        lm_kwargs: dict[str, Any],
-    ) -> list[dict[str, Any]]:
-        # TODO(adapters-plan): This still parses legacy adapter output objects.
-        # PR1 normalizes the LM boundary, then immediately converts back to this
-        # shape to avoid changing parser semantics. A later PR should parse
-        # `LMResponse` directly and merge text-parsed fields with explicit
-        # native fields from `_AdapterPlan`.
-        values = []
-
-        tool_call_output_field_name = self._get_tool_call_output_field_name(original_signature)
-
-        for output in outputs:
-            output_logprobs = None
-            tool_calls = None
-            text = output
-
-            if isinstance(output, dict):
-                text = output["text"]
-                output_logprobs = output.get("logprobs")
-                tool_calls = output.get("tool_calls")
-
-            if text:
-                value = self.parse(processed_signature, text)
-                for field_name in original_signature.output_fields.keys():
-                    if field_name not in value:
-                        # We need to set the field not present in the processed signature to None for consistency.
-                        value[field_name] = None
-            elif tool_calls and tool_call_output_field_name:
-                value = {}
-                for field_name in original_signature.output_fields.keys():
-                    value[field_name] = None
-            else:
-                raise AdapterParseError(
-                    adapter_name=type(self).__name__,
-                    signature=original_signature,
-                    lm_response=str(output),
-                    message="The LM returned an empty or null response.",
-                )
-
-            if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
-
-            # TODO(adapter-types): Once `Type.parse_lm_output(context, output)` is
-            # the real normalized hook, this should not call the legacy
-            # provider-shaped `parse_lm_response()` directly.
-            # Parse custom types that does not rely on the `Adapter.parse()` method
-            for name, field in original_signature.output_fields.items():
-                if (
-                    isinstance(field.annotation, type)
-                    and field.annotation in self.native_response_types
-                    and issubclass(field.annotation, Type)
-                ):
-                    parsed_value = field.annotation.parse_lm_response(output)
-                    if parsed_value is not None:
-                        value[name] = parsed_value
-
-            if output_logprobs:
-                value["logprobs"] = output_logprobs
-
-            values.append(value)
-
-        return values
-
     def _render_request(
         self,
+        partition: _SignatureFieldPartition,
         lm: BaseLM,
-        lm_kwargs: dict[str, Any],
-        messages: list[LMMessage | dict[str, Any]],
+        demos: list[dict[str, Any]],
     ) -> LMRequest:
-        """Build the normalized LM request for the current adapter call path.
-
-        TODO(adapters-plan): This currently receives already-rendered messages.
-        Once planning lands, this should render from `_AdapterPlan` and apply
-        planned message/part insertions before creating `LMRequest`.
-        """
+        """Render the remaining signature fields into a normalized LM request."""
+        messages = self.format(partition.remaining_signature, demos, partition.remaining_inputs)
+        request_kwargs = dict(partition.request_kwargs)
+        tools = list(partition.tool_specs)
+        if "tools" in request_kwargs:
+            tools.extend(request_kwargs.pop("tools") or [])
         return LMRequest.from_call(
             model=lm.model,
             messages=self._coerce_lm_messages(messages),
-            **lm_kwargs,
+            tools=tools,
+            **request_kwargs,
         )
 
     def _call_lm(self, lm: BaseLM, request: LMRequest) -> LMResponse:
@@ -308,6 +179,77 @@ class Adapter:
         """
         return lm_response_from_legacy_outputs(outputs, request)
 
+    def _parse_response(self, partition: _SignatureFieldPartition, response: LMResponse, lm: BaseLM) -> list[dict[str, Any]]:
+        """Parse a normalized LM response into dictionaries for the source signature."""
+        values = []
+        tool_call_output_field_name = self._get_tool_call_output_field_name(partition.source_signature)
+
+        for output in response.outputs:
+            if output.metadata.get("empty_legacy_outputs"):
+                continue
+
+            has_text_output = bool(output.text and partition.remaining_signature.output_fields)
+            has_tool_output = bool(output.tool_calls and tool_call_output_field_name)
+
+            if has_text_output:
+                value = self.parse(partition.remaining_signature, output.text)
+                for field_name in partition.source_signature.output_fields:
+                    value.setdefault(field_name, None)
+            else:
+                value = dict.fromkeys(partition.source_signature.output_fields.keys())
+
+            if has_tool_output:
+                value[tool_call_output_field_name] = ToolCalls.from_dict_list(
+                    [{"name": call.name, "args": call.args} for call in output.tool_calls]
+                )
+
+            has_native_output = self._parse_native_response_fields(value, partition, output, lm)
+
+            if not (has_text_output or has_tool_output or has_native_output):
+                raise AdapterParseError(
+                    adapter_name=type(self).__name__,
+                    signature=partition.source_signature,
+                    lm_response=str(output.to_output_dict()),
+                    message="The LM returned an empty or null response.",
+                )
+
+            if output.logprobs is not None:
+                value["logprobs"] = output.logprobs
+
+            values.append(value)
+
+        return values
+
+    def _parse_native_response_fields(
+        self,
+        value: dict[str, Any],
+        partition: _SignatureFieldPartition,
+        output: LMOutput,
+        lm: BaseLM,
+    ) -> bool:
+        parsed_any = False
+        for native_field in partition.native_response_fields:
+            parsed_value = self._parse_native_response_field(native_field, output, partition, lm)
+            if parsed_value is not None:
+                value[native_field.name] = parsed_value
+                parsed_any = True
+        return parsed_any
+
+    def _parse_native_response_field(
+        self,
+        native_field: _NativeResponseField,
+        output: LMOutput,
+        partition: _SignatureFieldPartition,
+        lm: BaseLM,
+    ) -> Type | None:
+        # TODO(adapter-types): Replace this provider-shaped compatibility call
+        # with `Type.parse_lm_output(context, output)` once the normalized type
+        # hook lands. Prefer the exact legacy provider output when present so
+        # existing custom types keep seeing the shape they saw before normalized
+        # request/response parsing moved into adapters.
+        legacy_response = output.provider_output if output.provider_output is not None else output.to_output_dict()
+        return native_field.annotation.parse_lm_response(legacy_response)
+
     def __call__(
         self,
         lm: BaseLM,
@@ -332,16 +274,10 @@ class Adapter:
             List of dictionaries representing parsed LM responses. Each dictionary contains keys matching the
             signature's output field names. For multiple generations (n > 1), returns multiple dictionaries.
         """
-        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
-        messages = self.format(processed_signature, demos, inputs)
-        request = self._render_request(lm, lm_kwargs, messages)
+        partition = _partition_signature_fields(self, lm, lm_kwargs, signature, inputs)
+        request = self._render_request(partition, lm, demos)
         response = self._call_lm(lm, request)
-        # TODO(adapters-response): We normalize at the LM boundary, but still
-        # convert back to legacy postprocess dictionaries here to keep this PR
-        # behavior-preserving. Replace with direct `LMResponse` parsing once the
-        # explicit adapter plan exists.
-        outputs = legacy_outputs_from_lm_response(response)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        return self._parse_response(partition, response, lm)
 
     async def acall(
         self,
@@ -351,14 +287,10 @@ class Adapter:
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
-        messages = self.format(processed_signature, demos, inputs)
-        request = self._render_request(lm, lm_kwargs, messages)
+        partition = _partition_signature_fields(self, lm, lm_kwargs, signature, inputs)
+        request = self._render_request(partition, lm, demos)
         response = await self._acall_lm(lm, request)
-        # TODO(adapters-response): Keep in sync with `__call__()` until both use
-        # direct `LMResponse` parsing.
-        outputs = legacy_outputs_from_lm_response(response)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        return self._parse_response(partition, response, lm)
 
     def format(
         self,

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -7,6 +7,7 @@ import pydantic
 import regex
 from pydantic.fields import FieldInfo
 
+from dspy.adapters._signature_field_partition import _partition_signature_fields
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
 from dspy.adapters.types.tool import ToolCalls
 from dspy.adapters.utils import (
@@ -68,11 +69,14 @@ class JSONAdapter(ChatAdapter):
             return result
 
         try:
+            partition = _partition_signature_fields(self, lm, lm_kwargs, signature, inputs)
             structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
+                partition.remaining_signature, self.use_native_function_calling
             )
-            lm_kwargs["response_format"] = structured_output_model
-            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+            partition.request_kwargs["response_format"] = structured_output_model
+            request = self._render_request(partition, lm, demos)
+            response = self._call_lm(lm, request)
+            return self._parse_response(partition, response, lm)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -91,11 +95,14 @@ class JSONAdapter(ChatAdapter):
             return await result
 
         try:
+            partition = _partition_signature_fields(self, lm, lm_kwargs, signature, inputs)
             structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
+                partition.remaining_signature, self.use_native_function_calling
             )
-            lm_kwargs["response_format"] = structured_output_model
-            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+            partition.request_kwargs["response_format"] = structured_output_model
+            request = self._render_request(partition, lm, demos)
+            response = await self._acall_lm(lm, request)
+            return self._parse_response(partition, response, lm)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}

--- a/dspy/adapters/two_step_adapter.py
+++ b/dspy/adapters/two_step_adapter.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-import json_repair
-
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.types import ToolCalls
@@ -111,51 +109,52 @@ class TwoStepAdapter(Adapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        inputs = self.format(signature, demos, inputs)
+        from dspy.adapters._signature_field_partition import _partition_signature_fields
 
-        outputs = await lm.acall(messages=inputs, **lm_kwargs)
-        # The signature is supposed to be "text -> {original output fields}"
-        extractor_signature = self._create_extractor_signature(signature)
+        partition = _partition_signature_fields(self, lm, lm_kwargs, signature, inputs)
+        request = self._render_request(partition, lm, demos)
+        response = await self._acall_lm(lm, request)
 
         values = []
-
         tool_call_output_field_name = self._get_tool_call_output_field_name(signature)
-        for output in outputs:
-            output_logprobs = None
-            tool_calls = None
-            text = output
+        extractor_signature = self._create_extractor_signature(partition.remaining_signature)
 
-            if isinstance(output, dict):
-                text = output["text"]
-                output_logprobs = output.get("logprobs")
-                tool_calls = output.get("tool_calls")
+        for output in response.outputs:
+            if output.metadata.get("empty_legacy_outputs"):
+                continue
 
-            try:
-                # Call the smaller LM to extract structured data from the raw completion text with ChatAdapter
-                value = await ChatAdapter().acall(
-                    lm=self.extraction_model,
-                    lm_kwargs={},
-                    signature=extractor_signature,
-                    demos=[],
-                    inputs={"text": text},
+            has_text_output = bool(output.text and partition.remaining_signature.output_fields)
+            has_tool_output = bool(output.tool_calls and tool_call_output_field_name)
+
+            if has_text_output:
+                try:
+                    value = await ChatAdapter().acall(
+                        lm=self.extraction_model,
+                        lm_kwargs={},
+                        signature=extractor_signature,
+                        demos=[],
+                        inputs={"text": output.text},
+                    )
+                    value = value[0]
+                    for field_name in signature.output_fields:
+                        value.setdefault(field_name, None)
+                except Exception as e:
+                    raise ValueError(f"Failed to parse response from the original completion: {output}") from e
+            else:
+                value = dict.fromkeys(signature.output_fields.keys())
+
+            if has_tool_output:
+                value[tool_call_output_field_name] = ToolCalls.from_dict_list(
+                    [{"name": call.name, "args": call.args} for call in output.tool_calls]
                 )
-                value = value[0]
 
-            except Exception as e:
-                raise ValueError(f"Failed to parse response from the original completion: {output}") from e
+            has_native_output = self._parse_native_response_fields(value, partition, output, lm)
 
-            if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
+            if not (has_text_output or has_tool_output or has_native_output):
+                raise ValueError(f"Failed to parse response from the original completion: {output}")
 
-            if output_logprobs is not None:
-                value["logprobs"] = output_logprobs
+            if output.logprobs is not None:
+                value["logprobs"] = output.logprobs
 
             values.append(value)
         return values

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -882,26 +882,6 @@ def lm_response_from_legacy_outputs(outputs: list[dict[str, Any] | str | None], 
     return LMResponse(model=request.model, outputs=[lm_output_from_legacy_output(output) for output in outputs])
 
 
-def legacy_outputs_from_lm_response(response: LMResponse) -> list[dict[str, Any] | str | None]:
-    """Return legacy adapter postprocess values from a normalized response.
-
-    This is a temporary compatibility helper for current adapter postprocessing.
-    Prefer the exact original legacy output when it is available so compatibility
-    hooks that distinguish `str` from provider dictionaries keep working.
-    """
-    outputs = []
-    for output in response.outputs:
-        if output.metadata.get("empty_legacy_outputs"):
-            continue
-        if output.provider_output is not None:
-            outputs.append(output.provider_output)
-        elif output.text is not None and not output.reasoning_content and not output.tool_calls and not output.citations and output.logprobs is None:
-            outputs.append(output.text)
-        else:
-            outputs.append(output.to_output_dict())
-    return outputs
-
-
 def lm_output_from_legacy_output(output: dict[str, Any] | str | None) -> LMOutput:
     """Normalize one current legacy `BaseLM` output item into an `LMOutput`."""
     if isinstance(output, str):

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2028,13 +2028,16 @@ def test_chat_adapter_native_reasoning():
             ],
             model="anthropic/claude-3-7-sonnet-20250219",
         )
-        modified_signature = adapter._call_preprocess(
+        from dspy.adapters._signature_field_partition import _partition_signature_fields
+
+        partition = _partition_signature_fields(
+            adapter,
             dspy.LM(model="anthropic/claude-3-7-sonnet-20250219", reasoning_effort="low", cache=False),
             {},
             MySignature,
             {"question": "What is the capital of France?"},
         )
-        assert "reasoning" not in modified_signature.output_fields
+        assert "reasoning" not in partition.remaining_signature.output_fields
 
         result = adapter(
             dspy.LM(model="anthropic/claude-3-7-sonnet-20250219", reasoning_effort="low", cache=False),
@@ -2145,15 +2148,25 @@ def test_empty_string_content_raises_adapter_parse_error():
 
 
 def test_tool_call_with_null_content_does_not_raise():
-    """Tool-call-only responses legitimately have content=None.
-    _call_postprocess must NOT raise when tool_calls are present."""
+    """Tool-call-only responses legitimately have content=None and should parse."""
+    from dspy.adapters._signature_field_partition import _partition_signature_fields
+    from dspy.clients.openai_format import lm_response_from_legacy_outputs
+    from dspy.core.types import LMRequest
+
     adapter = dspy.ChatAdapter(use_native_function_calling=True)
     sig_cls = dspy.Signature("question, tools: list[dspy.Tool] -> answer, tool_calls: dspy.ToolCalls")
 
+    def search(query: str) -> str:
+        return query
+
+    inputs = {"question": "test", "tools": [dspy.Tool(search)]}
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+    partition = _partition_signature_fields(adapter, lm, {}, sig_cls, inputs)
     outputs = [{"text": None, "tool_calls": [
         {"function": {"name": "search", "arguments": '{"query": "test"}'}, "id": "call_1", "type": "function"}
     ]}]
+    response = lm_response_from_legacy_outputs(outputs, LMRequest.from_call(model=lm.model, messages=[]))
 
-    result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
+    result = adapter._parse_response(partition, response, lm)
     assert result is not None
     assert len(result) == 1

--- a/tests/adapters/test_citation.py
+++ b/tests/adapters/test_citation.py
@@ -151,13 +151,14 @@ def test_citations_postprocessing():
         ]
     }]
 
-    result = adapter._call_postprocess(
-        CitationSignature.delete("citations"),
-        CitationSignature,
-        outputs,
-        dspy.LM(model="anthropic/claude-3-5-sonnet-20241022"),
-        lm_kwargs={},
-    )
+    from dspy.adapters._signature_field_partition import _partition_signature_fields
+    from dspy.clients.openai_format import lm_response_from_legacy_outputs
+    from dspy.core.types import LMRequest
+
+    lm = dspy.LM(model="anthropic/claude-3-5-sonnet-20241022")
+    partition = _partition_signature_fields(adapter, lm, {}, CitationSignature, {"question": "What color is the sky?"})
+    response = lm_response_from_legacy_outputs(outputs, LMRequest.from_call(model=lm.model, messages=[]))
+    result = adapter._parse_response(partition, response, lm)
 
     assert len(result) == 1
     assert "citations" in result[0]

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1574,13 +1574,16 @@ def test_json_adapter_native_reasoning():
             ],
             model="anthropic/claude-3-7-sonnet-20250219",
         )
-        modified_signature = adapter._call_preprocess(
+        from dspy.adapters._signature_field_partition import _partition_signature_fields
+
+        partition = _partition_signature_fields(
+            adapter,
             dspy.LM(model="anthropic/claude-3-7-sonnet-20250219", reasoning_effort="low", cache=False),
             {},
             MySignature,
             {"question": "What is the capital of France?"},
         )
-        assert "reasoning" not in modified_signature.output_fields
+        assert "reasoning" not in partition.remaining_signature.output_fields
 
         result = adapter(
             dspy.LM(model="anthropic/claude-3-7-sonnet-20250219", reasoning_effort="low", cache=False),


### PR DESCRIPTION
Stacked on #9802. This PR should be reviewed after #9802 lands; until then, the GitHub diff may include the normalized-boundary commit from PR1.

## Why

PR1 introduced a normalized `LMRequest` / `LMResponse` boundary inside adapters while preserving the existing `BaseLM` behavior. That gave adapters a normalized LM call boundary, but the adapter lifecycle still used the old shape internally:

```text
_call_preprocess() -> processed_signature
format(processed_signature, ...)
LMRequest -> BaseLM -> LMResponse
LMResponse -> legacy str/dict outputs
_call_postprocess(processed_signature, original_signature, legacy_outputs, ...)
```

That old lifecycle is lossy. `_call_preprocess()` only returned a modified signature, but preprocessing actually decides more than a signature:

- which signature should be rendered into the prompt;
- which inputs should remain in textual rendering;
- which tools should be sent through native tool calling;
- which output fields should be filled from native LM response data;
- which LM kwargs/config changes were made.

A modified signature alone cannot preserve that intent. It also forced the main adapter path to convert the normalized `LMResponse` back into legacy `str | dict` outputs just to parse it again. That keeps the old architecture alive immediately after introducing the new boundary.

This PR replaces that old private lifecycle with an explicit adapter plan and direct normalized response parsing.

## What changed

### Add `_AdapterPlan`

This adds `dspy/adapters/_planning.py` with a private `_AdapterPlan`:

```python
_AdapterPlan(
    original_signature=...,
    render_signature=...,
    inputs=...,
    lm_kwargs=...,
    tools=...,
    native_output_fields=...,
)
```

The plan records the adapter call decisions that were previously hidden in `_call_preprocess()` mutations. In particular, native tool calling and native response fields are now explicit plan state.

### Plan native tool calling as normalized tools

Native tool calling now plans `LMToolSpec` values instead of immediately writing provider-shaped tool dictionaries into `lm_kwargs`.

This keeps the ownership boundary cleaner:

- adapters plan semantic tools;
- `dspy.clients.openai_format` converts normalized tools to OpenAI/LiteLLM shape at the legacy `BaseLM` boundary.

### Parse `LMResponse` directly in the main adapter path

The main sync and async adapter call paths now use:

```text
_plan_fields() -> _render_request() -> _call_lm() -> _parse_response()
```

Instead of converting `LMResponse` back to legacy outputs for `_call_postprocess()`, adapters now parse normalized output properties directly:

- `output.text`
- `output.tool_calls`
- `output.logprobs`

Native output fields are filled from the plan's `native_output_fields`.

### Remove `_call_preprocess()` and `_call_postprocess()`

These methods were private and represented the old lifecycle. Keeping them around would keep two competing adapter architectures in the codebase:

- old: preprocess/postprocess around legacy output shapes;
- new: explicit plan around normalized request/response types.

The tests now use the new private architecture directly where needed:

- `_plan_fields(...)` for planning assertions;
- `_parse_response(plan, response, lm)` for normalized parsing assertions.

### Make JSON structured-output schema use the render signature

`JSONAdapter` now plans first and builds structured-output schemas from `plan.render_signature`, not the original signature.

This matters because native features can remove fields from textual/JSON output rendering. If a field is planned as native, the JSON schema should not ask the LM to produce it textually.

### Align `TwoStepAdapter.acall()` with the new lifecycle

The async two-step path previously bypassed the base adapter normalized flow and manually parsed legacy outputs. It now uses the same plan/request/response foundation and normalized tool-call parsing as the rest of the adapter stack.

## Important behavior details

- Planned native fields no longer silently allow empty/null LM outputs. A response must contain text, tool calls, or a successfully parsed native output; otherwise the adapter still raises `AdapterParseError` / parse failure.
- Manually provided `lm_kwargs["tools"]` are merged safely with planned native tools before constructing `LMRequest`, avoiding duplicate `tools=` arguments.
- Native custom type parsing still uses the existing `Type.parse_lm_response(...)` compatibility hook for now, preferring `output.provider_output` when available. A later PR should replace this with a normalized `Type.parse_lm_output(context, output)` hook.

## What this PR intentionally does not do

This PR does not yet migrate adapter input types like `Image`, `Audio`, `File`, or `Document` to normalized `LMPart` rendering. It creates the planning and response-parsing structure needed to do that cleanly in a later stacked PR.

Future follow-ups can add:

- native input segments to `_AdapterPlan`;
- `Type.generate_patch(...)` / normalized input rendering;
- `Type.parse_lm_output(...)` for native output parsing;
- adapter-owned placement of native input parts;
- stream planning built from the same plan/type concepts.

## Tests

Targeted adapter suite:

```text
uv run pytest tests/adapters -q
202 passed
```

Lint/compile checks:

```text
uv run ruff check dspy/adapters/base.py dspy/adapters/_planning.py dspy/adapters/json_adapter.py dspy/adapters/two_step_adapter.py tests/adapters/test_chat_adapter.py tests/adapters/test_json_adapter.py tests/adapters/test_citation.py
uv run python -m compileall -q dspy/adapters
```
