### PR TITLE
Expose timeout / straggler_limit on dspy.Evaluate (#9574)

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -81,6 +81,8 @@ class Evaluate:
         failure_score: float = 0.0,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int = 120,
+        straggler_limit: int = 3,
         **kwargs,
     ):
         """
@@ -97,6 +99,12 @@ class Evaluate:
             failure_score (float): The default score to use if evaluation fails due to an exception.
             save_as_csv (Optional[str]): The file name where the csv will be saved.
             save_as_json (Optional[str]): The file name where the json will be saved.
+            timeout (int): Per-item timeout in seconds for the parallel executor's straggler
+                resubmission. Set higher when individual examples take longer than the
+                default 120 seconds (e.g., long reasoning chains or slow tool calls).
+                Pass 0 to disable straggler resubmission entirely.
+            straggler_limit (int): How many remaining stragglers trigger the resubmission
+                check. Defaults to 3 to match the executor.
 
         """
         self.devset = devset
@@ -109,6 +117,8 @@ class Evaluate:
         self.failure_score = failure_score
         self.save_as_csv = save_as_csv
         self.save_as_json = save_as_json
+        self.timeout = timeout
+        self.straggler_limit = straggler_limit
 
         if "return_outputs" in kwargs:
             raise ValueError("`return_outputs` is no longer supported. Results are always returned inside the `results` field of the `EvaluationResult` object.")
@@ -125,6 +135,8 @@ class Evaluate:
         callback_metadata: dict[str, Any] | None = None,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: int | None = None,
+        straggler_limit: int | None = None,
     ) -> EvaluationResult:
         """
         Args:
@@ -153,6 +165,8 @@ class Evaluate:
         display_table = display_table if display_table is not None else self.display_table
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
+        timeout = timeout if timeout is not None else self.timeout
+        straggler_limit = straggler_limit if straggler_limit is not None else self.straggler_limit
 
         if callback_metadata:
             logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
@@ -165,6 +179,8 @@ class Evaluate:
             max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
             provide_traceback=self.provide_traceback,
             compare_results=True,
+            timeout=timeout,
+            straggler_limit=straggler_limit,
         )
 
         def process_item(example):

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -81,8 +81,8 @@ class Evaluate:
         failure_score: float = 0.0,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
-        timeout: int = 120,
-        straggler_limit: int = 3,
+        timeout: int | None = None,
+        straggler_limit: int | None = None,
         **kwargs,
     ):
         """
@@ -99,12 +99,15 @@ class Evaluate:
             failure_score (float): The default score to use if evaluation fails due to an exception.
             save_as_csv (Optional[str]): The file name where the csv will be saved.
             save_as_json (Optional[str]): The file name where the json will be saved.
-            timeout (int): Per-item timeout in seconds for the parallel executor's straggler
-                resubmission. Set higher when individual examples take longer than the
-                default 120 seconds (e.g., long reasoning chains or slow tool calls).
-                Pass 0 to disable straggler resubmission entirely.
-            straggler_limit (int): How many remaining stragglers trigger the resubmission
-                check. Defaults to 3 to match the executor.
+            timeout (Optional[int]): Per-item timeout in seconds for the parallel executor's
+                straggler resubmission. ``None`` defers to ``ParallelExecutor``'s own default
+                (currently 120 seconds). Raise this when individual examples legitimately take
+                longer than the default, e.g. long reasoning chains or slow tool calls, so the
+                straggler logic does not resubmit work that has not actually hung. Pass ``0`` to
+                disable straggler resubmission entirely.
+            straggler_limit (Optional[int]): How many remaining stragglers trigger the
+                resubmission check. ``None`` defers to ``ParallelExecutor``'s default
+                (currently 3).
 
         """
         self.devset = devset
@@ -173,15 +176,20 @@ class Evaluate:
 
         tqdm.tqdm._instances.clear()
 
-        executor = ParallelExecutor(
-            num_threads=num_threads,
-            disable_progress_bar=not display_progress,
-            max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
-            provide_traceback=self.provide_traceback,
-            compare_results=True,
-            timeout=timeout,
-            straggler_limit=straggler_limit,
-        )
+        executor_kwargs: dict[str, Any] = {
+            "num_threads": num_threads,
+            "disable_progress_bar": not display_progress,
+            "max_errors": self.max_errors if self.max_errors is not None else dspy.settings.max_errors,
+            "provide_traceback": self.provide_traceback,
+            "compare_results": True,
+        }
+        # Only forward the straggler knobs when the caller actually picked a value, so
+        # `ParallelExecutor`'s own defaults stay authoritative if they ever change.
+        if timeout is not None:
+            executor_kwargs["timeout"] = timeout
+        if straggler_limit is not None:
+            executor_kwargs["straggler_limit"] = straggler_limit
+        executor = ParallelExecutor(**executor_kwargs)
 
         def process_item(example):
             prediction = program(**example.inputs())

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -33,6 +33,67 @@ def test_evaluate_initialization():
     assert ev.metric == answer_exact_match
     assert ev.num_threads is None
     assert not ev.display_progress
+    # Defaults match ParallelExecutor's own defaults so behaviour is unchanged.
+    assert ev.timeout == 120
+    assert ev.straggler_limit == 3
+
+
+def test_evaluate_threads_through_executor_timeout(monkeypatch):
+    # Confirm the new timeout / straggler_limit kwargs reach ParallelExecutor.
+    captured = {}
+
+    from dspy.utils import parallelizer as parallelizer_module
+
+    real_executor = parallelizer_module.ParallelExecutor
+
+    def spy(**kwargs):
+        captured.update(kwargs)
+        return real_executor(**kwargs)
+
+    monkeypatch.setattr("dspy.evaluate.evaluate.ParallelExecutor", spy)
+
+    dspy.configure(lm=DummyLM({"What is 1+1?": {"answer": "2"}}))
+    devset = [new_example("What is 1+1?", "2")]
+    program = Predict("question -> answer")
+
+    Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        display_progress=False,
+        timeout=600,
+        straggler_limit=5,
+    )(program)
+
+    assert captured["timeout"] == 600
+    assert captured["straggler_limit"] == 5
+
+
+def test_evaluate_call_overrides_timeout(monkeypatch):
+    # __call__ overrides should beat the constructor defaults.
+    captured = {}
+
+    from dspy.utils import parallelizer as parallelizer_module
+
+    real_executor = parallelizer_module.ParallelExecutor
+
+    def spy(**kwargs):
+        captured.update(kwargs)
+        return real_executor(**kwargs)
+
+    monkeypatch.setattr("dspy.evaluate.evaluate.ParallelExecutor", spy)
+
+    dspy.configure(lm=DummyLM({"What is 1+1?": {"answer": "2"}}))
+    devset = [new_example("What is 1+1?", "2")]
+    program = Predict("question -> answer")
+
+    Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        display_progress=False,
+        timeout=120,
+    )(program, timeout=900)
+
+    assert captured["timeout"] == 900
 
 
 def test_evaluate_call():

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -33,9 +33,11 @@ def test_evaluate_initialization():
     assert ev.metric == answer_exact_match
     assert ev.num_threads is None
     assert not ev.display_progress
-    # Defaults match ParallelExecutor's own defaults so behaviour is unchanged.
-    assert ev.timeout == 120
-    assert ev.straggler_limit == 3
+    # Defaults are None so ParallelExecutor's own defaults stay authoritative; the
+    # call-site test below confirms `timeout` and `straggler_limit` are NOT forwarded
+    # when neither the constructor nor the call passed a value.
+    assert ev.timeout is None
+    assert ev.straggler_limit is None
 
 
 def test_evaluate_threads_through_executor_timeout(monkeypatch):
@@ -66,6 +68,32 @@ def test_evaluate_threads_through_executor_timeout(monkeypatch):
 
     assert captured["timeout"] == 600
     assert captured["straggler_limit"] == 5
+
+
+def test_evaluate_defers_to_executor_defaults_when_unset(monkeypatch):
+    # If neither the constructor nor __call__ pass timeout / straggler_limit, they
+    # must NOT appear in the ParallelExecutor kwargs at all. That way the executor's
+    # own defaults stay the source of truth.
+    captured = {}
+
+    from dspy.utils import parallelizer as parallelizer_module
+
+    real_executor = parallelizer_module.ParallelExecutor
+
+    def spy(**kwargs):
+        captured.update(kwargs)
+        return real_executor(**kwargs)
+
+    monkeypatch.setattr("dspy.evaluate.evaluate.ParallelExecutor", spy)
+
+    dspy.configure(lm=DummyLM({"What is 1+1?": {"answer": "2"}}))
+    devset = [new_example("What is 1+1?", "2")]
+    program = Predict("question -> answer")
+
+    Evaluate(devset=devset, metric=answer_exact_match, display_progress=False)(program)
+
+    assert "timeout" not in captured
+    assert "straggler_limit" not in captured
 
 
 def test_evaluate_call_overrides_timeout(monkeypatch):


### PR DESCRIPTION
Closes #9574.

## What I found

\`ParallelExecutor\` (\`dspy/utils/parallelizer.py\`) already takes \`timeout\` and \`straggler_limit\` kwargs — they control the resubmission window for slow items in \`_execute_parallel\`. But \`dspy.Evaluate\` builds the executor with the hardcoded defaults (120 seconds, 3 stragglers) and never lets the caller tune them:

\`\`\`python
# dspy/evaluate/evaluate.py
executor = ParallelExecutor(
    num_threads=num_threads,
    disable_progress_bar=not display_progress,
    max_errors=...,
    provide_traceback=self.provide_traceback,
    compare_results=True,
)
\`\`\`

For long evals (slow tools, long reasoning chains, larger devsets), the 120s straggler timer fires, items get resubmitted, and on bigger runs you start hitting "cannot schedule new futures after shutdown" once the executor tears down with the resubmitted items still in flight.

## What's in this PR

Surface \`timeout\` and \`straggler_limit\` on \`Evaluate.__init__\` and \`Evaluate.__call__\`, and pass them through to \`ParallelExecutor\`. Defaults keep matching the executor's own defaults so this is a no-op for anyone not opting in:

\`\`\`python
ev = dspy.Evaluate(
    devset=devset,
    metric=my_metric,
    num_threads=8,
    timeout=600,        # bump for slow tools / long reasoning
    straggler_limit=5,
)
ev(program, timeout=1200)   # override per call too
\`\`\`

Setting \`timeout=0\` disables straggler resubmission entirely, which is the simplest way to keep one slow item from cascading on a very long eval.

## Notes / follow-ups

This PR is intentionally just the API surface — it gives the caller a way to keep the executor from re-arming on long-running items, which is the lever you most often want. The deeper question of why the executor sometimes shuts down with submissions still in flight is worth a separate look (the straggler resubmission path can race against the finally-block \`executor.shutdown(wait=False)\` in pathological cases), but that fix is independent of the user-facing knob and I didn't want to bundle them.

## Tests

\`tests/evaluate/test_evaluate.py\`:

- \`test_evaluate_initialization\` — extended to assert the new defaults (120 / 3).
- \`test_evaluate_threads_through_executor_timeout\` — spies on \`ParallelExecutor\` to confirm \`timeout\` and \`straggler_limit\` reach it.
- \`test_evaluate_call_overrides_timeout\` — confirms the per-call override beats the constructor default.

\`\`\`
$ pytest tests/evaluate/test_evaluate.py -q
12 passed, 25 skipped in 1.94s

$ ruff check dspy/evaluate/evaluate.py tests/evaluate/test_evaluate.py
All checks passed!
\`\`\`