### PR TITLE
Canonicalize ToolCalls formatting

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -2,7 +2,6 @@ import asyncio
 import inspect
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, get_origin, get_type_hints
 
-import json_repair
 import pydantic
 from jsonschema import ValidationError, validate
 from pydantic import BaseModel, TypeAdapter, create_model
@@ -270,13 +269,7 @@ class ToolCalls(Type):
         id: str | None = None
 
         def format(self):
-            formatted = {
-                "type": "function",
-                "function": {
-                    "name": self.name,
-                    "arguments": self.args,
-                },
-            }
+            formatted = {"name": self.name, "args": self.args}
             if self.id is not None:
                 formatted["id"] = self.id
             return formatted
@@ -396,7 +389,6 @@ class ToolCalls(Type):
         )
 
     def format(self) -> dict[str, Any]:
-        # The tool_call field is compatible with OpenAI's tool calls schema.
         return {
             "tool_calls": [tool_call.format() for tool_call in self.tool_calls],
         }
@@ -423,62 +415,23 @@ class ToolCalls(Type):
         ]
         return self.model_copy(update={"tool_calls": tool_calls})
 
-    @staticmethod
-    def _get_tool_call_value(item: Any, key: str, default: Any = None) -> Any:
+    @classmethod
+    def _canonical_tool_call(cls, item: Any) -> Any:
+        if isinstance(item, cls.ToolCall):
+            return item.model_dump()
         if isinstance(item, dict):
-            return item.get(key, default)
-        return getattr(item, key, default)
-
-    @staticmethod
-    def _parse_tool_call_args(args: Any) -> Any:
-        if isinstance(args, str):
-            return json_repair.loads(args)
-        return args
-
-    @classmethod
-    def _normalized_tool_call(cls, name: Any, args: Any, tool_call_id: Any = None) -> dict[str, Any] | None:
-        if name is None:
-            return None
-        normalized = {"name": name, "args": cls._parse_tool_call_args(args)}
-        if tool_call_id:
-            normalized["id"] = tool_call_id
-        return normalized
-
-    @classmethod
-    def _normalize_native_tool_call(cls, item: Any) -> Any:
-        if not isinstance(item, dict) and hasattr(item, "model_dump"):
-            try:
-                dumped_item = item.model_dump()
-            except TypeError:
-                dumped_item = None
-            if isinstance(dumped_item, dict):
-                item = dumped_item
-
-        function = cls._get_tool_call_value(item, "function")
-        if function is not None:
-            name = cls._get_tool_call_value(function, "name")
-            arguments = cls._get_tool_call_value(function, "arguments", {})
-            normalized = cls._normalized_tool_call(name, arguments, cls._get_tool_call_value(item, "id"))
-            if normalized is not None:
+            if "name" in item and "args" in item:
+                normalized = {"name": item["name"], "args": item["args"]}
+                if "id" in item:
+                    normalized["id"] = item["id"]
                 return normalized
-
-        name = cls._get_tool_call_value(item, "name")
-        if cls._get_tool_call_value(item, "type") == "function_call" and name is not None:
-            arguments = cls._get_tool_call_value(item, "arguments", {})
-            normalized = cls._normalized_tool_call(
-                name,
-                arguments,
-                cls._get_tool_call_value(item, "call_id") or cls._get_tool_call_value(item, "id"),
-            )
-            if normalized is not None:
-                return normalized
-
-        args = cls._get_tool_call_value(item, "args")
-        if args is not None:
-            normalized = cls._normalized_tool_call(name, args, cls._get_tool_call_value(item, "id"))
-            if normalized is not None:
-                return normalized
-
+            return item
+        if hasattr(item, "name") and hasattr(item, "args"):
+            normalized = {"name": item.name, "args": item.args}
+            tool_call_id = getattr(item, "id", None)
+            if tool_call_id is not None:
+                normalized["id"] = tool_call_id
+            return normalized
         return item
 
     @pydantic.model_validator(mode="before")
@@ -493,13 +446,11 @@ class ToolCalls(Type):
         elif isinstance(data, dict):
             if "tool_calls" in data:
                 tool_calls_data = data["tool_calls"]
-            else:
-                normalized = cls._normalize_native_tool_call(data)
-                if isinstance(normalized, dict) and "name" in normalized and "args" in normalized:
-                    return {"tool_calls": [normalized]}
+            elif "name" in data and "args" in data:
+                return {"tool_calls": [cls._canonical_tool_call(data)]}
 
         if isinstance(tool_calls_data, list):
-            normalized = [cls._normalize_native_tool_call(item) for item in tool_calls_data]
+            normalized = [cls._canonical_tool_call(item) for item in tool_calls_data]
             if all(isinstance(item, dict) and "name" in item and "args" in item for item in normalized):
                 return {"tool_calls": normalized}
 

--- a/tests/adapters/test_history_formatting.py
+++ b/tests/adapters/test_history_formatting.py
@@ -65,7 +65,7 @@ def test_json_adapter_formats_complete_tool_turn_without_duplicate_input():
     assert [message["role"] for message in messages] == ["system", "user", "assistant", "user", "user"]
     assert sum("What is 1+2?" in text for text in texts[1:]) == 1
     assert assistant["next_thought"] == "I should add."
-    assert assistant["tool_calls"]["tool_calls"][0]["function"]["name"] == "add"
+    assert assistant["tool_calls"]["tool_calls"][0]["name"] == "add"
     assert "[[ ## tool_call_results ## ]]" in texts[3]
     assert '"name": "add"' in texts[3]
     assert '"value": 3' in texts[3]

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -643,20 +643,17 @@ def test_json_adapter_format_exact_messages_with_tool_calls_output_demo():
                  '        Given the fields `question`, produce the fields `tool_calls`.'},
      {"role": "user", "content": "[[ ## question ## ]]\nQ1"},
      {"role": "assistant",
-      "content": '{\n'
-                 '  "tool_calls": {\n'
-                 '    "tool_calls": [\n'
-                 '      {\n'
-                 '        "type": "function",\n'
-                 '        "function": {\n'
-                 '          "name": "search",\n'
-                 '          "arguments": {\n'
-                 '            "query": "cats"\n'
-                 '          }\n'
-                 '        }\n'
-                 '      }\n'
-                 '    ]\n'
-                 '  }\n'
+     "content": '{\n'
+                '  "tool_calls": {\n'
+                '    "tool_calls": [\n'
+                '      {\n'
+                '        "name": "search",\n'
+                '        "args": {\n'
+                '          "query": "cats"\n'
+                '        }\n'
+                '      }\n'
+                '    ]\n'
+                '  }\n'
                  '}'},
      {"role": "user",
       "content": "[[ ## question ## ]]\n"

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -5,7 +5,8 @@ import pytest
 from pydantic import BaseModel
 
 import dspy
-from dspy.adapters.types.tool import Tool, ToolCalls, convert_input_schema_to_tool_args
+from dspy.adapters.types.tool import Tool, ToolCallResults, ToolCalls, convert_input_schema_to_tool_args
+from dspy.core.types import LMToolCallPart
 
 
 # Test fixtures
@@ -397,9 +398,7 @@ TOOL_CALL_TEST_CASES = [
     ([], {"tool_calls": []}),
     (
         [{"name": "search", "args": {"query": "hello"}}],
-        {
-            "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
-        },
+        {"tool_calls": [{"name": "search", "args": {"query": "hello"}}]},
     ),
     (
         [
@@ -408,19 +407,14 @@ TOOL_CALL_TEST_CASES = [
         ],
         {
             "tool_calls": [
-                {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
-                {
-                    "type": "function",
-                    "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
-                },
+                {"name": "search", "args": {"query": "hello"}},
+                {"name": "translate", "args": {"text": "world", "lang": "fr"}},
             ],
         },
     ),
     (
         [{"name": "get_time", "args": {}}],
-        {
-            "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
-        },
+        {"tool_calls": [{"name": "get_time", "args": {}}]},
     ),
 ]
 
@@ -446,8 +440,8 @@ def test_tool_calls_format_from_dict_list():
     result = tool_calls.format()
 
     assert len(result["tool_calls"]) == 2
-    assert result["tool_calls"][0]["function"]["name"] == "search"
-    assert result["tool_calls"][1]["function"]["name"] == "translate"
+    assert result["tool_calls"][0]["name"] == "search"
+    assert result["tool_calls"][1]["name"] == "translate"
 
 
 def test_tool_calls_preserve_call_ids_and_fill_missing_ids():
@@ -562,6 +556,47 @@ def test_toolcalls_vague_match():
         ToolCalls.model_validate({"foo": "bar"})
     with pytest.raises(ValueError):
         ToolCalls.model_validate([{"foo": "bar"}])
+
+
+def test_toolcalls_accepts_normalized_lm_tool_call_parts():
+    tool_calls = ToolCalls.model_validate([LMToolCallPart(id="call_1", name="search", args={"query": "hello"})])
+
+    assert tool_calls == ToolCalls.from_dict_list([{"id": "call_1", "name": "search", "args": {"query": "hello"}}])
+
+
+def test_toolcalls_rejects_provider_native_shapes():
+    with pytest.raises(ValueError):
+        ToolCalls.model_validate(
+            [
+                {
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"query": "hello"}'},
+                    "id": "call_1",
+                }
+            ]
+        )
+
+    with pytest.raises(ValueError):
+        ToolCalls.model_validate({"type": "function_call", "name": "search", "arguments": '{"query": "hello"}'})
+
+
+def test_tool_call_results_use_canonical_shape():
+    results = ToolCallResults.model_validate(
+        [{"call_id": "call_1", "name": "search", "value": {"answer": "hello"}, "is_error": False}]
+    )
+
+    assert results.format() == {
+        "tool_call_results": [
+            {"call_id": "call_1", "name": "search", "value": {"answer": "hello"}, "is_error": False}
+        ]
+    }
+
+
+def test_tool_call_results_reject_provider_native_shapes():
+    with pytest.raises(ValueError):
+        ToolCallResults.model_validate(
+            {"type": "function_call_output", "call_id": "call_1", "output": '{"answer": "hello"}'}
+        )
 
 
 def test_tool_convert_input_schema_to_tool_args_no_input_params():


### PR DESCRIPTION
## Summary
- Make `ToolCalls.format()` emit the canonical Pydantic shape (`name`, `args`, optional `id`) instead of an OpenAI function-call shape.
- Remove provider-native tool-call parsing from `ToolCalls`; provider shapes must be normalized before reaching this type.
- Add adversarial coverage for normalized tool-call parts, provider-native rejection, and the already-canonical `ToolCallResults` shape.

## Tests
- `uv run --extra dev ruff check dspy/adapters/types/tool.py tests/adapters/test_tool.py tests/adapters/test_history_formatting.py tests/adapters/test_json_adapter.py`
- `uv run --extra dev pytest -q tests/adapters/test_tool.py tests/adapters/test_history_formatting.py tests/adapters/test_history_lm_messages.py tests/adapters/test_json_adapter.py tests/adapters/test_chat_adapter.py`
- `uv run --extra dev pytest -q tests/adapters/test_history.py tests/adapters/test_tool.py tests/adapters/test_json_adapter.py tests/adapters/test_history_formatting.py tests/adapters/test_chat_adapter.py tests/adapters/test_history_lm_messages.py tests/predict/test_reactv2.py tests/adapters/test_citation.py tests/adapters/test_adapter_base.py tests/adapters/test_two_step_adapter.py tests/adapters/test_xml_adapter.py`