### PR TITLE
fix(module): attach lm usage to every prediction in list outputs

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -319,18 +319,23 @@ class Module(BaseModule, metaclass=ProgramMeta):
     def _set_lm_usage(self, tokens: dict[str, Any], output: Any):
         # Some optimizers (e.g., GEPA bootstrap tracing) temporarily patch
         # module.forward to return a tuple: (prediction, trace).
-        # When usage tracking is enabled, ensure we attach usage to the
-        # prediction object if present.
-        prediction_in_output = None
+        # `dspy.Parallel` (and any user-written parallel wrapper) returns a
+        # `list[Prediction]`. In all of these cases we want the captured
+        # usage attached to every produced prediction (#9201).
+        predictions: list[Prediction] = []
         if isinstance(output, Prediction):
-            prediction_in_output = output
+            predictions.append(output)
         elif isinstance(output, tuple) and len(output) > 0 and isinstance(output[0], Prediction):
-            prediction_in_output = output[0]
-        if prediction_in_output:
-            prediction_in_output.set_lm_usage(tokens)
+            predictions.append(output[0])
+        elif isinstance(output, list):
+            predictions.extend(item for item in output if isinstance(item, Prediction))
+        if predictions:
+            for prediction in predictions:
+                prediction.set_lm_usage(tokens)
         else:
-            logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking.")
-
+            logger.warning(
+                "Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking."
+            )
 
     def __getattribute__(self, name):
         attr = super().__getattribute__(name)

--- a/tests/primitives/test_base_module.py
+++ b/tests/primitives/test_base_module.py
@@ -105,9 +105,7 @@ def test_save_and_load_with_pkl(tmp_path):
     ]
     trainset = [dspy.Example(**example).with_inputs("current_date", "target_date") for example in trainset]
 
-    dspy.configure(
-        lm=DummyLM([{"date_diff": "1", "reasoning": "n/a"}, {"date_diff": "2", "reasoning": "n/a"}] * 10)
-    )
+    dspy.configure(lm=DummyLM([{"date_diff": "1", "reasoning": "n/a"}, {"date_diff": "2", "reasoning": "n/a"}] * 10))
 
     cot = dspy.ChainOfThought(MySignature)
     cot(current_date=datetime.date(2024, 1, 1), target_date=datetime.date(2024, 1, 2))
@@ -356,9 +354,7 @@ async def test_usage_tracker_async_parallel():
             program.acall(question="What is the capital of France?"),
             program.acall(question="What is the capital of France?"),
         ]
-        with dspy.context(
-            lm=dspy.LM("openai/gpt-4o-mini", cache=False), track_usage=True, adapter=dspy.JSONAdapter()
-        ):
+        with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False), track_usage=True, adapter=dspy.JSONAdapter()):
             results = await asyncio.gather(*coroutines)
 
         assert results[0].get_lm_usage() is not None
@@ -542,3 +538,34 @@ def test_forward_through_call_no_warning(capsys):
     module(x="test")
     captured = capsys.readouterr()
     assert "directly is discouraged" not in captured.err
+
+
+def test_module_call_attaches_usage_to_each_prediction_in_list_output():
+    """Regression for #9201.
+
+    When a `dspy.Module`'s `forward` returns a `list[Prediction]` (the
+    natural shape when calling `dspy.Parallel` inside `forward`),
+    `Module.__call__` previously only handled scalar `Prediction` and
+    `(Prediction, ...)` tuples, so the captured token totals never got
+    attached and `get_lm_usage()` returned `None` on each item. Verify
+    usage now lands on every prediction in the list.
+    """
+    predict = dspy.Predict("q -> a")
+    lm = DummyLM([{"a": "Paris"}, {"a": "Hanoi"}])
+
+    class ParallelMod(dspy.Module):
+        def forward(self):
+            return dspy.Parallel(num_threads=1, max_errors=0)(
+                [
+                    (predict, {"q": "Capital of France?"}),
+                    (predict, {"q": "Capital of Vietnam?"}),
+                ],
+            )
+
+    with dspy.settings.context(lm=lm, track_usage=True):
+        results = ParallelMod()()
+
+    assert isinstance(results, list) and len(results) == 2
+    for result in results:
+        usage = result.get_lm_usage()
+        assert usage, "Expected non-empty usage on each list-returned prediction"


### PR DESCRIPTION
## Summary

Closes #9201.

When a `dspy.Module`'s `forward` returns a `list[Prediction]` — the natural shape when calling `dspy.Parallel` inside `forward` — `Module.__call__`'s `_set_lm_usage` only handled scalar `Prediction` and `(Prediction, ...)` tuples. The captured token totals never landed on the list-returned predictions, so `get_lm_usage()` returned `None` on each item and the *Failed to set LM usage* warning fired on every call.

Reproduced on `main` with `DummyLM` to confirm.

## Fix shape

Extend `_set_lm_usage` to extract every `Prediction` from a list output and call `set_lm_usage(tokens)` on each. Scalar and `(Prediction, trace)`-tuple paths are unchanged.

## Test plan

- [x] New `test_module_call_attaches_usage_to_each_prediction_in_list_output` exercises the reported scenario (`dspy.Parallel` inside `forward`); asserts non-empty usage on every list item.
- [x] Existing `_set_lm_usage` coverage in `tests/primitives/test_base_module.py` and `tests/predict/test_predict.py` still passes (scalar / tuple paths are unchanged in semantics).