### PR TITLE
feat(adapter): preserve tool call ids and add tool results

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -6,7 +6,7 @@ from dspy.teleprompt import *
 
 from dspy.evaluate import Evaluate  # isort: skip
 from dspy.clients import *  # isort: skip
-from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, File, History, Type, Tool, ToolCalls, Code, Reasoning  # isort: skip
+from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, File, History, Type, Tool, ToolCalls, ToolCallResults, Code, Reasoning  # isort: skip
 from dspy.primitives.sandbox_serializable import SandboxSerializable  # isort: skip
 from dspy.utils.exceptions import ContextWindowExceededError
 from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, enable_logging

--- a/dspy/adapters/__init__.py
+++ b/dspy/adapters/__init__.py
@@ -2,7 +2,7 @@ from dspy.adapters.base import Adapter
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.two_step_adapter import TwoStepAdapter
-from dspy.adapters.types import Audio, Code, File, History, Image, Reasoning, Tool, ToolCalls, Type
+from dspy.adapters.types import Audio, Code, File, History, Image, Reasoning, Tool, ToolCallResults, ToolCalls, Type
 from dspy.adapters.xml_adapter import XMLAdapter
 
 __all__ = [
@@ -19,5 +19,6 @@ __all__ = [
     "TwoStepAdapter",
     "Tool",
     "ToolCalls",
+    "ToolCallResults",
     "Reasoning",
 ]

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -172,13 +172,7 @@ class Adapter:
                 )
 
             if tool_calls and tool_call_output_field_name:
-                tool_calls = [
-                    {
-                        "name": v["function"]["name"],
-                        "args": json_repair.loads(v["function"]["arguments"]),
-                    }
-                    for v in tool_calls
-                ]
+                tool_calls = [_provider_tool_call_to_tool_call_dict(tool_call) for tool_call in tool_calls]
                 value[tool_call_output_field_name] = ToolCalls.from_dict_list(tool_calls)
 
             # TODO(adapter-types): Once `Type.parse_lm_output(context, output)` is
@@ -673,3 +667,26 @@ class Adapter:
             A dictionary of the output fields.
         """
         raise NotImplementedError
+
+
+def _provider_value(value: Any, key: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(key, default)
+    return getattr(value, key, default)
+
+
+def _provider_tool_call_to_tool_call_dict(tool_call: Any) -> dict[str, Any]:
+    function = _provider_value(tool_call, "function", {}) or {}
+    arguments = _provider_value(function, "arguments", {})
+    if isinstance(arguments, str):
+        parsed_arguments = json_repair.loads(arguments)
+    elif isinstance(arguments, dict):
+        parsed_arguments = arguments
+    else:
+        parsed_arguments = {}
+
+    return {
+        "id": _provider_value(tool_call, "id") or _provider_value(tool_call, "call_id"),
+        "name": _provider_value(function, "name") or _provider_value(tool_call, "name"),
+        "args": parsed_arguments,
+    }

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -5,6 +5,7 @@ from typing import Any, NamedTuple
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.base import Adapter
+from dspy.adapters.types.tool import ToolCalls
 from dspy.adapters.utils import (
     format_field_value,
     get_annotation_name,
@@ -183,6 +184,8 @@ class ChatAdapter(Adapter):
         """
 
         def type_info(v):
+            if v.annotation == ToolCalls:
+                return ' (must be a JSON object like {"tool_calls": [{"name": "...", "args": {...}}]})'
             if v.annotation is not str:
                 return f" (must be formatted as a valid Python {get_annotation_name(v.annotation)})"
             else:

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -122,6 +122,8 @@ class JSONAdapter(ChatAdapter):
 
     def user_message_output_requirements(self, signature: type[Signature]) -> str:
         def type_info(v):
+            if v.annotation == ToolCalls:
+                return ' (must be a JSON object like {"tool_calls": [{"name": "...", "args": {...}}]})'
             return (
                 f" (must be formatted as a valid Python {get_annotation_name(v.annotation)})"
                 if v.annotation is not str

--- a/dspy/adapters/types/__init__.py
+++ b/dspy/adapters/types/__init__.py
@@ -5,6 +5,6 @@ from dspy.adapters.types.file import File
 from dspy.adapters.types.history import History
 from dspy.adapters.types.image import Image
 from dspy.adapters.types.reasoning import Reasoning
-from dspy.adapters.types.tool import Tool, ToolCalls
+from dspy.adapters.types.tool import Tool, ToolCallResults, ToolCalls
 
-__all__ = ["History", "Image", "Audio", "File", "Type", "Tool", "ToolCalls", "Code", "Reasoning"]
+__all__ = ["History", "Image", "Audio", "File", "Type", "Tool", "ToolCalls", "ToolCallResults", "Code", "Reasoning"]

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 from typing import TYPE_CHECKING, Any, Callable, get_origin, get_type_hints
 
+import json_repair
 import pydantic
 from jsonschema import ValidationError, validate
 from pydantic import BaseModel, TypeAdapter, create_model
@@ -261,17 +262,24 @@ class Tool(Type):
 
 class ToolCalls(Type):
     class ToolCall(Type):
+        id: str | None = None
         name: str
         args: dict[str, Any]
 
+        @classmethod
+        def __get_pydantic_json_schema__(cls, core_schema: Any, handler: Any) -> dict[str, Any]:
+            schema = super().__get_pydantic_json_schema__(core_schema, handler)
+            schema = handler.resolve_ref_schema(schema)
+            properties = schema.get("properties")
+            if isinstance(properties, dict):
+                properties.pop("id", None)
+            required = schema.get("required")
+            if isinstance(required, list):
+                schema["required"] = [field for field in required if field != "id"]
+            return schema
+
         def format(self):
-            return {
-                "type": "function",
-                "function": {
-                    "name": self.name,
-                    "arguments": self.args,
-                },
-            }
+            return {"name": self.name, "args": self.args}
 
         def execute(self, functions: dict[str, Any] | list[Tool] | None = None) -> Any:
             """Execute this individual tool call and return its result.
@@ -319,6 +327,19 @@ class ToolCalls(Type):
                 raise RuntimeError(f"Error executing tool '{self.name}': {e}") from e
 
     tool_calls: list[ToolCall]
+    tool_call_results: Any | None = None
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema: Any, handler: Any) -> dict[str, Any]:
+        schema = super().__get_pydantic_json_schema__(core_schema, handler)
+        schema = handler.resolve_ref_schema(schema)
+        properties = schema.get("properties")
+        if isinstance(properties, dict):
+            properties.pop("tool_call_results", None)
+        required = schema.get("required")
+        if isinstance(required, list):
+            schema["required"] = [field for field in required if field != "tool_call_results"]
+        return schema
 
     @classmethod
     def from_dict_list(cls, tool_calls_dicts: list[dict[str, Any]]) -> "ToolCalls":
@@ -340,21 +361,31 @@ class ToolCalls(Type):
             tool_calls = ToolCalls.from_dict_list(tool_calls_dict)
             ```
         """
-        tool_calls = [cls.ToolCall(**item) for item in tool_calls_dicts]
+        tool_calls = [cls.ToolCall(**_normalize_tool_call_dict(item)) for item in tool_calls_dicts]
         return cls(tool_calls=tool_calls)
 
     @classmethod
     def description(cls) -> str:
         return (
-            "Tool calls information, including the name of the tools and the arguments to be passed to it. "
-            "Arguments must be provided in JSON format."
+            "Tool calls must be a JSON object with `tool_calls`, a list of calls. "
+            "Each call must include `name` and `args`. "
+            'Example: {"tool_calls": [{"name": "search", "args": {"query": "cats"}}]}'
         )
 
-    def format(self) -> list[dict[str, Any]]:
-        # The tool_call field is compatible with OpenAI's tool calls schema.
+    def format(self) -> dict[str, Any]:
         return {
             "tool_calls": [tool_call.format() for tool_call in self.tool_calls],
         }
+
+    @pydantic.model_serializer()
+    def serialize_model(self):
+        data = self.format()
+        if self.tool_call_results is not None:
+            data["tool_call_results"] = TypeAdapter(type(self.tool_call_results)).dump_python(
+                self.tool_call_results,
+                mode="json",
+            )
+        return data
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -362,27 +393,112 @@ class ToolCalls(Type):
         if isinstance(data, cls):
             return data
 
-        # Handle case where data is a list of dicts with "name" and "args" keys
-        if isinstance(data, list) and all(
-            isinstance(item, dict) and "name" in item and "args" in item for item in data
-        ):
-            return {"tool_calls": [cls.ToolCall(**item) for item in data]}
+        # Handle case where data is a list of dicts with either DSPy or provider-shaped tool call keys.
+        if isinstance(data, list) and all(isinstance(item, dict) and _is_tool_call_dict(item) for item in data):
+            return {"tool_calls": [cls.ToolCall(**_normalize_tool_call_dict(item)) for item in data]}
         # Handle case where data is a dict
         elif isinstance(data, dict):
             if "tool_calls" in data:
                 # Handle case where data is a dict with "tool_calls" key
                 tool_calls_data = data["tool_calls"]
                 if isinstance(tool_calls_data, list):
-                    return {
+                    normalized = {
                         "tool_calls": [
-                            cls.ToolCall(**item) if isinstance(item, dict) else item for item in tool_calls_data
+                            cls.ToolCall(**_normalize_tool_call_dict(item)) if isinstance(item, dict) else item
+                            for item in tool_calls_data
                         ]
                     }
-            elif "name" in data and "args" in data:
+                    if "tool_call_results" in data:
+                        normalized["tool_call_results"] = data["tool_call_results"]
+                    return normalized
+            elif _is_tool_call_dict(data):
                 # Handle case where data is a dict with "name" and "args" keys
-                return {"tool_calls": [cls.ToolCall(**data)]}
+                return {"tool_calls": [cls.ToolCall(**_normalize_tool_call_dict(data))]}
 
         raise ValueError(f"Received invalid value for `dspy.ToolCalls`: {data}")
+
+
+class ToolCallResults(pydantic.BaseModel):
+    class ToolCallResult(pydantic.BaseModel):
+        call_id: str | None = None
+        name: str
+        value: Any
+        is_error: bool = False
+
+    tool_call_results: list[ToolCallResult]
+
+    @classmethod
+    def from_tool_calls_and_values(
+        cls,
+        tool_calls: list[ToolCalls.ToolCall] | ToolCalls,
+        values: list[Any],
+        is_errors: list[bool] | None = None,
+    ) -> "ToolCallResults":
+        if isinstance(tool_calls, ToolCalls):
+            tool_calls = tool_calls.tool_calls
+
+        if len(tool_calls) != len(values):
+            raise ValueError("`tool_calls` and `values` must have the same length.")
+
+        if is_errors is None:
+            is_errors = [False] * len(tool_calls)
+        elif len(is_errors) != len(tool_calls):
+            raise ValueError("`is_errors` must have the same length as `tool_calls` when provided.")
+
+        return cls(
+            tool_call_results=[
+                cls.ToolCallResult(call_id=tool_call.id, name=tool_call.name, value=value, is_error=is_error)
+                for tool_call, value, is_error in zip(tool_calls, values, is_errors, strict=True)
+            ]
+        )
+
+    @pydantic.model_validator(mode="before")
+    @classmethod
+    def validate_input(cls, data: Any):
+        if isinstance(data, cls):
+            return data
+
+        if isinstance(data, list):
+            return {"tool_call_results": data}
+
+        if isinstance(data, dict):
+            if "tool_call_results" in data:
+                return data
+            if {"name", "value"}.issubset(data):
+                return {"tool_call_results": [data]}
+
+        raise ValueError(f"Received invalid value for `dspy.ToolCallResults`: {data}")
+
+
+def _is_tool_call_dict(data: dict[str, Any]) -> bool:
+    return ("name" in data and ("args" in data or "arguments" in data)) or "function" in data
+
+
+def _normalize_tool_call_dict(data: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(data, dict):
+        raise ValueError(f"Received invalid tool call value for `dspy.ToolCalls`: {data}")
+
+    if "function" in data:
+        function = data.get("function") or {}
+        if not isinstance(function, dict):
+            raise ValueError(f"Received invalid function value for `dspy.ToolCalls`: {function}")
+
+        arguments = function.get("arguments", {})
+        name = function.get("name") or data.get("name")
+    else:
+        arguments = data.get("args", data.get("arguments", {}))
+        name = data.get("name")
+
+    if isinstance(arguments, str):
+        arguments = json_repair.loads(arguments)
+    elif not isinstance(arguments, dict):
+        arguments = {}
+
+    return {
+        "id": data.get("id") or data.get("call_id"),
+        "name": name,
+        "args": arguments,
+    }
 
 
 def _resolve_json_schema_reference(schema: dict) -> dict:

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -1926,7 +1926,13 @@ def test_chat_adapter_toolcalls_native_function_calling():
         )
 
         assert result[0]["tool_calls"] == dspy.ToolCalls(
-            tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"})]
+            tool_calls=[
+                dspy.ToolCalls.ToolCall(
+                    id="call_pQm8ajtSMxgA0nrzK2ivFmxG",
+                    name="get_weather",
+                    args={"city": "Paris"},
+                )
+            ]
         )
         # `answer` is not present, so we set it to None
         assert result[0]["answer"] is None
@@ -2157,3 +2163,30 @@ def test_tool_call_with_null_content_does_not_raise():
     result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
     assert result is not None
     assert len(result) == 1
+    assert result[0]["tool_calls"].tool_calls[0].id == "call_1"
+
+
+def test_provider_tool_calls_preserve_id_and_repair_arguments():
+    adapter = dspy.ChatAdapter(use_native_function_calling=True)
+    sig_cls = dspy.Signature("question, tools: list[dspy.Tool] -> tool_calls: dspy.ToolCalls")
+
+    outputs = [
+        {
+            "text": None,
+            "tool_calls": [
+                {
+                    "function": {"name": "search", "arguments": '{"query": "cats",}'},
+                    "call_id": "call_from_responses",
+                    "type": "function",
+                }
+            ],
+        }
+    ]
+
+    result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
+
+    assert result[0]["tool_calls"] == dspy.ToolCalls(
+        tool_calls=[
+            dspy.ToolCalls.ToolCall(id="call_from_responses", name="search", args={"query": "cats"})
+        ]
+    )

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -623,9 +623,9 @@ def test_json_adapter_format_exact_messages_with_tool_calls_output_demo():
                  '1. `question` (str):\n'
                  'Your output fields are:\n'
                  '1. `tool_calls` (ToolCalls): \n'
-                 '    Type description of ToolCalls: Tool calls information, including the name of the '
-                 'tools and the arguments to be passed to it. Arguments must be provided in JSON '
-                 'format.\n'
+                 '    Type description of ToolCalls: Tool calls must be a JSON object with `tool_calls`, '
+                 'a list of calls. Each call must include `name` and `args`. Example: {"tool_calls": '
+                 '[{"name": "search", "args": {"query": "cats"}}]}\n'
                  'All interactions will be structured in the following way, with the appropriate '
                  'values filled in.\n'
                  '\n'
@@ -654,12 +654,9 @@ def test_json_adapter_format_exact_messages_with_tool_calls_output_demo():
                  '  "tool_calls": {\n'
                  '    "tool_calls": [\n'
                  '      {\n'
-                 '        "type": "function",\n'
-                 '        "function": {\n'
-                 '          "name": "search",\n'
-                 '          "arguments": {\n'
-                 '            "query": "cats"\n'
-                 '          }\n'
+                 '        "name": "search",\n'
+                 '        "args": {\n'
+                 '          "query": "cats"\n'
                  '        }\n'
                  '      }\n'
                  '    ]\n'
@@ -669,8 +666,8 @@ def test_json_adapter_format_exact_messages_with_tool_calls_output_demo():
       "content": "[[ ## question ## ]]\n"
                  "Q2\n"
                  "\n"
-                 "Respond with a JSON object in the following order of fields: `tool_calls` (must be "
-                 "formatted as a valid Python ToolCalls)."}]
+                 'Respond with a JSON object in the following order of fields: `tool_calls` (must be '
+                 'a JSON object like {"tool_calls": [{"name": "...", "args": {...}}]}).'}]
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs
@@ -1500,7 +1497,13 @@ def test_json_adapter_toolcalls_native_function_calling():
         )
 
         assert result[0]["tool_calls"] == dspy.ToolCalls(
-            tool_calls=[dspy.ToolCalls.ToolCall(name="get_weather", args={"city": "Paris"})]
+            tool_calls=[
+                dspy.ToolCalls.ToolCall(
+                    id="call_pQm8ajtSMxgA0nrzK2ivFmxG",
+                    name="get_weather",
+                    args={"city": "Paris"},
+                )
+            ]
         )
         # `answer` is not present, so we set it to None
         assert result[0]["answer"] is None

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -2,10 +2,12 @@ import asyncio
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 
 import dspy
-from dspy.adapters.types.tool import Tool, ToolCalls, convert_input_schema_to_tool_args
+from dspy.adapters.types.tool import Tool, ToolCallResults, ToolCalls, convert_input_schema_to_tool_args
+from dspy.clients.openai_format import to_openai_chat_request
+from dspy.core.types import LMMessage, LMRequest, LMToolResultPart
 
 
 # Test fixtures
@@ -398,7 +400,7 @@ TOOL_CALL_TEST_CASES = [
     (
         [{"name": "search", "args": {"query": "hello"}}],
         {
-            "tool_calls": [{"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}],
+            "tool_calls": [{"name": "search", "args": {"query": "hello"}}],
         },
     ),
     (
@@ -408,18 +410,15 @@ TOOL_CALL_TEST_CASES = [
         ],
         {
             "tool_calls": [
-                {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}},
-                {
-                    "type": "function",
-                    "function": {"name": "translate", "arguments": {"text": "world", "lang": "fr"}},
-                },
+                {"name": "search", "args": {"query": "hello"}},
+                {"name": "translate", "args": {"text": "world", "lang": "fr"}},
             ],
         },
     ),
     (
         [{"name": "get_time", "args": {}}],
         {
-            "tool_calls": [{"type": "function", "function": {"name": "get_time", "arguments": {}}}],
+            "tool_calls": [{"name": "get_time", "args": {}}],
         },
     ),
 ]
@@ -446,8 +445,117 @@ def test_tool_calls_format_from_dict_list():
     result = tool_calls.format()
 
     assert len(result["tool_calls"]) == 2
-    assert result["tool_calls"][0]["function"]["name"] == "search"
-    assert result["tool_calls"][1]["function"]["name"] == "translate"
+    assert result["tool_calls"][0]["name"] == "search"
+    assert result["tool_calls"][1]["name"] == "translate"
+
+
+def test_tool_calls_preserves_ids_from_dict_list_and_format_omits_ids():
+    tool_calls = ToolCalls.from_dict_list(
+        [
+            {"id": "call_1", "name": "search", "args": {"query": "hello"}},
+            {"name": "translate", "args": {"text": "world", "lang": "fr"}},
+        ]
+    )
+
+    assert tool_calls.tool_calls[0].id == "call_1"
+    assert tool_calls.tool_calls[1].id is None
+
+    formatted = tool_calls.format()["tool_calls"]
+    assert "id" not in formatted[0]
+    assert "id" not in formatted[1]
+
+
+def test_tool_calls_json_schema_omits_internal_id_field():
+    schema = TypeAdapter(ToolCalls).json_schema()
+
+    assert "tool_call_results" not in schema["properties"]
+    assert "id" not in schema["$defs"]["ToolCall"]["properties"]
+    assert schema["$defs"]["ToolCall"]["required"] == ["name", "args"]
+
+
+def test_tool_calls_can_carry_results_without_formatting_them_for_lm():
+    tool_call = ToolCalls.ToolCall(id="call_1", name="search", args={"query": "hello"})
+    results = ToolCallResults.from_tool_calls_and_values([tool_call], [{"answer": "world"}])
+    tool_calls = ToolCalls(tool_calls=[tool_call], tool_call_results=results)
+
+    assert "tool_call_results" not in tool_calls.format()
+    assert tool_calls.model_dump(mode="json")["tool_call_results"] == {
+        "tool_call_results": [
+            {"call_id": "call_1", "name": "search", "value": {"answer": "world"}, "is_error": False}
+        ]
+    }
+
+
+def test_tool_call_results_from_tool_calls_and_values():
+    tool_calls = [
+        ToolCalls.ToolCall(id="call_1", name="search", args={"query": "hello"}),
+        ToolCalls.ToolCall(id="call_2", name="fetch", args={"url": "https://example.com"}),
+    ]
+
+    results = ToolCallResults.from_tool_calls_and_values(
+        tool_calls,
+        [{"items": [1, 2]}, "failed"],
+        is_errors=[False, True],
+    )
+
+    assert results.tool_call_results[0].call_id == "call_1"
+    assert results.tool_call_results[0].name == "search"
+    assert results.tool_call_results[0].value == {"items": [1, 2]}
+    assert results.tool_call_results[0].is_error is False
+    assert results.tool_call_results[1].call_id == "call_2"
+    assert results.tool_call_results[1].name == "fetch"
+    assert results.tool_call_results[1].value == "failed"
+    assert results.tool_call_results[1].is_error is True
+
+
+def test_tool_call_results_history_serialization_round_trip():
+    tool_call = ToolCalls.ToolCall(id="call_1", name="search", args={"query": "hello"})
+    results = ToolCallResults.from_tool_calls_and_values(
+        [tool_call],
+        [{"answer": "world"}],
+    )
+    tool_calls = ToolCalls(tool_calls=[tool_call], tool_call_results=results)
+
+    history = dspy.History(messages=[{"tool_calls": tool_calls}])
+    dumped = history.model_dump(mode="json")
+    restored = dspy.History.model_validate(dumped)
+
+    assert dumped == {
+        "messages": [
+            {
+                "tool_calls": {
+                    "tool_calls": [
+                        {"name": "search", "args": {"query": "hello"}}
+                    ],
+                    "tool_call_results": {
+                        "tool_call_results": [
+                            {"call_id": "call_1", "name": "search", "value": {"answer": "world"}, "is_error": False}
+                        ]
+                    },
+                }
+            }
+        ]
+    }
+    assert restored.messages == dumped["messages"]
+
+
+def test_tool_call_results_can_round_trip_as_native_tool_result_message():
+    tool_call = ToolCalls.ToolCall(id="call_1", name="search", args={"query": "cats"})
+    results = ToolCallResults.from_tool_calls_and_values([tool_call], ['{"items": ["cat"]}'])
+    result = results.tool_call_results[0]
+
+    message = LMMessage(role="tool", tool_call_id=result.call_id, name=result.name, content=result.value)
+
+    assert len(message.parts) == 1
+    assert isinstance(message.parts[0], LMToolResultPart)
+    assert message.parts[0].call_id == "call_1"
+    assert message.parts[0].name == "search"
+    assert message.parts[0].content[0].text == '{"items": ["cat"]}'
+
+    request = LMRequest(model="test-model", messages=[message])
+    assert to_openai_chat_request(request)["messages"] == [
+        {"role": "tool", "content": '{"items": ["cat"]}', "tool_call_id": "call_1", "name": "search"}
+    ]
 
 
 def test_toolcalls_vague_match():
@@ -490,11 +598,48 @@ def test_toolcalls_vague_match():
     assert tc.tool_calls[0].name == "search"
     assert tc.tool_calls[1].name == "get_time"
 
+    # Top-level "arguments" should be accepted as an alias for "args".
+    tc = ToolCalls.model_validate({"name": "search", "arguments": {"query": "hello"}})
+    assert len(tc.tool_calls) == 1
+    assert tc.tool_calls[0].name == "search"
+    assert tc.tool_calls[0].args == {"query": "hello"}
+
+    # List entries with "arguments" should normalize to ToolCall.args.
+    tc = ToolCalls.model_validate(
+        [
+            {"name": "search", "arguments": {"query": "hello"}},
+            {"name": "get_time", "arguments": {}},
+        ]
+    )
+    assert len(tc.tool_calls) == 2
+    assert tc.tool_calls[0].args == {"query": "hello"}
+    assert tc.tool_calls[1].args == {}
+
+    # "tool_calls" wrappers may also use "arguments".
+    tc = ToolCalls.model_validate({"tool_calls": [{"name": "search", "arguments": {"query": "hello"}}]})
+    assert len(tc.tool_calls) == 1
+    assert tc.tool_calls[0].args == {"query": "hello"}
+
+    # Provider-style nested function.arguments should accept dict and JSON-string values.
+    tc = ToolCalls.model_validate(
+        {"type": "function", "function": {"name": "search", "arguments": {"query": "hello"}}}
+    )
+    assert len(tc.tool_calls) == 1
+    assert tc.tool_calls[0].args == {"query": "hello"}
+
+    tc = ToolCalls.model_validate(
+        {"type": "function", "function": {"name": "search", "arguments": '{"query":"hello"}'}}
+    )
+    assert len(tc.tool_calls) == 1
+    assert tc.tool_calls[0].args == {"query": "hello"}
+
     # Invalid input should raise ValueError
     with pytest.raises(ValueError):
         ToolCalls.model_validate({"foo": "bar"})
     with pytest.raises(ValueError):
         ToolCalls.model_validate([{"foo": "bar"}])
+    with pytest.raises(ValueError, match="function value"):
+        ToolCalls.from_dict_list([{"function": "bad"}])
 
 
 def test_tool_convert_input_schema_to_tool_args_no_input_params():
@@ -575,11 +720,9 @@ def test_tool_call_execute():
 
     # Test error case
     tool_call4 = dspy.ToolCalls.ToolCall(name="nonexistent", args={})
-    try:
+    with pytest.raises(ValueError) as exc_info:
         tool_call4.execute(functions=tools)
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        assert "not found" in str(e)
+    assert "not found" in str(exc_info.value)
 
 
 def test_tool_call_execute_with_local_functions():


### PR DESCRIPTION
## Summary

Adds the minimal typed data needed to connect native provider tool calls to later observations.

- Preserves provider tool call IDs on `ToolCalls.ToolCall` while keeping `ToolCalls.format()` free of IDs for prompt/JSON rendering.
- Adds `ToolCallResults` with call IDs, tool names, values, and error flags.
- Exports `ToolCallResults` alongside the existing adapter/tool types.
- Adds exact prompt coverage for `ToolCallResults` stored inside `History`.

## Validation

- `uv run pytest -q tests/adapters tests/predict/test_react.py tests/predict/test_react_v2.py`

Stack: PR 1 of 3 for the minimal ReActV2 implementation.