### PR TITLE
fix(react): preserve user signature outputs over framework-attached fields

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -115,7 +115,10 @@ class ReAct(Module):
                 break
 
         extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        return dspy.Prediction(trajectory=trajectory, **extract)
+        # User signature outputs (from `extract`) take precedence over the
+        # framework-attached `trajectory` to avoid a kwarg-collision `TypeError`
+        # when the user declares an output named `trajectory` (#9853).
+        return dspy.Prediction(**{"trajectory": trajectory, **extract})
 
     async def aforward(self, **input_args):
         trajectory = {}
@@ -140,7 +143,8 @@ class ReAct(Module):
                 break
 
         extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
-        return dspy.Prediction(trajectory=trajectory, **extract)
+        # See note in `forward` above: user outputs win over framework `trajectory` (#9853).
+        return dspy.Prediction(**{"trajectory": trajectory, **extract})
 
     def _call_with_potential_trajectory_truncation(self, module, trajectory, **input_args):
         for _ in range(3):

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -44,10 +44,7 @@ class ReActV2(Module):
                 raise ValueError(f"Missing required final output field(s): {', '.join(missing)}")
             return {name: kwargs[name] for name in output_names}
 
-        args = {
-            name: _json_schema_for_annotation(field.annotation)
-            for name, field in output_fields.items()
-        }
+        args = {name: _json_schema_for_annotation(field.annotation) for name, field in output_fields.items()}
         arg_types = {name: field.annotation for name, field in output_fields.items()}
         return Tool(
             submit,
@@ -121,7 +118,10 @@ class ReActV2(Module):
             pending_inputs = {}
 
             if final_outputs is not None:
-                return Prediction(**final_outputs, history=history, termination_reason="submit")
+                # User signature outputs take precedence over framework-attached
+                # `history` / `termination_reason` to avoid a kwarg-collision
+                # `TypeError` when the user declares an output with that name (#9853).
+                return Prediction(**{"history": history, "termination_reason": "submit", **final_outputs})
 
         return self._forced_submit(history, pending_inputs, break_reason, max_iters)
 
@@ -197,7 +197,8 @@ class ReActV2(Module):
         _append_history_event(history, event)
 
         if final_outputs is not None:
-            return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
+            # See note above: user outputs win over framework-attached fields (#9853).
+            return Prediction(**{"history": history, "termination_reason": "forced_submit", **final_outputs})
 
         return Prediction(history=history, termination_reason=break_reason or "failed")
 

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -25,7 +25,6 @@ def test_tool_observation_preserves_custom_type():
     def make_images():
         return dspy.Image("https://example.com/test.png"), dspy.Image(Image.new("RGB", (100, 100), "red"))
 
-
     adapter = SpyChatAdapter()
     lm = DummyLM(
         [
@@ -471,3 +470,26 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_react_user_signature_trajectory_output_does_not_collide():
+    """Regression for #9853: when the user's signature declares an output named
+    `trajectory`, the user's value must win — previously this raised
+    `TypeError: got multiple values for keyword argument 'trajectory'` because
+    `ReAct.forward` constructed the final `Prediction` with both
+    `trajectory=trajectory` and `**extract` (where `extract` itself contained
+    `trajectory` from the user's signature).
+    """
+    react = dspy.ReAct("question -> answer, trajectory: str", tools=[])
+    lm = DummyLM(
+        [
+            {"next_thought": "I will finish.", "next_tool_name": "finish", "next_tool_args": {}},
+            {"reasoning": "done", "answer": "x", "trajectory": "user-trajectory-value"},
+        ]
+    )
+    dspy.configure(lm=lm)
+    outputs = react(question="q")
+
+    assert outputs.answer == "x"
+    # User signature output takes precedence over the framework-attached `trajectory`.
+    assert outputs.trajectory == "user-trajectory-value"

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -23,15 +23,11 @@ def test_react_v2_text_mock_lm_loop_records_inputs_once():
         [
             {
                 "next_thought": "I should look this up.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "lookup", "args": {"query": "cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "lookup", "args": {"query": "cats"}}]),
             },
             {
                 "next_thought": "I can answer now.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "found cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "found cats"}}]),
             },
         ]
     )
@@ -55,15 +51,11 @@ def test_react_v2_continuation_omits_missing_original_inputs():
         [
             {
                 "next_thought": "I should look this up.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "lookup", "args": {"query": "cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "lookup", "args": {"query": "cats"}}]),
             },
             {
                 "next_thought": "I can answer now.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "found cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "found cats"}}]),
             },
         ]
     )
@@ -91,9 +83,7 @@ def test_react_v2_text_mode_accepts_top_level_tool_arguments():
             },
             {
                 "next_thought": "I can answer now.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "found cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "found cats"}}]),
             },
         ]
     )
@@ -128,15 +118,11 @@ def test_react_v2_unknown_tool_observation_can_continue():
         [
             {
                 "next_thought": "Try a missing tool.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "missing_tool", "args": {"query": "cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "missing_tool", "args": {"query": "cats"}}]),
             },
             {
                 "next_thought": "Recover with a final answer.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "done"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "done"}}]),
             },
         ]
     )
@@ -156,9 +142,7 @@ def test_react_v2_accepts_serialized_history_input():
         [
             {
                 "next_thought": "I can answer.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "done"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "done"}}]),
             }
         ]
     )
@@ -177,9 +161,7 @@ def test_react_v2_forced_submit_on_empty_tool_calls():
             {"next_thought": "No action.", "tool_calls": dspy.ToolCalls(tool_calls=[])},
             {
                 "next_thought": "Forced final.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "forced"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "forced"}}]),
             },
         ]
     )
@@ -310,17 +292,75 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
         "call_provider_2",
     ]
     assert [
-        result.call_id
-        for result in pred.history.messages[0]["tool_calls"].tool_call_results.tool_call_results
+        result.call_id for result in pred.history.messages[0]["tool_calls"].tool_call_results.tool_call_results
     ] == [
         "call_provider_1",
         "call_provider_2",
     ]
-    assert [
-        message["tool_call_id"]
-        for message in lm.calls[1]["messages"]
-        if message["role"] == "tool"
-    ] == [
+    assert [message["tool_call_id"] for message in lm.calls[1]["messages"] if message["role"] == "tool"] == [
         "call_provider_1",
         "call_provider_2",
     ]
+
+
+def test_react_v2_user_signature_history_output_does_not_collide():
+    """Regression for #9853: when the user's signature declares an output named
+    `history`, the user's value must win — previously this raised
+    `TypeError: got multiple values for keyword argument 'history'` because
+    `ReActV2` constructed the final `Prediction` with both `**final_outputs`
+    and an explicit `history=...` kwarg.
+    """
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "ready",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [{"name": "submit", "args": {"answer": "x", "history": "user-history-value"}}]
+                ),
+            },
+        ]
+    )
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2("question -> answer, history: str", tools=[])(question="q")
+
+    assert pred.answer == "x"
+    # User signature output takes precedence over the framework-attached `history`.
+    assert pred.history == "user-history-value"
+
+
+def test_react_v2_user_signature_termination_reason_output_does_not_collide():
+    """Regression for #9853: same as above but for `termination_reason`."""
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "ready",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [{"name": "submit", "args": {"answer": "x", "termination_reason": "custom"}}]
+                ),
+            },
+        ]
+    )
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2("question -> answer, termination_reason: str", tools=[])(question="q")
+
+    assert pred.answer == "x"
+    assert pred.termination_reason == "custom"
+
+
+def test_react_v2_framework_history_and_termination_preserved_without_collision():
+    """Control: without a user-signature name collision, the framework's
+    `history` and `termination_reason` are still attached as before."""
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "ready",
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "x"}}]),
+            },
+        ]
+    )
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2("question -> answer", tools=[])(question="q")
+
+    assert pred.answer == "x"
+    assert pred.termination_reason == "submit"
+    assert isinstance(pred.history, dspy.History)


### PR DESCRIPTION
## Summary

Closes #9853.

`ReActV2.forward` and `ReAct.forward` built the final `Prediction` by spreading user outputs with `**` alongside explicit `history=` / `trajectory=` / `termination_reason=` kwargs. When a user's signature declared an output named one of those framework-reserved names, Python's kwarg expansion raised:

```
TypeError: dspy.primitives.prediction.Prediction() got multiple values for keyword argument 'history'
```

(Equivalents for `trajectory` and `termination_reason`.)

The issue body also flagged the sister bug in ReAct v1 (`dspy/predict/react.py:118` and `:143`) — this PR fixes both.

## Fix shape

Merge through a dict so user signature outputs take precedence over framework-attached fields. The framework values still appear in the `Prediction` when there is no name collision; a user who deliberately declares an output named `history` (etc.) gets *their* value at that field rather than a crash.

Touched sites:
- `dspy/predict/react_v2.py:124` (`forward` submit path)
- `dspy/predict/react_v2.py:200` (`_forced_submit` path)
- `dspy/predict/react.py:118` (sync `forward`)
- `dspy/predict/react.py:143` (`aforward`)

## Test plan

- [x] `test_react_v2_user_signature_history_output_does_not_collide`
- [x] `test_react_v2_user_signature_termination_reason_output_does_not_collide`
- [x] `test_react_v2_framework_history_and_termination_preserved_without_collision` (control)
- [x] `test_react_user_signature_trajectory_output_does_not_collide` (v1 sister bug)
- [x] All existing tests in `tests/predict/test_react_v2.py` and `tests/predict/test_react.py` pass (22 passed, 1 skipped) — no regressions
- [x] `ruff check` / `ruff format` clean on touched files