### PR TITLE
[codex] Fix cached provider Pydantic serializers

### DIFF
--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -854,7 +854,11 @@ def get_value(value: Any, key: str, default: Any = None) -> Any:
 
 def _rebuild_pydantic_serializers(value: Any) -> None:
     stack = [value]
+    seen = set()
     for item in stack:
+        if id(item) in seen:
+            continue
+        seen.add(id(item))
         if isinstance(item, pydantic.BaseModel):
             type(item).model_rebuild(force=True, raise_errors=False)
             stack.extend([*item.__dict__.values(), *((item.__pydantic_extra__ or {}).values())])

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -674,7 +674,7 @@ def responses_function_call_to_part(output_item: Any) -> LMToolCallPart:
 
 def citation_to_part(citation: Any) -> LMCitationPart:
     if hasattr(citation, "model_dump"):
-        citation = citation.model_dump(exclude_none=True)
+        citation = model_dump(citation)
     if not isinstance(citation, dict):
         citation = {"text": str(citation)}
     citation_fields = {"cited_text", "text", "supported_text", "document_title", "title", "url"}
@@ -779,7 +779,7 @@ def usage_from_response(response: Any) -> LMUsage | None:
     if usage is None:
         return None
     if hasattr(usage, "model_dump"):
-        usage = usage.model_dump(exclude_none=True)
+        usage = model_dump(usage)
     elif not isinstance(usage, dict):
         data = {}
         for key in dir(usage):
@@ -852,9 +852,25 @@ def get_value(value: Any, key: str, default: Any = None) -> Any:
     return value.get(key, default) if isinstance(value, dict) else getattr(value, key, default)
 
 
+def _rebuild_pydantic_serializers(value: Any) -> None:
+    stack = [value]
+    for item in stack:
+        if isinstance(item, pydantic.BaseModel):
+            type(item).model_rebuild(force=True, raise_errors=False)
+            stack.extend([*item.__dict__.values(), *((item.__pydantic_extra__ or {}).values())])
+        elif isinstance(item, (dict, list, tuple)):
+            stack.extend(item.values() if isinstance(item, dict) else item)
+
+
 def model_dump(value: Any) -> dict[str, Any]:
     if hasattr(value, "model_dump"):
-        return value.model_dump(exclude_none=True)
+        try:
+            return value.model_dump(exclude_none=True)
+        except TypeError as error:
+            if "MockValSer" not in str(error):
+                raise
+            _rebuild_pydantic_serializers(value)
+            return value.model_dump(exclude_none=True)
     if isinstance(value, dict):
         return dict(value)
     data = {}

--- a/tests/clients/test_disk_serialization.py
+++ b/tests/clients/test_disk_serialization.py
@@ -2,6 +2,8 @@
 
 import io
 import pickle
+import subprocess
+import sys
 from dataclasses import dataclass
 
 import diskcache
@@ -10,13 +12,15 @@ import pydantic
 import pytest
 from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
 from litellm.types.utils import EmbeddingResponse, ModelResponse, TextCompletionResponse
-from openai.types.responses import ResponseOutputMessage, ResponseOutputText
+from openai.types.responses import ResponseFunctionToolCall, ResponseOutputMessage, ResponseOutputText
 
 from dspy.clients.disk_serialization import (
     DeserializationError,
     _restricted_load,
     restricted_disk,
 )
+from dspy.clients.openai_format import completion_to_lm_response, responses_to_lm_response
+from dspy.core.types import LMRequest
 
 
 class AllowedPydanticModel(pydantic.BaseModel):
@@ -58,6 +62,108 @@ def _make_cache(directory, allowed):
         disk=restricted_disk(allowed),
         timeout=10,
     )
+
+
+def _run_subprocess_cache_case(case, directory):
+    subprocess.run(
+        [sys.executable, "-m", "tests.clients.test_disk_serialization", case, str(directory)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_tool_call_cache(directory):
+    cache = _make_cache(directory, set())
+    cache["k"] = ModelResponse(
+        id="chatcmpl-tool",
+        model="dummy",
+        choices=[{
+            "message": {
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city":"SF"}'},
+                }],
+            },
+            "index": 0,
+            "finish_reason": "tool_calls",
+        }],
+        usage={"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+    )
+    cache.close()
+
+
+def _assert_cached_tool_call_normalizes(directory):
+    response = _make_cache(directory, set())["k"]
+    tool_call = response.choices[0].message.tool_calls[0]
+    assert type(type(tool_call).__pydantic_serializer__).__name__ == "MockValSer"
+    assert type(type(tool_call.function).__pydantic_serializer__).__name__ == "MockValSer"
+
+    lm_response = completion_to_lm_response(response, LMRequest(model="dummy", messages=[]))
+    part = lm_response.outputs[0].tool_calls[0]
+    assert part.name == "get_weather"
+    assert part.args == {"city": "SF"}
+    assert part.provider_data["function"]["name"] == "get_weather"
+    assert lm_response.usage.total_tokens == 3
+
+
+def _write_responses_function_call_cache(directory):
+    cache = _make_cache(directory, set())
+    cache["k"] = ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0.0,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        model="dummy",
+        object="response",
+        output=[ResponseFunctionToolCall(
+            id="fc_1",
+            call_id="call_1",
+            type="function_call",
+            name="get_weather",
+            arguments='{"city":"SF"}',
+            status="completed",
+        )],
+        metadata={},
+        parallel_tool_calls=False,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text=None,
+        truncation="disabled",
+        usage=ResponseAPIUsage(input_tokens=1, output_tokens=2, total_tokens=3),
+        user=None,
+    )
+    cache.close()
+
+
+def _assert_cached_responses_function_call_normalizes(directory):
+    response = _make_cache(directory, set())["k"]
+    function_call = response.output[0]
+    assert type(type(function_call).__pydantic_serializer__).__name__ == "MockValSer"
+
+    lm_response = responses_to_lm_response(response, LMRequest(model="dummy", messages=[]))
+    part = lm_response.outputs[0].tool_calls[0]
+    assert part.name == "get_weather"
+    assert part.args == {"city": "SF"}
+    assert part.provider_data["call_id"] == "call_1"
+    assert lm_response.usage.total_tokens == 3
+
+
+_SUBPROCESS_CASES = {
+    "write-tool-call-cache": _write_tool_call_cache,
+    "assert-tool-call-cache-normalizes": _assert_cached_tool_call_normalizes,
+    "write-responses-function-call-cache": _write_responses_function_call_cache,
+    "assert-responses-function-call-cache-normalizes": _assert_cached_responses_function_call_normalizes,
+}
 
 
 @pytest.mark.parametrize("value", [
@@ -197,6 +303,16 @@ def test_tool_call_response_roundtrip(tmp_path):
     assert result.choices[0].message.tool_calls[0].function.name == "get_weather"
 
 
+def test_cached_tool_call_normalizes_after_fresh_process_roundtrip(tmp_path):
+    _run_subprocess_cache_case("write-tool-call-cache", tmp_path)
+    _run_subprocess_cache_case("assert-tool-call-cache-normalizes", tmp_path)
+
+
+def test_cached_responses_function_call_normalizes_after_fresh_process_roundtrip(tmp_path):
+    _run_subprocess_cache_case("write-responses-function-call-cache", tmp_path)
+    _run_subprocess_cache_case("assert-responses-function-call-cache-normalizes", tmp_path)
+
+
 # -- allowlist enforcement --
 
 def test_unlisted_type_blocked_on_read(tmp_path):
@@ -284,3 +400,7 @@ def test_all_cached_lm_types_roundtrip():
     for value in test_values:
         result = _roundtrip(value)
         assert type(result) is type(value), f"Failed roundtrip for {type(value).__name__}"
+
+
+if __name__ == "__main__":
+    _SUBPROCESS_CASES[sys.argv[1]](sys.argv[2])

--- a/tests/clients/test_disk_serialization.py
+++ b/tests/clients/test_disk_serialization.py
@@ -68,8 +68,6 @@ def _run_subprocess_cache_case(case, directory):
     subprocess.run(
         [sys.executable, "-m", "tests.clients.test_disk_serialization", case, str(directory)],
         check=True,
-        capture_output=True,
-        text=True,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #9737 by making DSPy's provider-object normalization resilient to Pydantic `MockValSer` serializers that can appear after cached provider responses are read in a fresh Python process.

## Problem

LiteLLM and OpenAI provider response objects are Pydantic models with deferred serializer construction. A response can be written to DSPy's restricted disk cache after the writer process has built the serializer, then read back in a fresh process where the unpickled provider object and nested provider objects still have `__pydantic_serializer__ = MockValSer`.

DSPy's OpenAI-format normalization path calls `.model_dump(exclude_none=True)` for provider tool calls, Responses function calls, citations, usage, image/audio/file outputs, and related provider objects. For cached native tool calls, this produced:

```text
TypeError: 'MockValSer' object cannot be converted to 'SchemaSerializer'
```

Rebuilding only the outer Pydantic model is not sufficient because nested provider objects, such as a chat-completion tool call's `function`, can retain their own stale serializer.

Related upstream reports/context:

- https://github.com/pydantic/pydantic/issues/7713
- https://github.com/pydantic/pydantic/discussions/7710
- https://github.com/BerriAI/litellm/issues/9345
- https://github.com/run-llama/llama_index/issues/16405

## Changes

- Centralize the `MockValSer` repair in `dspy.clients.openai_format.model_dump`.
- Catch only the expected `TypeError` containing `MockValSer`; unrelated `TypeError`s still raise.
- Recursively rebuild serializers for Pydantic provider objects and nested dict/list/tuple values before retrying the dump.
- Route citation and usage provider dumps through the same helper.
- Add deterministic fresh-process cache regression tests without inline `python -c` strings.

## Validation

- `uv run --frozen pytest --deno tests/clients/test_disk_serialization.py`
- `uv run --frozen pytest --deno tests/clients/test_lm.py::test_dspy_cache tests/clients/test_lm.py::test_rollout_id_bypasses_cache`
- `uv run --frozen ruff check dspy/clients/openai_format.py tests/clients/test_disk_serialization.py`
- `git diff --check`

Note: `ruff format --check` was inspected but not applied because it would reformat older long lines elsewhere in the touched files, creating unrelated churn.