### PR TITLE
fix(packaging): add py.typed marker per PEP 561

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ include = ["dspy", "dspy.*"]
 exclude = ["tests", "tests.*"]
 
 [tool.setuptools.package-data]
-dspy = ["primitives/*.js"]
+dspy = ["primitives/*.js", "py.typed"]
 
 [project.urls]
 homepage = "https://github.com/stanfordnlp/dspy"


### PR DESCRIPTION
## Summary

Closes #8873.

DSPy ships type annotations on its public API but lacks a `py.typed` marker, so consumers using strict type-checkers (mypy in strict mode, pyright, etc.) cannot pick up those annotations and instead get:

```
error: Cannot find implementation or library stub for module named "dspy"  [import-not-found]
```

Per [PEP 561](https://peps.python.org/pep-0561/), a package's type annotations are only consumed by downstream type-checkers if a `py.typed` marker file is shipped in the package.

## Fix shape

- Add empty `dspy/py.typed`.
- Include it in `tool.setuptools.package-data` so the marker is bundled into the wheel.

## Test plan

- [x] Wheel build (`python -m build`) includes `dspy/py.typed`.
- [x] Downstream project with `mypy --strict` no longer errors on `import dspy`.