### PR TITLE
fix: make eval_kwargs optional in COPRO.compile

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -121,7 +121,7 @@ class COPRO(Teleprompter):
         assert hasattr(predictor, "signature")
         predictor.signature = updated_signature
 
-    def compile(self, student, *, trainset, eval_kwargs):
+    def compile(self, student, *, trainset, eval_kwargs=None):
         """
         optimizes `signature` of `student` program - note that it may be zero-shot or already pre-optimized (demos already chosen - `demos != []`)
 
@@ -133,6 +133,7 @@ class COPRO(Teleprompter):
 
         Returns optimized version of `student`.
         """
+        eval_kwargs = eval_kwargs or {}
         module = student.deepcopy()
         evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
         total_calls = 0

--- a/dspy/teleprompt/signature_opt.py
+++ b/dspy/teleprompt/signature_opt.py
@@ -48,5 +48,5 @@ class SignatureOptimizer(COPRO):
         )
         super().__init__(prompt_model, metric, breadth, depth, init_temperature, verbose, track_stats)
 
-    def compile(self, student, *, devset, eval_kwargs):
+    def compile(self, student, *, devset, eval_kwargs=None):
         return super().compile(student, trainset=devset, eval_kwargs=eval_kwargs)

--- a/tests/teleprompt/test_copro_optimizer.py
+++ b/tests/teleprompt/test_copro_optimizer.py
@@ -154,3 +154,31 @@ def test_statistics_tracking_during_optimization():
     ), "Optimizer did not properly populate the latest results statistics"
 
     # Additional detailed checks can be added here to verify the contents of the tracked statistics
+
+
+def test_compile_without_eval_kwargs():
+    """Test that COPRO.compile works when eval_kwargs is not provided (defaults to {})."""
+    lm = DummyLM(
+        [
+            {"proposed_instruction": "Optimized Prompt", "proposed_prefix_for_output_field": "Optimized Prefix"},
+            {"reasoning": "france", "output": "Paris"},
+            {"reasoning": "france", "output": "Paris"},
+            {"reasoning": "france", "output": "Paris"},
+            {"reasoning": "france", "output": "Paris"},
+            {"reasoning": "france", "output": "Paris"},
+            {"reasoning": "france", "output": "Paris"},
+            {"reasoning": "france", "output": "Paris"},
+        ]
+    )
+    dspy.configure(lm=lm)
+    optimizer = COPRO(metric=simple_metric, breadth=2, depth=1, init_temperature=1.4)
+
+    student = SimpleModule("input -> output")
+
+    # Should work without eval_kwargs parameter
+    optimized_student = optimizer.compile(student, trainset=trainset)
+
+    assert optimized_student is not student, "Optimization did not modify the student"
+    test_input = "What is the capital of France?"
+    prediction = optimized_student(input=test_input)
+    assert prediction.output == "Paris"


### PR DESCRIPTION
## Summary

Fixes #9080

The COPRO optimizer's `compile` method documented `eval_kwargs` as an optional parameter, but it was actually required (no default value). This creates a discrepancy between the documented API and the actual implementation.

This change makes `eval_kwargs` truly optional by:
- Defaulting it to `None` in `COPRO.compile()`
- Converting to an empty dict internally with `eval_kwargs = eval_kwargs or {}`
- Also applying the same fix to the deprecated `SignatureOptimizer` subclass for consistency

## Changes

- **dspy/teleprompt/copro_optimizer.py**: Changed `compile()` signature from `eval_kwargs` (required) to `eval_kwargs=None` (optional), added `eval_kwargs = eval_kwargs or {}` at the start of the method body
- **dspy/teleprompt/signature_opt.py**: Changed `SignatureOptimizer.compile()` signature from `eval_kwargs` (required) to `eval_kwargs=None` (optional)
- **tests/teleprompt/test_copro_optimizer.py**: Added `test_compile_without_eval_kwargs` test to verify the optimizer works without passing `eval_kwargs`

## Testing

All 6 tests in `test_copro_optimizer.py` pass (5 existing + 1 new).

```
tests/teleprompt/test_copro_optimizer.py::test_signature_optimizer_initialization PASSED
tests/teleprompt/test_copro_optimizer.py::test_signature_optimizer_optimization_process PASSED
tests/teleprompt/test_copro_optimizer.py::test_signature_optimizer_statistics_tracking PASSED
tests/teleprompt/test_copro_optimizer.py::test_optimization_and_output_verification PASSED
tests/teleprompt/test_copro_optimizer.py::test_statistics_tracking_during_optimization PASSED
tests/teleprompt/test_copro_optimizer.py::test_compile_without_eval_kwargs PASSED
```