### PR TITLE
fix: exclude args with defaults from required in Tool function-callin…

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -158,7 +158,7 @@ class Tool(Type):
                 "parameters": {
                     "type": "object",
                     "properties": self.args,
-                    "required": list(self.args.keys()),
+                    "required": [k for k, v in self.args.items() if "default" not in v],
                 },
             },
         }

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -146,6 +146,19 @@ def test_tool_from_function():
     assert tool.args["y"]["default"] == "hello"
 
 
+def test_tool_required_excludes_defaults():
+    def look_up(query: str, state_optional: str = "fresh") -> str:
+        """Look something up."""
+        return f"{query}:{state_optional}"
+
+    tool = Tool(look_up)
+    schema = tool.format_as_litellm_function_call()
+    required = schema["function"]["parameters"]["required"]
+
+    assert "query" in required
+    assert "state_optional" not in required  # has default, must not be required
+
+
 def test_tool_from_class():
     class Foo:
         def __init__(self, user_id: str):


### PR DESCRIPTION
## Summary

Fixes a bug in `Tool.format_as_litellm_function_call` where arguments 
with default values were incorrectly included in the `required` array 
of the generated JSON Schema.

## Root Cause

In `dspy/adapters/types/tool.py`, the `format_as_litellm_function_call` 
method builds the function schema like this:

```python
"required": list(self.args.keys()),
```

This blindly marks **every** argument as required, even when the tool 
construction code (lines 108–109) already correctly stores `default` 
values on the argument properties:

```python
if default_values[k] is not inspect.Parameter.empty:
    args[k]["default"] = default_values[k]
```

So the `properties` object correctly advertises defaults, but `required` 
contradicts it — which confuses LLMs and violates the JSON Schema spec.

## Fix

Filter `required` to only include args that do not have a `default` key 
in their schema property:

```python
# Before
"required": list(self.args.keys()),

# After
"required": [k for k, v in self.args.items() if "default" not in v],
```

## Before / After

Given this tool:
```python
def look_up(query: str, state_optional: str = "fresh") -> str:
    """Look something up."""
    return f"{query}:{state_optional}"
```

**Before:**
```json
{
  "required": ["query", "state_optional"]
}
```

**After:**
```json
{
  "required": ["query"]
}
```

## Testing

Verified locally by calling `Tool(look_up).format_as_litellm_function_call()` 
and confirming only `query` appears in `required`.

Existing tests pass. A targeted test for this behavior can be added if 
the maintainers prefer it in this PR.

## References
- Fixes #9882
- JSON Schema spec: properties with `default` values should not be `required`