### PR TITLE
Make Example.__hash__ order-insensitive to match __eq__

### DIFF
--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -159,7 +159,10 @@ class Example:
         return isinstance(other, Example) and self._store == other._store
 
     def __hash__(self):
-        return hash(tuple(self._store.items()))
+        # `__eq__` above compares the underlying dicts (order-insensitive), so
+        # the hash must be order-insensitive too — Python's data model requires
+        # `a == b` to imply `hash(a) == hash(b)`.
+        return hash(frozenset(self._store.items()))
 
     def keys(self, include_dspy=False):
         """Return field names, like `dict.keys()`.

--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -159,9 +159,6 @@ class Example:
         return isinstance(other, Example) and self._store == other._store
 
     def __hash__(self):
-        # `__eq__` above compares the underlying dicts (order-insensitive), so
-        # the hash must be order-insensitive too — Python's data model requires
-        # `a == b` to imply `hash(a) == hash(b)`.
         return hash(frozenset(self._store.items()))
 
     def keys(self, include_dspy=False):

--- a/tests/primitives/test_example.py
+++ b/tests/primitives/test_example.py
@@ -84,6 +84,24 @@ def test_example_hash():
     assert hash(example1) == hash(example2)
 
 
+def test_example_hash_is_order_insensitive():
+    # `__eq__` compares the underlying dict (order-insensitive), so the hash
+    # contract requires `__hash__` to be order-insensitive as well.
+    example1 = Example(a=1, b=2)
+    example2 = Example(b=2, a=1)
+    assert example1 == example2
+    assert hash(example1) == hash(example2)
+
+
+def test_example_set_and_dict_lookup_after_reorder():
+    # Direct consequence of the hash contract: equal Examples constructed in
+    # different field orders must deduplicate in sets and look up in dicts.
+    example1 = Example(a=1, b=2)
+    example2 = Example(b=2, a=1)
+    assert len({example1, example2}) == 1
+    assert {example1: "v"}.get(example2) == "v"
+
+
 def test_example_keys_values_items():
     example = Example(a=1, b=2, dspy_hidden=3)
     assert set(example.keys()) == {"a", "b"}


### PR DESCRIPTION
## Summary

`Example.__eq__` compares the underlying `_store` dict (order-insensitive), but `__hash__` returns `hash(tuple(self._store.items()))`, which is order-sensitive. So `Example(a=1, b=2) == Example(b=2, a=1)` is `True` while their hashes differ, violating Python's data-model invariant that `a == b` must imply `hash(a) == hash(b)`. `Prediction` (subclass of `Example`) inherits the same broken hash.

Reproducer on `main`:

```python
import dspy
e1 = dspy.Example(a=1, b=2)
e2 = dspy.Example(b=2, a=1)
e1 == e2              # True
hash(e1) == hash(e2)  # False  <-- contract violation
len({e1, e2})         # 2     <-- should be 1
{e1: "v"}.get(e2)     # None  <-- should be "v"
```

## Fix

Use `hash(frozenset(self._store.items()))` so the hash matches the order-insensitive equality semantics. Same hashability requirements as the previous tuple form (both require hashable values), so no new failure modes.

## Tests

Two regression tests added next to the existing `test_example_hash` in `tests/primitives/test_example.py`:

- `test_example_hash_is_order_insensitive` — same fields, different construction order, equal hashes.
- `test_example_set_and_dict_lookup_after_reorder` — direct consequence: set dedup + dict lookup.

Both **fail on `main`** and **pass** with this change. The pre-existing `test_example_hash` still passes (it constructs both Examples in the same order, which both implementations hash identically). `pytest tests/primitives/test_example.py` → 20 passed. Ruff lint clean.

## AI assistance disclosure

Used Claude Code to audit `dspy/primitives/` and `dspy/utils/` for clean Python-contract violations. The audit prompt asked specifically for indisputable correctness bugs, required empirical reproduction, and required checking `tests/` to ensure no test pinned the current behavior. I reproduced the contract violation directly (the snippet above), confirmed the existing `test_example_hash` only covers same-order construction (so it still passes with either hash implementation), and verified the `__eq__`/`__hash__` invariant in Python's data-model docs to confirm the fix direction.