### PR TITLE
feat(signatures): per-field max_tokens budget on OutputField

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -198,9 +198,49 @@ class Adapter:
             if output_logprobs:
                 value["logprobs"] = output_logprobs
 
+            self._enforce_per_field_max_tokens(original_signature, value)
+
             values.append(value)
 
         return values
+
+    def _enforce_per_field_max_tokens(self, signature: type[Signature], value: dict[str, Any]) -> None:
+        """Apply per-field `max_tokens` budgets after parsing.
+
+        For string-typed output fields, the parsed value is truncated to the configured
+        whitespace-token budget. For non-string fields, exceeding the budget raises
+        `AdapterParseError` rather than risk silently corrupting structured output.
+        """
+        for name, field in signature.output_fields.items():
+            extra = getattr(field, "json_schema_extra", None) or {}
+            max_tokens = extra.get("max_tokens")
+            if not max_tokens:
+                continue
+            parsed = value.get(name)
+            if parsed is None:
+                continue
+            if isinstance(parsed, str):
+                tokens = parsed.split()
+                if len(tokens) > max_tokens:
+                    value[name] = " ".join(tokens[:max_tokens])
+                continue
+            # Non-string fields: refuse to truncate to avoid corrupting structured data.
+            token_count = self._approximate_token_count(parsed)
+            if token_count > max_tokens:
+                raise AdapterParseError(
+                    adapter_name=type(self).__name__,
+                    signature=signature,
+                    lm_response=str(parsed),
+                    message=(
+                        f"Output field '{name}' exceeded its max_tokens budget of "
+                        f"{max_tokens} (got approximately {token_count} tokens) and "
+                        "cannot be safely truncated because it is not a string."
+                    ),
+                )
+
+    @staticmethod
+    def _approximate_token_count(value: Any) -> int:
+        return len(str(value).split())
 
     def _render_request(
         self,

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -234,6 +234,11 @@ def get_field_description_string(fields: dict) -> str:
             if len(custom_type.description()) > 0:
                 desc += f"\n    Type description of {get_annotation_name(custom_type)}: {custom_type.description()}"
 
+        max_tokens = v.json_schema_extra.get("max_tokens") if v.json_schema_extra else None
+        if max_tokens:
+            suffix = f" (at most {max_tokens} tokens)"
+            desc = f"{desc}{suffix}" if desc else suffix.lstrip()
+
         field_message += f": {desc}"
         field_message += (
             f"\nConstraints: {v.json_schema_extra['constraints']}" if v.json_schema_extra.get("constraints") else ""

--- a/dspy/signatures/field.py
+++ b/dspy/signatures/field.py
@@ -7,7 +7,15 @@ from dspy.utils.constants import IS_TYPE_UNDEFINED
 # The following arguments can be used in DSPy InputField and OutputField in addition
 # to the standard pydantic.Field arguments. We just hope pydanitc doesn't add these,
 # as it would give a name clash.
-DSPY_FIELD_ARG_NAMES = ["desc", "prefix", "format", "parser", "__dspy_field_type", IS_TYPE_UNDEFINED]
+DSPY_FIELD_ARG_NAMES = [
+    "desc",
+    "prefix",
+    "format",
+    "parser",
+    "max_tokens",
+    "__dspy_field_type",
+    IS_TYPE_UNDEFINED,
+]
 
 _DEPRECATED_FIELD_ARGS = {
     "prefix": (
@@ -76,14 +84,34 @@ def _warn_deprecated_field_args(**kwargs):
             warnings.warn(message, DeprecationWarning, stacklevel=3)
 
 
-def InputField(**kwargs): # noqa: N802
+def InputField(**kwargs):  # noqa: N802
     _warn_deprecated_field_args(**kwargs)
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="input"))
 
 
-def OutputField(**kwargs): # noqa: N802
+def OutputField(**kwargs):  # noqa: N802
+    """Declare an output field on a `dspy.Signature`.
+
+    Args:
+        desc: Human-readable description of the field.
+        max_tokens: Optional per-field token budget. The adapter will surface this as a
+            hint in the prompt and truncate string-typed fields to this many tokens after
+            parsing. The truncation is heuristic (whitespace token split). For non-string
+            fields, exceeding the budget raises an `AdapterParseError` rather than risk
+            silently corrupting structured output like mid-JSON. This is independent of
+            the LM's global `max_tokens` setting and applies per output field.
+        **kwargs: Standard `pydantic.Field` kwargs (e.g. `default`, `description`).
+    """
     _warn_deprecated_field_args(**kwargs)
+    _validate_max_tokens(kwargs.get("max_tokens"))
     return pydantic.Field(**move_kwargs(**kwargs, __dspy_field_type="output"))
+
+
+def _validate_max_tokens(value):
+    if value is None:
+        return
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        raise ValueError(f"OutputField 'max_tokens' must be a positive integer, got {value!r}.")
 
 
 def new_to_old_field(field):

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2157,3 +2157,82 @@ def test_tool_call_with_null_content_does_not_raise():
     result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
     assert result is not None
     assert len(result) == 1
+
+
+def test_max_tokens_per_field_renders_hint_in_prompt():
+    """The per-field max_tokens budget is surfaced as a hint in the system prompt."""
+
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        summary: str = dspy.OutputField(desc="A short summary", max_tokens=10)
+        verdict: str = dspy.OutputField(desc="The verdict")
+
+    program = dspy.Predict(TestSignature)
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o"), adapter=dspy.ChatAdapter())
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[
+                Choices(
+                    message=Message(
+                        content="[[ ## summary ## ]]\nshort\n\n[[ ## verdict ## ]]\nyes\n\n[[ ## completed ## ]]\n"
+                    )
+                )
+            ]
+        )
+        program(question="anything")
+
+    _, call_kwargs = mock_completion.call_args
+    system_content = call_kwargs["messages"][0]["content"]
+    assert "at most 10 tokens" in system_content
+
+
+def test_max_tokens_per_field_truncates_string_field_over_budget():
+    """A string output field whose parsed value exceeds its budget is truncated."""
+
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        summary: str = dspy.OutputField(max_tokens=5)
+        verdict: str = dspy.OutputField()
+
+    long_summary = "one two three four five six seven eight nine ten"
+    lm = dspy.utils.DummyLM([{"summary": long_summary, "verdict": "ok"}])
+    adapter = dspy.ChatAdapter()
+
+    result = adapter(lm, {}, TestSignature, [], {"question": "anything"})
+
+    assert result[0]["summary"] == "one two three four five"
+    assert len(result[0]["summary"].split()) == 5
+    # Fields without a budget are untouched.
+    assert result[0]["verdict"] == "ok"
+
+
+def test_max_tokens_per_field_passes_through_when_within_budget():
+    """When a field is within its budget the parsed value is preserved verbatim."""
+
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        summary: str = dspy.OutputField(max_tokens=20)
+
+    short_summary = "this is short"
+    lm = dspy.utils.DummyLM([{"summary": short_summary}])
+    adapter = dspy.ChatAdapter()
+
+    result = adapter(lm, {}, TestSignature, [], {"question": "anything"})
+
+    assert result[0]["summary"] == short_summary
+
+
+def test_max_tokens_per_field_raises_for_non_string_over_budget():
+    """For non-string fields, exceeding the budget raises rather than silently corrupts."""
+    from dspy.utils.exceptions import AdapterParseError
+
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        items: list[str] = dspy.OutputField(max_tokens=3)
+
+    lm = dspy.utils.DummyLM([{"items": ["alpha beta gamma", "delta epsilon zeta", "eta theta iota"]}])
+    adapter = dspy.ChatAdapter(use_json_adapter_fallback=False)
+
+    with pytest.raises(AdapterParseError, match="max_tokens"):
+        adapter(lm, {}, TestSignature, [], {"question": "anything"})

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -609,3 +609,36 @@ def test_predict_cloudpickle_roundtrip():
     loaded = pickle.loads(data)
 
     assert list(loaded.signature.fields.keys()) == ["question", "answer"]
+
+
+def test_output_field_accepts_max_tokens_kwarg():
+    class TestSignature(Signature):
+        question: str = InputField()
+        summary: str = OutputField(desc="Short summary", max_tokens=10)
+        verdict: str = OutputField()
+
+    assert TestSignature.output_fields["summary"].json_schema_extra["max_tokens"] == 10
+    # Fields without the kwarg should not have max_tokens set.
+    assert TestSignature.output_fields["verdict"].json_schema_extra.get("max_tokens") is None
+
+
+def test_output_field_max_tokens_rejects_invalid_values():
+    with pytest.raises(ValueError, match="positive integer"):
+        OutputField(max_tokens=0)
+    with pytest.raises(ValueError, match="positive integer"):
+        OutputField(max_tokens=-5)
+    with pytest.raises(ValueError, match="positive integer"):
+        OutputField(max_tokens="10")
+    with pytest.raises(ValueError, match="positive integer"):
+        OutputField(max_tokens=True)
+
+
+def test_output_field_max_tokens_renders_in_prompt():
+    from dspy.adapters.utils import get_field_description_string
+
+    class TestSignature(Signature):
+        question: str = InputField()
+        summary: str = OutputField(desc="Short summary", max_tokens=10)
+
+    description = get_field_description_string(TestSignature.output_fields)
+    assert "at most 10 tokens" in description


### PR DESCRIPTION
Closes #8849.

Adds a `max_tokens` kwarg to `dspy.OutputField` so users can constrain individual output fields independently of the LM's global token budget. The adapter pipes the constraint into the prompt as a hint, then truncates any field whose parsed value exceeds its budget after the response comes back. This is the post-parse approach @okhat outlined in the original thread; native provider-side enforcement is left as a follow-up.

For string-typed fields, an over-budget value is truncated to the configured whitespace-token count. For non-string fields, exceeding the budget raises `AdapterParseError` rather than risk silently corrupting structured output such as mid-JSON values. The kwarg is validated to be a positive integer at field construction time.

Tests cover both within-budget and over-budget paths, prompt-rendering of the hint, validation of invalid `max_tokens` values, and the non-string error path.