### PR TITLE
fix(UsageTracker): handle None inputs and type mismatch in _merge_usage_entries

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -35,16 +35,21 @@ class UsageTracker:
     def _merge_usage_entries(
         self, usage_entry1: dict[str, Any] | None, usage_entry2: dict[str, Any] | None
     ) -> dict[str, Any]:
-        if usage_entry1 is None or len(usage_entry1) == 0:
-            return dict(usage_entry2)
-        if usage_entry2 is None or len(usage_entry2) == 0:
+        if not usage_entry1:
+            return dict(usage_entry2) if usage_entry2 else {}
+        if not usage_entry2:
             return dict(usage_entry1)
 
         result = dict(usage_entry2)
         for k, v in usage_entry1.items():
             current_v = result.get(k)
-            if isinstance(v, dict) or isinstance(current_v, dict):
+            if isinstance(v, dict) and isinstance(current_v, dict):
+                # Both are dicts: recurse
                 result[k] = self._merge_usage_entries(current_v, v)
+            elif isinstance(v, dict) or isinstance(current_v, dict):
+                # Type mismatch: one is a dict, the other is a scalar.
+                # Prefer whichever is a dict to avoid losing structure.
+                result[k] = v if isinstance(v, dict) else current_v
             elif current_v is not None or v is not None:
                 result[k] = (current_v or 0) + (v or 0)
         return result


### PR DESCRIPTION
## Bugs

`UsageTracker._merge_usage_entries` has two crashes that can be triggered at runtime.

### 1 — `TypeError` when both entries are `None`

```python
if usage_entry1 is None or len(usage_entry1) == 0:
    return dict(usage_entry2)   # ← dict(None) → TypeError
```

When `usage_entry1 is None`, Python short-circuits the `or` and returns `dict(usage_entry2)`. If `usage_entry2` is also `None`, this crashes:

```
TypeError: 'NoneType' object is not iterable
```

### 2 — `TypeError` on type-mismatch in recursive call

```python
if isinstance(v, dict) or isinstance(current_v, dict):
    result[k] = self._merge_usage_entries(current_v, v)
```

This branch fires when *either* operand is a dict. But if one is a dict and the other is a scalar (e.g. an `int`), the recursive call receives a non-dict as one argument and the next call tries `len(scalar)`:

```
TypeError: object of type 'int' has no len()
```

This happens in practice when two LM providers return different shapes for the same usage key — e.g., OpenAI returns `{"prompt_tokens": {"cached_tokens": 10}}` (nested dict) while another provider returns `{"prompt_tokens": 10}` (plain int).

## Fix

1. Replace the `None or len(...) == 0` guards with a simple `not entry` check (handles both `None` and empty dicts), and guard the fallback `dict(...)` call.
2. Split the dict-vs-dict branch from the mixed-type branch: recurse only when **both** operands are dicts. When there's a type mismatch, prefer the dict side to preserve structure rather than crashing.

```python
if isinstance(v, dict) and isinstance(current_v, dict):
    result[k] = self._merge_usage_entries(current_v, v)
elif isinstance(v, dict) or isinstance(current_v, dict):
    result[k] = v if isinstance(v, dict) else current_v
```

## Verification

```python
t = UsageTracker()
t._merge_usage_entries(None, None)                          # {} (was TypeError)
t._merge_usage_entries({'pt': {'cached': 10}}, {'pt': 20}) # {'pt': {'cached': 10}} (was TypeError)
t._merge_usage_entries({'a': 3}, {'a': 7})                 # {'a': 10} (unchanged)
```