### PR TITLE
[codex] Silence missing-input warning for optional fields

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,7 +1,7 @@
 import logging
 import random
 import types
-from typing import Any, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
@@ -216,9 +216,13 @@ class Predict(Module, Parameter):
                             value,
                         )
 
-        if not all(k in kwargs for k in signature.input_fields):
+        missing = [
+            k
+            for k, field_info in signature.input_fields.items()
+            if k not in kwargs and not _annotation_allows_none(field_info.annotation)
+        ]
+        if missing:
             present = [k for k in signature.input_fields if k in kwargs]
-            missing = [k for k in signature.input_fields if k not in kwargs]
             logger.warning(
                 "Not all input fields were provided to module. Present: %s. Missing: %s.",
                 present,
@@ -304,6 +308,23 @@ def _get_type_name(type_annotation) -> str:
         return f"{origin_name}[{args_str}]"
 
     return getattr(origin, "__name__", str(origin))
+
+
+def _annotation_allows_none(annotation: Any) -> bool:
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+
+    if annotation is None or annotation is type(None):
+        return True
+
+    if origin is Annotated:
+        return bool(args) and _annotation_allows_none(args[0])
+
+    if origin is Union or origin is types.UnionType:
+        return any(_annotation_allows_none(arg) for arg in args)
+
+    return False
+
 
 def _is_value_compatible_with_type(value: Any, expected: type) -> bool:
     """Return True if the value matches the expected type hint."""

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1104,6 +1104,39 @@ def test_extra_fields_warning(caplog):
     assert "extra_field" in caplog.text
 
 
+def test_missing_optional_input_field_no_warning(caplog):
+    log_test_helper()
+
+    class OptionalInputSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        context: str | None = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    predict_instance = Predict(OptionalInputSignature)
+
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(question="test")
+
+    assert "Not all input fields were provided" not in caplog.text
+
+
+def test_missing_required_input_field_still_warns(caplog):
+    log_test_helper()
+
+    class OptionalInputSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        context: str | None = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    predict_instance = Predict(OptionalInputSignature)
+
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance()
+
+    assert "Not all input fields were provided" in caplog.text
+    assert "Missing: ['question']" in caplog.text
+
+
 def test_warning_images(caplog):
     """Test whether type mismatch for images generates a warning."""
     log_test_helper()


### PR DESCRIPTION
## Summary

- Skip the missing-input warning for omitted signature inputs whose annotation allows `None`.
- Preserve the warning for genuinely missing required inputs.
- Add focused coverage for omitted optional inputs and mixed required/optional missing inputs.

## Why

`Predict._forward_preprocess` populated explicit defaults before checking for missing fields, but it still warned for optional fields declared as `T | None` when callers omitted them. This made optional continuation-style inputs noisy even though omission is valid.

## Validation

- `uv run --extra dev pytest -q tests/predict/test_predict.py -k 'missing_optional_input_field_no_warning or missing_required_input_field_still_warns or extra_fields_warning or input_field_default_value'`
- `uv run --extra dev ruff check --fix-only dspy/predict/predict.py tests/predict/test_predict.py`
- `git diff --check`