### PR TITLE
Expose typed LM API symbols

### DIFF
--- a/docs/docs/community/normalized-lm-api-migration.md
+++ b/docs/docs/community/normalized-lm-api-migration.md
@@ -103,8 +103,8 @@ response.provider_data
 
 The typed path also makes direct `lm(...)` calls more expressive. Strings, typed messages, media parts, previous responses, and explicit `LMRequest` objects all flow through one call API.
 
-!!! warning "Planned 3.3 API"
-    The examples below illustrate the proposed typed LM call API. Helpers such as `dspy.System`, `dspy.User`, `dspy.Assistant`, `dspy.ToolCall`, and `dspy.ToolResult` are part of the planned implementation and may not exist in the current stable namespace yet.
+!!! warning "Experimental 3.3 API"
+    The typed LM symbols are importable without `experimental=True`. During the 3.3 release-candidate period, the direct typed `lm(...)` call path will land incrementally behind `dspy.context(experimental=True)` as the API settles. These helpers are expected to be available in DSPy 3.3. Key helpers such as `dspy.LMRequest`, `dspy.LMResponse`, `dspy.System`, `dspy.User`, `dspy.Assistant`, `dspy.ToolCall`, and `dspy.ToolResult` are available at the top level. The complete typed LM vocabulary is available under `dspy.core.types`, e.g. `dspy.core.types.LMTextPart`.
 
 Multimodal request with instructions:
 

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -7,6 +7,18 @@ from dspy.teleprompt import *
 from dspy.evaluate import Evaluate  # isort: skip
 from dspy.clients import *  # isort: skip
 from dspy.adapters import Adapter, ChatAdapter, JSONAdapter, XMLAdapter, TwoStepAdapter, Image, Audio, File, History, Type, Tool, ToolCalls, ToolCallResults, Code, Reasoning  # isort: skip
+from dspy.core import (  # isort: skip
+    Assistant,
+    Developer,
+    LMConfig,
+    LMMessage,
+    LMRequest,
+    LMResponse,
+    System,
+    ToolCall,
+    ToolResult,
+    User,
+)
 from dspy.primitives.sandbox_serializable import SandboxSerializable  # isort: skip
 from dspy.utils.exceptions import (
     AdapterParseError,

--- a/dspy/core/__init__.py
+++ b/dspy/core/__init__.py
@@ -1,0 +1,4 @@
+"""Core typed request/response objects used by DSPy internals."""
+
+from dspy.core.types import *
+from dspy.core.types import __all__ as __all__

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -14,6 +14,38 @@ from urllib.parse import urlparse
 import pydantic
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+__all__ = [
+    "Assistant",
+    "Developer",
+    "LMAudioPart",
+    "LMBinaryPart",
+    "LMCacheConfig",
+    "LMCitationPart",
+    "LMConfig",
+    "LMDocumentPart",
+    "LMImagePart",
+    "LMMessage",
+    "LMOutput",
+    "LMPart",
+    "LMPromptCacheConfig",
+    "LMReasoningConfig",
+    "LMRefusalPart",
+    "LMRequest",
+    "LMResponse",
+    "LMTextPart",
+    "LMThinkingPart",
+    "LMToolCallPart",
+    "LMToolChoice",
+    "LMToolResultPart",
+    "LMToolSpec",
+    "LMUsage",
+    "LMVideoPart",
+    "System",
+    "ToolCall",
+    "ToolResult",
+    "User",
+]
+
 
 class LMBasePart(BaseModel):
     """A single content item in an LM message or output."""


### PR DESCRIPTION
   ## Summary

   Exposes the first public symbols for DSPy's typed LM API migration.

   Top-level `dspy.*` now includes the main user-facing helpers:

   - `dspy.LMRequest`
   - `dspy.LMResponse`
   - `dspy.LMConfig`
   - `dspy.LMMessage`
   - `dspy.System`
   - `dspy.Developer`
   - `dspy.User`
   - `dspy.Assistant`
   - `dspy.ToolCall`
   - `dspy.ToolResult`

   The full typed LM vocabulary remains under `dspy.core.types`, e.g.
 `dspy.core.types.LMTextPart`.

   ## Notes

   This only exposes symbols and updates docs. It does not change LM runtime behavior.