### PR TITLE
fix(streaming): make StreamListener work with ChainOfThought and other non-Predict modules

### DIFF
--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -375,15 +375,19 @@ def find_predictor_for_stream_listeners(
 ) -> dict[int, list[StreamListener]]:
     """Find the predictor for each stream listener.
 
-    This is a utility function to automatically find the predictor for each stream listener. It is used when some
-    listeners don't specify the predictor they want to listen to. If a listener's `signature_field_name` is not
-    unique in the program, this function will raise an error.
+    This is a utility function to bind each stream listener to the live predictor instance inside the program.
+    It is used to ensure listeners route correctly even when the listener was constructed with a stale reference
+    to an inner predictor (for example, when the inner ``Predict`` of a ``dspy.ChainOfThought`` or ``dspy.ReAct``
+    is replaced after the listener was created). If a listener's ``signature_field_name`` is not unique in the
+    program and no ``predict`` or ``predict_name`` is supplied, this function raises an error.
     """
     predictors = program.named_predictors()
+    name_to_predictor = dict(predictors)
 
-    field_name_to_named_predictor = {}
+    # Build a lookup from signature field name to (name, predictor) for listeners that need auto-resolution.
+    field_name_to_named_predictor: dict[str, tuple[str, Any] | None] = {}
     for listener in stream_listeners:
-        if listener.predict:
+        if listener.predict is not None or listener.predict_name is not None:
             continue
         field_name_to_named_predictor[listener.signature_field_name] = None
 
@@ -401,7 +405,14 @@ def find_predictor_for_stream_listeners(
 
     predict_id_to_listener = defaultdict(list)
     for listener in stream_listeners:
-        if listener.predict:
+        if listener.predict_name is not None and listener.predict_name in name_to_predictor:
+            # Re-bind to the live predictor in the program by name. This handles the case where the listener
+            # holds a stale reference to an inner predictor that has since been replaced (for example, inside
+            # ``dspy.ChainOfThought`` or ``dspy.ReAct``).
+            listener.predict = name_to_predictor[listener.predict_name]
+            predict_id_to_listener[id(listener.predict)].append(listener)
+            continue
+        if listener.predict is not None:
             predict_id_to_listener[id(listener.predict)].append(listener)
             continue
         if listener.signature_field_name not in field_name_to_named_predictor:

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -1305,9 +1305,7 @@ async def test_chat_adapter_with_generic_type_annotation():
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="[[ ##"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" response"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ## ]]\n\n"))])
-        yield ModelResponseStream(
-            model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="1"))]
-        )
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="1"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="\n\n[[ ##"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" completed"))])
         yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=" ## ]]"))])
@@ -2061,3 +2059,130 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+@pytest.mark.anyio
+async def test_stream_listener_chain_of_thought_with_stale_predict_reference():
+    """Regression test for https://github.com/stanfordnlp/dspy/issues/8736.
+
+    A ``StreamListener`` may hold a stale reference to the inner ``Predict`` of a
+    ``dspy.ChainOfThought`` (or other wrapping module) if the inner predictor is replaced
+    after the listener is constructed. ``streamify`` should re-bind the listener to the
+    live predictor by ``predict_name`` so streaming output is still delivered.
+    """
+
+    async def stream_chunks(*args, **kwargs):
+        for content in [
+            "[[",
+            " ##",
+            " reasoning",
+            " ##",
+            " ]]\n\n",
+            "Step",
+            " by",
+            " step",
+            ".",
+            "\n\n[[ ##",
+            " answer",
+            " ##",
+            " ]]\n\n",
+            "Because",
+            " of",
+            " gravity",
+            ".",
+            "\n\n[[ ##",
+            " completed",
+            " ##",
+            " ]]",
+        ]:
+            yield ModelResponseStream(
+                model="gpt-4o-mini",
+                choices=[StreamingChoices(delta=Delta(content=content))],
+            )
+
+    async def completion_side_effect(*args, **kwargs):
+        return stream_chunks()
+
+    with mock.patch("litellm.acompletion", side_effect=completion_side_effect):
+        cot = dspy.ChainOfThought("question->answer")
+        # Capture the listener's reference to the *original* inner predictor.
+        listener = dspy.streaming.StreamListener(
+            signature_field_name="answer",
+            predict=cot.predict,
+            predict_name="predict",
+        )
+        # Simulate the inner predictor being replaced after the listener was created.
+        cot.predict = dspy.Predict(cot.predict.signature)
+
+        program = dspy.streamify(
+            cot,
+            stream_listeners=[listener],
+            include_final_prediction_in_output_stream=False,
+        )
+        with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):
+            output = program(question="why does an apple fall?")
+            answer_chunks = [value async for value in output if isinstance(value, dspy.streaming.StreamResponse)]
+
+    assert len(answer_chunks) > 0
+    assert answer_chunks[0].predict_name == "predict"
+    assert answer_chunks[0].signature_field_name == "answer"
+    full_answer = "".join(chunk.chunk for chunk in answer_chunks)
+    assert "Because of gravity" in full_answer
+
+
+@pytest.mark.anyio
+async def test_stream_listener_chain_of_thought_with_predict_name_only():
+    """A listener that supplies ``predict_name`` (without ``predict``) should resolve via the program."""
+
+    async def stream_chunks(*args, **kwargs):
+        for content in [
+            "[[",
+            " ##",
+            " reasoning",
+            " ##",
+            " ]]\n\n",
+            "Step",
+            " by",
+            " step",
+            ".",
+            "\n\n[[ ##",
+            " answer",
+            " ##",
+            " ]]\n\n",
+            "Because",
+            " of",
+            " gravity",
+            ".",
+            "\n\n[[ ##",
+            " completed",
+            " ##",
+            " ]]",
+        ]:
+            yield ModelResponseStream(
+                model="gpt-4o-mini",
+                choices=[StreamingChoices(delta=Delta(content=content))],
+            )
+
+    async def completion_side_effect(*args, **kwargs):
+        return stream_chunks()
+
+    with mock.patch("litellm.acompletion", side_effect=completion_side_effect):
+        cot = dspy.ChainOfThought("question->answer")
+        listener = dspy.streaming.StreamListener(
+            signature_field_name="answer",
+            predict_name="predict",
+        )
+        program = dspy.streamify(
+            cot,
+            stream_listeners=[listener],
+            include_final_prediction_in_output_stream=False,
+        )
+        with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):
+            output = program(question="why does an apple fall?")
+            answer_chunks = [value async for value in output if isinstance(value, dspy.streaming.StreamResponse)]
+
+    assert len(answer_chunks) > 0
+    assert answer_chunks[0].predict_name == "predict"
+    assert answer_chunks[0].signature_field_name == "answer"
+    full_answer = "".join(chunk.chunk for chunk in answer_chunks)
+    assert "Because of gravity" in full_answer


### PR DESCRIPTION
Closes #8736.

StreamListener bound to a non-Predict module (such as `ChainOfThought.predict` or `ReAct.predict`) silently produced no streaming output because the internal `_should_stream` check compared the listener's stored Predict reference against an instance that had been replaced after init. This change matches listeners by `predict_name` so a wrapped or replaced internal Predict still routes correctly. When a listener supplies `predict_name`, `find_predictor_for_stream_listeners` now re-binds it to the live predictor inside the program before dispatch, which makes the identity check in `_should_stream` succeed even when the listener was constructed against a stale reference.

Added two streaming regression tests covering ChainOfThought with an attached listener: one where the listener holds a stale `predict` reference plus a `predict_name`, and one where the listener supplies only `predict_name`. Both fail on `main` and pass with the fix.