### PR TITLE
fix: prevent reserved field collision in ReActV2 and ReAct Prediction

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -115,7 +115,8 @@ class ReAct(Module):
                 break
 
         extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        return dspy.Prediction(trajectory=trajectory, **extract)
+        safe_extract = {k: v for k, v in extract.items() if k != "trajectory"}
+        return dspy.Prediction(trajectory=trajectory, **safe_extract)
 
     async def aforward(self, **input_args):
         trajectory = {}
@@ -140,7 +141,8 @@ class ReAct(Module):
                 break
 
         extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        return dspy.Prediction(trajectory=trajectory, **extract)
+        safe_extract = {k: v for k, v in extract.items() if k != "trajectory"}
+        return dspy.Prediction(trajectory=trajectory, **safe_extract)
 
     def _call_with_potential_trajectory_truncation(self, module, trajectory, **input_args):
         for _ in range(3):

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -41,10 +41,16 @@ class ReAct(Module):
         self.signature = signature = ensure_signature(signature)
         self.max_iters = max_iters
 
-        # Validate that user signature does not use reserved output field names.
+        # Validate that user signature does not use reserved output or input field names.
+        # 'trajectory' is injected as both an input and output field by ReAct internals.
         if "trajectory" in signature.output_fields:
             raise ValueError(
                 "Output field 'trajectory' is reserved by ReAct and cannot be used in the signature. "
+                "Please rename it."
+            )
+        if "trajectory" in signature.input_fields:
+            raise ValueError(
+                "Input field 'trajectory' is reserved by ReAct and cannot be used in the signature. "
                 "Please rename it."
             )
 

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -41,6 +41,13 @@ class ReAct(Module):
         self.signature = signature = ensure_signature(signature)
         self.max_iters = max_iters
 
+        # Validate that user signature does not use reserved output field names.
+        if "trajectory" in signature.output_fields:
+            raise ValueError(
+                "Output field 'trajectory' is reserved by ReAct and cannot be used in the signature. "
+                "Please rename it."
+            )
+
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
         tools = {tool.name: tool for tool in tools}
 
@@ -115,8 +122,7 @@ class ReAct(Module):
                 break
 
         extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        safe_extract = {k: v for k, v in extract.items() if k != "trajectory"}
-        return dspy.Prediction(trajectory=trajectory, **safe_extract)
+        return dspy.Prediction(trajectory=trajectory, **extract)
 
     async def aforward(self, **input_args):
         trajectory = {}
@@ -141,8 +147,7 @@ class ReAct(Module):
                 break
 
         extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        safe_extract = {k: v for k, v in extract.items() if k != "trajectory"}
-        return dspy.Prediction(trajectory=trajectory, **safe_extract)
+        return dspy.Prediction(trajectory=trajectory, **extract)
 
     def _call_with_potential_trajectory_truncation(self, module, trajectory, **input_args):
         for _ in range(3):

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 @experimental
 class ReActV2(Module):
     RESERVED_OUTPUT_FIELDS = {"history", "termination_reason"}
+    RESERVED_INPUT_FIELDS = {"history", "tools"}
 
     def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
         super().__init__()
@@ -29,11 +30,19 @@ class ReActV2(Module):
         self.max_iters = max_iters
 
         # Validate that user signature does not use reserved output field names.
-        reserved_conflicts = self.RESERVED_OUTPUT_FIELDS & set(self.signature.output_fields)
-        if reserved_conflicts:
+        reserved_output_conflicts = self.RESERVED_OUTPUT_FIELDS & set(self.signature.output_fields)
+        if reserved_output_conflicts:
             raise ValueError(
-                f"Output field(s) {sorted(reserved_conflicts)} are reserved by ReActV2 and cannot be used "
+                f"Output field(s) {sorted(reserved_output_conflicts)} are reserved by ReActV2 and cannot be used "
                 f"in the signature. Please rename them. Reserved names: {sorted(self.RESERVED_OUTPUT_FIELDS)}"
+            )
+
+        # Validate that user signature does not use reserved input field names.
+        reserved_input_conflicts = self.RESERVED_INPUT_FIELDS & set(self.signature.input_fields)
+        if reserved_input_conflicts:
+            raise ValueError(
+                f"Input field(s) {sorted(reserved_input_conflicts)} are reserved by ReActV2 and cannot be used "
+                f"in the signature. Please rename them. Reserved names: {sorted(self.RESERVED_INPUT_FIELDS)}"
             )
 
         user_tools = [tool if isinstance(tool, Tool) else Tool(tool) for tool in tools]

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -21,10 +21,20 @@ if TYPE_CHECKING:
 
 @experimental
 class ReActV2(Module):
+    RESERVED_OUTPUT_FIELDS = {"history", "termination_reason"}
+
     def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
         super().__init__()
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
+
+        # Validate that user signature does not use reserved output field names.
+        reserved_conflicts = self.RESERVED_OUTPUT_FIELDS & set(self.signature.output_fields)
+        if reserved_conflicts:
+            raise ValueError(
+                f"Output field(s) {sorted(reserved_conflicts)} are reserved by ReActV2 and cannot be used "
+                f"in the signature. Please rename them. Reserved names: {sorted(self.RESERVED_OUTPUT_FIELDS)}"
+            )
 
         user_tools = [tool if isinstance(tool, Tool) else Tool(tool) for tool in tools]
         self.tools = {tool.name: tool for tool in user_tools}
@@ -121,10 +131,7 @@ class ReActV2(Module):
             pending_inputs = {}
 
             if final_outputs is not None:
-                # Remove reserved keys from final_outputs to avoid duplicate keyword argument errors
-                # when the user's signature declares an output field with the same name.
-                safe_outputs = {k: v for k, v in final_outputs.items() if k not in ("history", "termination_reason")}
-                return Prediction(**safe_outputs, history=history, termination_reason="submit")
+                return Prediction(**final_outputs, history=history, termination_reason="submit")
 
         return self._forced_submit(history, pending_inputs, break_reason, max_iters)
 
@@ -200,8 +207,7 @@ class ReActV2(Module):
         _append_history_event(history, event)
 
         if final_outputs is not None:
-            safe_outputs = {k: v for k, v in final_outputs.items() if k not in ("history", "termination_reason")}
-            return Prediction(**safe_outputs, history=history, termination_reason="forced_submit")
+            return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
 
         return Prediction(history=history, termination_reason=break_reason or "failed")
 

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -121,7 +121,10 @@ class ReActV2(Module):
             pending_inputs = {}
 
             if final_outputs is not None:
-                return Prediction(**final_outputs, history=history, termination_reason="submit")
+                # Remove reserved keys from final_outputs to avoid duplicate keyword argument errors
+                # when the user's signature declares an output field with the same name.
+                safe_outputs = {k: v for k, v in final_outputs.items() if k not in ("history", "termination_reason")}
+                return Prediction(**safe_outputs, history=history, termination_reason="submit")
 
         return self._forced_submit(history, pending_inputs, break_reason, max_iters)
 
@@ -197,7 +200,8 @@ class ReActV2(Module):
         _append_history_event(history, event)
 
         if final_outputs is not None:
-            return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
+            safe_outputs = {k: v for k, v in final_outputs.items() if k not in ("history", "termination_reason")}
+            return Prediction(**safe_outputs, history=history, termination_reason="forced_submit")
 
         return Prediction(history=history, termination_reason=break_reason or "failed")
 

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -10,6 +10,12 @@ from dspy.utils.dummies import DummyLM
 from dspy.utils.exceptions import ContextWindowExceededError
 
 
+@pytest.mark.parametrize("signature", ["trajectory -> answer", "question -> trajectory"])
+def test_react_rejects_reserved_trajectory_field(signature):
+    with pytest.raises(ValueError, match="trajectory"):
+        dspy.ReAct(signature, tools=[])
+
+
 @pytest.mark.extra
 def test_tool_observation_preserves_custom_type():
     pytest.importorskip("PIL.Image")

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -1,3 +1,5 @@
+import pytest
+
 import dspy
 from dspy.dsp.utils.utils import dotdict
 
@@ -6,6 +8,20 @@ class ReasoningDummyLM(dspy.utils.DummyLM):
     @property
     def supports_reasoning(self):
         return True
+
+
+@pytest.mark.parametrize(
+    ("signature", "reserved_name"),
+    [
+        ("history -> answer", "history"),
+        ("tools -> answer", "tools"),
+        ("question -> history", "history"),
+        ("question -> termination_reason", "termination_reason"),
+    ],
+)
+def test_react_v2_rejects_reserved_signature_fields(signature, reserved_name):
+    with pytest.raises(ValueError, match=rf"{reserved_name}.*reserved"):
+        dspy.ReActV2(signature, tools=[])
 
 
 def test_react_v2_submit_tool_returns_original_output_fields():


### PR DESCRIPTION
## Summary

Fixes #9853.

ReAct and ReActV2 inject internal fields when constructing their signatures and predictions. User signatures with the same names currently fail later with duplicate-keyword or field-collision errors.

This change fails fast during initialization with a clear `ValueError`:

- ReAct rejects `trajectory` as an input or output field.
- ReActV2 rejects `history` and `tools` as input fields.
- ReActV2 rejects `history` and `termination_reason` as output fields.

Focused regression tests cover every reserved input and output field.

## Tests

```text
uv run pytest tests/predict/test_react.py tests/predict/test_react_v2.py -q
24 passed, 1 skipped
```

Pre-commit checks also pass for the changed files.

## AI assistance

I used OpenAI Codex to inspect the collision paths, draft the validation and regression tests, rebase the branch onto the latest `main`, and run the focused tests. My prompts asked it to reproduce #9853, address the automated review feedback, validate reserved input and output fields at initialization, and add regression coverage. I reviewed the resulting diff and test results and take responsibility for the contribution.
