### PR TITLE
reject reserved output names in ReActV2 signatures

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -15,6 +15,11 @@ from dspy.utils.exceptions import AdapterParseError, ContextWindowExceededError
 
 logger = logging.getLogger(__name__)
 
+# Keys ReActV2 attaches to every returned `Prediction` alongside the user's output fields.
+# A user signature that declares any of these as an output would collide with the keyword
+# expansion at the `Prediction(**final_outputs, history=..., termination_reason=...)` call sites.
+_RESERVED_PREDICTION_KEYS = frozenset({"history", "termination_reason"})
+
 if TYPE_CHECKING:
     from dspy.signatures.signature import Signature
 
@@ -25,6 +30,14 @@ class ReActV2(Module):
         super().__init__()
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
+
+        reserved_outputs = _RESERVED_PREDICTION_KEYS.intersection(self.signature.output_fields)
+        if reserved_outputs:
+            names = ", ".join(f"`{name}`" for name in sorted(reserved_outputs))
+            raise ValueError(
+                f"Output field name(s) {names} are reserved by ReActV2 and attached to every "
+                "returned Prediction. Rename these output fields on your signature."
+            )
 
         user_tools = [tool if isinstance(tool, Tool) else Tool(tool) for tool in tools]
         self.tools = {tool.name: tool for tool in user_tools}

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -1,3 +1,5 @@
+import pytest
+
 import dspy
 from dspy.dsp.utils.utils import dotdict
 
@@ -324,3 +326,9 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
         "call_provider_1",
         "call_provider_2",
     ]
+
+
+@pytest.mark.parametrize("reserved", ["history", "termination_reason"])
+def test_react_v2_rejects_reserved_output_field_names(reserved):
+    with pytest.raises(ValueError, match=reserved):
+        dspy.ReActV2(f"question -> answer, {reserved}: str", tools=[])


### PR DESCRIPTION
 ReActV2 attaches `history` and `termination_reason` to every returned Prediction. A user signature declaring either as an output collided at `Prediction(**final_outputs, history=..., termination_reason=...)` with `TypeError: got multiple values for keyword argument`. Validate in __init__ against a reserved-key set, mirroring the existing `submit` tool reservation, so the conflict surfaces at construction with a clear error.
 
ReAct v1 has the same bug class with a different reserved key — dspy.Prediction(trajectory=trajectory, **extract) at dspy/predict/react.py:118 and :143. A user signature with an output field named trajectory would hit the identical TypeError. Not addressed here since it predates 3.3.0 and isn't a regression, but worth tracking as a follow-up.

Fixes #9853 

- [x] added a unit test.