### PR TITLE
fix(lm): raise actionable error for ollama_chat + image inputs

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -29,6 +29,42 @@ def _get_litellm():
     return get_litellm(feature="dspy.LM")
 
 
+def _messages_contain_image(messages: list[dict[str, Any]] | None) -> bool:
+    """Return True if any message in ``messages`` carries an ``image_url`` content block."""
+    if not messages:
+        return False
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "image_url":
+                return True
+    return False
+
+
+def _check_ollama_chat_image_unsupported(model: str, messages: list[dict[str, Any]] | None) -> None:
+    """Raise a clear error when ``ollama_chat/`` is paired with image inputs.
+
+    LiteLLM's ``ollama_chat`` provider currently drops ``image_url`` content blocks before
+    forwarding to Ollama, surfacing as ``BadRequestError: Invalid Message passed in`` or a
+    404 on ``/api/chat``. Until the upstream LiteLLM fix lands (tracked in
+    BerriAI/litellm#24598 and stanfordnlp/dspy#8067), the working path is to point dspy.LM
+    at Ollama's OpenAI-compatible endpoint using the ``openai/`` prefix.
+    """
+    if not isinstance(model, str) or not model.startswith("ollama_chat/"):
+        return
+    if not _messages_contain_image(messages):
+        return
+    raise ValueError(
+        "dspy.LM('ollama_chat/...') does not currently support image inputs because LiteLLM's "
+        "ollama_chat provider drops image_url content blocks before sending to Ollama (see "
+        "BerriAI/litellm#24598 and stanfordnlp/dspy#8067). Use Ollama's OpenAI-compatible "
+        "endpoint instead, for example: "
+        "dspy.LM('openai/<model>', api_base='http://localhost:11434/v1', api_key='ollama')."
+    )
+
+
 class LM(BaseLM):
     """
     A language model supporting chat or text completion requests for use with DSPy modules.
@@ -160,12 +196,7 @@ class LM(BaseLM):
 
         return completion_fn, litellm_cache_args
 
-    def forward(
-        self,
-        prompt: str | None = None,
-        messages: list[dict[str, Any]] | None = None,
-        **kwargs
-    ):
+    def forward(self, prompt: str | None = None, messages: list[dict[str, Any]] | None = None, **kwargs):
         # Build the request.
         kwargs = dict(kwargs)
         cache = kwargs.pop("cache", self.cache)
@@ -173,6 +204,7 @@ class LM(BaseLM):
         messages = messages or [{"role": "user", "content": prompt}]
         if self.use_developer_role and self.model_type == "responses":
             messages = [{**m, "role": "developer"} if m.get("role") == "system" else m for m in messages]
+        _check_ollama_chat_image_unsupported(self.model, messages)
         kwargs = {**self.kwargs, **kwargs}
         self._warn_zero_temp_rollout(kwargs.get("temperature"), kwargs.get("rollout_id"))
         if kwargs.get("rollout_id") is None:
@@ -216,6 +248,7 @@ class LM(BaseLM):
         messages = messages or [{"role": "user", "content": prompt}]
         if self.use_developer_role and self.model_type == "responses":
             messages = [{**m, "role": "developer"} if m.get("role") == "system" else m for m in messages]
+        _check_ollama_chat_image_unsupported(self.model, messages)
         kwargs = {**self.kwargs, **kwargs}
         self._warn_zero_temp_rollout(kwargs.get("temperature"), kwargs.get("rollout_id"))
         if kwargs.get("rollout_id") is None:

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1103,9 +1103,7 @@ async def test_responses_api_with_none_usage_async():
                     "type": "message",
                     "role": "assistant",
                     "status": "incomplete",
-                    "content": [
-                        {"type": "output_text", "text": "Partial async response", "annotations": []}
-                    ],
+                    "content": [{"type": "output_text", "text": "Partial async response", "annotations": []}],
                 },
             ),
         ],
@@ -1177,3 +1175,103 @@ async def test_streaming_passes_headers_correctly():
             mock_acompletion.assert_called_once()
             call_kwargs = mock_acompletion.call_args.kwargs
             assert call_kwargs["headers"]["Authorization"] == "Bearer my-custom-token"
+
+
+def _image_message():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image."},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+                    },
+                },
+            ],
+        }
+    ]
+
+
+def test_ollama_chat_with_image_raises_actionable_error():
+    """ollama_chat + image_url must raise before the request reaches LiteLLM.
+
+    LiteLLM's ollama_chat provider drops image_url blocks (see BerriAI/litellm#24598
+    and stanfordnlp/dspy#8067). Surface a clear error pointing at the OpenAI-compatible
+    workaround rather than letting it fail deep inside LiteLLM.
+    """
+    lm = dspy.LM(
+        "ollama_chat/llama3.2-vision",
+        api_base="http://localhost:11434",
+        api_key="",
+        cache=False,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        lm(messages=_image_message())
+
+    error_message = str(exc_info.value)
+    assert "ollama_chat" in error_message
+    assert "openai/" in error_message
+    assert "11434" in error_message
+
+
+def test_ollama_chat_without_image_does_not_raise():
+    """ollama_chat without image content should not be blocked by the image guard."""
+    lm = dspy.LM(
+        "ollama_chat/llama3.2",
+        api_base="http://localhost:11434",
+        api_key="",
+        cache=False,
+    )
+
+    mock_response = ModelResponse(
+        choices=[Choices(message=Message(content="ok"))],
+        model="ollama_chat/llama3.2",
+    )
+
+    with mock.patch("litellm.completion", return_value=mock_response) as mock_completion:
+        result = lm(messages=[{"role": "user", "content": "hi"}])
+
+    assert mock_completion.called
+    assert result == ["ok"]
+
+
+def test_ollama_image_guard_does_not_trigger_for_openai_prefix():
+    """The image-with-ollama_chat guard must not fire for openai/<model> (the workaround)."""
+    lm = dspy.LM(
+        "openai/llama3.2-vision",
+        api_base="http://localhost:11434/v1",
+        api_key="ollama",
+        cache=False,
+    )
+
+    mock_response = ModelResponse(
+        choices=[Choices(message=Message(content="image described"))],
+        model="openai/llama3.2-vision",
+    )
+
+    with mock.patch("litellm.completion", return_value=mock_response) as mock_completion:
+        result = lm(messages=_image_message())
+
+    assert mock_completion.called
+    assert result == ["image described"]
+
+
+@pytest.mark.asyncio
+async def test_ollama_chat_with_image_raises_actionable_error_async():
+    """The async forward path must enforce the same guard as the sync path."""
+    lm = dspy.LM(
+        "ollama_chat/llama3.2-vision",
+        api_base="http://localhost:11434",
+        api_key="",
+        cache=False,
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        await lm.acall(messages=_image_message())
+
+    error_message = str(exc_info.value)
+    assert "ollama_chat" in error_message
+    assert "openai/" in error_message


### PR DESCRIPTION
Closes #8067.

Requests through dspy.LM('ollama_chat/...') with image messages currently fail inside LiteLLM with either a BadRequestError "Invalid Message passed in" or a 404 on /api/chat. The issue thread (#8067) and the upstream tracking issue (BerriAI/litellm#24598) confirm that LiteLLM's ollama_chat provider drops image_url content blocks before forwarding to Ollama. Until that lands upstream, the supported path is Ollama's OpenAI-compatible endpoint via the openai/ prefix, as suggested in the thread.

Rather than letting the call fail deep inside LiteLLM with a cryptic message, this raises a clear ValueError at the LM boundary that names the broken provider, mentions the upstream tracking issue, and shows the exact workaround so users can move forward without spelunking the trace:

    dspy.LM('openai/<model>', api_base='http://localhost:11434/v1', api_key='ollama')

Notes on scope:
- The guard only fires for ollama_chat/ models when at least one message carries an image_url content block. Text-only ollama_chat traffic is unaffected.
- The openai/ workaround is not blocked. The new test covers that path explicitly.
- Both the sync forward and async aforward paths enforce the check.
- Once LiteLLM fixes the URL builder and content-block handling upstream, this guard can be removed in a follow-up.

Added regression tests in tests/clients/test_lm.py covering: ollama_chat + image raises with actionable text, ollama_chat without image is unaffected, the openai/ prefix workaround still works, and the async path enforces the same guard. All 41 tests in tests/clients/test_lm.py pass. Full tests/clients/ and tests/adapters/ suites also pass.