### PR TITLE
fix(base_module): allow dotted directory names when save_program=True

### DIFF
--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -200,7 +200,10 @@ class BaseModule:
         path = Path(path)
 
         if save_program:
-            if path.suffix:
+            # Only block when the path looks like one of the state-only formats
+            # (.json / .pkl). Arbitrary directory names with dots ("model.v1",
+            # "dspy.2") are valid filesystem paths and must be accepted.
+            if path.suffix in (".json", ".pkl"):
                 raise ValueError(
                     f"`path` must point to a directory without a suffix when `save_program=True`, but received: {path}"
                 )

--- a/tests/primitives/test_save_dot_in_dirname.py
+++ b/tests/primitives/test_save_dot_in_dirname.py
@@ -1,0 +1,35 @@
+"""Regression test for #8489: directories with `.` in name raise ValueError when save_program=True."""
+import pytest
+
+import dspy
+
+
+def test_save_program_accepts_directory_with_dot_in_name(tmp_path):
+    """A directory like `dspy.2/` is a valid filesystem path and must work."""
+    cot = dspy.Predict("question -> answer")
+    target = tmp_path / "dspy.2"
+    cot.save(str(target), save_program=True)
+    assert (target / "program.pkl").exists()
+    assert (target / "metadata.json").exists()
+
+
+def test_save_program_accepts_versioned_directory(tmp_path):
+    """Common pattern: `model.v1/`, `model.exp/`, etc."""
+    cot = dspy.Predict("question -> answer")
+    target = tmp_path / "model.v1"
+    cot.save(str(target), save_program=True)
+    assert (target / "program.pkl").exists()
+
+
+def test_save_program_still_rejects_json_path(tmp_path):
+    """Guard: passing a .json file with save_program=True should still error."""
+    cot = dspy.Predict("question -> answer")
+    with pytest.raises(ValueError, match="must point to a directory"):
+        cot.save(str(tmp_path / "module.json"), save_program=True)
+
+
+def test_save_program_still_rejects_pkl_path(tmp_path):
+    """Guard: passing a .pkl file with save_program=True should still error."""
+    cot = dspy.Predict("question -> answer")
+    with pytest.raises(ValueError, match="must point to a directory"):
+        cot.save(str(tmp_path / "module.pkl"), save_program=True)


### PR DESCRIPTION
Refs #8489.

`Path("dspy.2").suffix` returns `'.2'`, so the current `if path.suffix:` check in `BaseModule.save` rejects any directory whose name happens to contain a dot — `dspy.2/`, `model.v1/`, `proj.exp/`. All valid filesystem paths that show up in real workflows.

The check was added to catch users who accidentally pass a state-file path (`model.json`, `model.pkl`) together with `save_program=True`. Narrowing the suffix check to those two extensions keeps the original safety while letting dotted directory names through.

## RED

```
ValueError: `path` must point to a directory without a suffix when `save_program=True`,
            but received: /tmp/pytest-.../dspy.2

dspy/primitives/base_module.py:204: ValueError
FAILED tests/primitives/test_save_dot_in_dirname.py::test_save_program_accepts_directory_with_dot_in_name
```

## GREEN

```
tests/primitives/test_save_dot_in_dirname.py::test_save_program_accepts_directory_with_dot_in_name PASSED
tests/primitives/test_save_dot_in_dirname.py::test_save_program_accepts_versioned_directory PASSED
tests/primitives/test_save_dot_in_dirname.py::test_save_program_still_rejects_json_path PASSED
tests/primitives/test_save_dot_in_dirname.py::test_save_program_still_rejects_pkl_path PASSED
4 passed in 0.87s
```

Also reran `tests/primitives/test_base_module.py`, `tests/utils/test_saving.py`, `tests/primitives/test_module.py` — 36 passed, 5 skipped (network-dependent), no regression.