### PR TITLE
fix(predict): explicit temperature=0.0 silently discarded by falsy or

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -162,7 +162,11 @@ class Predict(Module, Parameter):
             raise ValueError(f"LM must be an instance of `dspy.BaseLM`, not {type(lm)}. Received `lm={lm}`.")
 
         # If temperature is unset or <=0.15, and n > 1, set temperature to 0.7 to keep randomness.
-        temperature = config.get("temperature") or lm.kwargs.get("temperature")
+        # Use `is not None` instead of truthiness so that an explicit temperature=0.0 in config
+        # is not silently discarded (0.0 is falsy, so `config.get("temperature") or ...` would
+        # fall through to lm.kwargs even when the caller explicitly requested deterministic mode).
+        _cfg_temp = config.get("temperature")
+        temperature = _cfg_temp if _cfg_temp is not None else lm.kwargs.get("temperature")
         num_generations = config.get("n") or lm.kwargs.get("n") or lm.kwargs.get("num_generations") or 1
 
         if (temperature is None or temperature <= 0.15) and num_generations > 1:

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1678,3 +1678,53 @@ def test_custom_signature_types(caplog, enable_type_warnings):
         assert "Type mismatch for field 'query': expected Query" in caplog.text
     else:
         assert "Type mismatch" not in caplog.text
+
+
+def test_predict_explicit_zero_temperature_not_overridden_by_lm_default():
+    """Regression test: explicit temperature=0.0 in predict config must not be silently
+    discarded.
+
+    Prior to the fix, ``config.get("temperature") or lm.kwargs.get("temperature")``
+    evaluated ``0.0`` as falsy, so when the caller set ``temperature=0.0`` via the
+    predict config (full determinism) and the LM had a non-zero default temperature in
+    its kwargs, the Predict module would ignore the explicit zero and use the LM default
+    instead.
+
+    The ``config`` dict passed to the LM adapter is assembled from ``self.config`` merged
+    with the per-call ``config=`` kwarg.  Temperature passed there is the correct way to
+    set per-call LM parameters.
+    """
+    # Build a DummyLM whose kwargs contain a non-zero default temperature.
+    lm = DummyLM([{"answer": "deterministic"}])
+    lm.kwargs["temperature"] = 0.9  # LM-level default that must NOT win
+
+    dspy.configure(lm=lm)
+
+    predict_instance = Predict("question -> answer")
+
+    # Capture the lm_kwargs (== config) that the adapter receives.
+    captured_lm_kwargs: dict = {}
+    from dspy.adapters.chat_adapter import ChatAdapter
+
+    original_call = ChatAdapter.__call__
+
+    def capturing_call(self_adapter, lm_obj, lm_kwargs, **kw):
+        captured_lm_kwargs.update(lm_kwargs)
+        return original_call(self_adapter, lm_obj, lm_kwargs=lm_kwargs, **kw)
+
+    import dspy.adapters.chat_adapter as _chat_mod
+
+    _chat_mod.ChatAdapter.__call__ = capturing_call  # type: ignore[method-assign]
+
+    try:
+        # Pass temperature=0.0 via the per-call config dict.
+        predict_instance(question="What is 1+1?", config={"temperature": 0.0})
+    finally:
+        _chat_mod.ChatAdapter.__call__ = original_call
+
+    # The temperature forwarded to the adapter must be 0.0, not 0.9.
+    assert captured_lm_kwargs.get("temperature") == 0.0, (
+        f"Expected temperature=0.0 to be forwarded to the LM adapter, "
+        f"got temperature={captured_lm_kwargs.get('temperature')!r} instead. "
+        "Explicit zero temperature was silently discarded (falsy `or` bug)."
+    )


### PR DESCRIPTION
## Problem

In `Predict._forward_preprocess` the effective temperature is resolved with:

```python
temperature = config.get("temperature") or lm.kwargs.get("temperature")
```

`0.0` is falsy in Python.  If a caller explicitly sets `temperature=0.0`
(fully deterministic mode) via the per-call `config={"temperature": 0.0}`
kwarg (or via `Predict.config`), and the configured LM has a non-zero
default temperature in its `kwargs` (e.g. `0.9`), the `or` silently
discards the explicit zero and returns `0.9` instead.

The downstream effect is that the condition

```python
if (temperature is None or temperature <= 0.15) and num_generations > 1:
    config["temperature"] = 0.7
```

also evaluates incorrectly: with `temperature=0.9` the branch is skipped,
so multi-generation calls with an explicit `temperature=0.0` are never
bumped to `0.7` either.

## Fix

Replace the `or` with an `is not None` guard:

```python
_cfg_temp = config.get("temperature")
temperature = _cfg_temp if _cfg_temp is not None else lm.kwargs.get("temperature")
```

This is consistent with how the rest of the codebase checks for "was this
value explicitly provided?" — `None` is the sentinel for "not set", not
falsiness.

## Test

Added `test_predict_explicit_zero_temperature_not_overridden_by_lm_default`
which sets `lm.kwargs["temperature"] = 0.9`, calls predict with
`config={"temperature": 0.0}`, and asserts the adapter receives `0.0`.