### PR TITLE
Fix native tool calling for Responses API models

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -157,7 +157,7 @@ class Adapter:
             text = output
 
             if isinstance(output, dict):
-                text = output["text"]
+                text = output.get("text")
                 output_logprobs = output.get("logprobs")
                 tool_calls = output.get("tool_calls")
 
@@ -217,10 +217,13 @@ class Adapter:
         Once planning lands, this should render from `_AdapterPlan` and apply
         planned message/part insertions before creating `LMRequest`.
         """
+        kwargs = dict(lm_kwargs)
+        tools = kwargs.pop("tools", None)
         return LMRequest.from_call(
             model=lm.model,
             messages=self._coerce_lm_messages(messages),
-            **lm_kwargs,
+            tools=tools,
+            **kwargs,
         )
 
     def _call_lm(self, lm: BaseLM, request: LMRequest) -> LMResponse:

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -461,34 +461,13 @@ class BaseLM:
         Returns:
             List of processed outputs, which is always of size 1 because the Response API only supports one output.
         """
-        text_outputs = []
-        tool_calls = []
-        reasoning_contents = []
+        from dspy.clients.openai_format import responses_to_lm_response
+        from dspy.core.types import LMRequest
 
-        for output_item in response.output:
-            output_item_type = output_item.type
-            if output_item_type == "message":
-                for content_item in output_item.content:
-                    text_outputs.append(content_item.text)
-            elif output_item_type == "function_call":
-                tool_calls.append(output_item.model_dump())
-            elif output_item_type == "reasoning":
-                if getattr(output_item, "content", None) and len(output_item.content) > 0:
-                    for content_item in output_item.content:
-                        reasoning_contents.append(content_item.text)
-                elif getattr(output_item, "summary", None) and len(output_item.summary) > 0:
-                    for summary_item in output_item.summary:
-                        reasoning_contents.append(summary_item.text)
-
-        result = {}
-        if len(text_outputs) > 0:
-            result["text"] = "".join(text_outputs)
-        if len(tool_calls) > 0:
-            result["tool_calls"] = tool_calls
-        if len(reasoning_contents) > 0:
-            result["reasoning_content"] = "".join(reasoning_contents)
-        # All `response.output` items map to one answer, so we return a list of size 1.
-        return [result]
+        request = LMRequest(model=self.model, messages=[])
+        outputs = responses_to_lm_response(response, request).to_legacy_outputs()
+        # Preserve the existing Responses API shape: even text-only outputs are dictionaries.
+        return [{"text": output} if isinstance(output, str) else output for output in outputs]
 
 
 def inspect_history(n: int = 1, file: "TextIO | None" = None) -> None:

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -5,6 +5,8 @@ import inspect
 import uuid
 from typing import Any, TextIO
 
+from dspy.clients.openai_format import responses_to_lm_response
+from dspy.core.types import LMRequest
 from dspy.dsp.utils import settings
 from dspy.utils.callback import BaseCallback, with_callbacks
 from dspy.utils.inspect_history import pretty_print_history
@@ -461,9 +463,6 @@ class BaseLM:
         Returns:
             List of processed outputs, which is always of size 1 because the Response API only supports one output.
         """
-        from dspy.clients.openai_format import responses_to_lm_response
-        from dspy.core.types import LMRequest
-
         request = LMRequest(model=self.model, messages=[])
         outputs = responses_to_lm_response(response, request).to_legacy_outputs()
         # Preserve the existing Responses API shape: even text-only outputs are dictionaries.

--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -79,12 +79,12 @@ class Cache:
         else:
             self.memory_cache = {}
         if self.enable_disk_cache:
-            fanout_kwargs = dict(
-                directory=self.disk_cache_dir,
-                shards=16,
-                timeout=10,
-                size_limit=disk_size_limit_bytes,
-            )
+            fanout_kwargs = {
+                "directory": self.disk_cache_dir,
+                "shards": 16,
+                "timeout": 10,
+                "size_limit": disk_size_limit_bytes,
+            }
             if restrict_pickle:
                 for t in safe_types or []:
                     if not isinstance(t, type):
@@ -149,9 +149,15 @@ class Cache:
     def _prepare_cached_response(self, response):
         response = copy.deepcopy(response)
         if hasattr(response, "usage"):
-            # Clear the usage data when cache is hit, because no LM call is made
+            # Clear the usage data when cache is hit, because no LM call is made.
             response.usage = {}
-            response.cache_hit = True
+            try:
+                response.cache_hit = True
+            except (AttributeError, ValueError):
+                # Some provider SDK objects are strict Pydantic models that reject
+                # ad-hoc attributes. The cleared usage still preserves the main
+                # cache-hit semantics without mutating the provider object shape.
+                pass
         return response
 
     def put(

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -14,8 +14,10 @@ import dspy
 from dspy.clients._litellm import get_litellm, is_litellm_context_window_error
 from dspy.clients.cache import request_cache
 from dspy.clients.openai import OpenAIProvider
+from dspy.clients.openai_format import tool_choice_to_openai_responses, tool_to_openai_responses
 from dspy.clients.provider import Provider, ReinforceJob, TrainingJob
 from dspy.clients.utils_finetune import TrainDataFormat
+from dspy.core.types import LMRequest
 from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import (
     ContextWindowExceededError,
@@ -651,6 +653,19 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
             }
         text = request.pop("text", {})
         request["text"] = {**text, "format": response_format}
+
+    # Convert Chat Completions tool definitions/choices to Responses API function-tool shape.
+    if "tools" in request:
+        tool_request = LMRequest.from_call(model=request.get("model", ""), messages=[], tools=request.pop("tools") or [])
+        request["tools"] = [tool_to_openai_responses(tool) for tool in tool_request.tools]
+    if isinstance(request.get("tool_choice"), dict):
+        choice_request = LMRequest.from_call(
+            model=request.get("model", ""),
+            messages=[],
+            tool_choice=request["tool_choice"],
+            parallel_tool_calls=request.get("parallel_tool_calls"),
+        )
+        request.update(tool_choice_to_openai_responses(choice_request.config.tool_choice))
 
     return request
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -631,6 +631,12 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     if "max_completion_tokens" in request and "max_tokens" not in request:
         request["max_tokens"] = request.pop("max_completion_tokens")
 
+    # Preserve the legacy `reasoning_effort=...` Responses behavior from this LM
+    # compatibility shim: requesting reasoning effort also asks OpenAI for an
+    # automatic reasoning summary, which DSPy can expose as `reasoning_content`.
+    if "reasoning_effort" in request and request.get("reasoning") is None:
+        request["reasoning"] = {"effort": request.pop("reasoning_effort"), "summary": "auto"}
+
     lm_request = LMRequest.from_call(model=model, messages=messages, tools=tools, **request)
     return to_openai_responses_request(lm_request)
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -7,14 +7,13 @@ import warnings
 from typing import Any, Literal, cast
 
 import anyio.from_thread
-import pydantic
 from anyio.streams.memory import MemoryObjectSendStream
 
 import dspy
 from dspy.clients._litellm import get_litellm, is_litellm_context_window_error
 from dspy.clients.cache import request_cache
 from dspy.clients.openai import OpenAIProvider
-from dspy.clients.openai_format import tool_choice_to_openai_responses, tool_to_openai_responses
+from dspy.clients.openai_format import to_openai_responses_request
 from dspy.clients.provider import Provider, ReinforceJob, TrainingJob
 from dspy.clients.utils_finetune import TrainDataFormat
 from dspy.core.types import LMRequest
@@ -618,96 +617,20 @@ async def alitellm_responses_completion(request: dict[str, Any], num_retries: in
 
 
 def _convert_chat_request_to_responses_request(request: dict[str, Any]):
-    """
-    Convert a chat request to a responses request
-    See https://platform.openai.com/docs/api-reference/responses/create for the responses API specification.
-    Also see https://platform.openai.com/docs/api-reference/chat/create for the chat API specification.
-    """
+    """Convert legacy chat-shaped LM kwargs into Responses API kwargs."""
     request = dict(request)
-    if "messages" in request:
-        input_items = []
-        for msg in request.pop("messages"):
-            content_blocks = []
-            c = msg.get("content")
-            if isinstance(c, str):
-                content_blocks.append({"type": "input_text", "text": c})
-            elif isinstance(c, list):
-                # Convert each content item from Chat API format to Responses API format
-                for item in c:
-                    content_blocks.append(_convert_content_item_to_responses_format(item))
-            input_items.append({"role": msg.get("role", "user"), "content": content_blocks})
-        request["input"] = input_items
-    # Convert `reasoning_effort` to reasoning format supported by the Responses API
-    if "reasoning_effort" in request:
-        effort = request.pop("reasoning_effort")
-        request["reasoning"] = {"effort": effort, "summary": "auto"}
+    model = request.pop("model")
+    messages = request.pop("messages", [])
+    tools = request.pop("tools", None)
 
-    # Convert `response_format` to `text.format` for Responses API
-    if "response_format" in request:
-        response_format = request.pop("response_format")
-        if isinstance(response_format, type) and issubclass(response_format, pydantic.BaseModel):
-            response_format = {
-                "name": response_format.__name__,
-                "type": "json_schema",
-                "schema": response_format.model_json_schema(),
-            }
-        text = request.pop("text", {})
-        request["text"] = {**text, "format": response_format}
+    # Reasoning models use `max_completion_tokens` in the chat path. The
+    # normalized Responses mapper expects the shared `max_tokens` name and emits
+    # `max_output_tokens`.
+    if "max_completion_tokens" in request and "max_tokens" not in request:
+        request["max_tokens"] = request.pop("max_completion_tokens")
 
-    # Convert Chat Completions tool definitions/choices to Responses API function-tool shape.
-    if "tools" in request:
-        tool_request = LMRequest.from_call(model=request.get("model", ""), messages=[], tools=request.pop("tools") or [])
-        request["tools"] = [tool_to_openai_responses(tool) for tool in tool_request.tools]
-    if isinstance(request.get("tool_choice"), dict):
-        choice_request = LMRequest.from_call(
-            model=request.get("model", ""),
-            messages=[],
-            tool_choice=request["tool_choice"],
-            parallel_tool_calls=request.get("parallel_tool_calls"),
-        )
-        request.update(tool_choice_to_openai_responses(choice_request.config.tool_choice))
-
-    return request
-
-
-def _convert_content_item_to_responses_format(item: dict[str, Any]) -> dict[str, Any]:
-    """
-    Convert a content item from Chat API format to Responses API format.
-
-    For images, converts from:
-        {"type": "image_url", "image_url": {"url": "..."}}
-    To:
-        {"type": "input_image", "image_url": "..."}
-
-    For text, converts from:
-        {"type": "text", "text": "..."}
-    To:
-        {"type": "input_text", "text": "..."}
-
-    For other types, passes through as-is.
-    """
-    if item.get("type") == "image_url":
-        image_url = item.get("image_url", {}).get("url", "")
-        return {
-            "type": "input_image",
-            "image_url": image_url,
-        }
-    elif item.get("type") == "text":
-        return {
-            "type": "input_text",
-            "text": item.get("text", ""),
-        }
-    elif item.get("type") == "file":
-        file = item.get("file", {})
-        return {
-            "type": "input_file",
-            "file_data": file.get("file_data"),
-            "filename": file.get("filename"),
-            "file_id": file.get("file_id"),
-        }
-
-    # For other items, return as-is
-    return item
+    lm_request = LMRequest.from_call(model=model, messages=messages, tools=tools, **request)
+    return to_openai_responses_request(lm_request)
 
 
 def _add_dspy_identifier_to_headers(headers: dict[str, Any] | None = None):

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -482,8 +482,7 @@ def reasoning_to_responses_kwargs(reasoning: Any) -> dict[str, Any]:
     data = {}
     if reasoning.effort is not None:
         data["effort"] = reasoning.effort
-        data["summary"] = reasoning.summary or "auto"
-    elif reasoning.summary is not None:
+    if reasoning.summary is not None:
         data["summary"] = reasoning.summary
     return {"reasoning": data} if data else {}
 

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -55,6 +55,7 @@ __all__ = [
     "to_openai_chat_request",
     "to_openai_responses_request",
     "to_openai_text_request",
+    "tool_to_openai_responses",
     "completion_to_lm_response",
     "responses_to_lm_response",
     "provider_tool_call_to_part",
@@ -129,9 +130,9 @@ def to_openai_responses_request(request: LMRequest) -> dict[str, Any]:
     }
     data.update(responses_config_kwargs(config, model=request.model))
     if config.tool_choice is not None:
-        data.update(tool_choice_to_openai(config.tool_choice))
+        data.update(tool_choice_to_openai_responses(config.tool_choice))
     if request.tools:
-        data["tools"] = [tool_to_openai(tool) for tool in request.tools]
+        data["tools"] = [tool_to_openai_responses(tool) for tool in request.tools]
     return data
 
 
@@ -351,6 +352,15 @@ def tool_to_openai(tool: LMToolSpec) -> dict[str, Any]:
     return data
 
 
+def tool_to_openai_responses(tool: LMToolSpec) -> dict[str, Any]:
+    """Convert a normalized tool spec into Responses API function-tool shape."""
+    data = {"type": "function", "name": tool.name, "parameters": tool.parameters}
+    if tool.description is not None:
+        data["description"] = tool.description
+    data.update(tool.provider_data)
+    return data
+
+
 def tool_choice_to_openai(choice: LMToolChoice) -> dict[str, Any]:
     if choice.allowed:
         if len(choice.allowed) != 1 or choice.mode not in {"required", "auto"}:
@@ -359,6 +369,21 @@ def tool_choice_to_openai(choice: LMToolChoice) -> dict[str, Any]:
                 "with mode 'required' or 'auto'."
             )
         data: dict[str, Any] = {"tool_choice": {"type": "function", "function": {"name": choice.allowed[0]}}}
+    else:
+        data = {"tool_choice": choice.mode}
+    if choice.parallel is not None:
+        data["parallel_tool_calls"] = choice.parallel
+    return data
+
+
+def tool_choice_to_openai_responses(choice: LMToolChoice) -> dict[str, Any]:
+    if choice.allowed:
+        if len(choice.allowed) != 1 or choice.mode not in {"required", "auto"}:
+            raise ValueError(
+                "OpenAI Responses tool_choice only supports constraining to a single allowed tool "
+                "with mode 'required' or 'auto'."
+            )
+        data: dict[str, Any] = {"tool_choice": {"type": "function", "name": choice.allowed[0]}}
     else:
         data = {"tool_choice": choice.mode}
     if choice.parallel is not None:
@@ -457,7 +482,8 @@ def reasoning_to_responses_kwargs(reasoning: Any) -> dict[str, Any]:
     data = {}
     if reasoning.effort is not None:
         data["effort"] = reasoning.effort
-    if reasoning.summary is not None:
+        data["summary"] = reasoning.summary or "auto"
+    elif reasoning.summary is not None:
         data["summary"] = reasoning.summary
     return {"reasoning": data} if data else {}
 

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -1853,9 +1853,11 @@ def _audio_dict_to_part(audio: dict[str, Any]) -> LMAudioPart:
 
 
 def _binary_dict_to_part(file: dict[str, Any]) -> LMBinaryPart:
+    legacy_block = {"type": "file", "file": dict(file)} if file.get("file_data") is not None and file.get("file_id") is not None else None
     if file.get("file_data") is not None:
         media_type, data = _split_data_uri(file["file_data"])
-        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"))
+        metadata = {"legacy_content_block": legacy_block} if legacy_block is not None else {}
+        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"), metadata=metadata)
     if file.get("data") is not None:
         media_type, data = _split_data_uri(file["data"])
         return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"))

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2715,17 +2715,21 @@ def test_empty_string_content_raises_adapter_parse_error():
                 cot(question="test")
 
 
-def test_tool_call_with_null_content_does_not_raise():
-    """Tool-call-only responses legitimately have content=None.
+@pytest.mark.parametrize("output", [
+    {"text": None, "tool_calls": [
+        {"function": {"name": "search", "arguments": '{"query": "test"}'}, "id": "call_1", "type": "function"}
+    ]},
+    {"tool_calls": [
+        {"function": {"name": "search", "arguments": '{"query": "test"}'}, "id": "call_1", "type": "function"}
+    ]},
+])
+def test_tool_call_with_null_or_missing_content_does_not_raise(output):
+    """Tool-call-only responses legitimately have content=None or no text key.
     _call_postprocess must NOT raise when tool_calls are present."""
     adapter = dspy.ChatAdapter(use_native_function_calling=True)
     sig_cls = dspy.Signature("question, tools: list[dspy.Tool] -> answer, tool_calls: dspy.ToolCalls")
 
-    outputs = [{"text": None, "tool_calls": [
-        {"function": {"name": "search", "arguments": '{"query": "test"}'}, "id": "call_1", "type": "function"}
-    ]}]
-
-    result = adapter._call_postprocess(sig_cls, sig_cls, outputs, None, {})
+    result = adapter._call_postprocess(sig_cls, sig_cls, [output], None, {})
     assert result is not None
     assert len(result) == 1
     assert result[0]["tool_calls"].tool_calls[0].id == "call_1"
@@ -2771,6 +2775,71 @@ def test_tool_call_with_structured_content_preserves_other_outputs():
 
     assert result[0]["answer"] == "I should use a tool."
     assert result[0]["tool_calls"].tool_calls[0].id == "call_1"
+
+
+def test_responses_model_native_tool_calling_round_trips_tool_only_output():
+    from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        tool_calls: dspy.ToolCalls = dspy.OutputField()
+
+    def search(query: str) -> str:
+        return query
+
+    api_response = ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0.0,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        model="openai/dspy-test-model",
+        object="response",
+        output=[
+            {
+                "type": "function_call",
+                "name": "search",
+                "arguments": json.dumps({"query": "cats"}),
+                "call_id": "call_1",
+                "status": "completed",
+                "id": "fc_1",
+            }
+        ],
+        metadata={},
+        parallel_tool_calls=False,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text=None,
+        truncation="disabled",
+        usage=ResponseAPIUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        user=None,
+    )
+
+    adapter = dspy.ChatAdapter(use_native_function_calling=True)
+    lm = dspy.LM("openai/dspy-test-model", model_type="responses", cache=False)
+
+    with mock.patch("litellm.supports_function_calling", return_value=True), mock.patch(
+        "litellm.responses", return_value=api_response
+    ) as responses:
+        result = adapter(lm, {}, MySignature, [], {"question": "find cats", "tools": [dspy.Tool(search)]})
+
+    assert result == [
+        {"tool_calls": dspy.ToolCalls(tool_calls=[dspy.ToolCalls.ToolCall(id="call_1", name="search", args={"query": "cats"})])}
+    ]
+    assert responses.call_args.kwargs["tools"] == [
+        {
+            "type": "function",
+            "name": "search",
+            "parameters": {"type": "object", "properties": {"query": {"type": "string"}}, "required": ["query"]},
+        }
+    ]
 
 
 def test_provider_tool_calls_preserve_id_and_repair_arguments():

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -830,27 +830,35 @@ def test_lm_replaces_system_with_developer_role():
         assert mock_completion.call_args.kwargs["request"]["messages"][0]["role"] == "developer"
 
 
-def test_responses_api_tool_calls(litellm_test_server):
-    api_base, _ = litellm_test_server
-    expected_tool_call = {
+def test_responses_api_tool_calls():
+    response_tool_call = {
         "type": "function_call",
         "name": "get_weather",
         "arguments": json.dumps({"city": "Paris"}),
         "call_id": "call_1",
         "status": "completed",
-        "id": "call_1",
+        "id": "fc_1",
     }
-    expected_response = [{"tool_calls": [expected_tool_call]}]
+    expected_response = [
+        {
+            "text": None,
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})},
+                    "id": "call_1",
+                }
+            ],
+        }
+    ]
 
     api_response = make_response(
-        output_blocks=[expected_tool_call],
+        output_blocks=[response_tool_call],
     )
 
     with mock.patch("litellm.responses", autospec=True, return_value=api_response) as dspy_responses:
         lm = dspy.LM(
             model="openai/dspy-test-model",
-            api_base=api_base,
-            api_key="fakekey",
             model_type="responses",
             cache=False,
         )
@@ -862,8 +870,7 @@ def test_responses_api_tool_calls(litellm_test_server):
 
 def test_reasoning_effort_responses_api():
     """Test that reasoning_effort gets normalized to reasoning format for Responses API."""
-    with mock.patch("litellm.responses") as mock_responses:
-        # OpenAI model with Responses API - should normalize
+    with mock.patch("litellm.responses", return_value=make_response([])) as mock_responses:
         lm = dspy.LM(
             model="openai/gpt-5", model_type="responses", reasoning_effort="low", max_tokens=16000, temperature=1.0
         )
@@ -947,6 +954,46 @@ def test_api_key_not_saved_in_json():
         assert saved_state["lm"]["model"] == "openai/gpt-4o-mini"
         assert saved_state["lm"]["temperature"] == 1.0
         assert saved_state["lm"]["max_tokens"] == 100
+
+
+def test_responses_api_converts_tools_to_responses_shape():
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    result = _convert_chat_request_to_responses_request(
+        {
+            "model": "openai/gpt-4o-mini",
+            "messages": [{"role": "user", "content": "What is the weather?"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+            "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+        }
+    )
+
+    assert result["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    assert result["tool_choice"] == {"type": "function", "name": "get_weather"}
 
 
 def test_responses_api_converts_images_correctly():

--- a/tests/clients/test_lm_responses_contract.py
+++ b/tests/clients/test_lm_responses_contract.py
@@ -65,7 +65,7 @@ def test_openai_format_responses_request_maps_tools_choices_and_config():
         tools=[_chat_shaped_weather_tool()],
         tool_choice={"type": "function", "function": {"name": "get_weather"}},
         parallel_tool_calls=False,
-        reasoning_effort="low",
+        reasoning={"effort": "low", "summary": "auto"},
         response_format=ContractSchema,
         max_tokens=123,
     )
@@ -99,6 +99,17 @@ def test_openai_format_responses_request_maps_tools_choices_and_config():
         "name": "ContractSchema",
         "schema": ContractSchema.model_json_schema(),
     }
+
+
+def test_openai_format_responses_request_preserves_unspecified_reasoning_summary():
+    request = LMRequest.from_call(
+        model="openai/gpt-5-mini",
+        messages=[{"role": "user", "content": "Say OK."}],
+        reasoning={"effort": "low"},
+    )
+
+    assert request.config.reasoning.summary is None
+    assert to_openai_responses_request(request)["reasoning"] == {"effort": "low"}
 
 
 def test_responses_to_lm_response_normalizes_mixed_text_reasoning_and_tool_calls():

--- a/tests/clients/test_lm_responses_contract.py
+++ b/tests/clients/test_lm_responses_contract.py
@@ -1,0 +1,262 @@
+import json
+from unittest import mock
+
+import pydantic
+import pytest
+from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+from openai.types.responses import ResponseOutputMessage
+from openai.types.responses.response_reasoning_item import Summary
+
+import dspy
+from dspy.clients.openai_format import responses_to_lm_response, to_openai_responses_request
+from dspy.core.types import LMRequest, LMThinkingPart
+
+
+def _responses_response(output_blocks, *, usage=None):
+    return ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0.0,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        model="openai/dspy-test-model",
+        object="response",
+        output=output_blocks,
+        metadata={},
+        parallel_tool_calls=False,
+        temperature=1.0,
+        tool_choice="auto",
+        tools=[],
+        top_p=1.0,
+        max_output_tokens=None,
+        previous_response_id=None,
+        reasoning=None,
+        status="completed",
+        text=None,
+        truncation="disabled",
+        usage=usage or ResponseAPIUsage(input_tokens=1, output_tokens=2, total_tokens=3),
+        user=None,
+    )
+
+
+def _chat_shaped_weather_tool():
+    return {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+
+
+class ContractSchema(pydantic.BaseModel):
+    answer: str
+
+
+def test_openai_format_responses_request_maps_tools_choices_and_config():
+    request = LMRequest.from_call(
+        model="openai/gpt-5-mini",
+        messages=[{"role": "user", "content": "What is the weather in Paris?"}],
+        tools=[_chat_shaped_weather_tool()],
+        tool_choice={"type": "function", "function": {"name": "get_weather"}},
+        parallel_tool_calls=False,
+        reasoning_effort="low",
+        response_format=ContractSchema,
+        max_tokens=123,
+    )
+
+    data = to_openai_responses_request(request)
+
+    assert data["input"] == [
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": "What is the weather in Paris?"}],
+        }
+    ]
+    assert data["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+    assert data["tool_choice"] == {"type": "function", "name": "get_weather"}
+    assert data["parallel_tool_calls"] is False
+    assert data["reasoning"] == {"effort": "low", "summary": "auto"}
+    assert data["max_output_tokens"] == 123
+    assert data["text"]["format"] == {
+        "type": "json_schema",
+        "name": "ContractSchema",
+        "schema": ContractSchema.model_json_schema(),
+    }
+
+
+def test_responses_to_lm_response_normalizes_mixed_text_reasoning_and_tool_calls():
+    response = _responses_response(
+        [
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "I should use weather.", "annotations": []}],
+            ),
+            {
+                "type": "function_call",
+                "name": "get_weather",
+                "arguments": '{"city": "Paris",}',
+                "call_id": "call_1",
+                "id": "fc_1",
+                "status": "completed",
+            },
+            {
+                "type": "reasoning",
+                "summary": [Summary(type="summary_text", text="Need live weather.")],
+            },
+        ]
+    )
+
+    lm_response = responses_to_lm_response(response, LMRequest(model="openai/dspy-test-model", messages=[]))
+    output = lm_response.outputs[0]
+
+    assert output.text == "I should use weather."
+    assert output.reasoning_content == "Need live weather."
+    assert output.tool_calls[0].id == "call_1"
+    assert output.tool_calls[0].name == "get_weather"
+    assert output.tool_calls[0].args == {}
+    assert output.tool_calls[0].provider_data["raw_arguments"] == '{"city": "Paris",}'
+    assert "arguments_parse_error" in output.tool_calls[0].provider_data
+    assert lm_response.usage.total_tokens == 3
+
+
+def test_lm_responses_direct_native_tool_calling_uses_responses_tool_shape():
+    response = _responses_response(
+        [
+            {
+                "type": "function_call",
+                "name": "get_weather",
+                "arguments": json.dumps({"city": "Paris"}),
+                "call_id": "call_1",
+                "id": "fc_1",
+                "status": "completed",
+            }
+        ]
+    )
+
+    with mock.patch("litellm.responses", autospec=True, return_value=response) as responses:
+        lm = dspy.LM("openai/dspy-test-model", model_type="responses", cache=False)
+        outputs = lm("What is the weather in Paris?", tools=[_chat_shaped_weather_tool()])
+
+    assert outputs == [
+        {
+            "text": None,
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})},
+                    "id": "call_1",
+                }
+            ],
+        }
+    ]
+    assert responses.call_args.kwargs["tools"] == [
+        {
+            "type": "function",
+            "name": "get_weather",
+            "description": "Get weather.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_lm_responses_async_native_tool_calling_matches_sync_contract():
+    response = _responses_response(
+        [
+            {
+                "type": "function_call",
+                "name": "get_weather",
+                "arguments": json.dumps({"city": "Paris"}),
+                "call_id": "call_1",
+                "id": "fc_1",
+                "status": "completed",
+            }
+        ]
+    )
+
+    with mock.patch("litellm.aresponses", autospec=True, return_value=response) as responses:
+        lm = dspy.LM("openai/dspy-test-model", model_type="responses", cache=False)
+        outputs = await lm.acall("What is the weather in Paris?", tools=[_chat_shaped_weather_tool()])
+
+    assert outputs[0]["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert responses.call_args.kwargs["tools"][0]["name"] == "get_weather"
+    assert "function" not in responses.call_args.kwargs["tools"][0]
+
+
+def test_lm_responses_cache_history_and_usage_use_normalized_output(tmp_path):
+    response = _responses_response(
+        [
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "cached answer", "annotations": []}],
+            ),
+            {
+                "type": "reasoning",
+                "summary": [Summary(type="summary_text", text="cached reasoning")],
+            },
+        ],
+        usage=ResponseAPIUsage(input_tokens=4, output_tokens=5, total_tokens=9),
+    )
+
+    original_cache = dspy.cache
+    dspy.configure_cache(enable_disk_cache=True, enable_memory_cache=True, disk_cache_dir=tmp_path / ".dspy_cache")
+    try:
+        with mock.patch("litellm.responses", autospec=True, return_value=response) as responses:
+            lm = dspy.LM("openai/dspy-test-model", model_type="responses")
+            with dspy.context(track_usage=True):
+                first = lm("cache me")
+                second = lm("cache me")
+
+        assert first == [{"text": "cached answer", "reasoning_content": "cached reasoning"}]
+        assert second == first
+        assert responses.call_count == 1
+        assert lm.history[-1]["outputs"] == first
+        assert lm.history[0]["usage"]["input_tokens"] == 4
+        assert lm.history[0]["usage"]["output_tokens"] == 5
+        assert lm.history[0]["usage"]["total_tokens"] == 9
+        assert lm.history[-1]["usage"] == {}
+    finally:
+        dspy.cache = original_cache
+
+
+def test_lm_responses_reasoning_output_uses_thinking_part_in_normalized_response():
+    response = _responses_response(
+        [
+            {
+                "type": "reasoning",
+                "summary": [Summary(type="summary_text", text="think first")],
+            }
+        ]
+    )
+
+    lm_response = responses_to_lm_response(response, LMRequest(model="openai/dspy-test-model", messages=[]))
+
+    assert lm_response.outputs[0].parts == [LMThinkingPart(text="think first")]
+    assert lm_response.to_legacy_outputs() == [{"text": None, "reasoning_content": "think first"}]

--- a/tests/clients/test_lm_responses_contract.py
+++ b/tests/clients/test_lm_responses_contract.py
@@ -139,6 +139,40 @@ def test_responses_to_lm_response_normalizes_mixed_text_reasoning_and_tool_calls
     assert lm_response.usage.total_tokens == 3
 
 
+def test_responses_request_converts_assistant_tool_calls_and_tool_results():
+    request = LMRequest.from_call(
+        model="openai/gpt-5-mini",
+        messages=[
+            {"role": "user", "content": "What is the weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "name": "get_weather", "content": "sunny"},
+        ],
+    )
+
+    data = to_openai_responses_request(request)
+
+    assert data["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "What is the weather?"}]},
+        {
+            "type": "function_call",
+            "name": "get_weather",
+            "arguments": json.dumps({"city": "Paris"}),
+            "call_id": "call_1",
+        },
+        {"type": "function_call_output", "output": "sunny", "call_id": "call_1"},
+    ]
+
+
 def test_lm_responses_direct_native_tool_calling_uses_responses_tool_shape():
     response = _responses_response(
         [

--- a/tests/clients/test_lm_responses_contract.py
+++ b/tests/clients/test_lm_responses_contract.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pydantic
 import pytest
 from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
-from openai.types.responses import ResponseOutputMessage
+from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response_reasoning_item import Summary
 
 import dspy
@@ -119,10 +119,11 @@ def test_responses_to_lm_response_normalizes_mixed_text_reasoning_and_tool_calls
                 "id": "fc_1",
                 "status": "completed",
             },
-            {
-                "type": "reasoning",
-                "summary": [Summary(type="summary_text", text="Need live weather.")],
-            },
+            ResponseReasoningItem(
+                id="reasoning_1",
+                type="reasoning",
+                summary=[Summary(type="summary_text", text="Need live weather.")],
+            ),
         ]
     )
 
@@ -251,10 +252,11 @@ def test_lm_responses_cache_history_and_usage_use_normalized_output(tmp_path):
                 status="completed",
                 content=[{"type": "output_text", "text": "cached answer", "annotations": []}],
             ),
-            {
-                "type": "reasoning",
-                "summary": [Summary(type="summary_text", text="cached reasoning")],
-            },
+            ResponseReasoningItem(
+                id="reasoning_1",
+                type="reasoning",
+                summary=[Summary(type="summary_text", text="cached reasoning")],
+            ),
         ],
         usage=ResponseAPIUsage(input_tokens=4, output_tokens=5, total_tokens=9),
     )
@@ -283,10 +285,11 @@ def test_lm_responses_cache_history_and_usage_use_normalized_output(tmp_path):
 def test_lm_responses_reasoning_output_uses_thinking_part_in_normalized_response():
     response = _responses_response(
         [
-            {
-                "type": "reasoning",
-                "summary": [Summary(type="summary_text", text="think first")],
-            }
+            ResponseReasoningItem(
+                id="reasoning_1",
+                type="reasoning",
+                summary=[Summary(type="summary_text", text="think first")],
+            )
         ]
     )
 

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -3,6 +3,7 @@ import pytest
 
 from dspy.core.types import (
     LMAudioPart,
+    LMBinaryPart,
     LMConfig,
     LMDocumentPart,
     LMHistoryEntry,
@@ -140,6 +141,98 @@ def test_video_data_round_trips_through_history_messages():
     assert isinstance(round_tripped, LMVideoPart)
     assert round_tripped.data == "YWJj"
     assert round_tripped.media_type == "video/mp4"
+
+
+def test_file_content_blocks_normalize_to_binary_parts():
+    data_message = LMMessage(
+        role="user",
+        content=[
+            {
+                "type": "file",
+                "file": {
+                    "file_data": "data:text/plain;base64,SGVsbG8=",
+                    "filename": "hello.txt",
+                },
+            }
+        ],
+    )
+    data_part = data_message.parts[0]
+
+    assert isinstance(data_part, LMBinaryPart)
+    assert data_part.data == "SGVsbG8="
+    assert data_part.media_type == "text/plain"
+    assert data_part.filename == "hello.txt"
+
+    id_message = LMMessage(
+        role="user",
+        content=[{"type": "file", "file": {"file_id": "file_123", "filename": "report.pdf"}}],
+    )
+    id_part = id_message.parts[0]
+
+    assert isinstance(id_part, LMBinaryPart)
+    assert id_part.file_id == "file_123"
+    assert id_part.filename == "report.pdf"
+
+
+def test_file_content_block_with_data_and_id_round_trips_losslessly_to_responses_format():
+    from dspy.clients.openai_format import to_openai_responses_request
+
+    message = LMMessage(
+        role="user",
+        content=[
+            {
+                "type": "file",
+                "file": {
+                    "file_data": "data:application/pdf;base64,JVBERi0xLjQ=",
+                    "file_id": "file_123",
+                    "filename": "report.pdf",
+                },
+            }
+        ],
+    )
+    part = message.parts[0]
+
+    assert isinstance(part, LMBinaryPart)
+    assert part.metadata["legacy_content_block"] == {
+        "type": "file",
+        "file": {
+            "file_data": "data:application/pdf;base64,JVBERi0xLjQ=",
+            "file_id": "file_123",
+            "filename": "report.pdf",
+        },
+    }
+
+    request = LMRequest(model="model", messages=[message])
+    content = to_openai_responses_request(request)["input"][0]["content"]
+
+    assert content == [
+        {
+            "type": "input_file",
+            "file_data": "data:application/pdf;base64,JVBERi0xLjQ=",
+            "file_id": "file_123",
+            "filename": "report.pdf",
+        }
+    ]
+
+
+def test_tool_result_message_content_list_normalizes_to_parts():
+    message = LMMessage(
+        role="tool",
+        tool_call_id="call_1",
+        name="search",
+        content=[
+            {"type": "text", "text": "see this"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+        ],
+    )
+    result = message.parts[0]
+
+    assert isinstance(result, LMToolResultPart)
+    assert result.call_id == "call_1"
+    assert result.name == "search"
+    assert len(result.content) == 2
+    assert result.content[0].text == "see this"
+    assert result.content[1].url == "https://example.com/cat.png"
 
 
 def test_document_source_url_stays_url_and_round_trips_through_history_messages():


### PR DESCRIPTION
## Summary

Fixes native tool calling with `model_type="responses"`.

## Changes

- Send tools and `tool_choice` in the correct Responses API shape.
- Parse Responses API outputs through the normalized LM response path.
- Preserve the existing legacy output shape for Responses API callers.
- Handle tool-call-only responses with missing/null text.

## Tests

Added Responses API contract tests for tool calls, reasoning, caching/history, and sync/async behavior.

Focused checks run locally:

```bash
uv run pytest tests/clients/test_lm_responses_contract.py tests/clients/test_lm.py::test_responses_api tests/clients/test_lm.py::test_responses_api_tool_calls tests/clients/test_lm.py::test_responses_api_converts_tools_to_responses_shape tests/clients/test_lm.py::test_reasoning_effort_responses_api tests/adapters/test_chat_adapter.py::test_responses_model_native_tool_calling_round_trips_tool_only_output -q
uv run ruff check dspy/clients/openai_format.py dspy/clients/lm.py dspy/clients/base_lm.py dspy/adapters/base.py tests/clients/test_lm.py tests/adapters/test_chat_adapter.py tests/clients/test_lm_responses_contract.py
```