### PR TITLE
ChatAdapter: stop falling back to JSONAdapter when the LM gave a parseable but invalid value

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -87,9 +87,16 @@ class ChatAdapter(Adapter):
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 
-            if isinstance(e, LMError) or isinstance(self, JSONAdapter) or not self.use_json_adapter_fallback:
-                # On LM errors, already using JSONAdapter, or use_json_adapter_fallback is False, we don't want to
-                # retry with a different adapter. Raise the original error instead of the fallback error.
+            if (
+                isinstance(e, LMError)
+                or isinstance(self, JSONAdapter)
+                or not self.use_json_adapter_fallback
+                or (isinstance(e, AdapterParseError) and e.field_constraint_violation)
+            ):
+                # On LM errors, already using JSONAdapter, use_json_adapter_fallback is False, or the failure
+                # was a semantic field-value constraint violation rather than a structural parse failure, we
+                # don't want to retry with a different adapter. Raise the original error instead of the
+                # fallback error (#7843).
                 raise
             return self._make_json_adapter_fallback()(lm, lm_kwargs, signature, demos, inputs)
 
@@ -107,9 +114,16 @@ class ChatAdapter(Adapter):
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 
-            if isinstance(e, LMError) or isinstance(self, JSONAdapter) or not self.use_json_adapter_fallback:
-                # On LM errors, already using JSONAdapter, or use_json_adapter_fallback is False, we don't want to
-                # retry with a different adapter. Raise the original error instead of the fallback error.
+            if (
+                isinstance(e, LMError)
+                or isinstance(self, JSONAdapter)
+                or not self.use_json_adapter_fallback
+                or (isinstance(e, AdapterParseError) and e.field_constraint_violation)
+            ):
+                # On LM errors, already using JSONAdapter, use_json_adapter_fallback is False, or the failure
+                # was a semantic field-value constraint violation rather than a structural parse failure, we
+                # don't want to retry with a different adapter. Raise the original error instead of the
+                # fallback error (#7843).
                 raise
             return await self._make_json_adapter_fallback().acall(lm, lm_kwargs, signature, demos, inputs)
 
@@ -236,11 +250,18 @@ class ChatAdapter(Adapter):
                 try:
                     fields[k] = parse_value(v, signature.output_fields[k].annotation)
                 except Exception as e:
+                    # The field marker was located in the LM response, so this
+                    # is a value-level constraint failure (e.g. Literal/Enum
+                    # mismatch or a pydantic ValidationError on the annotation),
+                    # not a structural format failure. Mark it so callers do not
+                    # waste another LM call on the JSONAdapter fallback path
+                    # (issue #7843).
                     raise AdapterParseError(
                         adapter_name="ChatAdapter",
                         signature=signature,
                         lm_response=completion,
                         message=f"Failed to parse field {k} with value {v} from the LM response. Error message: {e}",
+                        field_constraint_violation=True,
                     )
         if fields.keys() != signature.output_fields.keys():
             raise AdapterParseError(

--- a/dspy/utils/exceptions.py
+++ b/dspy/utils/exceptions.py
@@ -230,6 +230,14 @@ class AdapterParseError(DSPyError):
         lm_response: Raw LM response text or representation being parsed.
         message: Optional additional context about the parse failure.
         parsed_result: Partial parsed result, if any.
+        field_constraint_violation: True if the adapter successfully located the
+            output field in the LM response but the parsed value violated a
+            field-level constraint (e.g. a Literal/Enum mismatch or a pydantic
+            ValidationError on the field annotation). When True the failure is
+            semantic rather than structural: retrying with a different adapter
+            (e.g. the ChatAdapter -> JSONAdapter auto-fallback) cannot recover
+            from it, so callers should propagate the error instead of silently
+            swallowing it with another LM call. Defaults to False.
     """
 
     default_code = "adapter_parse_error"
@@ -241,11 +249,13 @@ class AdapterParseError(DSPyError):
         lm_response: str,
         message: str | None = None,
         parsed_result: str | None = None,
+        field_constraint_violation: bool = False,
     ):
         self.adapter_name = adapter_name
         self.signature = signature
         self.lm_response = lm_response
         self.parsed_result = parsed_result
+        self.field_constraint_violation = field_constraint_violation
 
         message = f"{message}\n\n" if message else ""
         message = (

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2399,6 +2399,81 @@ def test_chat_adapter_respects_use_json_adapter_fallback_flag():
         mock_json_adapter_call.assert_not_called()
 
 
+def test_chat_adapter_does_not_fallback_on_field_constraint_violation():
+    """Regression for #7843.
+
+    When the LM produces a response that ChatAdapter can parse but whose value
+    violates an output-field constraint (e.g. a Literal/Enum), the failure is
+    semantic (the LM disobeyed the signature). Falling back to JSONAdapter
+    burns another LM call and masks the real error with a generic
+    AdapterParseError. The original constraint violation should propagate.
+    """
+
+    class SentimentSignature(dspy.Signature):
+        text: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+
+    adapter = dspy.ChatAdapter()
+
+    # Well-formed ChatAdapter output, but the value is not in the Literal.
+    content = "[[ ## sentiment ## ]]\nDEFINITELY_NEUTRAL\n[[ ## completed ## ]]\n"
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content=content))],
+            model="openai/gpt-4o-mini",
+        )
+
+        lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+        with mock.patch(
+            "dspy.adapters.json_adapter.JSONAdapter.__call__"
+        ) as mock_json_adapter_call:
+            with pytest.raises(dspy.utils.exceptions.AdapterParseError) as exc_info:
+                adapter(lm, {}, SentimentSignature, [], {"text": "I love it"})
+
+        # The fallback must not run: the LM call already produced parseable text,
+        # so a second JSONAdapter attempt cannot recover from a value constraint
+        # violation. It only wastes a call and masks the underlying error.
+        mock_json_adapter_call.assert_not_called()
+
+        # The propagated error must describe the original constraint violation,
+        # not a generic JSONAdapter parse failure.
+        assert "DEFINITELY_NEUTRAL" in str(exc_info.value)
+        assert exc_info.value.adapter_name == "ChatAdapter"
+
+
+@pytest.mark.asyncio
+async def test_chat_adapter_does_not_fallback_on_field_constraint_violation_async():
+    """Async counterpart of test_chat_adapter_does_not_fallback_on_field_constraint_violation."""
+
+    class SentimentSignature(dspy.Signature):
+        text: str = dspy.InputField()
+        sentiment: Literal["positive", "negative"] = dspy.OutputField()
+
+    adapter = dspy.ChatAdapter()
+
+    content = "[[ ## sentiment ## ]]\nDEFINITELY_NEUTRAL\n[[ ## completed ## ]]\n"
+
+    with mock.patch("litellm.acompletion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content=content))],
+            model="openai/gpt-4o-mini",
+        )
+
+        lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+        with mock.patch(
+            "dspy.adapters.json_adapter.JSONAdapter.acall"
+        ) as mock_json_adapter_acall:
+            with pytest.raises(dspy.utils.exceptions.AdapterParseError) as exc_info:
+                await adapter.acall(lm, {}, SentimentSignature, [], {"text": "I love it"})
+
+        mock_json_adapter_acall.assert_not_called()
+        assert "DEFINITELY_NEUTRAL" in str(exc_info.value)
+        assert exc_info.value.adapter_name == "ChatAdapter"
+
+
 @pytest.mark.asyncio
 async def test_chat_adapter_fallback_to_json_adapter_on_exception_async():
     signature = dspy.make_signature("question->answer")


### PR DESCRIPTION
Hit this debugging a Literal-typed field — the LM was responding in a perfectly well-formed ChatAdapter block, just with a value outside the Literal. Got back a vague "JSONAdapter failed to parse" error and an extra LM call, with no hint at the real constraint violation. Tracked it to the `except Exception` in `ChatAdapter.__call__`/`acall` falling back to `JSONAdapter` on any non-`LMError`. That's exactly what #7843 is about — @okhat had agreed ("Makes sense") in the thread that fatal errors shouldn't trigger the fallback.

### The split

There are two distinct failure modes the fallback was conflating:

1. **Structural failure** — LM ignored ChatAdapter's format entirely (returned nonsense, JSON, etc.). `parse()` can't find the field markers. JSONAdapter is a reasonable next try.
2. **Constraint violation** — LM produced a structurally-correct ChatAdapter block, but the value violates the annotation (Literal mismatch, pydantic ValidationError on a typed field). Falling back to JSONAdapter just costs another call and surfaces the wrong error.

The patch distinguishes the two:

- New `field_constraint_violation: bool = False` flag on `AdapterParseError`.
- In `ChatAdapter.parse()`, when the field marker was successfully located but `parse_value()` then raises (the value-level failure path at the end of the parse loop), set `field_constraint_violation=True` on the raised `AdapterParseError`.
- In `__call__`/`acall`, extend the existing no-fallback guard (`LMError`) to also re-raise when `isinstance(e, AdapterParseError) and e.field_constraint_violation`.

Structural failures keep falling back exactly as before — all four existing fallback regression tests (`test_chat_adapter_fallback_to_json_adapter_on_exception`, async variant, native-tool flag variant, opt-out variant) still pass.

### Tests

`test_chat_adapter_does_not_fallback_on_field_constraint_violation` (sync + async) at `tests/adapters/test_chat_adapter.py`. Mock LM returns a parseable `[[ ## sentiment ## ]]\nDEFINITELY_NEUTRAL\n[[ ## completed ## ]]` block for a `Literal["positive","negative"]` field. Asserts (a) JSONAdapter is never called, (b) the raised `AdapterParseError` carries the offending value in its message, (c) `adapter_name == "ChatAdapter"`.

RED:

```
Failed: DID NOT RAISE <class 'dspy.utils.exceptions.AdapterParseError'>
```

GREEN: both pass. Full `tests/adapters/` → 232 passed. Broader `tests/utils tests/predict` → 287 passed, 56 skipped. No regressions.

### Risk

Additive change. New kwarg defaults to False, so any code constructing `AdapterParseError` manually keeps existing behaviour. The guard only fires when `parse_value()` raised inside a successfully-located field marker, which is precisely the case we want to surface. The structural-failure fallback path that other users rely on is untouched.

Refs #7843