### PR TITLE
fix(cache): preserve usage payload on disk-cache hits

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -148,9 +148,13 @@ class Cache:
 
     def _prepare_cached_response(self, response):
         response = copy.deepcopy(response)
-        if hasattr(response, "usage"):
-            # Clear the usage data when cache is hit, because no LM call is made
-            response.usage = {}
+        # Mark the response so downstream consumers can tell it came from the cache.
+        # The usage payload from the original response is preserved so that
+        # `lm.history[-1].usage` reports the same numbers on cache hits as on
+        # cache misses (see issue #7570). The aggregate usage tracker in
+        # `dspy.clients.lm` already skips cache hits via `cache_hit`, so this
+        # does not double-count tokens against `dspy.track_usage`.
+        if hasattr(response, "cache_hit") or hasattr(response, "usage"):
             response.cache_hit = True
         return response
 

--- a/tests/clients/test_cache.py
+++ b/tests/clients/test_cache.py
@@ -147,7 +147,10 @@ def test_put_and_get(cache):
     result = cache.get(request)
 
     assert result.message == value.message
-    assert result.usage == {}
+    # Usage payload is preserved on cache hits so `lm.history[-1].usage`
+    # matches the original response (see issue #7570).
+    assert result.usage == {"prompt_tokens": 10, "completion_tokens": 20}
+    assert result.cache_hit is True
 
     # Test with disk cache
     # First, clear memory cache to ensure we're using disk cache
@@ -156,7 +159,8 @@ def test_put_and_get(cache):
     # Get from disk cache
     result_from_disk = cache.get(request)
     assert result_from_disk.message == value.message
-    assert result_from_disk.usage == {}
+    assert result_from_disk.usage == {"prompt_tokens": 10, "completion_tokens": 20}
+    assert result_from_disk.cache_hit is True
 
     # Verify it was also added back to memory cache
     assert cache.cache_key(request) in cache.memory_cache

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -100,6 +100,70 @@ def test_dspy_cache(litellm_test_server, tmp_path):
     dspy.cache = original_cache
 
 
+def test_history_usage_preserved_on_cache_hit(monkeypatch, tmp_path):
+    """Regression test for #7570: `lm.history[-1].usage` was empty on cache hits.
+
+    The disk cache previously cleared the usage payload when serving a cached
+    response, so any code that read `lm.history[-1].usage` (e.g. token-cost
+    accounting) only worked on the very first call. After this fix, the cached
+    response carries the original usage forward while still being flagged with
+    `cache_hit=True` so the aggregate usage tracker can avoid double counting.
+    """
+
+    call_count = {"n": 0}
+
+    def fake_completion(*, cache, num_retries, retry_strategy, **request):
+        call_count["n"] += 1
+        return ModelResponse(
+            choices=[Choices(message=Message(role="assistant", content="Hi!"))],
+            usage={"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+            model="openai/dspy-test-model",
+        )
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+
+    original_cache = dspy.cache
+    dspy.clients.configure_cache(
+        enable_disk_cache=True,
+        enable_memory_cache=True,
+        disk_cache_dir=tmp_path / ".disk_cache",
+    )
+
+    try:
+        lm = dspy.LM(model="openai/dspy-test-model", model_type="chat")
+
+        lm(messages=[{"role": "user", "content": "Query"}])
+        first_usage = lm.history[-1]["usage"]
+        # The exact shape can include litellm-normalised fields (e.g. *_details: None),
+        # so just assert the core counts and that the dict is non-empty.
+        assert first_usage
+        assert first_usage.get("prompt_tokens") == 5
+        assert first_usage.get("completion_tokens") == 7
+        assert first_usage.get("total_tokens") == 12
+
+        # Second call should hit the memory cache.
+        lm(messages=[{"role": "user", "content": "Query"}])
+        second_usage = lm.history[-1]["usage"]
+        assert second_usage == first_usage
+        assert call_count["n"] == 1
+
+        # Clear memory cache and force a disk-cache hit.
+        dspy.cache.reset_memory_cache()
+        lm(messages=[{"role": "user", "content": "Query"}])
+        third_usage = lm.history[-1]["usage"]
+        assert third_usage == first_usage
+        assert call_count["n"] == 1
+
+        # Aggregate usage tracker should still skip cache hits to avoid double-counting.
+        with track_usage() as usage_tracker:
+            lm(messages=[{"role": "user", "content": "Query"}])
+        assert len(usage_tracker.usage_data) == 0
+        # History still reports the per-call usage even when the tracker skipped it.
+        assert lm.history[-1]["usage"] == first_usage
+    finally:
+        dspy.cache = original_cache
+
+
 def test_disabled_cache_skips_cache_key(monkeypatch):
     original_cache = dspy.cache
     dspy.configure_cache(enable_disk_cache=False, enable_memory_cache=False)


### PR DESCRIPTION
Closes #7570.

When a response was served from the disk or memory cache, `lm.history[-1].usage` came back empty because the cache layer cleared the original usage payload on cache hits. The documented workaround was to disable caching entirely with `dspy.configure_cache(enable_disk_cache=False, enable_memory_cache=False)`, which defeats the point of having a cache.

This change keeps the original usage on the cached response while still setting `cache_hit=True` on it, so per-call history entries report identical numbers regardless of whether the call hit or missed the cache. Aggregate usage tracking via `dspy.track_usage()` is unaffected because `dspy/clients/lm.py` already gates the tracker on `cache_hit` to avoid double counting.

Existing on-disk cache entries that lack a usage attribute continue to work, since the new path is guarded by `hasattr(response, "usage")` and reads through normal attribute access.

Builds on the recently merged usage normalization work in #9718 and #9786.

Added a regression test that exercises the memory-cache hit, the disk-cache hit, and the `track_usage` interaction to lock in the fix.