### PR TITLE
[codex] Mark NumPy KNN tests as extra

### DIFF
--- a/tests/predict/test_knn.py
+++ b/tests/predict/test_knn.py
@@ -1,9 +1,10 @@
-import numpy as np
 import pytest
 
 import dspy
 from dspy.predict import KNN
 from dspy.utils import DummyVectorizer
+
+pytestmark = pytest.mark.extra
 
 
 def mock_example(question: str, answer: str) -> dspy.Example:
@@ -24,6 +25,8 @@ def setup_knn() -> KNN:
 
 def test_knn_initialization(setup_knn):
     """Tests the KNN initialization and checks if the trainset vectors are correctly created."""
+    import numpy as np
+
     knn = setup_knn
     assert knn.k == 2, "Incorrect k value"
     assert len(knn.trainset_vectors) == 3, "Incorrect size of trainset vectors"


### PR DESCRIPTION
## What changed

- Marked `tests/predict/test_knn.py` with `pytest.mark.extra`.
- Moved the NumPy import out of module import time and into the assertion that needs `np.ndarray`.

## Why

The release smoke test installs the built wheel plus pytest dependencies, then collects `tests/predict`. Since NumPy is now optional, collecting `test_knn.py` failed before pytest could skip optional-dependency tests.

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_knn.py` -> 3 skipped
- `uv run --frozen pytest --deno --extra -q tests/predict/test_knn.py` -> 3 passed
- Release-smoke mimic in a fresh Python 3.11 venv with the built wheel, `pytest`, and `pytest-asyncio` only, then `pytest --deno -q tests/metadata/test_metadata.py tests/predict` -> 244 passed, 6 skipped

## Similar-issue check

- Confirmed NumPy is absent from the release-smoke venv.
- Checked top-level optional-dependency imports in `tests/metadata` and `tests/predict`; no remaining matches after this change.