### PR TITLE
refactor(adapter): preserve public formatting through LMRequest

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -1,11 +1,12 @@
 import json
 import logging
-from typing import Any, get_origin
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import Any, get_args, get_origin
 
 import json_repair
 
 from dspy.adapters._legacy_type_markers import (
-    _expand_legacy_custom_type_markers_in_chat_message,
     _expand_legacy_custom_type_markers_in_lm_message,
 )
 from dspy.adapters.types import History, Type
@@ -15,9 +16,10 @@ from dspy.clients.base_lm import BaseLM
 from dspy.clients.openai_format import (
     legacy_outputs_from_lm_response,
     lm_response_from_legacy_outputs,
+    message_to_openai_chat,
     to_openai_chat_request,
 )
-from dspy.core.types import LMMessage, LMRequest, LMResponse
+from dspy.core.types import LMMessage, LMRequest, LMResponse, LMToolSpec
 from dspy.experimental import Citations
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback, with_callbacks
@@ -26,6 +28,16 @@ from dspy.utils.exceptions import AdapterParseError
 logger = logging.getLogger(__name__)
 
 _DEFAULT_NATIVE_RESPONSE_TYPES = [Citations, Reasoning]
+
+
+@dataclass
+class _AdapterRequestState:
+    source_signature: type[Signature]
+    render_signature: type[Signature]
+    inputs: dict[str, Any]
+    lm_kwargs: dict[str, Any]
+    tools: list[LMToolSpec] = dataclass_field(default_factory=list)
+    hidden_output_fields: tuple[str, ...] = ()
 
 
 class Adapter:
@@ -149,7 +161,7 @@ class Adapter:
             text = output
 
             if isinstance(output, dict):
-                text = output["text"]
+                text = output.get("text")
                 output_logprobs = output.get("logprobs")
                 tool_calls = output.get("tool_calls")
 
@@ -205,20 +217,19 @@ class Adapter:
     def _render_request(
         self,
         lm: BaseLM,
-        lm_kwargs: dict[str, Any],
+        state: _AdapterRequestState,
         messages: list[LMMessage | dict[str, Any]],
     ) -> LMRequest:
-        """Build the normalized LM request for the current adapter call path.
-
-        TODO(adapters-plan): This currently receives already-rendered messages.
-        Once planning lands, this should render from `_AdapterPlan` and apply
-        planned message/part insertions before creating `LMRequest`.
-        """
+        request_kwargs = self._prepare_request_kwargs(lm, state)
         return LMRequest.from_call(
             model=lm.model,
             messages=self._coerce_lm_messages(messages),
-            **lm_kwargs,
+            tools=state.tools,
+            **request_kwargs,
         )
+
+    def _prepare_request_kwargs(self, lm: BaseLM, state: _AdapterRequestState) -> dict[str, Any]:
+        return dict(state.lm_kwargs)
 
     def _call_lm(self, lm: BaseLM, request: LMRequest) -> LMResponse:
         """Call current `BaseLM` through the normalized request/response boundary.
@@ -299,14 +310,106 @@ class Adapter:
                 message["content"] = sanitized
             return LMMessage(**message)
 
-    def _normalize_legacy_outputs(self, outputs: list[dict[str, Any] | str | None], request: LMRequest) -> LMResponse:
+    def _normalize_legacy_outputs(
+        self, outputs: list[dict[str, Any] | str | None] | LMResponse, request: LMRequest
+    ) -> LMResponse:
         """Convert current `BaseLM` outputs into a normalized `LMResponse`.
 
         TODO(language-models): Current `BaseLM` returns `list[str | dict | None]`.
         Future LMs should return `LMResponse` directly, making this method a
         compatibility-only path for old/custom LMs.
         """
+        if isinstance(outputs, LMResponse):
+            return outputs
         return lm_response_from_legacy_outputs(outputs, request)
+
+    def _prepare_request_state(
+        self,
+        lm: BaseLM,
+        lm_kwargs: dict[str, Any],
+        signature: type[Signature],
+        inputs: dict[str, Any],
+    ) -> _AdapterRequestState:
+        """Build the normalized state for one adapter request.
+
+        Preprocessing may rewrite the signature, inputs, and LM kwargs, so this copies caller-owned data before
+        applying it and records both the source signature used for final outputs and the render signature used for
+        prompt formatting.
+        """
+        copied_inputs = dict(inputs)
+        copied_lm_kwargs = dict(lm_kwargs)
+        render_signature = self._call_preprocess(lm, copied_lm_kwargs, signature, copied_inputs)
+        tools = self._extract_lm_tools(copied_lm_kwargs)
+
+        hidden_output_fields = tuple(
+            field_name for field_name in signature.output_fields if field_name not in render_signature.output_fields
+        )
+        return _AdapterRequestState(
+            source_signature=signature,
+            render_signature=render_signature,
+            inputs=copied_inputs,
+            lm_kwargs=copied_lm_kwargs,
+            tools=tools,
+            hidden_output_fields=hidden_output_fields,
+        )
+
+    def _extract_lm_tools(self, lm_kwargs: dict[str, Any]) -> list[LMToolSpec]:
+        """Remove native LM tool specs from LM kwargs and normalize them for request rendering."""
+        raw_tools = lm_kwargs.pop("tools", None)
+        if not raw_tools:
+            return []
+        tools = raw_tools if isinstance(raw_tools, list) else [raw_tools]
+        return [self._coerce_lm_tool_spec(tool) for tool in tools]
+
+    @staticmethod
+    def _coerce_lm_tool_spec(tool: Any) -> LMToolSpec:
+        """Convert supported tool shapes into the internal LMToolSpec representation."""
+        if isinstance(tool, LMToolSpec):
+            return tool
+        if hasattr(tool, "to_lm_tool_spec"):
+            return tool.to_lm_tool_spec()
+        if isinstance(tool, dict):
+            if "function" in tool:
+                function = tool["function"]
+                provider_data = {key: value for key, value in tool.items() if key not in {"type", "function"}}
+                return LMToolSpec(
+                    name=function.get("name"),
+                    description=function.get("description"),
+                    parameters=function.get("parameters", {}),
+                    provider_data=provider_data,
+                )
+            return LMToolSpec(**tool)
+        raise TypeError(f"Cannot convert {type(tool)!r} to LMToolSpec.")
+
+    def _parse_response(
+        self,
+        state: _AdapterRequestState,
+        response: LMResponse,
+        lm: BaseLM | None = None,
+        request: LMRequest | None = None,
+    ) -> list[dict[str, Any]]:
+        """Parse normalized LM outputs through the legacy postprocess hook.
+
+        Keep `LMResponse` as the LM boundary while preserving custom adapters that override `_call_postprocess`.
+        """
+        lm_kwargs = self._legacy_call_kwargs(request) if request is not None else dict(state.lm_kwargs)
+        lm_kwargs.pop("messages", None)
+        return self._call_postprocess(
+            state.render_signature,
+            state.source_signature,
+            legacy_outputs_from_lm_response(response),
+            lm,
+            lm_kwargs,
+        )
+
+    async def _aparse_response(
+        self,
+        state: _AdapterRequestState,
+        response: LMResponse,
+        lm: BaseLM | None = None,
+        request: LMRequest | None = None,
+    ) -> list[dict[str, Any]]:
+        return self._parse_response(state, response, lm=lm, request=request)
 
     def __call__(
         self,
@@ -332,16 +435,11 @@ class Adapter:
             List of dictionaries representing parsed LM responses. Each dictionary contains keys matching the
             signature's output field names. For multiple generations (n > 1), returns multiple dictionaries.
         """
-        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
-        messages = self.format(processed_signature, demos, inputs)
-        request = self._render_request(lm, lm_kwargs, messages)
+        state = self._prepare_request_state(lm, lm_kwargs, signature, inputs)
+        messages = self.format(state.render_signature, demos, state.inputs)
+        request = self._render_request(lm, state, messages)
         response = self._call_lm(lm, request)
-        # TODO(adapters-response): We normalize at the LM boundary, but still
-        # convert back to legacy postprocess dictionaries here to keep this PR
-        # behavior-preserving. Replace with direct `LMResponse` parsing once the
-        # explicit adapter plan exists.
-        outputs = legacy_outputs_from_lm_response(response)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        return self._parse_response(state, response, lm=lm, request=request)
 
     async def acall(
         self,
@@ -351,14 +449,11 @@ class Adapter:
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
-        messages = self.format(processed_signature, demos, inputs)
-        request = self._render_request(lm, lm_kwargs, messages)
+        state = self._prepare_request_state(lm, lm_kwargs, signature, inputs)
+        messages = self.format(state.render_signature, demos, state.inputs)
+        request = self._render_request(lm, state, messages)
         response = await self._acall_lm(lm, request)
-        # TODO(adapters-response): Keep in sync with `__call__()` until both use
-        # direct `LMResponse` parsing.
-        outputs = legacy_outputs_from_lm_response(response)
-        return self._call_postprocess(processed_signature, signature, outputs, lm, lm_kwargs)
+        return await self._aparse_response(state, response, lm=lm, request=request)
 
     def format(
         self,
@@ -406,34 +501,26 @@ class Adapter:
             A list of multiturn messages as expected by the LM.
         """
         inputs_copy = dict(inputs)
+        conversation_history: list[LMMessage] = []
+        render_signature = signature
 
-        # If the signature and inputs have conversation history, we need to format the conversation history and
-        # remove the history field from the signature.
-        history_field_name = self._get_history_field_name(signature)
+        input_signature = render_signature
+
+        history_field_name = self._get_history_field_name(render_signature)
         if history_field_name:
-            # In order to format the conversation history, we need to remove the history field from the signature.
-            signature_without_history = signature.delete(history_field_name)
-            conversation_history = self.format_conversation_history(
-                signature_without_history,
-                history_field_name,
-                inputs_copy,
-            )
+            input_signature = render_signature.delete(history_field_name)
+            history_obj = inputs_copy.pop(history_field_name, None)
+            if history_obj is not None:
+                conversation_history = self.format_history(history_obj, input_signature)
 
-        messages = []
-        system_message = self.format_system_message(signature)
-        messages.append({"role": "system", "content": system_message})
-        messages.extend(self.format_demos(signature, demos))
-        if history_field_name:
-            # Conversation history and current input
-            content = self.format_user_message_content(signature_without_history, inputs_copy, main_request=True)
-            messages.extend(conversation_history)
-            messages.append({"role": "user", "content": content})
-        else:
-            # Only current input
-            content = self.format_user_message_content(signature, inputs_copy, main_request=True)
-            messages.append({"role": "user", "content": content})
+        messages: list[LMMessage | dict[str, Any]] = [
+            {"role": "system", "content": self.format_system_message(render_signature)}
+        ]
 
-        return [_expand_legacy_custom_type_markers_in_chat_message(message) for message in messages]
+        messages.extend(self.format_demos(render_signature, demos))
+        messages.extend(conversation_history)
+        messages.extend(self._format_input_messages(input_signature, inputs_copy, main_request=True))
+        return [message_to_openai_chat(message) for message in self._coerce_lm_messages(messages)]
 
     def format_system_message(self, signature: type[Signature]) -> str:
         """Format the system message for the LM call.
@@ -546,6 +633,9 @@ class Adapter:
         Returns:
             A list of multiturn messages.
         """
+        return [message_to_openai_chat(message) for message in self._format_demos_as_lm_messages(signature, demos)]
+
+    def _format_demos_as_lm_messages(self, signature: type[Signature], demos: list[dict[str, Any]]) -> list[LMMessage]:
         complete_demos = []
         incomplete_demos = []
 
@@ -563,45 +653,94 @@ class Adapter:
                 # We only keep incomplete demos that have at least one input and one output field
                 incomplete_demos.append(demo)
 
-        messages = []
+        messages: list[LMMessage] = []
 
         incomplete_demo_prefix = "This is an example of the task, though some input or output fields are not supplied."
         for demo in incomplete_demos:
-            messages.append(
-                {
-                    "role": "user",
-                    "content": self.format_user_message_content(signature, demo, prefix=incomplete_demo_prefix),
-                }
+            messages.extend(
+                self._format_input_messages(
+                    signature,
+                    demo,
+                    main_request=False,
+                    prefix=incomplete_demo_prefix,
+                )
             )
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": self.format_assistant_message_content(
-                        signature, demo, missing_field_message="Not supplied for this particular example. "
-                    ),
-                }
+            messages.extend(
+                self._format_output_messages(
+                    signature,
+                    demo,
+                    missing_field_message="Not supplied for this particular example. ",
+                )
             )
 
         for demo in complete_demos:
-            messages.append({"role": "user", "content": self.format_user_message_content(signature, demo)})
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": self.format_assistant_message_content(
-                        signature, demo, missing_field_message="Not supplied for this conversation history message. "
-                    ),
-                }
+            messages.extend(self._format_input_messages(signature, demo, main_request=False))
+            messages.extend(
+                self._format_output_messages(
+                    signature,
+                    demo,
+                    missing_field_message="Not supplied for this conversation history message. ",
+                )
             )
 
         return messages
 
-    def _get_history_field_name(self, signature: type[Signature]) -> bool:
+    def _format_input_messages(
+        self,
+        signature: type[Signature],
+        inputs: dict[str, Any],
+        *,
+        main_request: bool,
+        prefix: str = "",
+        suffix: str = "",
+    ) -> list[LMMessage]:
+        regular_inputs = self._drop_absent_optional_inputs(signature, dict(inputs))
+        content = self.format_user_message_content(
+            signature,
+            regular_inputs,
+            prefix=prefix,
+            suffix=suffix,
+            main_request=main_request,
+        )
+        return [LMMessage.model_validate({"role": "user", "content": content})] if self._has_content(content) else []
+
+    def _format_output_messages(
+        self,
+        signature: type[Signature],
+        outputs: dict[str, Any],
+        *,
+        missing_field_message: str | None,
+    ) -> list[LMMessage]:
+        content = self.format_assistant_message_content(
+            signature,
+            outputs,
+            missing_field_message=missing_field_message,
+        )
+        return (
+            [LMMessage.model_validate({"role": "assistant", "content": content})] if self._has_content(content) else []
+        )
+
+    @staticmethod
+    def _drop_absent_optional_inputs(signature: type[Signature], inputs: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in inputs.items()
+            if not (value is None and key in signature.input_fields and signature.input_fields[key].default is None)
+        }
+
+    @staticmethod
+    def _has_content(content: Any) -> bool:
+        if isinstance(content, str):
+            return bool(content.strip())
+        return bool(content)
+
+    def _get_history_field_name(self, signature: type[Signature]) -> str | None:
         for name, field in signature.input_fields.items():
             if field.annotation == History:
                 return name
         return None
 
-    def _get_tool_call_input_field_name(self, signature: type[Signature]) -> bool:
+    def _get_tool_call_input_field_name(self, signature: type[Signature]) -> str | None:
         for name, field in signature.input_fields.items():
             # Look for annotation `list[dspy.Tool]` or `dspy.Tool`
             origin = get_origin(field.annotation)
@@ -611,11 +750,49 @@ class Adapter:
                 return name
         return None
 
-    def _get_tool_call_output_field_name(self, signature: type[Signature]) -> bool:
+    def _get_tool_call_output_field_name(self, signature: type[Signature]) -> str | None:
         for name, field in signature.output_fields.items():
-            if field.annotation == ToolCalls:
+            if self._annotation_includes(field.annotation, ToolCalls):
                 return name
         return None
+
+    @classmethod
+    def _annotation_includes(cls, annotation: Any, target: type) -> bool:
+        if annotation is target:
+            return True
+        return any(cls._annotation_includes(arg, target) for arg in get_args(annotation))
+
+    def force_tool_call_config(self, tool_name: str) -> dict[str, Any]:
+        if not self.use_native_function_calling:
+            return {}
+        return {"tool_choice": {"mode": "required", "allowed": [tool_name]}}
+
+    def format_history(
+        self,
+        history: History,
+        signature: type[Signature],
+    ) -> list[LMMessage]:
+        history = history if isinstance(history, History) else History.model_validate(history)
+        messages: list[LMMessage] = []
+
+        for entry in history.messages:
+            if not isinstance(entry, dict):
+                continue
+
+            input_values = {key: value for key, value in entry.items() if key in signature.input_fields}
+            output_values = {key: value for key, value in entry.items() if key in signature.output_fields}
+            if input_values:
+                messages.extend(self._format_input_messages(signature, input_values, main_request=False))
+            if output_values:
+                messages.extend(
+                    self._format_output_messages(
+                        signature,
+                        output_values,
+                        missing_field_message="Not supplied for this conversation history message. ",
+                    )
+                )
+
+        return messages
 
     def format_conversation_history(
         self,
@@ -640,25 +817,10 @@ class Adapter:
         if conversation_history is None:
             return []
 
-        messages = []
-        for message in conversation_history:
-            messages.append(
-                {
-                    "role": "user",
-                    "content": self.format_user_message_content(signature, message),
-                }
-            )
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": self.format_assistant_message_content(signature, message),
-                }
-            )
-
         # Remove the history field from the inputs
         del inputs[history_field_name]
-
-        return messages
+        history = History(messages=conversation_history)
+        return [message_to_openai_chat(message) for message in self.format_history(history, signature)]
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
         """Parse the LM output into a dictionary of the output fields.

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -70,19 +70,23 @@ class ChatAdapter(Adapter):
     ) -> list[dict[str, Any]]:
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
-        except Exception as e:
+        except Exception as err:
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 
             if (
-                isinstance(e, ContextWindowExceededError)
+                isinstance(err, ContextWindowExceededError)
                 or isinstance(self, JSONAdapter)
                 or not self.use_json_adapter_fallback
             ):
                 # On context window exceeded error, already using JSONAdapter, or use_json_adapter_fallback is False
                 # we don't want to retry with a different adapter. Raise the original error instead of the fallback error.
-                raise e
-            return JSONAdapter()(lm, lm_kwargs, signature, demos, inputs)
+                raise
+            return JSONAdapter(
+                callbacks=self.callbacks,
+                use_native_function_calling=self.use_native_function_calling,
+                native_response_types=self.native_response_types,
+            )(lm, lm_kwargs, signature, demos, inputs)
 
     async def acall(
         self,
@@ -94,25 +98,29 @@ class ChatAdapter(Adapter):
     ) -> list[dict[str, Any]]:
         try:
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
-        except Exception as e:
+        except Exception as err:
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 
             if (
-                isinstance(e, ContextWindowExceededError)
+                isinstance(err, ContextWindowExceededError)
                 or isinstance(self, JSONAdapter)
                 or not self.use_json_adapter_fallback
             ):
                 # On context window exceeded error, already using JSONAdapter, or use_json_adapter_fallback is False
                 # we don't want to retry with a different adapter. Raise the original error instead of the fallback error.
-                raise e
-            return await JSONAdapter().acall(lm, lm_kwargs, signature, demos, inputs)
+                raise
+            return await JSONAdapter(
+                callbacks=self.callbacks,
+                use_native_function_calling=self.use_native_function_calling,
+                native_response_types=self.native_response_types,
+            ).acall(lm, lm_kwargs, signature, demos, inputs)
 
     def format_field_description(self, signature: type[Signature]) -> str:
-        return (
-            f"Your input fields are:\n{get_field_description_string(signature.input_fields)}\n"
-            f"Your output fields are:\n{get_field_description_string(signature.output_fields)}"
-        )
+        description = f"Your input fields are:\n{get_field_description_string(signature.input_fields)}"
+        if signature.output_fields:
+            description += f"\nYour output fields are:\n{get_field_description_string(signature.output_fields)}"
+        return description
 
     def format_field_structure(self, signature: type[Signature]) -> str:
         """
@@ -132,8 +140,9 @@ class ChatAdapter(Adapter):
             )
 
         parts.append(format_signature_fields_for_instructions(signature.input_fields))
-        parts.append(format_signature_fields_for_instructions(signature.output_fields))
-        parts.append("[[ ## completed ## ]]\n")
+        if signature.output_fields:
+            parts.append(format_signature_fields_for_instructions(signature.output_fields))
+            parts.append("[[ ## completed ## ]]\n")
         return "\n\n".join(parts).strip()
 
     def format_task_description(self, signature: type[Signature]) -> str:
@@ -164,7 +173,7 @@ class ChatAdapter(Adapter):
         messages.append(suffix)
         return "\n\n".join(messages).strip()
 
-    def user_message_output_requirements(self, signature: type[Signature]) -> str:
+    def user_message_output_requirements(self, signature: type[Signature]) -> str | None:
         """Returns a simplified format reminder for the language model.
 
         In chat-based interactions, language models may lose track of the required output format
@@ -181,6 +190,9 @@ class ChatAdapter(Adapter):
             This is a more lightweight version of `format_field_structure` specifically designed
             for inline reminders within chat messages.
         """
+
+        if not signature.output_fields:
+            return None
 
         def type_info(v):
             if v.annotation is not str:

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -38,9 +38,18 @@ def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
 
 
 class JSONAdapter(ChatAdapter):
-    def __init__(self, callbacks: list[BaseCallback] | None = None, use_native_function_calling: bool = True):
+    def __init__(
+        self,
+        callbacks: list[BaseCallback] | None = None,
+        use_native_function_calling: bool = True,
+        native_response_types: list[type[type]] | None = None,
+    ):
         # JSONAdapter uses native function calling by default.
-        super().__init__(callbacks=callbacks, use_native_function_calling=use_native_function_calling)
+        super().__init__(
+            callbacks=callbacks,
+            use_native_function_calling=use_native_function_calling,
+            native_response_types=native_response_types,
+        )
 
     def _json_adapter_call_common(self, lm, lm_kwargs, signature, demos, inputs, call_fn):
         """Common call logic to be used for both sync and async calls."""
@@ -49,7 +58,11 @@ class JSONAdapter(ChatAdapter):
 
         has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
 
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
+        if (
+            _has_open_ended_mapping(signature)
+            or (not self.use_native_function_calling and has_tool_calls)
+            or not lm.supports_response_schema
+        ):
             # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
             # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -63,20 +76,18 @@ class JSONAdapter(ChatAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().__call__)
+        request_lm_kwargs = dict(lm_kwargs)
+        result = self._json_adapter_call_common(lm, request_lm_kwargs, signature, demos, inputs, super().__call__)
         if result:
             return result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
-            lm_kwargs["response_format"] = structured_output_model
-            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+            return super().__call__(lm, request_lm_kwargs, signature, demos, inputs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
-            lm_kwargs["response_format"] = {"type": "json_object"}
-            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+            fallback_lm_kwargs = dict(request_lm_kwargs)
+            fallback_lm_kwargs["response_format"] = {"type": "json_object"}
+            return super().__call__(lm, fallback_lm_kwargs, signature, demos, inputs)
 
     async def acall(
         self,
@@ -86,20 +97,43 @@ class JSONAdapter(ChatAdapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().acall)
+        request_lm_kwargs = dict(lm_kwargs)
+        result = self._json_adapter_call_common(lm, request_lm_kwargs, signature, demos, inputs, super().acall)
         if result:
             return await result
 
         try:
-            structured_output_model = _get_structured_outputs_response_format(
-                signature, self.use_native_function_calling
-            )
-            lm_kwargs["response_format"] = structured_output_model
-            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+            return await super().acall(lm, request_lm_kwargs, signature, demos, inputs)
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
-            lm_kwargs["response_format"] = {"type": "json_object"}
-            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+            fallback_lm_kwargs = dict(request_lm_kwargs)
+            fallback_lm_kwargs["response_format"] = {"type": "json_object"}
+            return await super().acall(lm, fallback_lm_kwargs, signature, demos, inputs)
+
+    def _prepare_request_kwargs(self, lm: BaseLM, state) -> dict[str, Any]:
+        request_kwargs = dict(state.lm_kwargs)
+        if "response_format" in request_kwargs or "response_format" not in lm.supported_params:
+            return request_kwargs
+        if not state.render_signature.output_fields:
+            return request_kwargs
+
+        has_tool_calls = any(
+            self._annotation_includes(field.annotation, ToolCalls)
+            for field in state.source_signature.output_fields.values()
+        )
+        if (
+            _has_open_ended_mapping(state.render_signature)
+            or (not self.use_native_function_calling and has_tool_calls)
+            or not lm.supports_response_schema
+        ):
+            request_kwargs["response_format"] = {"type": "json_object"}
+            return request_kwargs
+
+        request_kwargs["response_format"] = _get_structured_outputs_response_format(
+            state.render_signature,
+            self.use_native_function_calling,
+        )
+        return request_kwargs
 
     def format_field_structure(self, signature: type[Signature]) -> str:
         parts = []
@@ -116,11 +150,15 @@ class JSONAdapter(ChatAdapter):
 
         parts.append("Inputs will have the following structure:")
         parts.append(format_signature_fields_for_instructions(signature.input_fields, role="user"))
-        parts.append("Outputs will be a JSON object with the following fields.")
-        parts.append(format_signature_fields_for_instructions(signature.output_fields, role="assistant"))
+        if signature.output_fields:
+            parts.append("Outputs will be a JSON object with the following fields.")
+            parts.append(format_signature_fields_for_instructions(signature.output_fields, role="assistant"))
         return "\n\n".join(parts).strip()
 
-    def user_message_output_requirements(self, signature: type[Signature]) -> str:
+    def user_message_output_requirements(self, signature: type[Signature]) -> str | None:
+        if not signature.output_fields:
+            return None
+
         def type_info(v):
             return (
                 f" (must be formatted as a valid Python {get_annotation_name(v.annotation)})"

--- a/dspy/adapters/two_step_adapter.py
+++ b/dspy/adapters/two_step_adapter.py
@@ -1,14 +1,13 @@
 from typing import Any
 
-import json_repair
-
 from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
-from dspy.adapters.types import ToolCalls
+from dspy.adapters.types import ToolCalls, Type
 from dspy.adapters.utils import get_field_description_string
 from dspy.clients.base_lm import BaseLM
 from dspy.signatures.field import InputField
 from dspy.signatures.signature import Signature, make_signature
+from dspy.utils.exceptions import AdapterParseError
 
 """
 NOTE/TODO/FIXME:
@@ -103,59 +102,75 @@ class TwoStepAdapter(Adapter):
         except Exception as e:
             raise ValueError(f"Failed to parse response from the original completion: {completion}") from e
 
-    async def acall(
-        self,
-        lm: BaseLM,
-        lm_kwargs: dict[str, Any],
-        signature: type[Signature],
-        demos: list[dict[str, Any]],
-        inputs: dict[str, Any],
-    ) -> list[dict[str, Any]]:
-        inputs = self.format(signature, demos, inputs)
-
-        outputs = await lm.acall(messages=inputs, **lm_kwargs)
-        # The signature is supposed to be "text -> {original output fields}"
+    async def aparse(self, signature: Signature, completion: str) -> dict[str, Any]:
         extractor_signature = self._create_extractor_signature(signature)
 
+        try:
+            parsed_result = await ChatAdapter().acall(
+                lm=self.extraction_model,
+                lm_kwargs={},
+                signature=extractor_signature,
+                demos=[],
+                inputs={"text": completion},
+            )
+            return parsed_result[0]
+
+        except Exception as e:
+            raise ValueError(f"Failed to parse response from the original completion: {completion}") from e
+
+    async def _aparse_response(self, state, response, lm=None, request=None) -> list[dict[str, Any]]:
         values = []
+        tool_call_output_field_name = self._get_tool_call_output_field_name(state.source_signature)
 
-        tool_call_output_field_name = self._get_tool_call_output_field_name(signature)
-        for output in outputs:
-            output_logprobs = None
-            tool_calls = None
-            text = output
+        for output in response.outputs:
+            if output.metadata.get("empty_legacy_outputs"):
+                continue
 
-            if isinstance(output, dict):
-                text = output["text"]
-                output_logprobs = output.get("logprobs")
-                tool_calls = output.get("tool_calls")
+            value: dict[str, Any] = {}
+            parsed_any = False
 
-            try:
-                # Call the smaller LM to extract structured data from the raw completion text with ChatAdapter
-                value = await ChatAdapter().acall(
-                    lm=self.extraction_model,
-                    lm_kwargs={},
-                    signature=extractor_signature,
-                    demos=[],
-                    inputs={"text": text},
+            if output.text and state.render_signature.output_fields:
+                value.update(await self.aparse(state.render_signature, output.text))
+                parsed_any = True
+
+            if output.tool_calls and tool_call_output_field_name:
+                value[tool_call_output_field_name] = ToolCalls.from_dict_list(
+                    [
+                        {
+                            "name": tool_call.name,
+                            "args": tool_call.args,
+                        }
+                        for tool_call in output.tool_calls
+                    ]
                 )
-                value = value[0]
+                parsed_any = True
 
-            except Exception as e:
-                raise ValueError(f"Failed to parse response from the original completion: {output}") from e
+            output_dict = output.to_output_dict()
+            legacy_output = output.provider_output if output.provider_output is not None else output_dict
+            for name, field_info in state.source_signature.output_fields.items():
+                if (
+                    isinstance(field_info.annotation, type)
+                    and field_info.annotation in self.native_response_types
+                    and issubclass(field_info.annotation, Type)
+                ):
+                    parsed_value = field_info.annotation.parse_lm_response(legacy_output)
+                    if parsed_value is not None:
+                        value[name] = parsed_value
+                        parsed_any = True
 
-            if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
-                value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
+            for field_name in state.source_signature.output_fields:
+                value.setdefault(field_name, None)
 
-            if output_logprobs is not None:
-                value["logprobs"] = output_logprobs
+            if not parsed_any:
+                raise AdapterParseError(
+                    adapter_name=type(self).__name__,
+                    signature=state.source_signature,
+                    lm_response=str(output_dict),
+                    message="The LM returned an empty or null response.",
+                )
+
+            if output.logprobs is not None:
+                value["logprobs"] = output.logprobs
 
             values.append(value)
         return values
@@ -180,6 +195,7 @@ class TwoStepAdapter(Adapter):
         inputs: dict[str, Any],
         prefix: str = "",
         suffix: str = "",
+        main_request: bool = False,
     ) -> str:
         parts = [prefix]
 

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -38,7 +38,8 @@ class XMLAdapter(ChatAdapter):
             )
 
         parts.append(format_signature_fields_for_instructions(signature.input_fields))
-        parts.append(format_signature_fields_for_instructions(signature.output_fields))
+        if signature.output_fields:
+            parts.append(format_signature_fields_for_instructions(signature.output_fields))
         return "\n\n".join(parts).strip()
 
     def format_user_message_content(
@@ -51,12 +52,15 @@ class XMLAdapter(ChatAdapter):
     ) -> str:
         messages = [prefix]
 
-        messages.append(self.format_field_with_value(
-            {
-                FieldInfoWithName(name=k, info=v): inputs.get(k)
-                for k, v in signature.input_fields.items() if k in inputs
-            },
-        ))
+        messages.append(
+            self.format_field_with_value(
+                {
+                    FieldInfoWithName(name=k, info=v): inputs.get(k)
+                    for k, v in signature.input_fields.items()
+                    if k in inputs
+                },
+            )
+        )
 
         if main_request:
             output_requirements = self.user_message_output_requirements(signature)
@@ -79,7 +83,10 @@ class XMLAdapter(ChatAdapter):
             },
         )
 
-    def user_message_output_requirements(self, signature: type[Signature]) -> str:
+    def user_message_output_requirements(self, signature: type[Signature]) -> str | None:
+        if not signature.output_fields:
+            return None
+
         message = "Respond with the corresponding output fields wrapped in XML tags "
         message += ", then ".join(f"`<{f}>`" for f in signature.output_fields)
         message += "."

--- a/tests/adapters/test_adapter_base.py
+++ b/tests/adapters/test_adapter_base.py
@@ -1,0 +1,331 @@
+from typing import ClassVar
+
+import pytest
+
+import dspy
+from dspy.core.types import LMOutput, LMResponse, LMTextPart
+from dspy.utils.callback import BaseCallback
+
+
+def search(query: str) -> str:
+    return query
+
+
+def add(a: int, b: int) -> int:
+    return a + b
+
+
+class NativeToolLM:
+    model = "openai/gpt-5-nano"
+    model_type = "chat"
+    kwargs: ClassVar[dict] = {}
+    supported_params = frozenset()
+    supports_function_calling = True
+    supports_reasoning = False
+    supports_response_schema = False
+
+    def __init__(self, output=None):
+        self.output = output
+        self.messages = None
+        self.kwargs = None
+
+    def __call__(self, messages, **kwargs):
+        self.messages = messages
+        self.kwargs = kwargs
+        return [self.output]
+
+    async def acall(self, messages, **kwargs):
+        return self(messages, **kwargs)
+
+
+class QASignature(dspy.Signature):
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField()
+
+
+class PostprocessOverrideAdapter(dspy.Adapter):
+    def __init__(self):
+        super().__init__()
+        self.seen = None
+
+    def format(self, signature, demos, inputs):
+        return [{"role": "user", "content": inputs["question"]}]
+
+    def _call_postprocess(self, processed_signature, original_signature, outputs, lm, lm_kwargs):
+        self.seen = {
+            "processed_signature": processed_signature,
+            "original_signature": original_signature,
+            "outputs": outputs,
+            "lm": lm,
+            "lm_kwargs": lm_kwargs,
+        }
+        return [{"answer": f"postprocessed {outputs[0]}"}]
+
+
+def test_prepare_request_state_copies_kwargs_and_extracts_tools():
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    adapter = dspy.Adapter(use_native_function_calling=True)
+    lm_kwargs = {"temperature": 0.2}
+    inputs = {"question": "Q?", "tools": [dspy.Tool(search)]}
+
+    state = adapter._prepare_request_state(NativeToolLM(), lm_kwargs, ToolSignature, inputs)
+
+    assert lm_kwargs == {"temperature": 0.2}
+    assert inputs["tools"][0].name == "search"
+    assert "tools" not in state.lm_kwargs
+    assert state.tools[0].name == "search"
+    assert "tools" not in state.render_signature.input_fields
+    assert "tool_calls" not in state.render_signature.output_fields
+    assert state.hidden_output_fields == ("tool_calls",)
+
+def test_prepare_request_state_preserves_normal_signature_and_copies_data():
+    adapter = dspy.Adapter()
+    lm_kwargs = {"temperature": 0.2, "metadata": {"trace_id": "abc"}}
+    inputs = {"question": "Q?"}
+
+    state = adapter._prepare_request_state(NativeToolLM(), lm_kwargs, QASignature, inputs)
+
+    assert state.source_signature is QASignature
+    assert state.render_signature is QASignature
+    assert state.inputs == inputs
+    assert state.inputs is not inputs
+    assert state.lm_kwargs == lm_kwargs
+    assert state.lm_kwargs is not lm_kwargs
+    assert state.tools == []
+    assert state.hidden_output_fields == ()
+    assert lm_kwargs == {"temperature": 0.2, "metadata": {"trace_id": "abc"}}
+    assert inputs == {"question": "Q?"}
+
+
+def test_render_request_normal_state_preserves_messages_and_kwargs():
+    adapter = dspy.ChatAdapter()
+    lm = NativeToolLM()
+    state = adapter._prepare_request_state(
+        lm,
+        {"temperature": 0.7, "n": 2, "custom_option": "value"},
+        QASignature,
+        {"question": "Q2?"},
+    )
+
+    messages = adapter.format(state.render_signature, [{"question": "Q1?", "answer": "A1"}], state.inputs)
+    request = adapter._render_request(lm, state, messages)
+
+    assert request.model == lm.model
+    assert request.tools == []
+    assert request.config.temperature == 0.7
+    assert request.config.n == 2
+    assert request.config.extensions == {"custom_option": "value"}
+    assert [message.role for message in request.messages] == ["system", "user", "assistant", "user"]
+    assert "Q1?" in request.messages[1].text
+    assert "A1" in request.messages[2].text
+    assert "Q2?" in request.messages[3].text
+
+
+def test_render_request_normal_state_expands_history_without_mutating_inputs():
+    class HistorySignature(dspy.Signature):
+        history: dspy.History = dspy.InputField()
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    adapter = dspy.ChatAdapter()
+    lm = NativeToolLM()
+    history = dspy.History(messages=[{"question": "What is the capital of France?", "answer": "Paris"}])
+    inputs = {"history": history, "question": "What country is it in?"}
+
+    state = adapter._prepare_request_state(lm, {}, HistorySignature, inputs)
+    messages = adapter.format(state.render_signature, [], state.inputs)
+    request = adapter._render_request(lm, state, messages)
+
+    assert inputs == {"history": history, "question": "What country is it in?"}
+    assert [message.role for message in request.messages] == ["system", "user", "assistant", "user"]
+    assert "What is the capital of France?" in request.messages[1].text
+    assert "Paris" in request.messages[2].text
+    assert "What country is it in?" in request.messages[3].text
+    assert "[[ ## history ## ]]" not in request.messages[3].text
+    assert "Paris" not in request.messages[3].text
+
+
+def test_adapter_format_callbacks_receive_public_arguments():
+    class CaptureFormatCallback(BaseCallback):
+        def __init__(self):
+            self.inputs = None
+
+        def on_adapter_format_start(self, call_id, instance, inputs):
+            self.inputs = inputs
+
+    callback = CaptureFormatCallback()
+    lm = NativeToolLM("[[ ## answer ## ]]\nA\n\n[[ ## completed ## ]]")
+
+    dspy.ChatAdapter(callbacks=[callback], use_json_adapter_fallback=False)(
+        lm,
+        {},
+        QASignature,
+        [{"question": "demo question", "answer": "demo answer"}],
+        {"question": "Q?"},
+    )
+
+    assert set(callback.inputs) == {"signature", "demos", "inputs"}
+    assert callback.inputs["signature"] is QASignature
+    assert callback.inputs["demos"] == [{"question": "demo question", "answer": "demo answer"}]
+    assert callback.inputs["inputs"] == {"question": "Q?"}
+
+
+def test_call_path_uses_public_format_override():
+    class FormatOverrideAdapter(dspy.Adapter):
+        def format(self, signature, demos, inputs):
+            return [
+                {"role": "system", "content": "custom system"},
+                {"role": "user", "content": f"custom user: {inputs['question']}"},
+            ]
+
+        def parse(self, signature, completion):
+            return {"answer": completion}
+
+    lm = NativeToolLM("custom answer")
+
+    result = FormatOverrideAdapter()(
+        lm,
+        {},
+        QASignature,
+        [{"question": "demo question", "answer": "demo answer"}],
+        {"question": "Q?"},
+    )
+
+    assert result == [{"answer": "custom answer"}]
+    assert lm.messages == [
+        {"role": "system", "content": "custom system"},
+        {"role": "user", "content": "custom user: Q?"},
+    ]
+
+
+def test_call_path_uses_public_format_demos_override():
+    class DemoOverrideAdapter(dspy.ChatAdapter):
+        def format_demos(self, signature, demos):
+            return [{"role": "user", "content": "custom demo message"}]
+
+    lm = NativeToolLM("[[ ## answer ## ]]\nA\n\n[[ ## completed ## ]]")
+
+    result = DemoOverrideAdapter(use_json_adapter_fallback=False)(
+        lm,
+        {},
+        QASignature,
+        [{"question": "demo question", "answer": "demo answer"}],
+        {"question": "Q?"},
+    )
+
+    assert result == [{"answer": "A"}]
+    assert any(message["content"] == "custom demo message" for message in lm.messages)
+    assert not any("demo question" in message["content"] for message in lm.messages)
+
+
+def test_call_path_uses_call_postprocess_override():
+    adapter = PostprocessOverrideAdapter()
+    lm = NativeToolLM("raw completion")
+
+    result = adapter(lm, {"temperature": 0.3}, QASignature, [], {"question": "Q?"})
+
+    assert result == [{"answer": "postprocessed raw completion"}]
+    assert adapter.seen["processed_signature"] is QASignature
+    assert adapter.seen["original_signature"] is QASignature
+    assert adapter.seen["outputs"] == ["raw completion"]
+    assert adapter.seen["lm"] is lm
+    assert adapter.seen["lm_kwargs"]["temperature"] == 0.3
+
+
+@pytest.mark.asyncio
+async def test_acall_path_uses_call_postprocess_override():
+    adapter = PostprocessOverrideAdapter()
+    lm = NativeToolLM("raw completion")
+
+    result = await adapter.acall(lm, {"temperature": 0.3}, QASignature, [], {"question": "Q?"})
+
+    assert result == [{"answer": "postprocessed raw completion"}]
+    assert adapter.seen["processed_signature"] is QASignature
+    assert adapter.seen["original_signature"] is QASignature
+    assert adapter.seen["outputs"] == ["raw completion"]
+    assert adapter.seen["lm"] is lm
+    assert adapter.seen["lm_kwargs"]["temperature"] == 0.3
+
+
+def test_parse_response_normal_state_parses_text_output_and_logprobs():
+    adapter = dspy.ChatAdapter()
+    state = adapter._prepare_request_state(NativeToolLM(), {}, QASignature, {"question": "Q?"})
+    response = LMResponse(
+        model="dummy",
+        outputs=[
+            LMOutput(
+                parts=[LMTextPart(text="[[ ## answer ## ]]\nA\n\n[[ ## completed ## ]]")],
+                logprobs={"tokens": ["A"]},
+            )
+        ],
+    )
+
+    assert adapter._parse_response(state, response) == [{"answer": "A", "logprobs": {"tokens": ["A"]}}]
+
+
+def test_native_tool_response_can_combine_visible_text_and_tool_calls():
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        answer: str = dspy.OutputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    lm = NativeToolLM(
+        {
+            "text": "[[ ## answer ## ]]\nworking\n\n[[ ## completed ## ]]",
+            "tool_calls": [
+                {
+                    "id": "call_add",
+                    "type": "function",
+                    "function": {"name": "add", "arguments": '{"a": 1, "b": 2}'},
+                }
+            ],
+        }
+    )
+
+    result = dspy.ChatAdapter(use_native_function_calling=True)(
+        lm,
+        {},
+        ToolSignature,
+        [],
+        {"question": "What is 1+2?", "tools": [dspy.Tool(add)]},
+    )[0]
+
+    assert result["answer"] == "working"
+    assert result["tool_calls"].tool_calls[0].name == "add"
+    assert result["tool_calls"].tool_calls[0].args == {"a": 1, "b": 2}
+    assert "tools" in lm.kwargs
+    assert lm.kwargs["tools"][0]["function"]["name"] == "add"
+
+
+def test_native_tool_response_repairs_nonstandard_json_arguments():
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    lm = NativeToolLM(
+        {
+            "tool_calls": [
+                {
+                    "id": "call_add",
+                    "type": "function",
+                    "function": {"name": "add", "arguments": "{'a': 1, 'b': 2}"},
+                }
+            ],
+        }
+    )
+
+    result = dspy.ChatAdapter(use_native_function_calling=True)(
+        lm,
+        {},
+        ToolSignature,
+        [],
+        {"question": "What is 1+2?", "tools": [dspy.Tool(add)]},
+    )[0]
+
+    assert result["tool_calls"].tool_calls[0].args == {"a": 1, "b": 2}

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -1080,25 +1080,16 @@ def test_chat_adapter_format_exact_messages_and_lm_kwargs_with_native_tool_calli
     expected_messages = [{"role": "system",
       "content": "Your input fields are:\n"
                  "1. `question` (str):\n"
-                 "Your output fields are:\n"
-                 "\n"
                  "All interactions will be structured in the following way, with the appropriate "
                  "values filled in.\n"
                  "\n"
                  "[[ ## question ## ]]\n"
                  "{question}\n"
-                 "\n"
-                 "\n"
-                 "\n"
-                 "[[ ## completed ## ]]\n"
                  "In adhering to this structure, your objective is: \n"
                  "        Given the fields `question`, `tools`, produce the fields `tool_calls`."},
      {"role": "user",
       "content": "[[ ## question ## ]]\n"
-                 "Q?\n"
-                 "\n"
-                 "Respond with the corresponding output fields, starting with the field , and then "
-                 "ending with the marker for `[[ ## completed ## ]]`."}]
+                 "Q?"}]
     assert messages == expected_messages
     expected_lm_kwargs = {"tools": [{"type": "function",
                 "function": {"name": "search",

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Literal
+from typing import Any, ClassVar, Literal
 from unittest import mock
 
 import pydantic
@@ -10,6 +10,36 @@ from openai.types.responses import ResponseOutputMessage
 
 import dspy
 from tests.adapters.conftest import format_messages_and_lm_kwargs
+
+
+class RecordingJSONLM:
+    model = "openai/gpt-5-nano"
+    model_type = "chat"
+    kwargs: ClassVar[dict[str, Any]] = {}
+    supported_params = frozenset({"response_format"})
+    supports_function_calling = False
+    supports_reasoning = False
+
+    def __init__(self, supports_response_schema: bool, fail_structured_once: bool = False):
+        self.supports_response_schema = supports_response_schema
+        self.fail_structured_once = fail_structured_once
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, messages, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": dict(kwargs)})
+        response_format = kwargs.get("response_format")
+        if self.fail_structured_once and isinstance(response_format, type) and issubclass(response_format, pydantic.BaseModel):
+            self.fail_structured_once = False
+            raise RuntimeError("Structured output failed!")
+        return ["{'answer': 'Test output'}"]
+
+    async def acall(self, messages, **kwargs):
+        return self(messages, **kwargs)
+
+
+class JSONMutationSignature(dspy.Signature):
+    question: str = dspy.InputField()
+    answer: str = dspy.OutputField(desc="String output field")
 
 
 def test_json_adapter_format_exact_messages_for_simple_signature():
@@ -577,8 +607,6 @@ def test_json_adapter_format_exact_messages_and_lm_kwargs_with_native_tool_calli
     expected_messages = [{"role": "system",
       "content": "Your input fields are:\n"
                  "1. `question` (str):\n"
-                 "Your output fields are:\n"
-                 "\n"
                  "All interactions will be structured in the following way, with the appropriate "
                  "values filled in.\n"
                  "\n"
@@ -586,17 +614,11 @@ def test_json_adapter_format_exact_messages_and_lm_kwargs_with_native_tool_calli
                  "\n"
                  "[[ ## question ## ]]\n"
                  "{question}\n"
-                 "\n"
-                 "Outputs will be a JSON object with the following fields.\n"
-                 "\n"
-                 "{}\n"
                  "In adhering to this structure, your objective is: \n"
                  "        Given the fields `question`, `tools`, produce the fields `tool_calls`."},
      {"role": "user",
       "content": "[[ ## question ## ]]\n"
-                 "Q?\n"
-                 "\n"
-                 "Respond with a JSON object in the following order of fields: ."}]
+                 "Q?"}]
     assert messages == expected_messages
     expected_lm_kwargs = {"tools": [{"type": "function",
                 "function": {"name": "search",
@@ -1319,6 +1341,30 @@ def test_json_adapter_fallback_to_json_mode_on_structured_output_failure():
         assert second_call_kwargs.get("response_format") == {"type": "json_object"}
 
 
+@pytest.mark.parametrize(
+    ("supports_response_schema", "fail_structured_once", "expected_call_count"),
+    [(False, False, 1), (True, True, 2)],
+)
+def test_json_adapter_does_not_mutate_caller_lm_kwargs(
+    supports_response_schema, fail_structured_once, expected_call_count
+):
+    adapter = dspy.JSONAdapter()
+    lm = RecordingJSONLM(
+        supports_response_schema=supports_response_schema,
+        fail_structured_once=fail_structured_once,
+    )
+    lm_kwargs = {"temperature": 0.2}
+
+    result = adapter(lm, lm_kwargs, JSONMutationSignature, [], {"question": "Dummy question!"})
+
+    assert result == [{"answer": "Test output"}]
+    assert lm_kwargs == {"temperature": 0.2}
+    assert len(lm.calls) == expected_call_count
+    if expected_call_count == 2:
+        assert issubclass(lm.calls[0]["kwargs"].get("response_format"), pydantic.BaseModel)
+    assert lm.calls[-1]["kwargs"].get("response_format") == {"type": "json_object"}
+
+
 def test_json_adapter_json_mode_no_structured_outputs():
     class TestSignature(dspy.Signature):
         question: str = dspy.InputField()
@@ -1406,6 +1452,31 @@ async def test_json_adapter_fallback_to_json_mode_on_structured_output_failure_a
         # The second call should have used JSON mode
         _, second_call_kwargs = mock_acompletion.call_args_list[1]
         assert second_call_kwargs.get("response_format") == {"type": "json_object"}
+
+
+@pytest.mark.parametrize(
+    ("supports_response_schema", "fail_structured_once", "expected_call_count"),
+    [(False, False, 1), (True, True, 2)],
+)
+@pytest.mark.asyncio
+async def test_json_adapter_does_not_mutate_caller_lm_kwargs_async(
+    supports_response_schema, fail_structured_once, expected_call_count
+):
+    adapter = dspy.JSONAdapter()
+    lm = RecordingJSONLM(
+        supports_response_schema=supports_response_schema,
+        fail_structured_once=fail_structured_once,
+    )
+    lm_kwargs = {"temperature": 0.2}
+
+    result = await adapter.acall(lm, lm_kwargs, JSONMutationSignature, [], {"question": "Dummy question!"})
+
+    assert result == [{"answer": "Test output"}]
+    assert lm_kwargs == {"temperature": 0.2}
+    assert len(lm.calls) == expected_call_count
+    if expected_call_count == 2:
+        assert issubclass(lm.calls[0]["kwargs"].get("response_format"), pydantic.BaseModel)
+    assert lm.calls[-1]["kwargs"].get("response_format") == {"type": "json_object"}
 
 
 def test_error_message_on_json_adapter_failure():

--- a/tests/adapters/test_two_step_adapter.py
+++ b/tests/adapters/test_two_step_adapter.py
@@ -1,9 +1,30 @@
+from typing import Any, ClassVar
 from unittest import mock
 
 import pytest
 
 import dspy
 from tests.adapters.conftest import format_messages_and_lm_kwargs
+
+
+class AsyncNativeToolLM:
+    model = "openai/gpt-5-nano"
+    model_type = "chat"
+    kwargs: ClassVar[dict[str, Any]] = {}
+    supported_params = frozenset()
+    supports_function_calling = True
+    supports_reasoning = False
+    supports_response_schema = False
+
+    def __init__(self, output):
+        self.output = output
+        self.messages = None
+        self.call_kwargs = None
+
+    async def acall(self, messages, **kwargs):
+        self.messages = messages
+        self.call_kwargs = kwargs
+        return [self.output]
 
 
 def test_two_step_adapter_format_exact_messages_for_simple_signature_with_demo():
@@ -187,6 +208,62 @@ async def test_two_step_adapter_async_call():
     assert call_kwargs["messages"][1]["role"] == "user"
     content = call_kwargs["messages"][1]["content"]
     assert "text from main LM" in content
+
+
+@pytest.mark.asyncio
+async def test_two_step_adapter_async_call_uses_normalized_request_pipeline_with_tools():
+    def search(query: str) -> str:
+        """Search for documents."""
+        return query
+
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        answer: str = dspy.OutputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    main_lm = AsyncNativeToolLM(
+        {
+            "text": "The answer is in the documents.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"query": "documents"}'},
+                }
+            ],
+        }
+    )
+
+    extraction_lm = mock.MagicMock(spec=dspy.LM)
+    extraction_lm.acall.return_value = [
+        """
+[[ ## answer ## ]] extracted answer
+[[ ## completed ## ]]
+"""
+    ]
+    extraction_lm.kwargs = {"temperature": 1.0}
+    extraction_lm.model = "openai/gpt-4o"
+
+    adapter = dspy.TwoStepAdapter(extraction_model=extraction_lm, use_native_function_calling=True)
+    lm_kwargs = {"temperature": 0.2}
+
+    result = await adapter.acall(
+        main_lm,
+        lm_kwargs,
+        ToolSignature,
+        [],
+        {"question": "What should I search?", "tools": [dspy.Tool(search)]},
+    )
+
+    assert lm_kwargs == {"temperature": 0.2}
+    assert main_lm.call_kwargs["temperature"] == 0.2
+    assert main_lm.call_kwargs["tools"][0]["function"]["name"] == "search"
+    assert "tools:" not in main_lm.messages[-1]["content"]
+    assert result[0]["answer"] == "extracted answer"
+    assert result[0]["tool_calls"] == dspy.ToolCalls.from_dict_list(
+        [{"name": "search", "args": {"query": "documents"}}]
+    )
 
 
 def test_two_step_adapter_parse():


### PR DESCRIPTION
## Summary

This PR contains only the first commit from the minimal ReActV2 stack, rebased onto `origin/main`.

It preserves the existing public adapter formatting contract while keeping `LMRequest` / `LMResponse` as the adapter-to-LM boundary:

- `Adapter.__call__` / `Adapter.acall` still call public `format(state.render_signature, demos, state.inputs)`
- public `format()` and `format_demos()` overrides continue to affect the real sync/async call paths
- adapter format callbacks continue to observe public `signature`, `demos`, and `inputs` keys
- `_AdapterRequestState` remains private request/parse bookkeeping rather than becoming a formatting API
- `_render_request(...)` consumes already formatted messages and builds an `LMRequest`
- native tool specs stay on `LMRequest.tools`, outside rendered prompt messages
- `_parse_response(...)` uses the existing `legacy_outputs_from_lm_response(...)` bridge so `_call_postprocess(...)` overrides remain reachable

Reviewer follow-ups addressed:

- `JSONAdapter` now copies caller-provided `lm_kwargs` before JSON-mode or structured-output fallback injects `response_format`, including sync and async paths.
- `Adapter.acall` now dispatches through a private `_aparse_response(...)` hook, and `TwoStepAdapter` overrides that hook for its async extraction LM call instead of bypassing the normalized request pipeline.

## Validation

- `uv run --frozen ruff check dspy/adapters/base.py dspy/adapters/two_step_adapter.py dspy/adapters/json_adapter.py dspy/adapters/chat_adapter.py dspy/adapters/xml_adapter.py tests/adapters/test_adapter_base.py tests/adapters/test_chat_adapter.py tests/adapters/test_json_adapter.py tests/adapters/test_two_step_adapter.py`
- `uv run --frozen pytest -q --tb=short tests/adapters/test_adapter_base.py tests/adapters/test_chat_adapter.py tests/adapters/test_json_adapter.py tests/adapters/test_two_step_adapter.py`
  - `109 passed, 13 warnings`

Note: local `docs/reports/` files remain untracked and are not included.