### PR TITLE
[codex] Fix GPT-5 LM state roundtrip

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -44,6 +44,14 @@ def _get_litellm():
     return get_litellm(feature="dspy.LM")
 
 
+def _is_openai_reasoning_model(model: str) -> bool:
+    model_family = model.split("/")[-1].lower() if "/" in model else model.lower()
+    return re.match(
+        r"^(?:o[1345](?:-(?:mini|nano|pro))?(?:-\d{4}-\d{2}-\d{2})?|gpt-5(?!-chat)(?:-.*)?)$",
+        model_family,
+    ) is not None
+
+
 class LM(BaseLM):
     """
     A language model supporting chat or text completion requests for use with DSPy modules.
@@ -111,18 +119,7 @@ class LM(BaseLM):
 
     def _get_initial_kwargs(self, *, temperature, max_tokens, **kwargs) -> dict[str, Any]:
         # Override BaseLM's default kwargs shape for LiteLLM/model-family-specific token parameters.
-        model_family = self.model.split("/")[-1].lower() if "/" in self.model else self.model.lower()
-
-        # Recognize OpenAI reasoning models (o1, o3, o4, gpt-5 family)
-        # Exclude non-reasoning variants like gpt-5-chat this is in azure ai foundry
-        # Allow date suffixes like -2023-01-01 after model name or mini/nano/pro
-        # For gpt-5, use negative lookahead to exclude -chat and allow other suffixes
-        model_pattern = re.match(
-            r"^(?:o[1345](?:-(?:mini|nano|pro))?(?:-\d{4}-\d{2}-\d{2})?|gpt-5(?!-chat)(?:-.*)?)$",
-            model_family,
-        )
-
-        if model_pattern:
+        if _is_openai_reasoning_model(self.model):
             if (temperature and temperature != 1.0) or (max_tokens and max_tokens < 16000):
                 raise LMConfigurationError(
                     "OpenAI's reasoning models require passing temperature=1.0 or None and max_tokens >= 16000 or None to "
@@ -418,7 +415,21 @@ class LM(BaseLM):
         )
         if self.use_developer_role:
             state["use_developer_role"] = self.use_developer_role
+        if _is_openai_reasoning_model(self.model) and "max_completion_tokens" in state:
+            state["max_tokens"] = state.pop("max_completion_tokens")
         return state
+
+    @classmethod
+    def load_state(cls, state: dict[str, Any], *, allow_custom_lm_class: bool = False):
+        state = dict(state)
+
+        model = state.get("model")
+        if isinstance(model, str) and _is_openai_reasoning_model(model) and "max_completion_tokens" in state:
+            if "max_tokens" not in state:
+                state["max_tokens"] = state["max_completion_tokens"]
+            state.pop("max_completion_tokens")
+
+        return super().load_state(state, allow_custom_lm_class=allow_custom_lm_class)
 
     def _check_truncation(self, results):
         if self.model_type != "responses" and any(c.finish_reason == "length" for c in results["choices"]):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -519,6 +519,22 @@ def test_dump_state():
     }
 
 
+def test_reasoning_model_dump_state_uses_constructor_max_tokens():
+    lm = dspy.LM(
+        model="openai/gpt-5-nano",
+        temperature=1.0,
+        max_tokens=16_000,
+        cache=False,
+        num_retries=1,
+    )
+
+    state = lm.dump_state()
+
+    assert lm.kwargs["max_completion_tokens"] == 16_000
+    assert "max_completion_tokens" not in state
+    assert state["max_tokens"] == 16_000
+
+
 def test_dump_state_preserves_enabled_developer_role():
     lm = dspy.LM("openai/gpt-4o-mini", use_developer_role=True)
 
@@ -553,6 +569,59 @@ def test_load_state():
 
     assert isinstance(loaded_lm, dspy.LM)
     assert loaded_lm.dump_state() == lm.dump_state()
+
+
+def test_reasoning_model_load_state_round_trips_canonical_state():
+    lm = dspy.LM(
+        model="openai/gpt-5-nano",
+        temperature=1.0,
+        max_tokens=16_000,
+        cache=False,
+        num_retries=1,
+    )
+
+    loaded_lm = dspy.BaseLM.load_state(lm.dump_state())
+
+    assert isinstance(loaded_lm, dspy.LM)
+    assert loaded_lm.kwargs["max_completion_tokens"] == 16_000
+    assert loaded_lm.dump_state() == lm.dump_state()
+
+
+def test_reasoning_model_load_state_accepts_max_completion_tokens_alias():
+    state = {
+        "_dspy_lm_class": "dspy.clients.lm.LM",
+        "model": "openai/gpt-5-nano",
+        "model_type": "chat",
+        "cache": False,
+        "num_retries": 1,
+        "temperature": 1.0,
+        "max_completion_tokens": 16_000,
+        "finetuning_model": None,
+        "launch_kwargs": {},
+        "train_kwargs": {},
+    }
+
+    loaded_lm = dspy.BaseLM.load_state(state)
+
+    assert isinstance(loaded_lm, dspy.LM)
+    assert loaded_lm.kwargs["max_completion_tokens"] == 16_000
+    assert "max_completion_tokens" not in loaded_lm.dump_state()
+    assert loaded_lm.dump_state()["max_tokens"] == 16_000
+
+
+def test_lm_load_state_forwards_allow_custom_lm_class(monkeypatch):
+    calls = []
+    original_load_state = dspy.BaseLM.load_state.__func__
+
+    def spy_load_state(cls, state, *, allow_custom_lm_class=False):
+        calls.append(allow_custom_lm_class)
+        return original_load_state(cls, state, allow_custom_lm_class=allow_custom_lm_class)
+
+    monkeypatch.setattr(dspy.BaseLM, "load_state", classmethod(spy_load_state))
+
+    dspy.LM.load_state(dspy.LM("openai/gpt-4o-mini").dump_state(), allow_custom_lm_class=True)
+
+    assert calls == [True]
 
 
 def test_exponential_backoff_retry():


### PR DESCRIPTION
## Summary

Fix GPT-5-family `dspy.LM` state serialization so `BaseLM.load_state(lm.dump_state())` round-trips correctly.

## Root Cause

OpenAI reasoning models store their runtime token parameter as `max_completion_tokens`, while the public `dspy.LM(...)` constructor accepts `max_tokens`. `BaseLM.dump_state()` serialized `self.kwargs` directly, so GPT-5-family states persisted `max_completion_tokens`. On load, `LM.__init__` received that key through `**kwargs` and also generated `max_completion_tokens=max_tokens`, causing Python to raise:

```text
TypeError: dict() got multiple values for keyword argument 'max_completion_tokens'
```

## Changes

- Persist canonical constructor state for OpenAI reasoning models by converting `max_completion_tokens` back to `max_tokens` in `LM.dump_state()`.
- Add `LM.load_state()` normalization so already-written states containing `max_completion_tokens` still load, while delegating to `BaseLM.load_state()` with `allow_custom_lm_class` forwarded.
- Reuse the OpenAI reasoning-model predicate in both initialization and state normalization.
- Add regression tests for GPT-5 dump/load behavior, legacy alias tolerance, and load-state delegation.

## Validation

```bash
uv run --frozen pytest --deno -q tests/clients/test_lm.py -k 'dump_state or load_state or reasoning_model_token_parameter or reasoning_model_requirements'
```

Result: `12 passed`.