### PR TITLE
docs: update homepage release status

### DIFF
--- a/docs/docs/stylesheets/home.css
+++ b/docs/docs/stylesheets/home.css
@@ -190,6 +190,7 @@
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+    min-width: 0;
 }
 .hp-code-chrome {
     display: flex;
@@ -221,7 +222,7 @@
 }
 .hp-code-body {
     display: grid;
-    grid-template-columns: 40px 1fr;
+    grid-template-columns: 40px minmax(0, 1fr);
 }
 .hp-line-nums {
     padding: 18px 0;
@@ -239,8 +240,9 @@
     font-family: var(--hp-mono);
     font-size: 13px;
     line-height: 1.7;
-    overflow: hidden;
+    overflow-x: auto;
     color: #e6edf3;
+    -webkit-overflow-scrolling: touch;
 }
 .hp-code-content .line {
     white-space: pre;
@@ -266,6 +268,8 @@
     font-size: 12.5px;
     line-height: 1.7;
     color: #8b949e;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 .hp-code-output .line {
     white-space: pre;
@@ -481,9 +485,10 @@
     font-size: 11.5px;
     line-height: 1.7;
     align-self: stretch;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-wrap: anywhere;
 }
-.hp-feature-code .line { white-space: pre; min-height: 1em; overflow: hidden; text-overflow: ellipsis; }
+.hp-feature-code .line { white-space: pre-wrap; min-height: 1em; }
 
 /* ===== EXAMPLES (TABBED) ===== */
 .hp-examples {
@@ -528,23 +533,25 @@
     transition: color 0.15s;
 }
 .hp-tabs-bar label:hover { color: var(--hp-fg-2); }
-.hp-tab-panel { display: none; grid-template-columns: 1.2fr 1fr; }
+.hp-tab-panel { display: none; grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr); }
 .hp-tab-code {
     border-right: 1px solid var(--hp-line);
     padding: 22px 28px;
     font-family: var(--hp-mono);
     font-size: 13px;
     line-height: 1.75;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-wrap: anywhere;
 }
-.hp-tab-code .line { white-space: pre; min-height: 1em; }
+.hp-tab-code .line { white-space: pre-wrap; min-height: 1em; }
 .hp-tab-output {
     background: var(--hp-bg-2);
     padding: 22px 28px;
     font-family: var(--hp-mono);
     font-size: 12.5px;
     line-height: 1.7;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-wrap: anywhere;
 }
 .hp-tab-output-header {
     display: flex;
@@ -557,7 +564,7 @@
     text-transform: uppercase;
     color: var(--hp-fg-3);
 }
-.hp-tab-output .line { white-space: pre; min-height: 1em; }
+.hp-tab-output .line { white-space: pre-wrap; min-height: 1em; }
 .hp-tab-footer {
     border-top: 1px solid var(--hp-line);
     padding: 12px 18px;

--- a/docs/hooks/fetch_stats.py
+++ b/docs/hooks/fetch_stats.py
@@ -21,13 +21,14 @@ REPO = "stanfordnlp/dspy"
 DISCORD_INVITE = "XCGy2WDCQB"
 CACHE_DIR = Path(__file__).parent.parent / ".cache"
 CACHE_FILE = CACHE_DIR / "stats.json"
+CACHE_VERSION = 3
 CACHE_TTL = 3600  # 1 hour
 
 DEFAULTS = {
-    "release_version": "3.2.1",
-    "release_major_minor": "3.2",
-    "release_date": "May 2025",
-    "release_blurb": "Improved tool calling and more",
+    "release_version": "3.3.0b1",
+    "release_major_minor": "3.3",
+    "release_date": "May 2026",
+    "release_blurb": "New ReActV2 Module and improved LM/BaseLM",
     "monthly_downloads": "7.5M+",
     "contributors": "400+",
     "stars": "34.6k",
@@ -58,6 +59,8 @@ def _load_cache():
     try:
         if CACHE_FILE.exists():
             data = json.loads(CACHE_FILE.read_text())
+            if data.get("_cache_version") != CACHE_VERSION:
+                return None
             if time.time() - data.get("_ts", 0) < CACHE_TTL:
                 log.info("Using cached stats (age: %ds)", int(time.time() - data["_ts"]))
                 return data
@@ -70,6 +73,7 @@ def _save_cache(stats):
     try:
         CACHE_DIR.mkdir(parents=True, exist_ok=True)
         stats["_ts"] = time.time()
+        stats["_cache_version"] = CACHE_VERSION
         CACHE_FILE.write_text(json.dumps(stats, indent=2))
     except Exception as e:
         log.warning("Could not write stats cache: %s", e)
@@ -77,13 +81,21 @@ def _save_cache(stats):
 
 def _fetch_release():
     data, _ = _get(
-        f"https://api.github.com/repos/{REPO}/releases/latest",
+        f"https://api.github.com/repos/{REPO}/releases?per_page=20",
         headers=GITHUB_HEADERS,
     )
-    tag = data["tag_name"].lstrip("v")
+    releases = [release for release in data if not release.get("draft") and release.get("published_at")]
+    if not releases:
+        return {}
+
+    release = max(
+        releases,
+        key=lambda release: datetime.fromisoformat(release["published_at"].replace("Z", "+00:00")),
+    )
+    tag = release["tag_name"].lstrip("v")
     parts = tag.split(".")
     major_minor = f"{parts[0]}.{parts[1]}" if len(parts) >= 2 else tag
-    pub = datetime.fromisoformat(data["published_at"].replace("Z", "+00:00"))
+    pub = datetime.fromisoformat(release["published_at"].replace("Z", "+00:00"))
     return {
         "release_version": tag,
         "release_major_minor": major_minor,

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -17,7 +17,7 @@
       <div class="hp-hero-text">
         <div class="hp-hero-badge">
           <span class="hp-dot"></span>
-          DSPy {{ config.extra.stats.release_major_minor }} &mdash; {{ config.extra.stats.release_blurb }}
+          DSPy {{ config.extra.stats.release_version }} &mdash; {{ config.extra.stats.release_blurb }}
           <span style="color:var(--hp-fg-3)">&middot;</span>
           <a href="https://github.com/stanfordnlp/dspy/releases">learn more &rarr;</a>
         </div>


### PR DESCRIPTION
## Summary

- Fetch release stats from the releases list so prereleases are considered
- Show the full release version on the homepage badge
- Update the homepage blurb for 3.3.0b1
- Allow homepage code blocks to scroll horizontally instead of clipping long lines

## Test

- `uv run --frozen python -m py_compile docs/hooks/fetch_stats.py`