### PR TITLE
fix(streaming): propagate exceptions from async generator in apply_sync_streaming (fixes #9142)

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -229,9 +229,16 @@ def streamify(
 
 
 def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
-    """Convert the async streaming generator to a sync generator."""
-    queue = Queue()  # Queue to hold items from the async generator
-    stop_sentinel = object()  # Sentinel to signal the generator is complete
+    """Convert the async streaming generator to a sync generator.
+
+    Exceptions raised inside the async generator are propagated to the caller
+    of the sync generator.  Previously any exception was silently swallowed
+    because the ``finally`` block placed only the stop sentinel on the queue,
+    giving the consumer no way to distinguish a clean finish from an error.
+    See https://github.com/stanfordnlp/dspy/issues/9142
+    """
+    queue: Queue = Queue()  # Queue to hold items (or a caught exception)
+    stop_sentinel = object()  # Sentinel to signal clean completion
 
     # To propagate prediction request ID context to the child thread
     context = contextvars.copy_context()
@@ -243,8 +250,12 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
-            finally:
-                # Signal completion
+            except Exception as exc:  # noqa: BLE001
+                # Put the live exception on the queue so the consumer can
+                # re-raise it in the calling thread.
+                queue.put(exc)
+            else:
+                # Only place the sentinel when the generator completes cleanly.
                 queue.put(stop_sentinel)
 
         context.run(asyncio.run, runner())
@@ -258,6 +269,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if isinstance(item, Exception):
+            raise item
         yield item
 
 

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2061,3 +2061,42 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/stanfordnlp/dspy/issues/9142
+# ---------------------------------------------------------------------------
+
+
+def test_apply_sync_streaming_propagates_exceptions():
+    """Exceptions raised inside the async generator must not be silently swallowed.
+
+    Before the fix, the producer thread's ``finally`` block placed only the
+    stop sentinel on the queue when an exception occurred, so the consumer
+    saw a clean stop with no indication of the error.
+    """
+    from dspy.streaming.streamify import apply_sync_streaming
+
+    class CustomError(RuntimeError):
+        pass
+
+    async def failing_generator():
+        yield "first"
+        raise CustomError("boom")
+
+    gen = apply_sync_streaming(failing_generator())
+    assert next(gen) == "first"
+    with pytest.raises(CustomError, match="boom"):
+        next(gen)
+
+
+def test_apply_sync_streaming_clean_generator_does_not_raise():
+    """A generator that finishes without error must still work normally."""
+    from dspy.streaming.streamify import apply_sync_streaming
+
+    async def clean_generator():
+        for i in range(3):
+            yield i
+
+    result = list(apply_sync_streaming(clean_generator()))
+    assert result == [0, 1, 2]


### PR DESCRIPTION
## Summary

Fixes #9142 — exceptions raised inside the async generator passed to `apply_sync_streaming` are silently swallowed.

**Before:**
```python
async def runner():
    try:
        async for item in async_generator:
            queue.put(item)
    finally:
        # Signal completion — but also reached when an exception was raised!
        queue.put(stop_sentinel)
```
The `finally` block puts the stop sentinel on the queue regardless of whether the generator finished cleanly or raised. The consumer loop sees `stop_sentinel` and breaks with no indication that an error occurred. Programs that relied on exception propagation would silently produce no output instead of surfacing the error.

**After:**
```python
async def runner():
    try:
        async for item in async_generator:
            queue.put(item)
    except Exception as exc:
        # Put the live exception on the queue so the consumer re-raises it
        queue.put(exc)
    else:
        # Only placed on clean completion
        queue.put(stop_sentinel)
```
The consumer checks whether the dequeued item is an `Exception` and re-raises it in the calling thread:
```python
if isinstance(item, Exception):
    raise item
```

## Changes

**`dspy/streaming/streamify.py`**
- Split `finally` into `except` + `else` so the stop sentinel is only queued on clean exit
- Added `except Exception` handler that places the live exception object on the queue
- Consumer loop re-raises the exception when it dequeues an `Exception` instance
- Updated docstring to document the propagation behaviour

**`tests/streaming/test_streaming.py`**
Two new regression tests (no external dependencies, run synchronously):
| Test | Assertion |
|---|---|
| `test_apply_sync_streaming_propagates_exceptions` | Consuming the generator after a yielded item raises the original exception type |
| `test_apply_sync_streaming_clean_generator_does_not_raise` | A clean generator still yields all items normally |

## Test plan
- [x] Both new tests pass: `python -m pytest tests/streaming/test_streaming.py::test_apply_sync_streaming_propagates_exceptions tests/streaming/test_streaming.py::test_apply_sync_streaming_clean_generator_does_not_raise -v` → `2 passed`