### PR TITLE
docs: drop stray .pdf from arxiv link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you're looking to understand the underlying research, this is a set of our pa
 [Feb'24] [Assisting in Writing Wikipedia-like Articles From Scratch with Large Language Models](https://arxiv.org/abs/2402.14207)         
 [Jan'24] [In-Context Learning for Extreme Multi-Label Classification](https://arxiv.org/abs/2401.12178)       
 [Dec'23] [DSPy Assertions: Computational Constraints for Self-Refining Language Model Pipelines](https://arxiv.org/abs/2312.13382)   
-[Dec'22] [Demonstrate-Search-Predict: Composing Retrieval & Language Models for Knowledge-Intensive NLP](https://arxiv.org/abs/2212.14024.pdf)
+[Dec'22] [Demonstrate-Search-Predict: Composing Retrieval & Language Models for Knowledge-Intensive NLP](https://arxiv.org/abs/2212.14024)
 
 To stay up to date or learn more, follow [@DSPyOSS](https://twitter.com/DSPyOSS) on Twitter or the DSPy page on LinkedIn.
 
@@ -84,5 +84,5 @@ If you use DSPy or DSP in a research paper, please cite our work as follows:
 * [**Releasing DSPy, the latest iteration of the framework**](https://twitter.com/lateinteraction/status/1694748401374490946) (Twitter Thread, Aug 2023)
 * [**Releasing the DSP Compiler (v0.1)**](https://twitter.com/lateinteraction/status/1625231662849073160)  (Twitter Thread, Feb 2023)
 * [**Introducing DSP**](https://twitter.com/lateinteraction/status/1617953413576425472)  (Twitter Thread, Jan 2023)
-* [**Demonstrate-Search-Predict: Composing retrieval and language models for knowledge-intensive NLP**](https://arxiv.org/abs/2212.14024.pdf) (Academic Paper, Dec 2022) -->
+* [**Demonstrate-Search-Predict: Composing retrieval and language models for knowledge-intensive NLP**](https://arxiv.org/abs/2212.14024) (Academic Paper, Dec 2022) -->
 


### PR DESCRIPTION
The README's reference to the Demonstrate-Search-Predict paper points to
`https://arxiv.org/abs/2212.14024.pdf` — an `/abs/` URL with a trailing
`.pdf` suffix. arxiv 301-redirects that to the clean `/abs/2212.14024`,
so it works today but goes through an unnecessary redirect and is
inconsistent with every other arxiv link in the file.

Fixes the visible link in the citation list, plus the matching link in
the commented-out history block below it for consistency.

Verified:
- `curl -sI https://arxiv.org/abs/2212.14024.pdf` -> `301 -> /abs/2212.14024`
- `curl -sI https://arxiv.org/abs/2212.14024` -> `200`