### PR TITLE
fix(clients/lm): temperature=0.0 silently bypasses reasoning-model validation

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -101,7 +101,7 @@ class LM(BaseLM):
         )
 
         if model_pattern:
-            if (temperature and temperature != 1.0) or (max_tokens and max_tokens < 16000):
+            if (temperature is not None and temperature != 1.0) or (max_tokens is not None and max_tokens < 16000):
                 raise ValueError(
                     "OpenAI's reasoning models require passing temperature=1.0 or None and max_tokens >= 16000 or None to "
                     "`dspy.LM(...)`, e.g., dspy.LM('openai/gpt-5', temperature=1.0, max_tokens=16000)"

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -363,6 +363,25 @@ def test_reasoning_model_requirements(model_name):
     assert lm.kwargs["max_completion_tokens"] is None
 
 
+@pytest.mark.parametrize("model_name", ["openai/o1", "openai/gpt-5-nano", "openai/gpt-5-mini"])
+def test_reasoning_model_rejects_zero_temperature(model_name):
+    """temperature=0.0 must trigger the validation error for reasoning models.
+
+    The previous guard used ``temperature and temperature != 1.0`` which short-circuits
+    on 0.0 (falsy) and silently accepts an invalid configuration.  The fix uses
+    ``temperature is not None and temperature != 1.0`` so that 0.0 is correctly rejected.
+    """
+    with pytest.raises(
+        ValueError,
+        match="reasoning models require passing temperature=1.0 or None and max_tokens >= 16000 or None",
+    ):
+        dspy.LM(
+            model=model_name,
+            temperature=0.0,  # Falsy but invalid for reasoning models
+            max_tokens=16_000,
+        )
+
+
 def test_gpt_5_chat_not_reasoning_model():
     """Test that gpt-5-chat is NOT treated as a reasoning model."""
     # Should NOT raise validation error - gpt-5-chat is not a reasoning model


### PR DESCRIPTION
## Summary

`dspy/clients/lm.py` guards against invalid configurations for OpenAI reasoning models (o1, o3, gpt-5 family) with:

```python
if (temperature and temperature != 1.0) or (max_tokens and max_tokens < 16000):
    raise ValueError(...)
```

Because Python evaluates `0.0` as falsy, `temperature and temperature != 1.0` short-circuits to `False` when `temperature=0.0`. The `ValueError` is **never raised** even though `temperature=0.0` is an invalid value for these models.

## Reproduction

```python
import dspy
# Should raise — does not
lm = dspy.LM("openai/o1", temperature=0.0, max_tokens=16_000)
```

## Fix

```python
# Before
if (temperature and temperature != 1.0) or (max_tokens and max_tokens < 16000):

# After
if (temperature is not None and temperature != 1.0) or (max_tokens is not None and max_tokens < 16000):
```

The same falsy-zero pattern in `dspy/predict/predict.py` was fixed in #9817; this PR addresses the second occurrence.

## Tests

Added `test_reasoning_model_rejects_zero_temperature` parametrised over `openai/o1`, `openai/gpt-5-nano`, `openai/gpt-5-mini` to cover the `temperature=0.0` case that was previously silently accepted.