### PR TITLE
Mark ReActV2 experimental

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -10,6 +10,7 @@ from dspy.adapters.types.tool import Tool, ToolCallResults, ToolCalls
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import ensure_signature
+from dspy.utils.annotation import experimental
 from dspy.utils.exceptions import AdapterParseError, ContextWindowExceededError
 
 logger = logging.getLogger(__name__)
@@ -18,6 +19,7 @@ if TYPE_CHECKING:
     from dspy.signatures.signature import Signature
 
 
+@experimental
 class ReActV2(Module):
     def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
         super().__init__()


### PR DESCRIPTION
## Summary

- Mark `ReActV2` with the existing `@experimental` decorator.
- Match the existing experimental API pattern used by modules such as `RLM`.

## Validation

- `uv run ruff check dspy/predict/react_v2.py`
- `uv run pytest -q tests/predict/test_react_v2.py tests/utils/test_annotation.py`
- `git diff --check`