### PR TITLE
Fix typo in customer service agent tutorial

### DIFF
--- a/docs/docs/tutorials/customer_service_agent/index.ipynb
+++ b/docs/docs/tutorials/customer_service_agent/index.ipynb
@@ -477,7 +477,7 @@
       "source": [
         "### Interpret the Result\n",
         "\n",
-        "The result contains the the `process_result` as required by the user, and a `reasoning` field that carries the reasoning behind the answer. In addition, it has a `trajectory` field which contains:\n",
+        "The result contains the `process_result` as required by the user, and a `reasoning` field that carries the reasoning behind the answer. In addition, it has a `trajectory` field which contains:\n",
         "\n",
         "- Reasoning (thought) at each step\n",
         "- Tools picked by LM at each step\n",


### PR DESCRIPTION
This pull request makes a minor documentation correction to the customer service agent tutorial. It fixes a small typo in the explanation of the result fields.

* Fixed a duplicate "the" in the description of the result fields in `docs/docs/tutorials/customer_service_agent/index.ipynb`.