### PR TITLE
feat: add append_instructions to Signature

### DIFF
--- a/docs/docs/api/signatures/Signature.md
+++ b/docs/docs/api/signatures/Signature.md
@@ -6,6 +6,7 @@
     options:
         members:
             - append
+            - append_instructions
             - delete
             - dump_state
             - equals

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -288,18 +288,17 @@ class Signature(BaseModel, metaclass=SignatureMeta):
             A new Signature class whose fields match `cls.fields`
             and whose instructions equal `instructions`.
 
-Examples:
+        Examples:
 ```python
-        import dspy
+            import dspy
 
-        class MySig(dspy.Signature):
-            input_text: str = dspy.InputField(desc="Input text")
-            output_text: str = dspy.OutputField(desc="Output text")
+            class MySig(dspy.Signature):
+                input_text: str = dspy.InputField(desc="Input text")
+                output_text: str = dspy.OutputField(desc="Output text")
 
-        NewSig = MySig.append_instructions("Always respond in French.")
-        assert NewSig is not MySig
-        assert NewSig.instructions == MySig.instructions + "\n" + "Always respond in French."
-        assert MySig.instructions == original_instructions  # original unchanged
+            NewSig = MySig.with_instructions("Translate to French.")
+            assert NewSig is not MySig
+            assert NewSig.instructions == "Translate to French."
 ```
         """
         return Signature(cls.fields, instructions)
@@ -328,10 +327,11 @@ Examples:
                 input_text: str = dspy.InputField(desc="Input text")
                 output_text: str = dspy.OutputField(desc="Output text")
 
+            original = MySig.instructions
             NewSig = MySig.append_instructions("Always respond in French.")
             assert NewSig is not MySig
-            assert NewSig.instructions == MySig.instructions + "\n" + "Always respond in French."
-            assert MySig.instructions == original_instructions  # original unchanged
+            assert NewSig.instructions == original + "\n" + "Always respond in French."
+            assert MySig.instructions == original  # original unchanged
 ```
         """
         return cls.with_instructions(cls.instructions + "\n" + instructions)

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -289,7 +289,7 @@ class Signature(BaseModel, metaclass=SignatureMeta):
             and whose instructions equal `instructions`.
 
         Examples:
-            ```python
+```python
             import dspy
 
             class MySig(dspy.Signature):
@@ -299,10 +299,41 @@ class Signature(BaseModel, metaclass=SignatureMeta):
             NewSig = MySig.with_instructions("Translate to French.")
             assert NewSig is not MySig
             assert NewSig.instructions == "Translate to French."
-            ```
+```
         """
         return Signature(cls.fields, instructions)
 
+    @classmethod
+    def append_instructions(cls, instructions: str) -> type["Signature"]:
+        """Return a new Signature class with additional instructions appended.
+
+        This method does not mutate `cls`. It constructs a fresh Signature
+        class using the current fields and the existing instructions with
+        the provided ``instructions`` appended on a new line.
+
+        Args:
+            instructions (str): Instruction text to append to the existing instructions.
+
+        Returns:
+            A new Signature class whose fields match ``cls.fields``
+            and whose instructions are the original instructions with
+            the new instructions appended.
+
+        Examples:
+```python
+            import dspy
+
+            class MySig(dspy.Signature):
+                input_text: str = dspy.InputField(desc="Input text")
+                output_text: str = dspy.OutputField(desc="Output text")
+
+            NewSig = MySig.append_instructions("Always respond in French.")
+            assert NewSig is not MySig
+            assert NewSig.instructions == MySig.instructions + "\n" + "Always respond in French."
+            assert MySig.instructions == MySig.instructions  # original unchanged
+```
+        """
+        return cls.with_instructions(cls.instructions + "\n" + instructions)
     @classmethod
     def with_updated_fields(cls, name: str, type_: type | None = None, **kwargs: dict[str, Any]) -> type["Signature"]:
         """Create a new Signature class with the updated field information.

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -334,7 +334,9 @@ class Signature(BaseModel, metaclass=SignatureMeta):
             assert MySig.instructions == original  # original unchanged
 ```
         """
-        return cls.with_instructions(cls.instructions + "\n" + instructions)
+        current = cls.instructions
+        new_instructions = (current + "\n" + instructions) if current else instructions
+        return cls.with_instructions(new_instructions)
     @classmethod
     def with_updated_fields(cls, name: str, type_: type | None = None, **kwargs: dict[str, Any]) -> type["Signature"]:
         """Create a new Signature class with the updated field information.

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -288,17 +288,18 @@ class Signature(BaseModel, metaclass=SignatureMeta):
             A new Signature class whose fields match `cls.fields`
             and whose instructions equal `instructions`.
 
-        Examples:
+Examples:
 ```python
-            import dspy
+        import dspy
 
-            class MySig(dspy.Signature):
-                input_text: str = dspy.InputField(desc="Input text")
-                output_text: str = dspy.OutputField(desc="Output text")
+        class MySig(dspy.Signature):
+            input_text: str = dspy.InputField(desc="Input text")
+            output_text: str = dspy.OutputField(desc="Output text")
 
-            NewSig = MySig.with_instructions("Translate to French.")
-            assert NewSig is not MySig
-            assert NewSig.instructions == "Translate to French."
+        NewSig = MySig.append_instructions("Always respond in French.")
+        assert NewSig is not MySig
+        assert NewSig.instructions == MySig.instructions + "\n" + "Always respond in French."
+        assert MySig.instructions == original_instructions  # original unchanged
 ```
         """
         return Signature(cls.fields, instructions)
@@ -330,7 +331,7 @@ class Signature(BaseModel, metaclass=SignatureMeta):
             NewSig = MySig.append_instructions("Always respond in French.")
             assert NewSig is not MySig
             assert NewSig.instructions == MySig.instructions + "\n" + "Always respond in French."
-            assert MySig.instructions == MySig.instructions  # original unchanged
+            assert MySig.instructions == original_instructions  # original unchanged
 ```
         """
         return cls.with_instructions(cls.instructions + "\n" + instructions)

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -609,3 +609,26 @@ def test_predict_cloudpickle_roundtrip():
     loaded = pickle.loads(data)
 
     assert list(loaded.signature.fields.keys()) == ["question", "answer"]
+
+    
+def test_append_instructions():
+    class MySig(dspy.Signature):
+        """Original instructions."""
+        input_text: str = dspy.InputField(desc="Input text")
+        output_text: str = dspy.OutputField(desc="Output text")
+
+    original_instructions = MySig.instructions
+
+    NewSig = MySig.append_instructions("Always respond in French.")
+
+    # New signature has appended instructions
+    assert NewSig.instructions == original_instructions + "\n" + "Always respond in French."
+
+    # Original signature is unchanged
+    assert MySig.instructions == original_instructions
+
+    # New signature is a different class
+    assert NewSig is not MySig
+
+    # Fields are preserved
+    assert list(NewSig.fields.keys()) == list(MySig.fields.keys())

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -610,7 +610,7 @@ def test_predict_cloudpickle_roundtrip():
 
     assert list(loaded.signature.fields.keys()) == ["question", "answer"]
 
-    
+
 def test_append_instructions():
     class MySig(dspy.Signature):
         """Original instructions."""
@@ -632,3 +632,14 @@ def test_append_instructions():
 
     # Fields are preserved
     assert list(NewSig.fields.keys()) == list(MySig.fields.keys())
+
+
+def test_append_instructions_empty_base():
+    class EmptySig(dspy.Signature):
+        input_text: str = dspy.InputField()
+        output_text: str = dspy.OutputField()
+
+    original = EmptySig.instructions  # auto-generated, not empty
+    NewSig = EmptySig.append_instructions("Focus on equipment.")
+    assert NewSig.instructions == original + "\n" + "Focus on equipment."
+    assert not NewSig.instructions.startswith("\n")  # no stray leading newline


### PR DESCRIPTION
Closes #9829

## Summary
Adds `append_instructions` method to `Signature` class, complementing the existing `with_instructions` method.

`with_instructions` replaces instructions entirely. `append_instructions` appends to existing instructions without replacing them, which is useful when base instructions need to stay intact while adding context-specific ones dynamically.

## Changes
- Added `append_instructions` classmethod to `Signature` in `dspy/signatures/signature.py`
- Added `append_instructions` to the Signature API docs
- Added `test_append_instructions` in `tests/signatures/test_signature.py`

## Usage
```python
class ExtractInfo(dspy.Signature):
    """Extract information from text."""
    text: str = dspy.InputField()
    info: str = dspy.OutputField()

EquipmentSig = ExtractInfo.append_instructions("Focus on equipment details only.")
```