### PR TITLE
fix(adapters): preserve Python literals in ChatAdapter dict parsing

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -219,7 +219,7 @@ class ChatAdapter(Adapter):
         for k, v in sections:
             if (k not in fields) and (k in signature.output_fields):
                 try:
-                    fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                    fields[k] = parse_value(v, signature.output_fields[k].annotation, prefer_python_literal=True)
                 except Exception as e:
                     raise AdapterParseError(
                         adapter_name="ChatAdapter",

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -146,7 +146,33 @@ def find_enum_member(enum, identifier):
     raise ValueError(f"{identifier} is not a valid name or value for the enum {enum.__name__}")
 
 
-def parse_value(value, annotation):
+def _parse_string_candidate(value: str, prefer_python_literal: bool):
+    """Parse a raw string into a Python object, choosing the parser ordering by adapter.
+
+    ChatAdapter instructs the LM (via ``user_message_output_requirements``) to emit a "valid
+    Python dict", so its responses contain Python literals such as ``None``, ``True``, ``False``,
+    and single-quoted strings. Running ``json_repair.loads`` first would silently coerce these
+    (e.g. ``None`` -> the string ``"None"``), corrupting the value. When ``prefer_python_literal``
+    is True we therefore try ``ast.literal_eval`` first and fall back to the json-first logic,
+    which still handles JSON-style payloads (e.g. ``null``). JSONAdapter and XMLAdapter keep the
+    default json-first behavior unchanged.
+    """
+    if prefer_python_literal:
+        try:
+            return ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            pass
+
+    candidate = json_repair.loads(value)  # json_repair.loads returns "" on failure.
+    if candidate == "" and value != "":
+        try:
+            candidate = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            candidate = value
+    return candidate
+
+
+def parse_value(value, annotation, *, prefer_python_literal: bool = False):
     if annotation is str:
         return str(value)
 
@@ -179,12 +205,7 @@ def parse_value(value, annotation):
         # Handle union annotations, e.g., `str | None`, `Optional[str]`, `Union[str, int, None]`, etc.
         return TypeAdapter(annotation).validate_python(value)
 
-    candidate = json_repair.loads(value)  # json_repair.loads returns "" on failure.
-    if candidate == "" and value != "":
-        try:
-            candidate = ast.literal_eval(value)
-        except (ValueError, SyntaxError):
-            candidate = value
+    candidate = _parse_string_candidate(value, prefer_python_literal)
 
     try:
         return TypeAdapter(annotation).validate_python(candidate)

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -161,7 +161,10 @@ def _parse_string_candidate(value: str, prefer_python_literal: bool):
         try:
             return ast.literal_eval(value)
         except (ValueError, SyntaxError):
-            pass
+            # ast.literal_eval already failed; fall back to json_repair for JSON-style
+            # payloads (e.g. ``null``) without retrying ast.literal_eval below.
+            candidate = json_repair.loads(value)
+            return candidate if candidate != "" else value
 
     candidate = json_repair.loads(value)  # json_repair.loads returns "" on failure.
     if candidate == "" and value != "":

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -1,5 +1,5 @@
 import re
-from typing import Literal
+from typing import Any, Literal
 from unittest import mock
 
 import pydantic
@@ -1561,6 +1561,67 @@ def test_chat_adapter_exception_raised_on_failure():
     invalid_completion = "{'output':'mismatched value'}"
     with pytest.raises(dspy.utils.exceptions.AdapterParseError, match=r"Adapter ChatAdapter failed to parse.*"):
         adapter.parse(signature, invalid_completion)
+
+
+class _ArgumentsSignature(dspy.Signature):
+    """Signature with a free-form dict output field used by the literal-parsing tests."""
+
+    question: str = dspy.InputField()
+    arguments: dict[str, Any] = dspy.OutputField()
+
+
+def test_chat_adapter_parses_python_literal_none_as_real_none():
+    """ChatAdapter must preserve a Python-literal ``None`` as real ``None``, not the string ``"None"``.
+
+    This is the core bug from stanfordnlp/dspy#8820: ChatAdapter instructs the LM to emit a
+    "valid Python dict", so completions contain ``None`` (not JSON ``null``). Running json_repair
+    first would coerce ``None`` into the string ``"None"``.
+    """
+    adapter = dspy.ChatAdapter()
+    completion = "[[ ## arguments ## ]]\n{'city': 'Paris', 'limit': None}\n\n[[ ## completed ## ]]\n"
+
+    parsed = adapter.parse(_ArgumentsSignature, completion)
+
+    assert parsed["arguments"] == {"city": "Paris", "limit": None}
+    assert parsed["arguments"]["limit"] is None
+    assert parsed["arguments"]["limit"] != "None"
+
+
+def test_chat_adapter_preserves_python_literal_bools_and_none():
+    """ChatAdapter must preserve Python-literal ``True``/``False``/``None`` as real bools/None."""
+    adapter = dspy.ChatAdapter()
+    completion = "[[ ## arguments ## ]]\n{'a': True, 'b': False, 'c': None}\n\n[[ ## completed ## ]]\n"
+
+    parsed = adapter.parse(_ArgumentsSignature, completion)
+
+    arguments = parsed["arguments"]
+    assert arguments == {"a": True, "b": False, "c": None}
+    assert arguments["a"] is True
+    assert arguments["b"] is False
+    assert arguments["c"] is None
+
+
+def test_chat_adapter_parses_json_style_null_via_fallback():
+    """A JSON-style dict using ``null`` must still parse to real ``None`` (json_repair fallback)."""
+    adapter = dspy.ChatAdapter()
+    completion = '[[ ## arguments ## ]]\n{"city": "Paris", "limit": null}\n\n[[ ## completed ## ]]\n'
+
+    parsed = adapter.parse(_ArgumentsSignature, completion)
+
+    assert parsed["arguments"] == {"city": "Paris", "limit": None}
+    assert parsed["arguments"]["limit"] is None
+
+
+def test_chat_adapter_does_not_coerce_string_none_value():
+    """A quoted string ``'None'`` must stay the string ``"None"`` (no over-coercion)."""
+    adapter = dspy.ChatAdapter()
+    completion = "[[ ## arguments ## ]]\n{'status': 'None'}\n\n[[ ## completed ## ]]\n"
+
+    parsed = adapter.parse(_ArgumentsSignature, completion)
+
+    assert parsed["arguments"] == {"status": "None"}
+    assert parsed["arguments"]["status"] == "None"
+    assert parsed["arguments"]["status"] is not None
 
 
 def test_chat_adapter_formats_image():

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1,5 +1,5 @@
 import enum
-from typing import Literal
+from typing import Any, Literal
 from unittest import mock
 
 import pydantic
@@ -888,6 +888,28 @@ def test_json_adapter_parse_raise_error_on_mismatch_fields():
         "Expected to find output fields in the LM response: [answer] \n\n"
         "Actual output fields parsed from the LM response: [] \n\n"
     )
+
+
+def test_json_adapter_parses_dict_any_unchanged_by_chat_adapter_fix():
+    """Regression guard for stanfordnlp/dspy#8820: JSONAdapter keeps json-first parsing.
+
+    The ChatAdapter fix added ``prefer_python_literal=True`` only on the ChatAdapter path.
+    JSONAdapter must remain unaffected: a JSON object with ``null`` still parses a
+    ``dict[str, Any]`` field to real ``None`` (and bools to real bools).
+    """
+
+    class DictAnySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        arguments: dict[str, Any] = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter()
+    completion = '{"arguments": {"city": "Paris", "limit": null, "active": true}}'
+
+    parsed = adapter.parse(DictAnySignature, completion)
+
+    assert parsed["arguments"] == {"city": "Paris", "limit": None, "active": True}
+    assert parsed["arguments"]["limit"] is None
+    assert parsed["arguments"]["active"] is True
 
 
 def test_json_adapter_formats_image():


### PR DESCRIPTION
## 📝 Changes Description

`ChatAdapter` instructs the LM to format dict output fields as a "valid Python dict" (via `ChatAdapter.user_message_output_requirements`). So for a `Dict[str, Any]` field the model correctly returns Python literals, e.g.:

```
[[ ## arguments ## ]] {"title": "...", "revision_id": None}
```

But `parse_value` in `dspy/adapters/utils.py` runs `json_repair.loads()` first, which coerces the Python literal `None` into the string `"None"`. Tool-call arguments are silently corrupted, which is the high failure rate reported in #8820.

Rather than flip the parsing order globally (which would also affect `JSONAdapter`), this makes the behavior **adapter-aware**, matching the direction discussed on the issue — keep `ChatAdapter` parsing Python literals while leaving `JSONAdapter` untouched:

- `parse_value` gains a keyword-only `prefer_python_literal: bool = False`.
- When `True`, it tries `ast.literal_eval` first and falls back to the existing `json_repair`-first logic, so JSON-style payloads (`null`) still parse.
- `ChatAdapter` passes `prefer_python_literal=True`. `JSONAdapter` and `XMLAdapter` are unchanged — the flag defaults to `False`, so their current behavior is preserved exactly.

### Tests
- `tests/adapters/test_chat_adapter.py`: literal `None` stays real `None` (the bug), `True`/`False`/`None` preserved, JSON `null` still parses via the fallback, and a quoted `'None'` stays the string `"None"`.
- `tests/adapters/test_json_adapter.py`: regression guard confirming `JSONAdapter` `Dict[str, Any]` parsing is unaffected.

Closes #8820

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely) — `ruff check` is clean on the changed files
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Backward compatible: the new flag defaults to `False`, so only the `ChatAdapter` path changes behavior. `JSONAdapter` and `XMLAdapter` parsing is byte-for-byte unchanged.
