### PR TITLE
fix(Refine): stop mutating self.fail_count and fix off-by-one in error guard

### DIFF
--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -102,6 +102,8 @@ class Refine(Module):
         best_pred, best_trace, best_reward = None, None, -float("inf")
         advice = None
         adapter = dspy.settings.adapter or dspy.ChatAdapter()
+        # Local copy so that repeated forward() calls start with the same budget.
+        remaining_failures = self.fail_count
 
         for idx, rid in enumerate(rollout_ids):
             lm_ = lm.copy(rollout_id=rid, temperature=1.0)
@@ -169,9 +171,9 @@ class Refine(Module):
 
             except Exception as e:
                 print(f"Refine: Attempt failed with rollout id {rid}: {e}")
-                if idx > self.fail_count:
+                remaining_failures -= 1
+                if remaining_failures < 0:
                     raise e
-                self.fail_count -= 1
         if best_trace:
             dspy.settings.trace.extend(best_trace)
         return best_pred


### PR DESCRIPTION
## Bug

`Refine.forward` has two related bugs in its exception-handling logic.

### 1 — Instance-state mutation (`self.fail_count` shrinks across calls)

The exception handler decrements the **instance attribute** on every failed attempt:

```python
except Exception as e:
    if idx > self.fail_count:
        raise e
    self.fail_count -= 1   # ← mutates instance state
```

Calling `forward()` a second time therefore starts with a smaller failure budget than the first call. A `Refine` module that experiences even one failure becomes permanently more restrictive, silently breaking reuse in any evaluation loop.

### 2 — Off-by-one: the raise guard fires one attempt too early

The condition compares the 0-based loop index `idx` against the **already-decremented** `self.fail_count` (a moving target):

| attempt | `idx` | `self.fail_count` (after prev decrement) | `idx > fail_count` |
|---------|-------|-------------------------------------------|--------------------|
| 1st fail | 0 | 3 | False |
| 2nd fail | 1 | 2 | False |
| 3rd fail | 2 | 1 | **True → raises** |

With `N=3` and the default `fail_count=N=3`, the **third** exception triggers the guard even though the user intended to allow three failures before giving up.

## Fix

Introduce a **local** `remaining_failures` counter, initialised from `self.fail_count` at the start of each `forward()` call:

```python
remaining_failures = self.fail_count   # local copy, never mutates instance

# … in the except block:
remaining_failures -= 1
if remaining_failures < 0:
    raise e
```

This:
- leaves `self.fail_count` unchanged so repeated calls all start with the same budget
- allows exactly `fail_count` failed attempts before propagating the error