### PR TITLE
fix(teleprompt): avoid kwarg collision in bootstrap demo when output field name overlaps inputs

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -223,7 +223,22 @@ class BootstrapFewShot(Teleprompter):
         if success:
             for step in trace:
                 predictor, inputs, outputs = step
-                demo = dspy.Example(augmented=True, **inputs, **outputs)
+                # Merge inputs and outputs explicitly so a key that appears in
+                # both (e.g. an output field also marked as an input via
+                # `with_inputs`) does not raise the cryptic
+                # "got multiple values for keyword argument" TypeError when
+                # constructing the demo. Predictions take precedence over the
+                # input echo since the demo records what the model produced.
+                demo_fields = {**inputs, **dict(outputs)}
+                shared = set(inputs).intersection(dict(outputs))
+                if shared:
+                    logger.debug(
+                        "Bootstrap demo had fields appearing in both inputs and outputs (%s); "
+                        "using predicted values. This usually means a field is marked as both an "
+                        "input via `with_inputs(...)` and as an `OutputField` in the signature.",
+                        sorted(shared),
+                    )
+                demo = dspy.Example(augmented=True, **demo_fields)
 
                 try:
                     predictor_name = self.predictor2name[id(predictor)]

--- a/dspy/teleprompt/simba_utils.py
+++ b/dspy/teleprompt/simba_utils.py
@@ -90,7 +90,22 @@ def append_a_demo(demo_input_field_maxlen):
                 if demo_input_field_maxlen and len(str(v)) > demo_input_field_maxlen:
                     _inputs[k] = f"{str(v)[:demo_input_field_maxlen]}\n\t\t... <TRUNCATED FOR BREVITY>"
 
-            demo = dspy.Example(augmented=True, **_inputs, **_outputs)
+            # Merge inputs and outputs explicitly so a key that appears in
+            # both (e.g. an output field also marked as an input via
+            # `with_inputs`) does not raise the cryptic
+            # "got multiple values for keyword argument" TypeError when
+            # constructing the demo. Predictions take precedence over the
+            # input echo since the demo records what the model produced.
+            demo_fields = {**_inputs, **dict(_outputs)}
+            shared = set(_inputs).intersection(dict(_outputs))
+            if shared:
+                logger.debug(
+                    "Bootstrap demo had fields appearing in both inputs and outputs (%s); "
+                    "using predicted values. This usually means a field is marked as both an "
+                    "input via `with_inputs(...)` and as an `OutputField` in the signature.",
+                    sorted(shared),
+                )
+            demo = dspy.Example(augmented=True, **demo_fields)
             name = predictor2name[id(predictor)]
             name2demo[name] = demo  # keep the last demo for each predictor
         for name, demo in name2demo.items():

--- a/tests/teleprompt/test_bootstrap.py
+++ b/tests/teleprompt/test_bootstrap.py
@@ -112,6 +112,60 @@ def test_error_handling_during_bootstrap():
         bootstrap.compile(student, teacher=teacher, trainset=trainset)
 
 
+def test_bootstrap_handles_output_field_listed_as_input():
+    """Regression test for issue #9472.
+
+    If a column on the training Example is both an output field on the signature
+    and is included in `with_inputs(...)`, the bootstrap trace ends up with the
+    same key in both `inputs` and `outputs`. The old implementation unpacked
+    them as `dspy.Example(augmented=True, **inputs, **outputs)`, which raised
+    the cryptic `got multiple values for keyword argument` TypeError. Bootstrap
+    should now merge the two and let the predicted value win.
+    """
+
+    class TurnClassifier(dspy.Signature):
+        """Classify a turn."""
+
+        context: str = dspy.InputField()
+        turn: str = dspy.InputField()
+        category: str = dspy.OutputField()
+
+    class TurnModule(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predictor = Predict(TurnClassifier)
+
+        def forward(self, **kwargs):
+            return self.predictor(**kwargs)
+
+        def __deepcopy__(self, memo):
+            new = TurnModule()
+            new.predictor = self.predictor.deepcopy()
+            return new
+
+    # The user marks `category` (an output field) as an input via with_inputs.
+    collision_trainset = [
+        Example(context="ctx1", turn="t1", category="Humour").with_inputs("context", "turn", "category"),
+    ]
+
+    lm = DummyLM([{"category": "Humour"}] * 4)
+    dspy.configure(lm=lm)
+
+    def category_metric(example, prediction, trace=None):
+        return prediction.category == example.category
+
+    bootstrap = BootstrapFewShot(metric=category_metric, max_bootstrapped_demos=1, max_labeled_demos=0)
+    compiled = bootstrap.compile(TurnModule(), teacher=TurnModule(), trainset=collision_trainset)
+
+    assert len(compiled.predictor.demos) == 1
+    demo = compiled.predictor.demos[0]
+    # The predicted value wins over the echoed input.
+    assert demo.category == "Humour"
+    assert demo.context == "ctx1"
+    assert demo.turn == "t1"
+    assert demo.augmented is True
+
+
 def test_validation_set_usage():
     """
     Test to ensure the validation set is correctly used during bootstrapping


### PR DESCRIPTION
Closes #9472.

When a training Example carries a column whose name overlaps with an output field on the signature, for example when `category` is both an `OutputField` and is listed in `with_inputs("context", "turn", "category")`, the bootstrap trace ends up with the same key in the recorded inputs and in the predicted outputs. The old code built the demo as `dspy.Example(augmented=True, **inputs, **outputs)`, which Python rejects with the cryptic `got multiple values for keyword argument 'category'` TypeError before `Example.__init__` ever runs. That made `MIPROv2.compile` fail in a way that did not point to the actual signature mistake.

The fix merges the recorded inputs and outputs into a single dict before constructing the demo, in both `BootstrapFewShot._bootstrap_one_example` and the SIMBA `append_a_demo` helper that share the same pattern. Predicted values win over the input echo, since the demo records what the model actually produced for that step. When an overlap is detected, a debug log message names the conflicting field so users can fix their signature or their `with_inputs` call.

I added a regression test in `tests/teleprompt/test_bootstrap.py` that constructs the exact scenario from the issue: a signature with `context`, `turn`, and a `category` output field, where the example is built with `.with_inputs("context", "turn", "category")`. On main the test reproduces the original TypeError, and with the fix it builds a single demo whose `category` is the predicted value. `pytest tests/teleprompt tests/primitives` passes (134 passed, 48 skipped) and the broader suite excluding `tests/reliability` and `tests/clients` (an unrelated pre-existing failure on main about responses-API tool-call dict ordering) passes 804 tests.