### PR TITLE
fix: strip vendor schema extensions in JSONAdapter

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -249,9 +249,20 @@ def _get_structured_outputs_response_format(
     # Generate the initial schema.
     schema = pydantic_model.model_json_schema()
 
-    # Remove any DSPy-specific metadata.
-    for prop in schema.get("properties", {}).values():
-        prop.pop("json_schema_extra", None)
+    def clean_schema(schema_part: dict):
+        for key in list(schema_part.keys()):
+            if key == "json_schema_extra" or key.startswith("x-"):
+                schema_part.pop(key)
+
+        for value in schema_part.values():
+            if isinstance(value, dict):
+                clean_schema(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, dict):
+                        clean_schema(item)
+
+    clean_schema(schema)
 
     def enforce_required(schema_part: dict):
         """

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -713,6 +713,41 @@ def test_json_adapter_passes_structured_output_when_supported_by_model():
     assert response_format.model_fields.keys() == {"output1", "output2", "output3", "output4_unannotated"}
 
 
+def test_json_adapter_strips_vendor_extensions_from_structured_output_schema():
+    class NestedOutput(pydantic.BaseModel):
+        model_config = pydantic.ConfigDict(json_schema_extra={"x-model-tag": "internal"})
+
+        value: str = pydantic.Field(json_schema_extra={"x-provider-note": "internal"})
+
+    class TestSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: NestedOutput = dspy.OutputField()
+
+    program = dspy.Predict(TestSignature)
+
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o"), adapter=dspy.JSONAdapter())
+    with mock.patch("litellm.completion") as mock_completion:
+        program(question="Test input")
+
+    _, call_kwargs = mock_completion.call_args
+    schema = call_kwargs["response_format"].model_json_schema()
+
+    def collect_x_keys(value):
+        if isinstance(value, dict):
+            keys = [key for key in value if key.startswith("x-")]
+            for child in value.values():
+                keys.extend(collect_x_keys(child))
+            return keys
+        if isinstance(value, list):
+            keys = []
+            for child in value:
+                keys.extend(collect_x_keys(child))
+            return keys
+        return []
+
+    assert collect_x_keys(schema) == []
+
+
 def test_json_adapter_not_using_structured_outputs_when_not_supported_by_model():
     class TestSignature(dspy.Signature):
         input1: str = dspy.InputField()


### PR DESCRIPTION
﻿## Summary
- Strip `x-*` vendor extension keys from JSONAdapter structured output schemas before passing them to providers
- Keep the existing DSPy metadata cleanup recursive so nested Pydantic models do not leak provider-private schema annotations
- Add a regression test covering nested model and field `json_schema_extra` entries

Closes #9686.

## To verify
- `python -m py_compile dspy\adapters\json_adapter.py tests\adapters\test_json_adapter.py`
- `python -m pytest tests\adapters\test_json_adapter.py::test_json_adapter_strips_vendor_extensions_from_structured_output_schema tests\adapters\test_json_adapter.py::test_json_adapter_passes_structured_output_when_supported_by_model -q`
- `python -m ruff check dspy\adapters\json_adapter.py tests\adapters\test_json_adapter.py`
- `git diff --check`