### PR TITLE
fix(evaluate): expose timeout parameter and cap straggler resubmissions per item

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -81,6 +81,7 @@ class Evaluate:
         failure_score: float = 0.0,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int = 120,
         **kwargs,
     ):
         """
@@ -97,6 +98,9 @@ class Evaluate:
             failure_score (float): The default score to use if evaluation fails due to an exception.
             save_as_csv (Optional[str]): The file name where the csv will be saved.
             save_as_json (Optional[str]): The file name where the json will be saved.
+            timeout (int): Seconds before a straggler task is resubmitted. Set to 0 to disable
+                straggler resubmission entirely. Increase this when individual LLM calls are
+                expected to take longer than the default 120 s. Defaults to 120.
 
         """
         self.devset = devset
@@ -109,6 +113,7 @@ class Evaluate:
         self.failure_score = failure_score
         self.save_as_csv = save_as_csv
         self.save_as_json = save_as_json
+        self.timeout = timeout
 
         if "return_outputs" in kwargs:
             raise ValueError("`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object.")
@@ -125,6 +130,7 @@ class Evaluate:
         callback_metadata: dict[str, Any] | None = None,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int | None = None,
     ) -> EvaluationResult:
         """
         Args:
@@ -138,6 +144,8 @@ class Evaluate:
             display_table (Union[bool, int]): Whether to display the evaluation results in a table. if not provided, use
                 `self.display_table`. If a number is passed, the evaluation results will be truncated to that number before displayed.
             callback_metadata (dict): Metadata to be used for evaluate callback handlers.
+            timeout (int): Seconds before a straggler task is resubmitted. Overrides the value set
+                in ``__init__`` for this call only. See ``Evaluate.__init__`` for details.
 
         Returns:
             The evaluation results are returned as a dspy.EvaluationResult object containing the following attributes:
@@ -153,6 +161,7 @@ class Evaluate:
         display_table = display_table if display_table is not None else self.display_table
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
+        timeout = timeout if timeout is not None else self.timeout
 
         if callback_metadata:
             logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
@@ -165,6 +174,7 @@ class Evaluate:
             max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
             provide_traceback=self.provide_traceback,
             compare_results=True,
+            timeout=timeout,
         )
 
         def process_item(example):

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -106,10 +106,11 @@ class ParallelExecutor:
         results = [None] * len(data)
         job_cancelled = "cancelled"
 
-        # We resubmit at most once per item.
+        # Track which data indices have already been resubmitted so that a
+        # resubmitted future cannot itself spawn another resubmission.
         start_time_map = {}
         start_time_lock = threading.Lock()
-        resubmitted = set()
+        resubmitted_indices: set[int] = set()
 
         # This is the worker function each thread will run.
         def worker(parent_overrides, submission_id, index, item):
@@ -203,12 +204,12 @@ class ParallelExecutor:
                     if 0 < self.timeout and len(not_done) <= self.straggler_limit:
                         now = time.time()
                         for f in list(not_done):
-                            if f not in resubmitted:
-                                sid, idx, item = futures_map[f]
+                            sid, idx, item = futures_map[f]
+                            if idx not in resubmitted_indices:
                                 with start_time_lock:
                                     st = start_time_map.get(sid, None)
                                 if st and (now - st) >= self.timeout:
-                                    resubmitted.add(f)
+                                    resubmitted_indices.add(idx)
                                     nf = executor.submit(
                                         worker,
                                         parent_overrides,

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -423,3 +423,42 @@ def test_evaluate_save_as_csv_with_history():
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
 
+
+def test_evaluate_timeout_default():
+    """Evaluate stores the timeout=120 default and passes it to ParallelExecutor."""
+    devset = [new_example("What is 1+1?", "2")]
+    ev = Evaluate(devset=devset, metric=answer_exact_match)
+    assert ev.timeout == 120
+
+
+def test_evaluate_timeout_custom():
+    """A custom timeout is stored and forwarded to the executor."""
+    dspy.configure(lm=DummyLM({"What is 1+1?": {"answer": "2"}}))
+    devset = [new_example("What is 1+1?", "2")]
+    program = Predict("question -> answer")
+
+    captured = {}
+
+    original_init = __import__("dspy.utils.parallelizer", fromlist=["ParallelExecutor"]).ParallelExecutor.__init__
+
+    def tracking_init(self, *args, **kwargs):
+        captured["timeout"] = kwargs.get("timeout")
+        original_init(self, *args, **kwargs)
+
+    with patch("dspy.evaluate.evaluate.ParallelExecutor.__init__", tracking_init):
+        ev = Evaluate(devset=devset, metric=answer_exact_match, timeout=300)
+        ev(program)
+
+    assert captured["timeout"] == 300
+
+
+def test_evaluate_timeout_zero_disables_straggler():
+    """Setting timeout=0 disables straggler resubmission; evaluation still completes."""
+    dspy.configure(lm=DummyLM({"What is 1+1?": {"answer": "2"}, "What is 2+2?": {"answer": "4"}}))
+    devset = [new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")]
+    program = Predict("question -> answer")
+
+    ev = Evaluate(devset=devset, metric=answer_exact_match, display_progress=False, timeout=0)
+    result = ev(program)
+    assert result.score == 100.0
+

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -166,3 +166,44 @@ def test_sequential_compare_results():
     results = executor.execute(task, data)
 
     assert results == [(1, False), (2, False), (3, True), (4, True), (5, True)]
+
+
+def test_straggler_resubmitted_at_most_once_per_index():
+    """A straggler task must be resubmitted at most once, even if the resubmission itself
+    also exceeds the timeout.  Tracking by index (not by future) prevents an
+    unbounded resubmission chain that would otherwise grow until executor shutdown."""
+    call_counts: dict[int, int] = {}
+    lock = threading.Lock()
+    stall_item = 99
+
+    def task(item):
+        with lock:
+            call_counts[item] = call_counts.get(item, 0) + 1
+        if item == stall_item:
+            # Sleep longer than the straggler timeout so every submission of
+            # this item looks like a straggler from the monitor's perspective.
+            time.sleep(10)
+        return item
+
+    # Use a short timeout so the test completes quickly; straggler_limit=1 so
+    # stragglers are checked when only this one item is still pending.
+    executor = ParallelExecutor(
+        num_threads=4,
+        timeout=0.05,
+        straggler_limit=1,
+        max_errors=1,
+        disable_progress_bar=True,
+    )
+
+    try:
+        executor.execute(task, [1, 2, 3, stall_item])
+    except Exception:
+        pass  # cancellation due to max_errors is expected
+
+    with lock:
+        stall_runs = call_counts.get(stall_item, 0)
+
+    # The stalling item should be submitted exactly twice: the original run
+    # and one resubmission.  Without the fix it would be submitted N times
+    # (once every timeout interval until the executor shuts down).
+    assert stall_runs <= 2, f"Expected at most 2 runs for stall item, got {stall_runs}"


### PR DESCRIPTION
## Summary

Fixes #9574

Two related bugs caused `cannot schedule new futures after shutdown` errors and
evaluation hangs on long-running LLM calls.

### Bug 1 — `dspy.Evaluate` hardcodes the 120-second straggler timeout

`ParallelExecutor` accepts a `timeout` parameter that controls when a straggler
task is resubmitted, but `Evaluate` never passed it through.  Every evaluation
ran with the hardcoded 120-second default, giving users no way to:

- **increase** the threshold for slow models (large context, low-throughput endpoints, Bedrock cross-region profiles), or
- **disable** straggler resubmission entirely by setting `timeout=0`.

### Bug 2 — resubmitted stragglers can themselves be resubmitted (unbounded chain)

`ParallelExecutor._execute_parallel` tracked already-resubmitted tasks by
**future object**, not by **data index**.  When the resubmitted future also
exceeded the straggler timeout, it was treated as a fresh straggler and
resubmitted again, spawning another future.  This chain repeated on every
timeout interval until the executor was shut down, at which point any in-flight
`executor.submit()` call raised:

```
RuntimeError: cannot schedule new futures after shutdown
```

## Changes

| File | Change |
|---|---|
| `dspy/evaluate/evaluate.py` | Add `timeout: int = 120` to `__init__` and `__call__`; forward to `ParallelExecutor` |
| `dspy/utils/parallelizer.py` | Track resubmitted items by **data index** (not future) so each item is resubmitted at most once |
| `tests/evaluate/test_evaluate.py` | 3 new tests: default timeout stored, custom timeout forwarded, `timeout=0` disables resubmission |
| `tests/utils/test_parallelizer.py` | 1 new test: stalling task is resubmitted at most once, not in an unbounded chain |

## How to reproduce the bugs (before this fix)

```python
import dspy

# Bug 1: no way to raise the straggler threshold
# Evaluate does not accept a timeout keyword
ev = dspy.Evaluate(devset=devset, metric=metric, timeout=300)

# Bug 2: with a slow LM and enough time the executor can be overwhelmed
# by an ever-growing chain of straggler resubmissions, eventually raising
# RuntimeError: cannot schedule new futures after shutdown
```

## How to verify the fix

```python
import dspy

# Raise the threshold to 10 minutes for slow LLMs
ev = dspy.Evaluate(devset=devset, metric=metric, timeout=600)

# Disable straggler resubmission entirely
ev = dspy.Evaluate(devset=devset, metric=metric, timeout=0)

# Override per-call
result = ev(program, timeout=600)
```

All existing tests pass unchanged.  New tests cover both fixes without requiring
slow real-model calls.

Fixes #9574