### PR TITLE
fix: serialize LiteLLM lazy materialization

### DIFF
--- a/dspy/clients/_litellm.py
+++ b/dspy/clients/_litellm.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import functools
 import sys
+import threading
 import types
 from typing import Any
 
 from dspy.utils.lazy_import import require
+
+_LITELLM_IMPORT_LOCK = threading.RLock()
 
 
 @functools.cache
@@ -29,10 +32,11 @@ def _materialize_litellm(litellm: types.ModuleType) -> None:
 @functools.cache
 def get_litellm(*, feature: str) -> Any:
     """Import LiteLLM, apply DSPy's defaults once, and return the module."""
-    litellm = require("litellm", extra="litellm", feature=feature)
-    _materialize_litellm(litellm)
-    _configure_litellm_defaults(litellm)
-    return litellm
+    with _LITELLM_IMPORT_LOCK:
+        litellm = require("litellm", extra="litellm", feature=feature)
+        _materialize_litellm(litellm)
+        _configure_litellm_defaults(litellm)
+        return litellm
 
 
 def is_litellm_context_window_error(error: Exception) -> bool:

--- a/tests/clients/test_lazy_litellm_import.py
+++ b/tests/clients/test_lazy_litellm_import.py
@@ -1,7 +1,9 @@
 import importlib.util
 import sys
 import threading
-from concurrent.futures import ThreadPoolExecutor
+import time
+import types
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 
@@ -84,3 +86,56 @@ def test_concurrent_lm_first_use_materializes_litellm_once():
         get_litellm.cache_clear()
         if original_litellm is not None:
             sys.modules["litellm"] = original_litellm
+
+
+def test_concurrent_litellm_first_use_serializes_materialization(monkeypatch):
+    import dspy.clients._litellm as litellm_client
+
+    class RaceSensitiveLiteLLM(types.ModuleType):
+        def __init__(self):
+            super().__init__("litellm")
+            self._lock = threading.Lock()
+            self._materializing = False
+            self._materialized = False
+
+        @property
+        def completion(self):
+            with self._lock:
+                if self._materializing and not self._materialized:
+                    raise AttributeError("module 'litellm' has no attribute 'completion'")
+                if self._materialized:
+                    return object()
+                self._materializing = True
+
+            time.sleep(0.02)
+
+            with self._lock:
+                self._materialized = True
+                self._materializing = False
+            return object()
+
+    fake_litellm = RaceSensitiveLiteLLM()
+
+    def require_litellm(*args, **kwargs):
+        return fake_litellm
+
+    litellm_client.get_litellm.cache_clear()
+    litellm_client._configure_litellm_defaults.cache_clear()
+    monkeypatch.setattr(litellm_client, "require", require_litellm)
+
+    try:
+        workers = 8
+        barrier = threading.Barrier(workers)
+
+        def worker():
+            barrier.wait()
+            return litellm_client.get_litellm(feature="dspy.LM")
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(worker) for _ in range(workers)]
+            results = [future.result() for future in as_completed(futures)]
+
+        assert results == [fake_litellm] * workers
+    finally:
+        litellm_client.get_litellm.cache_clear()
+        litellm_client._configure_litellm_defaults.cache_clear()


### PR DESCRIPTION
## Summary
- serialize LiteLLM lazy materialization during first use
- keep DSPy's lazy import behavior unchanged for normal imports and missing LiteLLM errors
- add a concurrent first-use regression test that fails if another thread observes the partially materialized module

Fixes #9833

## To verify
- python -m pytest -p no:cacheprovider tests/clients/test_lazy_litellm_import.py -q
- python -m ruff check dspy/clients/_litellm.py tests/clients/test_lazy_litellm_import.py
- python -m ruff format --check dspy/clients/_litellm.py tests/clients/test_lazy_litellm_import.py
- python -m py_compile dspy/clients/_litellm.py tests/clients/test_lazy_litellm_import.py
- git diff --check

Note: on Windows I used a repo-local TMP/TEMP directory because the default pytest temp/cache paths had permission errors unrelated to this patch.