### PR TITLE
docs(models): document Azure Fabric usage with dspy.LM

### DIFF
--- a/docs/docs/learn/programming/language_models.md
+++ b/docs/docs/learn/programming/language_models.md
@@ -88,6 +88,47 @@ dspy.configure(lm=lm)
         dspy.configure(lm=lm)
         ```
 
+    === "Microsoft Fabric"
+        Microsoft Fabric notebooks expose Azure OpenAI through prebuilt AI services. The notebook environment does not surface a static API key or endpoint, so the standard `AZURE_API_KEY` / `AZURE_API_BASE` pattern does not apply. Instead, DSPy points at the Fabric workload endpoint and authenticates with a short lived bearer token resolved from the runtime.
+
+        The recommended pattern uses an `azure_ad_token_provider` so the token refreshes automatically on long running optimization runs. The provider is forwarded to LiteLLM and used by the underlying Azure OpenAI client.
+
+        ```python linenums="1"
+        import dspy
+        from synapse.ml.fabric.service_discovery import get_fabric_env_config
+        from synapse.ml.fabric.token_utils import TokenUtils
+
+        fabric_env_config = get_fabric_env_config().fabric_env_config
+        api_base = f"{fabric_env_config.ml_workload_endpoint}cognitive/openai"
+
+        def fabric_token_provider() -> str:
+            # `get_openai_auth_header` returns "Bearer <token>"; LiteLLM expects the
+            # raw token, so strip the prefix before handing it back.
+            return TokenUtils().get_openai_auth_header().split(" ", 1)[-1]
+
+        lm = dspy.LM(
+            "azure/gpt-4.1",  # the deployment name exposed by Fabric
+            api_base=api_base,
+            api_version="2024-02-15-preview",
+            azure_ad_token_provider=fabric_token_provider,
+        )
+        dspy.configure(lm=lm)
+        ```
+
+        For a one shot call where token refresh is not a concern, pass a static token via `azure_ad_token` instead:
+
+        ```python linenums="1"
+        token = TokenUtils().get_openai_auth_header().split(" ", 1)[-1]
+        lm = dspy.LM(
+            "azure/gpt-4.1",
+            api_base=api_base,
+            api_version="2024-02-15-preview",
+            azure_ad_token=token,
+        )
+        ```
+
+        Replace `gpt-4.1` with the Fabric deployment you want to call. The list of prebuilt models is documented under [Foundry Tools in Fabric](https://learn.microsoft.com/en-us/fabric/data-science/ai-services/ai-services-overview). If you are using Bring Your Own Key against an Azure OpenAI resource you provisioned yourself, follow the standard [Azure OpenAI instructions](https://docs.litellm.ai/docs/providers/azure) with `AZURE_API_KEY`, `AZURE_API_BASE`, and `AZURE_API_VERSION`.
+
     === "Local LMs on a GPU server"
           First, install [SGLang](https://sgl-project.github.io/start/install.html) and launch its server with your LM.
 


### PR DESCRIPTION
Closes #9043.

DSPy already supports Azure Fabric models through the LiteLLM passthrough in `dspy.LM`, but the docs do not show users how to wire that up. The Fabric notebook environment hides the static API key and endpoint, so the standard `AZURE_API_KEY` / `AZURE_API_BASE` instructions in the existing Azure section are unusable there.

This adds a Microsoft Fabric tab under the Language Models guide with a runnable example that resolves the workload endpoint via `synapse.ml.fabric`, passes the Fabric bearer token through `azure_ad_token_provider` for automatic refresh on long optimization runs, and offers a static `azure_ad_token` form for one shot calls. Bring Your Own Key users are pointed back at the existing Azure OpenAI flow.

The original feature request from @mindful-time stalled five months ago, and @TomeHirata noted that LiteLLM is the supported path, so documentation is the right shape for this issue.

No code changes; documentation only.