### PR TITLE
Document Tuning Engines as an OpenAI-compatible endpoint

### DIFF
--- a/docs/docs/learn/programming/language_models.md
+++ b/docs/docs/learn/programming/language_models.md
@@ -143,6 +143,20 @@ dspy.configure(lm=lm)
         lm = dspy.LM('openai/your-model-name', api_key='PROVIDER_API_KEY', api_base='YOUR_PROVIDER_URL')
         dspy.configure(lm=lm)
         ```
+
+        For example, you can route DSPy through a governed OpenAI-compatible endpoint such as [Tuning Engines](https://www.tuningengines.com/):
+
+        ```python linenums="1"
+        import dspy
+        lm = dspy.LM(
+            'openai/gpt-4o-mini',
+            api_key='TUNING_ENGINES_API_KEY',
+            api_base='https://api.tuningengines.com/v1',
+        )
+        dspy.configure(lm=lm)
+        ```
+
+        DSPy continues to own program composition and optimization while the gateway centralizes model routing, policy controls, audit logs, traces, approvals, and cost visibility.
 If you run into errors, please refer to the [LiteLLM Docs](https://docs.litellm.ai/docs/providers) to verify if you are using the same variable names/following the right procedure.
 
 ## Calling the LM directly.
@@ -343,4 +357,3 @@ Use this only for files you trust. The flag also preserves serialized LM endpoin
 DSPy uses `lm.copy(...)` when it needs the same LM with different request parameters, such as a different `temperature` or `rollout_id`. The default `BaseLM.copy()` implementation makes a shallow runtime copy: provider clients, sessions, and local model handles are shared by reference, while DSPy-owned mutable state (`history`, the `callbacks` list, and `kwargs`) is isolated on the copy. The callback list is copied, but callback objects themselves are shared.
 
 If your custom LM stores additional mutable DSPy-owned state that should not be shared across copies, override `copy()` and isolate that state explicitly. Runtime handles that are expensive or unsafe to duplicate should usually continue to be shared by reference.
-


### PR DESCRIPTION
## Summary

- Adds a small documentation example showing how to point this project’s existing OpenAI-compatible configuration at Tuning Engines.
- Keeps this project’s APIs and runtime behavior unchanged: no new dependency, adapter, or code path.
- Shows a path for teams to keep this framework in charge of app, agent, tool, workflow, or retrieval logic while routing model calls through a governed OpenAI-compatible endpoint.

## Why this belongs here

Tuning Engines is an AI control plane for teams that want centralized model access, routing, tenant-scoped keys, policy/guardrail checks, audit logs, traces, approvals, and usage/cost visibility around existing AI applications.

This project already supports OpenAI-compatible endpoints. The docs change makes that existing capability discoverable for users who want governance and observability without rewriting their application around a separate SDK or changing this project’s runtime behavior.

## Testing

- `git diff --check`
