### PR TITLE
Sandbox serializable output

### DIFF
--- a/docs/docs/api/modules/RLM.md
+++ b/docs/docs/api/modules/RLM.md
@@ -185,14 +185,26 @@ rlm = dspy.RLM(
 )
 ```
 
-### Custom Sandbox-Serializable Inputs
+### Custom Sandbox-Serializable Values
 
-For inputs that should be loaded into the sandbox differently from normal Python values, subclass `dspy.SandboxSerializable`. RLM detects these inputs, sends their serialized payload into the interpreter, runs their setup code, and exposes the reconstructed value under the original input name.
+For values that should cross the sandbox boundary differently from normal Python values, subclass `dspy.SandboxSerializable`. RLM detects serializable inputs, sends their payloads into the interpreter, runs shared setup code, and exposes the reconstructed value under the original input name. The same subclass can also be used as an output annotation: the agent passes the bare sandbox value to `SUBMIT(...)`, and RLM serializes it back to the host before reconstructing the wrapper.
 
 ```python
+import base64
+import io
+
+import pandas as pd
+
+import dspy
+
+
 class DataFrame(dspy.SandboxSerializable):
-    def sandbox_setup(self) -> str:
-        return "import pandas as pd\nimport base64\nimport io"
+    def __init__(self, data):
+        self.data = data
+
+    @classmethod
+    def sandbox_setup(cls) -> str:
+        return "import pandas as pd\nimport pyarrow\nimport base64\nimport io"
 
     def to_sandbox(self) -> bytes:
         return base64.b64encode(self.data.to_parquet(index=False))
@@ -202,9 +214,19 @@ class DataFrame(dspy.SandboxSerializable):
 
     def rlm_preview(self, max_chars: int = 500) -> str:
         return f"DataFrame: {self.data.shape[0]} rows x {self.data.shape[1]} columns"
+
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        return f"base64.b64encode({var_name}.to_parquet(index=False)).decode('ascii')"
+
+    @classmethod
+    def from_sandbox(cls, payload: str) -> "DataFrame":
+        return cls(pd.read_parquet(io.BytesIO(base64.b64decode(payload))))
 ```
 
-`SandboxSerializable` also defines a Pydantic schema hook so subclasses can be used directly in DSPy signatures, for example `data: DataFrame = dspy.InputField()`. The hook is intentionally pass-through: Pydantic accepts the object as-is and serializes it with `str(value)` for schema/metadata purposes. RLM's real sandbox transport still comes from `to_sandbox()` and `sandbox_assignment()`.
+`sandbox_setup()` is class-level shared setup for both input values and output annotations. Input transport uses `to_sandbox()` and `sandbox_assignment()`. Output transport uses `sandbox_serialize_code()` in the generated `SUBMIT(...)` wrapper and `from_sandbox()` on the host.
+
+`SandboxSerializable` also defines a Pydantic schema hook so subclasses can be used directly in DSPy signatures, for example `data: DataFrame = dspy.InputField()` or `result: DataFrame = dspy.OutputField()`. The hook is intentionally pass-through: Pydantic accepts the object as-is and serializes it with `str(value)` for schema/metadata purposes. RLM owns the real sandbox transport.
 
 ### Async Execution
 

--- a/docs/docs/tutorials/dataframe_rlm/cohort_analysis/cohort_analysis_demo.ipynb
+++ b/docs/docs/tutorials/dataframe_rlm/cohort_analysis/cohort_analysis_demo.ipynb
@@ -1220,6 +1220,115 @@
     "print(f\"\\nRecommendations:\\n  {result.recommendations}\")\n",
     "print(f\"\\nRLM completed in {len(result.trajectory)} iterations\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Returning a DataFrame: build a retention worklist\n",
+    "\n",
+    "So far the RLM has returned **scalar outputs** \u2014 a churn rate, a channel name, prose. The `SandboxSerializable` protocol works in both directions, so the same `DataFrame` wrapper that ferried our inputs into the sandbox can also bring an agent-built DataFrame back out.\n",
+    "\n",
+    "We'll ask the RLM to turn its analysis into something operational: a CSV-shaped worklist of at-risk users that the retention team can act on. The agent writes Python in the sandbox, calls `pd.concat`/`merge`/etc. against the inputs, and passes the resulting `pd.DataFrame` straight to `SUBMIT(...)`. On the host side, we get back a real `pd.DataFrame` (wrapped) \u2014 not JSON, not a markdown table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class RetentionWorklist(dspy.Signature):\n",
+    "    \"\"\"Build a retention-team worklist of at-risk users.\n",
+    "\n",
+    "    Using the same three DataFrames, return ONE DataFrame containing the users\n",
+    "    who match the at-risk profile we identified in the previous analysis:\n",
+    "    - signed up through `paid_campaign_x`\n",
+    "    - have NOT triggered an `advanced_reports` event\n",
+    "    - currently on an active subscription (not yet churned)\n",
+    "\n",
+    "    The worklist must have columns (in this order): user_id, signup_date, country,\n",
+    "    plan, mrr, days_since_signup, note. The `note` column is a short string\n",
+    "    explaining why the user is at risk.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    users: DataFrame = dspy.InputField(desc=\"User profiles with signup_date, acquisition_channel, country\")\n",
+    "    events: DataFrame = dspy.InputField(desc=\"Feature usage events with user_id, event_type, timestamp\")\n",
+    "    subscriptions: DataFrame = dspy.InputField(desc=\"Subscription records with status, plan, mrr, cancellation_reason\")\n",
+    "\n",
+    "    worklist: DataFrame = dspy.OutputField(desc=\"At-risk active users matching the profile above\")\n",
+    "    explanation: str = dspy.OutputField(desc=\"2-3 sentence explanation of how the worklist was built\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two things to notice about the signature:\n",
+    "\n",
+    "- **`worklist: DataFrame = dspy.OutputField(...)`** \u2014 the same wrapper class that handles inputs handles outputs. Inside the sandbox, the agent constructs a bare `pd.DataFrame` and passes it directly to `SUBMIT(...)`. RLM injects `DataFrame.sandbox_serialize_code` into the SUBMIT wrapper, base64-encoding the parquet bytes before they cross the wire.\n",
+    "- **Mixed outputs work fine.** The `explanation: str` field rides the regular JSON-RPC path. Only fields annotated with a `SandboxSerializable` subclass get the wrapper treatment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "builder = dspy.RLM(\n",
+    "    RetentionWorklist,\n",
+    "    max_iterations=10,\n",
+    "    verbose=True,\n",
+    ")\n",
+    "\n",
+    "worklist_result = builder(\n",
+    "    users=wrapped_users,\n",
+    "    events=wrapped_events,\n",
+    "    subscriptions=wrapped_subscriptions,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 9. Inspect the returned DataFrame\n",
+    "\n",
+    "`worklist_result.worklist` is a real `pd.DataFrame` wrapped in our `DataFrame` SandboxSerializable. You can use it directly, save it, or hand it off to another pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wl = worklist_result.worklist.data  # unwrap to the underlying pd.DataFrame\n",
+    "\n",
+    "print(f\"At-risk users found: {len(wl):,}\")\n",
+    "print(f\"\\nExplanation:\\n  {worklist_result.explanation}\")\n",
+    "print(f\"\\nFirst 10 rows of the worklist:\")\n",
+    "wl.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Because the round-trip preserves dtypes (Parquet, not CSV), columns like `signup_date` come back as proper `datetime64` and `mrr` stays numeric \u2014 same fidelity as the inputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick sanity-check on the round-trip:\n",
+    "print(\"Schema preserved across the sandbox boundary:\")\n",
+    "print(wl.dtypes)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/docs/tutorials/dataframe_rlm/cohort_analysis/dataframe.py
+++ b/docs/docs/tutorials/dataframe_rlm/cohort_analysis/dataframe.py
@@ -64,7 +64,8 @@ class DataFrame(SandboxSerializable):
 
     # SandboxSerializable methods
 
-    def sandbox_setup(self) -> str:
+    @classmethod
+    def sandbox_setup(cls) -> str:
         return "import pandas as pd\nimport pyarrow\nimport base64\nimport io"
 
     def to_sandbox(self) -> bytes:
@@ -97,6 +98,22 @@ class DataFrame(SandboxSerializable):
 
         preview = "\n".join(lines)
         return preview[:max_chars] + "..." if len(preview) > max_chars else preview
+
+    # Sandbox -> host (output) methods
+
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        """Convert a bare pandas DataFrame at ``var_name`` to a base64 Parquet string."""
+        return f"base64.b64encode({var_name}.to_parquet(index=False)).decode('ascii')"
+
+    @classmethod
+    def from_sandbox(cls, payload: str) -> "DataFrame":
+        """Reconstruct a DataFrame on the host from a base64 Parquet string."""
+        import io
+
+        import pandas as pd
+
+        return cls(pd.read_parquet(io.BytesIO(base64.b64decode(payload))))
 
     def __repr__(self) -> str:
         return f"DataFrame({self.data.shape[0]} rows x {self.data.shape[1]} cols)"

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -100,6 +100,14 @@ def _strip_code_fences(code: str) -> str:
     return remainder[:block_end].strip()
 
 
+def _is_sandbox_serializable_type(annotation: Any) -> bool:
+    """Return True only for concrete SandboxSerializable annotation classes."""
+    try:
+        return isinstance(annotation, type) and issubclass(annotation, SandboxSerializable)
+    except TypeError:
+        return False
+
+
 @experimental
 class RLM(Module):
     """Recursive Language Model module.
@@ -350,8 +358,23 @@ class RLM(Module):
             # Complex types like Literal, Union, etc. are not included
             if annotation in SIMPLE_TYPES:
                 field_info["type"] = annotation.__name__
+            # SandboxSerializable outputs need a sandbox-side serialize expression
+            # that converts the bare value to a wire payload before SUBMIT raises
+            # FinalOutput. The expression uses `__VAR__` as a placeholder that
+            # runner.js substitutes with the parameter name.
+            if _is_sandbox_serializable_type(annotation):
+                field_info["serialize_code"] = annotation.sandbox_serialize_code("__VAR__")
             fields.append(field_info)
         return fields
+
+    def _get_serializable_output_types(self) -> list[type[SandboxSerializable]]:
+        """Return SandboxSerializable output annotation classes in signature order."""
+        output_types = []
+        for field in self.signature.output_fields.values():
+            annotation = getattr(field, "annotation", str)
+            if _is_sandbox_serializable_type(annotation):
+                output_types.append(annotation)
+        return output_types
 
     def _build_variables(self, **input_args: Any) -> list[REPLVariable]:
         """Build REPLVariable list from input arguments with field metadata."""
@@ -381,19 +404,35 @@ class RLM(Module):
     ) -> dict[str, Any]:
         """Inject SandboxSerializable values into the interpreter.
 
-        For each SandboxSerializable value in input_args, serializes it and
-        executes setup + assignment code in the interpreter. Returns the
-        remaining non-serializable args (for per-iteration use).
+        Executes shared setup for SandboxSerializable input values and
+        output annotations, then injects input values. Returns the remaining
+        non-serializable args (for per-iteration use).
         """
         repl.start()
         regular_args = {}
+        serializable_inputs: list[tuple[str, SandboxSerializable]] = []
+        setup_blocks: list[str] = []
+
+        def add_setup(setup: str) -> None:
+            setup = setup.strip()
+            if setup and setup not in setup_blocks:
+                setup_blocks.append(setup)
+
         for name, value in input_args.items():
             if not isinstance(value, SandboxSerializable):
                 regular_args[name] = value
                 continue
+            serializable_inputs.append((name, value))
+            add_setup(value.sandbox_setup())
 
+        for output_type in self._get_serializable_output_types():
+            add_setup(output_type.sandbox_setup())
+
+        if setup_blocks:
+            repl.execute("\n".join(setup_blocks))
+
+        for name, value in serializable_inputs:
             payload = value.to_sandbox()
-            setup = value.sandbox_setup()
             raw_var_name = f"_raw_{name}"
             assignment = value.sandbox_assignment(name, raw_var_name)
             code_lines = []
@@ -411,8 +450,6 @@ class RLM(Module):
             else:
                 payload_vars[raw_var_name] = str(payload)
 
-            if setup:
-                code_lines.append(setup)
             code_lines.append(assignment)
             repl.execute("\n".join(code_lines), variables=payload_vars)
 
@@ -507,12 +544,29 @@ class RLM(Module):
         for name in output_field_names:
             field = self.signature.output_fields[name]
             annotation = getattr(field, "annotation", str)
+            raw_value = raw_output[name]
+
+            # SandboxSerializable outputs arrive as a marker dict produced by
+            # the SUBMIT wrapper in runner.js. Route them through from_sandbox
+            # to reconstruct a wrapper instance on the host.
+            if _is_sandbox_serializable_type(annotation):
+                if not (isinstance(raw_value, dict) and raw_value.get("__sandbox_serializable__")):
+                    type_errors.append(
+                        f"{name}: expected SandboxSerializable payload, got {type(raw_value).__name__}"
+                    )
+                    continue
+                try:
+                    parsed_outputs[name] = annotation.from_sandbox(raw_value["data"])
+                except Exception as e:
+                    type_errors.append(f"{name}: {annotation.__name__}.from_sandbox failed: {e}")
+                continue
+
             try:
-                parsed_outputs[name] = parse_value(raw_output[name], annotation)
+                parsed_outputs[name] = parse_value(raw_value, annotation)
             except (ValueError, pydantic.ValidationError) as e:
                 type_errors.append(
                     f"{name}: expected {annotation.__name__ if hasattr(annotation, '__name__') else annotation}, "
-                    f"got {type(raw_output[name]).__name__}: {e}"
+                    f"got {type(raw_value).__name__}: {e}"
                 )
 
         if type_errors:

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -65,7 +65,16 @@ def ${toolName}(${signature}):
 };
 
 // Generate SUBMIT function with output field signature.
-// Outputs is an array of {name, type?} objects.
+// Outputs is an array of {name, type?, serialize_code?} objects.
+// `serialize_code` is a Python expression containing `__VAR__` as a
+// placeholder for the parameter name; if present, the field's value is
+// wrapped as {"__sandbox_serializable__": true, "data": <expr>} so the
+// host can route it through SandboxSerializable.from_sandbox.
+//
+// The substitution is safe: the parameter name is a Python identifier
+// validated by RLM signature construction (no shell, no eval beyond
+// pyodide.runPython on the generated text), and substitution happens
+// here in JS before the Python source is ever handed to Pyodide.
 const makeSubmitWrapper = (outputs) => {
   if (!outputs || outputs.length === 0) {
     // Fallback to single-arg SUBMIT if no outputs defined
@@ -77,10 +86,18 @@ def SUBMIT(output):
 
   const sigParts = outputs.map(o => {
     let part = o.name;
-    if (o.type) part += `: ${o.type}`;
+    // Skip type annotation for serializable fields (the agent passes a bare
+    // value of the underlying type, not the wrapper class itself).
+    if (o.type && !o.serialize_code) part += `: ${o.type}`;
     return part;
   });
-  const dictParts = outputs.map(o => `"${o.name}": ${o.name}`);
+  const dictParts = outputs.map(o => {
+    if (o.serialize_code) {
+      const expr = o.serialize_code.replace(/__VAR__/g, o.name);
+      return `"${o.name}": {"__sandbox_serializable__": True, "data": ${expr}}`;
+    }
+    return `"${o.name}": ${o.name}`;
+  });
 
   return `
 def SUBMIT(${sigParts.join(', ')}):

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -300,31 +300,38 @@ while (true) {
   }
 
   if (method === "register") {
-    const toolNames = [];
+    try {
+      const toolNames = [];
 
-    // Register tools with typed signatures
-    if (params.tools) {
-      for (const tool of params.tools) {
-        // Support both old format (string) and new format (object with parameters)
-        if (typeof tool === 'string') {
-          pyodide.runPython(makeToolWrapper(tool, []));
-          toolNames.push(tool);
-        } else {
-          pyodide.runPython(makeToolWrapper(tool.name, tool.parameters || []));
-          toolNames.push(tool.name);
+      // Register tools with typed signatures
+      if (params.tools) {
+        for (const tool of params.tools) {
+          // Support both old format (string) and new format (object with parameters)
+          if (typeof tool === 'string') {
+            pyodide.runPython(makeToolWrapper(tool, []));
+            toolNames.push(tool);
+          } else {
+            pyodide.runPython(makeToolWrapper(tool.name, tool.parameters || []));
+            toolNames.push(tool.name);
+          }
         }
       }
-    }
 
-    // Register SUBMIT with output signature
-    if (params.outputs) {
-      pyodide.runPython(makeSubmitWrapper(params.outputs));
-    }
+      // Register SUBMIT with output signature
+      if (params.outputs) {
+        pyodide.runPython(makeSubmitWrapper(params.outputs));
+      }
 
-    console.log(jsonrpcResult({
-      tools: toolNames,
-      outputs: params.outputs ? params.outputs.map(o => o.name) : []
-    }, requestId));
+      console.log(jsonrpcResult({
+        tools: toolNames,
+        outputs: params.outputs ? params.outputs.map(o => o.name) : []
+      }, requestId));
+    } catch (error) {
+      const errorType = error.type || "Error";
+      const errorCode = JSONRPC_APP_ERRORS[errorType] || JSONRPC_APP_ERRORS.Unknown;
+      const errorMessage = (error.message || String(error)).trim();
+      console.log(jsonrpcError(errorCode, errorMessage, requestId, { type: errorType }));
+    }
     continue;
   }
 

--- a/dspy/primitives/sandbox_serializable.py
+++ b/dspy/primitives/sandbox_serializable.py
@@ -1,9 +1,28 @@
 """Abstract base class for RLM sandbox-serializable types.
 
-Types that subclass :class:`SandboxSerializable` can be injected into the
-REPL environment used by :class:`dspy.RLM`. Subclasses implement four
-abstract methods describing how a value enters and appears inside the
-sandbox, and inherit:
+Types that subclass :class:`SandboxSerializable` can flow between the host
+and the REPL environment used by :class:`dspy.RLM` in **both** directions:
+
+- **As an input** (``dspy.InputField``): the host wraps a value in a subclass
+  instance, the framework serializes it via ``to_sandbox()``, ships the
+  payload into the sandbox, and reconstructs it as a native Python object
+  via ``sandbox_assignment()``. The agent's code sees the underlying value
+  bound to the field name.
+
+- **As an output** (``dspy.OutputField``): the agent's code passes the
+  underlying value to ``SUBMIT(...)``. The framework injects a wrapper
+  around ``SUBMIT`` that converts the bare value to a wire string via
+  ``sandbox_serialize_code()`` before raising ``FinalOutput``. On the host
+  side, ``from_sandbox()`` reconstructs the wrapper instance from the wire
+  payload.
+
+Subclasses implement one shared setup classmethod, three required methods
+for the host -> sandbox direction, and two optional methods for the
+sandbox -> host direction. The two output methods default to
+``NotImplementedError`` so input-only subclasses keep working — the error
+only fires when the type is actually used as an ``OutputField``
+annotation. Implement them to opt in to OutputField support. Subclasses
+also inherit:
 
 - ``__get_pydantic_core_schema__`` so the type can be used directly as a
   :class:`dspy.Signature` field annotation (see "The pydantic hook" below).
@@ -19,7 +38,7 @@ The pydantic hook
 ``__get_pydantic_core_schema__`` lets subclasses be used as
 ``dspy.Signature`` field annotations. It is a pass-through (no validation,
 ``str()`` serialization) — RLM owns real serialization via ``to_sandbox()``
-and ``sandbox_assignment()``.
+and ``sandbox_serialize_code()``.
 """
 
 from __future__ import annotations
@@ -39,18 +58,37 @@ __all__ = ["SandboxSerializable", "build_repl_variable"]
 
 
 class SandboxSerializable(ABC):
-    """Abstract base for types that support RLM sandbox injection.
+    """Abstract base for types that round-trip through the RLM sandbox.
 
-    Subclasses implement four methods:
+    Shared sandbox setup — classmethod:
 
     - ``sandbox_setup``: Python statements (usually imports) executed once
-      in the sandbox. The returned text is also surfaced to the LLM in the
-      variable description, so the model knows which names are in scope
-      (e.g. ``pd`` when pandas is imported).
-    - ``to_sandbox``: serialize the value to text bytes or binary bytes.
+      in the sandbox for both inputs and output annotations. The returned
+      text is also surfaced to the LLM in the variable description for
+      inputs, so the model knows which names are in scope (e.g. ``pd``
+      when pandas is imported).
+
+    Host -> sandbox (input) — instance methods:
+
+    - ``to_sandbox``: serialize the wrapped value to text bytes or binary
+      bytes for transport.
     - ``sandbox_assignment``: Python code that reconstructs the value from
-      a data expression.
+      a data expression on the sandbox side.
     - ``rlm_preview``: a short, LLM-friendly description of the value.
+
+    Sandbox -> host (output) — classmethods, optional:
+
+    - ``sandbox_serialize_code``: Python expression (a *string*) that, when
+      evaluated inside the sandbox, converts the bare value (bound to
+      ``var_name``) into a JSON-serializable wire payload — typically a
+      base64-encoded string. The expression runs after ``sandbox_setup()``
+      has executed, so it can use names imported by setup.
+    - ``from_sandbox``: reconstruct a wrapper instance on the host from
+      the wire payload.
+
+    Both default to raising ``NotImplementedError`` so subclasses written
+    against the input-only API keep working as ``InputField`` annotations.
+    Implement them to make a subclass usable as an ``OutputField``.
 
     Example::
 
@@ -58,9 +96,11 @@ class SandboxSerializable(ABC):
             def __init__(self, df):
                 self.data = df
 
-            def sandbox_setup(self) -> str:
-                return "import pandas as pd\\nimport base64\\nimport io"
+            @classmethod
+            def sandbox_setup(cls) -> str:
+                return "import pandas as pd\\nimport pyarrow\\nimport base64\\nimport io"
 
+            # host -> sandbox
             def to_sandbox(self) -> bytes:
                 return base64.b64encode(self.data.to_parquet(index=False))
 
@@ -70,14 +110,26 @@ class SandboxSerializable(ABC):
             def rlm_preview(self, max_chars: int = 500) -> str:
                 return f"DataFrame: {self.data.shape[0]} rows x {self.data.shape[1]} columns"
 
+            # sandbox -> host
+            @classmethod
+            def sandbox_serialize_code(cls, var_name: str) -> str:
+                return f"base64.b64encode({var_name}.to_parquet(index=False)).decode('ascii')"
+
+            @classmethod
+            def from_sandbox(cls, payload: str) -> "DataFrame":
+                import base64, io
+                import pandas as pd
+                return cls(pd.read_parquet(io.BytesIO(base64.b64decode(payload))))
+
     Subclasses can be used directly as :class:`dspy.Signature` field
     annotations because of the inherited ``__get_pydantic_core_schema__``
     hook (see the module docstring for what that hook does and why it is
     needed).
     """
 
+    @classmethod
     @abstractmethod
-    def sandbox_setup(self) -> str: ...
+    def sandbox_setup(cls) -> str: ...
 
     @abstractmethod
     def to_sandbox(self) -> bytes: ...
@@ -89,11 +141,45 @@ class SandboxSerializable(ABC):
     def rlm_preview(self, max_chars: int = 500) -> str: ...
 
     @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        """Python expression that converts a bare value at ``var_name`` to a wire payload.
+
+        Optional: implement to support use as an ``OutputField`` annotation.
+        The expression is evaluated inside the sandbox by the generated
+        SUBMIT wrapper. It must produce a JSON-serializable value
+        (typically a base64-encoded string). Shared ``sandbox_setup()`` runs
+        before the REPL loop, so the expression can use names imported by
+        setup.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} does not support OutputField usage. "
+            f"Implement sandbox_serialize_code and from_sandbox to opt in."
+        )
+
+    @classmethod
+    def from_sandbox(cls, payload: Any) -> SandboxSerializable:
+        """Reconstruct a wrapper instance on the host from the wire payload.
+
+        Optional: implement to support use as an ``OutputField`` annotation.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} does not support OutputField usage. "
+            f"Implement sandbox_serialize_code and from_sandbox to opt in."
+        )
+
+    @classmethod
     def __get_pydantic_core_schema__(cls, source_type: Any, handler: GetCoreSchemaHandler) -> core_schema.CoreSchema:
-        """Pass-through schema so subclasses work as ``dspy.Signature`` annotations."""
+        """Pass-through schema so subclasses work as ``dspy.Signature`` annotations.
+
+        ``json_schema_input_schema`` keeps JSON-schema generation happy for
+        OutputField usage (RLM materialises field schemas while building
+        action signatures) — RLM only ever needs the type *name* anyway, so
+        ``any_schema`` is the right semantic.
+        """
         return core_schema.no_info_plain_validator_function(
             lambda v: v,
             serialization=core_schema.plain_serializer_function_ser_schema(lambda v: str(v)),
+            json_schema_input_schema=core_schema.any_schema(),
         )
 
     def to_repl_variable(self, name: str, field_info: FieldInfo | None = None) -> REPLVariable:

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -1203,7 +1203,8 @@ class _StubSerializable(SandboxSerializable):
     def __init__(self, data: str = "stub_data"):
         self.data = data
 
-    def sandbox_setup(self) -> str:
+    @classmethod
+    def sandbox_setup(cls) -> str:
         return "import json"
 
     def to_sandbox(self) -> bytes:
@@ -1215,11 +1216,20 @@ class _StubSerializable(SandboxSerializable):
     def rlm_preview(self, max_chars: int = 500) -> str:
         return f"StubData({self.data})"
 
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        return f"str({var_name})"
+
+    @classmethod
+    def from_sandbox(cls, payload):
+        return cls(str(payload))
+
 
 class _BinarySerializable(SandboxSerializable):
     """Serializable that emits non-UTF8 bytes to exercise binary payload path."""
 
-    def sandbox_setup(self) -> str:
+    @classmethod
+    def sandbox_setup(cls) -> str:
         return ""
 
     def to_sandbox(self) -> bytes:
@@ -1230,6 +1240,14 @@ class _BinarySerializable(SandboxSerializable):
 
     def rlm_preview(self, max_chars: int = 500) -> str:
         return "BinaryPayload"
+
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        return f"str({var_name})"
+
+    @classmethod
+    def from_sandbox(cls, payload):
+        return cls()
 
 
 class TestBuildVariablesWithSerializable:
@@ -1278,11 +1296,14 @@ class TestPrepareSerializableVars:
         assert regular["query"] == "hello"
         assert "data" not in regular
 
-        # MockInterpreter should have received an execute call for the setup
-        assert mock.call_count == 1
-        code, variables = mock.call_history[0]
-        assert "import json" in code
-        assert "_raw_data" in variables
+        # MockInterpreter should receive setup once, then input assignment.
+        assert mock.call_count == 2
+        setup_code, setup_variables = mock.call_history[0]
+        assignment_code, assignment_variables = mock.call_history[1]
+        assert setup_code == "import json"
+        assert setup_variables == {}
+        assert "_raw_data" in assignment_variables
+        assert "data = _raw_data" in assignment_code
 
     def test_no_serializable_returns_all(self):
         """When no SandboxSerializable values exist, all args are returned."""
@@ -1322,7 +1343,8 @@ class TestPrepareSerializableVars:
         large_text = "x" * (2 * 1024 * 1024)  # 2 MB UTF-8 payload
 
         class _LargeText(SandboxSerializable):
-            def sandbox_setup(self) -> str:
+            @classmethod
+            def sandbox_setup(cls) -> str:
                 return ""
 
             def to_sandbox(self) -> bytes:
@@ -1333,6 +1355,14 @@ class TestPrepareSerializableVars:
 
             def rlm_preview(self, max_chars: int = 500) -> str:
                 return f"LargeText({len(large_text)} chars)"
+
+            @classmethod
+            def sandbox_serialize_code(cls, var_name: str) -> str:
+                return var_name
+
+            @classmethod
+            def from_sandbox(cls, payload):
+                return cls()
 
         rlm._inject_execution_context(mock, rlm._prepare_execution_tools())
         rlm._prepare_serializable_vars({"data": _LargeText(), "query": "hi"}, mock)
@@ -1348,6 +1378,7 @@ class TestPrepareSerializableVars:
         """Full forward() pass with a SandboxSerializable input."""
         mock = MockInterpreter(responses=[
             "",  # setup execution for _prepare_serializable_vars
+            "",  # input assignment execution
             FinalOutput({"answer": "done"}),
         ])
         rlm = RLM("data, query -> answer", max_iterations=3, interpreter=mock)
@@ -1359,8 +1390,176 @@ class TestPrepareSerializableVars:
         result = rlm.forward(data=stub, query="test")
         assert result.answer == "done"
 
-        # First call should be the serializable setup, second should be the iteration
+        # Setup, assignment, then iteration.
+        assert mock.call_count == 3
+
+    def test_output_annotation_setup_runs_without_serializable_input(self):
+        """Output-only SandboxSerializable annotations should set up the sandbox."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            query: str = dspy.InputField()
+            answer: _StubSerializable = dspy.OutputField()
+
+        mock = MockInterpreter(responses=[""])
+        rlm = RLM(_Sig, interpreter=mock)
+
+        rlm._inject_execution_context(mock, rlm._prepare_execution_tools())
+        regular = rlm._prepare_serializable_vars({"query": "hello"}, mock)
+
+        assert regular == {"query": "hello"}
+        assert mock.call_count == 1
+        code, variables = mock.call_history[0]
+        assert code == "import json"
+        assert variables == {}
+
+    def test_input_and_output_setup_deduplicates(self):
+        """The same setup block should only execute once across inputs and outputs."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            data: _StubSerializable = dspy.InputField()
+            answer: _StubSerializable = dspy.OutputField()
+
+        mock = MockInterpreter(responses=["", ""])
+        rlm = RLM(_Sig, interpreter=mock)
+
+        rlm._inject_execution_context(mock, rlm._prepare_execution_tools())
+        rlm._prepare_serializable_vars({"data": _StubSerializable("payload")}, mock)
+
         assert mock.call_count == 2
+        assert mock.call_history[0][0] == "import json"
+        assert "data = _raw_data" in mock.call_history[1][0]
+
+
+class TestSerializableOutputs:
+    """Tests for SandboxSerializable used as OutputField annotations."""
+
+    def test_output_fields_info_includes_serialize_code(self):
+        """SandboxSerializable output annotations should carry a serialize_code template."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            query: str = dspy.InputField()
+            answer: _StubSerializable = dspy.OutputField()
+
+        rlm = RLM(_Sig)
+        fields = rlm._get_output_fields_info()
+        answer = next(f for f in fields if f["name"] == "answer")
+        assert "serialize_code" in answer
+        assert "str(__VAR__)" in answer["serialize_code"]
+
+    def test_simple_outputs_do_not_carry_serialize_code(self):
+        """Non-SandboxSerializable outputs should not carry the serialize_code key."""
+        rlm = RLM("query -> answer")
+        fields = rlm._get_output_fields_info()
+        for f in fields:
+            assert "serialize_code" not in f
+
+    def test_generic_annotations_do_not_break_serializable_detection(self):
+        """Generic annotations like list[int] must not raise from issubclass guard."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            query: str = dspy.InputField()
+            items: list[int] = dspy.OutputField()
+            tags: dict[str, str] = dspy.OutputField()
+            answer: str = dspy.OutputField()
+
+        rlm = RLM(_Sig)
+        fields = rlm._get_output_fields_info()
+        # No serialize_code on any of these — they're plain (generic) types.
+        for f in fields:
+            assert "serialize_code" not in f
+        names = {f["name"] for f in fields}
+        assert names == {"items", "tags", "answer"}
+
+    def test_subclass_without_output_methods_raises_clear_error(self):
+        """Subclasses written under the input-only API surface a clear error when
+        accidentally used as OutputField, instead of breaking at instantiation."""
+        import dspy
+
+        class _InputOnly(SandboxSerializable):
+            @classmethod
+            def sandbox_setup(cls) -> str:
+                return ""
+
+            def to_sandbox(self) -> bytes:
+                return b""
+
+            def sandbox_assignment(self, var_name: str, data_expr: str) -> str:
+                return f"{var_name} = {data_expr}"
+
+            def rlm_preview(self, max_chars: int = 500) -> str:
+                return "input only"
+
+        # Instantiation must keep working — backward compat for input-only subclasses.
+        instance = _InputOnly()
+        assert isinstance(instance, SandboxSerializable)
+
+        # The error only fires at OutputField construction time.
+        class _Sig(dspy.Signature):
+            answer: _InputOnly = dspy.OutputField()
+
+        rlm = RLM(_Sig)
+        with pytest.raises(NotImplementedError, match="OutputField"):
+            rlm._get_output_fields_info()
+
+    def test_process_final_output_routes_serializable_through_from_sandbox(self):
+        """Marker-tagged payloads should reconstruct via cls.from_sandbox on the host."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            query: str = dspy.InputField()
+            answer: _StubSerializable = dspy.OutputField()
+
+        rlm = RLM(_Sig)
+
+        marker = {"__sandbox_serializable__": True, "data": "hello-from-sandbox"}
+        final = FinalOutput({"answer": marker})
+
+        parsed, error = rlm._process_final_output(final, ["answer"])
+
+        assert error is None
+        assert isinstance(parsed["answer"], _StubSerializable)
+        assert parsed["answer"].data == "hello-from-sandbox"
+
+    def test_process_final_output_errors_when_marker_missing(self):
+        """If the agent forgets to wrap a serializable output, surface a clear error."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            answer: _StubSerializable = dspy.OutputField()
+
+        rlm = RLM(_Sig)
+        final = FinalOutput({"answer": "raw_string_without_marker"})
+
+        parsed, error = rlm._process_final_output(final, ["answer"])
+
+        assert parsed is None
+        assert "SandboxSerializable" in error
+        assert "answer" in error
+
+    def test_process_final_output_handles_mixed_outputs(self):
+        """A signature with one SandboxSerializable + one plain output should work end-to-end."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            answer: _StubSerializable = dspy.OutputField()
+            summary: str = dspy.OutputField()
+
+        rlm = RLM(_Sig)
+        final = FinalOutput({
+            "answer": {"__sandbox_serializable__": True, "data": "x"},
+            "summary": "all good",
+        })
+
+        parsed, error = rlm._process_final_output(final, ["answer", "summary"])
+
+        assert error is None
+        assert isinstance(parsed["answer"], _StubSerializable)
+        assert parsed["answer"].data == "x"
+        assert parsed["summary"] == "all good"
 
 
 @pytest.mark.deno
@@ -1372,7 +1571,8 @@ class TestLargeSerializableRoundTrip:
         large_text = "abc123" * (200 * 1024)  # ~1.2 MB UTF-8
 
         class _LargeText(SandboxSerializable):
-            def sandbox_setup(self) -> str:
+            @classmethod
+            def sandbox_setup(cls) -> str:
                 return ""
 
             def to_sandbox(self) -> bytes:
@@ -1384,6 +1584,14 @@ class TestLargeSerializableRoundTrip:
             def rlm_preview(self, max_chars: int = 500) -> str:
                 return f"LargeText({len(large_text)} chars)"
 
+            @classmethod
+            def sandbox_serialize_code(cls, var_name: str) -> str:
+                return var_name
+
+            @classmethod
+            def from_sandbox(cls, payload):
+                return cls()
+
         with PythonInterpreter(tools={}) as interp:
             rlm = RLM("data -> answer", interpreter=interp)
             rlm._inject_execution_context(interp, rlm._prepare_execution_tools())
@@ -1392,6 +1600,159 @@ class TestLargeSerializableRoundTrip:
 
         assert str(len(large_text)) in result
         assert "abc123" in result
+
+
+class _RoundTripStr(SandboxSerializable):
+    """SandboxSerializable for str values — exercises both directions through real sandbox."""
+
+    def __init__(self, data: str = ""):
+        self.data = data
+
+    @classmethod
+    def sandbox_setup(cls) -> str:
+        return ""
+
+    def to_sandbox(self) -> bytes:
+        return self.data.encode("utf-8")
+
+    def sandbox_assignment(self, var_name: str, data_expr: str) -> str:
+        return f"{var_name} = {data_expr}"
+
+    def rlm_preview(self, max_chars: int = 500) -> str:
+        return f"RoundTrip({self.data!r})"
+
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        # Round-trip the bare str value through the sandbox unchanged.
+        return f"str({var_name})"
+
+    @classmethod
+    def from_sandbox(cls, payload):
+        return cls(str(payload))
+
+
+class _JsonRoundTrip(SandboxSerializable):
+    """Output setup probe: serialize expression relies on sandbox_setup importing json."""
+
+    def __init__(self, data=None):
+        self.data = data
+
+    @classmethod
+    def sandbox_setup(cls) -> str:
+        return "import json"
+
+    def to_sandbox(self) -> bytes:
+        import json
+        return json.dumps(self.data).encode("utf-8")
+
+    def sandbox_assignment(self, var_name: str, data_expr: str) -> str:
+        return f"{var_name} = json.loads({data_expr})"
+
+    def rlm_preview(self, max_chars: int = 500) -> str:
+        return f"JsonRoundTrip({self.data!r})"
+
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        return f"json.dumps({var_name})"
+
+    @classmethod
+    def from_sandbox(cls, payload):
+        import json
+        return cls(json.loads(payload))
+
+
+@pytest.mark.deno
+class TestSerializableOutputRoundTripThroughSandbox:
+    """End-to-end: a SandboxSerializable output flows from the agent's SUBMIT call,
+    through runner.js's serialize wrapping, across the JSON-RPC wire, and back into
+    a wrapper instance on the host via _process_final_output."""
+
+    def test_submit_wraps_serializable_output_with_marker(self):
+        import dspy
+
+        class _Sig(dspy.Signature):
+            query: str = dspy.InputField()
+            answer: _RoundTripStr = dspy.OutputField()
+
+        with PythonInterpreter(tools={}) as interp:
+            rlm = RLM(_Sig, interpreter=interp)
+            rlm._inject_execution_context(interp, rlm._prepare_execution_tools())
+            # Agent's code passes a bare str; SUBMIT wrapper should base64-tag it.
+            result = interp.execute('SUBMIT(answer="hello from sandbox")')
+
+        assert isinstance(result, FinalOutput)
+        wire = result.output
+        assert wire["answer"]["__sandbox_serializable__"] is True
+        assert wire["answer"]["data"] == "hello from sandbox"
+
+        # Host-side reconstruction must produce a wrapper instance.
+        parsed, error = rlm._process_final_output(result, ["answer"])
+        assert error is None
+        assert isinstance(parsed["answer"], _RoundTripStr)
+        assert parsed["answer"].data == "hello from sandbox"
+
+    def test_submit_with_mixed_outputs_through_sandbox(self):
+        """Mix of serializable + plain outputs survives the wire end to end."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            query: str = dspy.InputField()
+            answer: _RoundTripStr = dspy.OutputField()
+            note: str = dspy.OutputField()
+
+        with PythonInterpreter(tools={}) as interp:
+            rlm = RLM(_Sig, interpreter=interp)
+            rlm._inject_execution_context(interp, rlm._prepare_execution_tools())
+            result = interp.execute('SUBMIT(answer="payload data", note="some plain text")')
+
+        assert isinstance(result, FinalOutput)
+        parsed, error = rlm._process_final_output(result, ["answer", "note"])
+        assert error is None
+        assert isinstance(parsed["answer"], _RoundTripStr)
+        assert parsed["answer"].data == "payload data"
+        assert parsed["note"] == "some plain text"
+
+    def test_output_only_setup_runs_before_submit_serialization(self):
+        """Output annotation setup should run even without a matching serializable input."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            query: str = dspy.InputField()
+            answer: _JsonRoundTrip = dspy.OutputField()
+            count: int = dspy.OutputField()
+
+        with PythonInterpreter(tools={}) as interp:
+            rlm = RLM(_Sig, interpreter=interp)
+            rlm._inject_execution_context(interp, rlm._prepare_execution_tools())
+            regular = rlm._prepare_serializable_vars({"query": "hi"}, interp)
+            assert regular == {"query": "hi"}
+            result = interp.execute('SUBMIT(answer={"value": 7}, count=1)')
+
+        assert isinstance(result, FinalOutput)
+        parsed, error = rlm._process_final_output(result, ["answer", "count"])
+        assert error is None
+        assert isinstance(parsed["answer"], _JsonRoundTrip)
+        assert parsed["answer"].data == {"value": 7}
+        assert parsed["count"] == 1
+
+    def test_large_serializable_output_round_trips_through_sandbox(self):
+        """A large serializable output should survive SUBMIT, the wire, and host parsing."""
+        import dspy
+
+        class _Sig(dspy.Signature):
+            answer: _RoundTripStr = dspy.OutputField()
+
+        with PythonInterpreter(tools={}) as interp:
+            rlm = RLM(_Sig, interpreter=interp)
+            rlm._inject_execution_context(interp, rlm._prepare_execution_tools())
+            result = interp.execute('payload = "abc123" * (200 * 1024)\nSUBMIT(answer=payload)')
+
+        assert isinstance(result, FinalOutput)
+        parsed, error = rlm._process_final_output(result, ["answer"])
+        assert error is None
+        assert isinstance(parsed["answer"], _RoundTripStr)
+        assert len(parsed["answer"].data) == len("abc123") * 200 * 1024
+        assert parsed["answer"].data.startswith("abc123abc123")
 
 
 if __name__ == "__main__":

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -78,6 +78,19 @@ def test_submit_with_list():
         assert result.output == {"output": ["The result is", token]}
 
 
+def test_register_malformed_submit_wrapper_returns_error():
+    """Malformed output registration should return a JSON-RPC error instead of killing Deno."""
+    with PythonInterpreter(output_fields=[{"name": "answer", "serialize_code": "x = __VAR__"}]) as interpreter:
+        with pytest.raises(CodeInterpreterError, match="registering tools/outputs"):
+            interpreter.execute('SUBMIT(answer="broken")')
+
+        interpreter.output_fields = [{"name": "answer"}]
+        result = interpreter.execute('SUBMIT(answer="ok")')
+
+    assert isinstance(result, FinalOutput)
+    assert result.output == {"answer": "ok"}
+
+
 def test_enable_env_vars_flag():
     os.environ["FOO_TEST_ENV"] = "test_value"
 

--- a/tests/primitives/test_sandbox_serializable.py
+++ b/tests/primitives/test_sandbox_serializable.py
@@ -15,7 +15,8 @@ class ExampleSerializable(SandboxSerializable):
     def __init__(self, data: str = "example_data"):
         self.data = data
 
-    def sandbox_setup(self) -> str:
+    @classmethod
+    def sandbox_setup(cls) -> str:
         return "import json"
 
     def to_sandbox(self) -> bytes:
@@ -28,18 +29,29 @@ class ExampleSerializable(SandboxSerializable):
         preview = f"ExampleData: {self.data}"
         return preview[:max_chars] + "..." if len(preview) > max_chars else preview
 
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        return f"json.dumps({var_name})"
+
+    @classmethod
+    def from_sandbox(cls, payload):
+        import json
+        return cls(json.loads(payload))
+
 
 class IncompleteSerializable(SandboxSerializable):
-    """Missing the other three abstract methods — should not be instantiable."""
+    """Missing the other abstract methods — should not be instantiable."""
 
-    def sandbox_setup(self) -> str:
+    @classmethod
+    def sandbox_setup(cls) -> str:
         return ""
 
 
 class NotASubclass:
-    """Implements all four methods but does not subclass — should NOT pass isinstance."""
+    """Implements all six methods but does not subclass — should NOT pass isinstance."""
 
-    def sandbox_setup(self) -> str:
+    @classmethod
+    def sandbox_setup(cls) -> str:
         return "import json"
 
     def to_sandbox(self) -> bytes:
@@ -50,6 +62,14 @@ class NotASubclass:
 
     def rlm_preview(self, max_chars: int = 500) -> str:
         return "NotASubclass"
+
+    @classmethod
+    def sandbox_serialize_code(cls, var_name: str) -> str:
+        return var_name
+
+    @classmethod
+    def from_sandbox(cls, payload):
+        return cls()
 
 
 # -- ABC enforcement and isinstance() --
@@ -76,7 +96,7 @@ class TestCoreMethods:
     """Smoke tests that a conforming implementation behaves as expected."""
 
     def test_sandbox_setup(self):
-        assert ExampleSerializable().sandbox_setup() == "import json"
+        assert ExampleSerializable.sandbox_setup() == "import json"
 
     def test_to_sandbox_returns_bytes(self):
         payload = ExampleSerializable("hello").to_sandbox()
@@ -147,3 +167,37 @@ class TestSignatureAnnotation:
             answer: str = dspy.OutputField()
 
         assert ExampleSignature.input_fields["data"].annotation is ExampleSerializable
+
+    def test_subclass_supports_output_field_annotation(self):
+        class ExampleSignature(dspy.Signature):
+            query: str = dspy.InputField()
+            answer: ExampleSerializable = dspy.OutputField()
+
+        assert ExampleSignature.output_fields["answer"].annotation is ExampleSerializable
+
+
+class TestOutputDirection:
+    """Sandbox -> host classmethods round-trip a value through the wire format."""
+
+    def test_sandbox_serialize_code_uses_var_name(self):
+        expr = ExampleSerializable.sandbox_serialize_code("my_value")
+        assert "my_value" in expr
+        assert "json.dumps" in expr
+
+    def test_from_sandbox_reconstructs_instance(self):
+        payload = '"hello"'  # json.dumps result for the string "hello"
+        obj = ExampleSerializable.from_sandbox(payload)
+        assert isinstance(obj, ExampleSerializable)
+        assert obj.data == "hello"
+
+    def test_round_trip_serialize_then_reconstruct(self):
+        """Simulate the wire round-trip end-to-end without a real sandbox."""
+        import json
+
+        original = "round-trip"
+        # Sandbox-side: evaluate the serialize expression against the bare value.
+        expr = ExampleSerializable.sandbox_serialize_code("my_value")
+        wire_payload = eval(expr, {"json": json, "my_value": original})
+        # Host-side: reconstruct.
+        reconstructed = ExampleSerializable.from_sandbox(wire_payload)
+        assert reconstructed.data == original


### PR DESCRIPTION
## Summary

Follows up on https://github.com/stanfordnlp/dspy/pull/9411, which added `SandboxSerializable` for moving custom host objects into the RLM sandbox.

This PR completes the round trip: `SandboxSerializable` subclasses can now also be used as `OutputField` annotations.
For example, this is now possible:
```python
class CohortAnalysis(dspy.Signature):
    users: DataFrame = dspy.InputField() # Dataframe is a user-defined SandboxSerializable class
    question: str = dspy.InputField()

    cohort: DataFrame = dspy.OutputField() # <--- New!
    summary: str = dspy.OutputField()
    count: int = dspy.OutputField()
```

The model still works with the bare sandbox value, e.g. a pandas `DataFrame`, and calls `SUBMIT(cohort=..., summary=..., count=...)`. RLM handles the serializable output field by wrapping it before `FinalOutput` leaves the sandbox, then reconstructing the host-side `SandboxSerializable` instance from the returned payload. Plain outputs continue through the existing parsing path.


Agent code works with the native sandbox value, passes it to `SUBMIT(...)`, and RLM serializes it back across the sandbox boundary before reconstructing the wrapper on the host.

## Changes

- Add sandbox-to-host hooks:
  - `sandbox_serialize_code(var_name)` for converting a bare sandbox value into a wire payload.
  - `from_sandbox(payload)` for reconstructing the wrapper on the host.
- Make `sandbox_setup()` class-level shared setup, used for both input values and output annotations.
- Run setup once for the union of serializable inputs and serializable outputs before the REPL loop.
- Teach `SUBMIT(...)` generation to wrap only the serializable output fields while leaving plain outputs on the normal path.
- Update the cohort DataFrame tutorial to show returning a `DataFrame` output alongside plain fields.
- Add focused unit and Deno-backed coverage for mixed outputs, output-only setup, and setup deduping.

## Why

Before this, `SandboxSerializable` was one-way: useful for giving RLM rich objects to inspect, but not for returning rich objects it creates or transforms.

This enables workflows like passing DataFrames into the sandbox, transforming them with normal pandas code, and returning a typed DataFrame result with dtypes preserved.

## Commentary
These changes add some complexity to `runner.js` because `SUBMIT(...)` now needs to wrap only the output fields annotated with `SandboxSerializable` before raising `FinalOutput`. The implementation keeps that logic field-local: ordinary outputs continue through the existing path, while serializable outputs provide a sandbox-side expression for converting the bare value into a wire payload.

Long term, the right shape still seems to be a small bidirectional interface on `SandboxSerializable`, where a shared sandbox setup runs once per RLM session, sandbox serialization happens inside the generated `SUBMIT(...)` wrapper, and host-side reconstruction happens through `from_sandbox(...)`. This keeps `PythonInterpreter` generic, avoids special-casing `DataFrames` in core, and gives custom types one place to define how they move across the RLM boundary.

## Tests

- `uv run --extra dev pytest tests/primitives/test_sandbox_serializable.py tests/predict/test_rlm.py::TestPrepareSerializableVars tests/predict/test_rlm.py::TestSerializableOutputs -q`
- `uv run --extra dev pytest tests/predict/test_rlm.py::TestSerializableOutputRoundTripThroughSandbox tests/predict/test_rlm.py::TestLargeSerializableRoundTrip -q --deno`
