### PR TITLE
fix: reject reserved output field names in ReAct and ReActV2 constructors

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -41,6 +41,12 @@ class ReAct(Module):
         self.signature = signature = ensure_signature(signature)
         self.max_iters = max_iters
 
+        if "trajectory" in self.signature.output_fields:
+            raise ValueError(
+                "Output field name `trajectory` is reserved by ReAct. "
+                "Please rename it in your signature."
+            )
+
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
         tools = {tool.name: tool for tool in tools}
 

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -32,6 +32,14 @@ class ReActV2(Module):
             raise ValueError("`submit` is reserved by ReActV2 as the final-output tool.")
         self.tools["submit"] = self._make_submit_tool()
 
+        reserved_output_field_names = {"history", "termination_reason"}
+        conflicting = reserved_output_field_names & set(self.signature.output_fields)
+        if conflicting:
+            raise ValueError(
+                f"Output field name(s) {sorted(conflicting)} are reserved by ReActV2. "
+                "Please rename them in your signature."
+            )
+
         self.react = dspy.Predict(self._make_react_signature())
 
     def _make_submit_tool(self) -> Tool:
@@ -121,7 +129,7 @@ class ReActV2(Module):
             pending_inputs = {}
 
             if final_outputs is not None:
-                return Prediction(**final_outputs, history=history, termination_reason="submit")
+                return _make_prediction(final_outputs, history, "submit")
 
         return self._forced_submit(history, pending_inputs, break_reason, max_iters)
 
@@ -197,7 +205,7 @@ class ReActV2(Module):
         _append_history_event(history, event)
 
         if final_outputs is not None:
-            return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
+            return _make_prediction(final_outputs, history, "forced_submit")
 
         return Prediction(history=history, termination_reason=break_reason or "failed")
 
@@ -244,6 +252,19 @@ def _ensure_tool_call_ids(tool_calls: ToolCalls, turn_index: int) -> ToolCalls:
 def _append_history_event(history: dspy.History, event: dict[str, Any]) -> None:
     if event:
         history.messages.append(event)
+
+
+_RESERVED_REACT_V2_KEYS = frozenset({"history", "termination_reason"})
+
+
+def _make_prediction(final_outputs: dict[str, Any], history: dspy.History, termination_reason: str) -> Prediction:
+    """Build a Prediction from ReActV2 final outputs.
+
+    ``history`` and ``termination_reason`` are internal ReActV2 metadata keys.
+    Signature output fields with these names are rejected in ``__init__`` so
+    this function should never encounter a key collision.
+    """
+    return Prediction(**final_outputs, history=history, termination_reason=termination_reason)
 
 
 def _fmt_exc(err: BaseException, *, limit: int = 5) -> str:

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -471,3 +471,12 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_react_rejects_reserved_output_field_trajectory():
+    try:
+        dspy.ReAct("question -> answer, trajectory: str", tools=[])
+        assert False, "Expected ValueError for reserved output field 'trajectory'"
+    except ValueError as e:
+        assert "trajectory" in str(e)
+        assert "reserved" in str(e).lower()

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -324,3 +324,31 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
         "call_provider_1",
         "call_provider_2",
     ]
+
+
+def test_react_v2_rejects_reserved_output_field_history():
+    try:
+        dspy.ReActV2("question -> answer, history: str", tools=[])
+        assert False, "Expected ValueError for reserved output field 'history'"
+    except ValueError as e:
+        assert "history" in str(e)
+        assert "reserved" in str(e).lower()
+
+
+def test_react_v2_rejects_reserved_output_field_termination_reason():
+    try:
+        dspy.ReActV2("question -> answer, termination_reason: str", tools=[])
+        assert False, "Expected ValueError for reserved output field 'termination_reason'"
+    except ValueError as e:
+        assert "termination_reason" in str(e)
+        assert "reserved" in str(e).lower()
+
+
+def test_react_v2_rejects_both_reserved_output_fields():
+    try:
+        dspy.ReActV2("question -> answer, history: str, termination_reason: str", tools=[])
+        assert False, "Expected ValueError for reserved output fields"
+    except ValueError as e:
+        msg = str(e)
+        assert "history" in msg
+        assert "termination_reason" in msg


### PR DESCRIPTION
## Summary

Fixes #9853

Both `dspy.ReAct` and `dspy.ReActV2` attach internal metadata to every returned `Prediction`:

- **ReActV2** adds `history` and `termination_reason` 
- **ReAct** adds `trajectory`

If the user's signature declares an output field with one of these reserved names, the keyword expansion at the `Prediction(**final_outputs, ...)` call site collides and raises:

```
TypeError: Prediction() got multiple values for keyword argument 'history'
```

This creates a confusing failure inside the agent loop rather than at construction time.

## Changes

- **dspy/predict/react_v2.py**: Added validation in `__init__` that raises a clear `ValueError` if the user's signature has output fields named `history` or `termination_reason`
- **dspy/predict/react.py**: Added validation in `__init__` that raises a clear `ValueError` if the user's signature has an output field named `trajectory`
- **tests/predict/test_react_v2.py**: 3 new tests for reserved field name validation
- **tests/predict/test_react.py**: 1 new test for reserved field name validation

## Testing

All 13 tests in `test_react_v2.py` pass (10 existing + 3 new).
All 9 tests in `test_react.py` pass (8 existing + 1 new).