### PR TITLE
Fix entity extraction tutorial dataset

### DIFF
--- a/docs/docs/tutorials/entity_extraction/index.ipynb
+++ b/docs/docs/tutorials/entity_extraction/index.ipynb
@@ -109,7 +109,7 @@
         "        # Use a temporary Hugging Face cache directory for compatibility with certain hosted notebook\n",
         "        # environments that don't support the default Hugging Face cache directory\n",
         "        os.environ[\"HF_DATASETS_CACHE\"] = temp_dir\n",
-        "        return load_dataset(\"conll2003\", trust_remote_code=True)\n",
+        "        return load_dataset(\"lhoestq/conll2003\")\n",
         "\n",
         "def extract_people_entities(data_row: dict[str, Any]) -> list[str]:\n",
         "    \"\"\"\n",


### PR DESCRIPTION
## Summary

This fixes the entity extraction tutorial, which currently fails while loading the CoNLL-
2003 dataset with modern versions of `datasets`.

The tutorial currently uses:

```python
load_dataset("conll2003", trust_remote_code=True)
```
That now raises:

```python
RuntimeError: Dataset scripts are no longer supported, but found conll2003.py
```

This PR switches the tutorial to:

```python
load_dataset("lhoestq/conll2003")
```
which loads the same CoNLL-2003 tutorial data without relying on the deprecated dataset-
script path.

lhoestq/conll2003 is a legitimate Hugging Face dataset source maintained by Quentin Lhoest,
a Hugging Face engineer and core maintainer of the datasets library. It provides the same
CoNLL-2003 data without relying on the deprecated dataset-script loading path.

## Testing

- Verified the notebook JSON parses:
```python
python3 -m json.tool docs/docs/tutorials/entity_extraction/index.ipynb
```
- Confirmed the old conll2003 / trust_remote_code=True reference is removed from docs/docs/
  tutorials/entity_extraction/index.ipynb.
- And it works functionally