### PR TITLE
fix(types): asyncify returns a variadic Callable

### DIFF
--- a/dspy/utils/asyncify.py
+++ b/dspy/utils/asyncify.py
@@ -28,7 +28,7 @@ def get_limiter():
     return _limiter
 
 
-def asyncify(program: "Module") -> Callable[[Any, Any], Awaitable[Any]]:
+def asyncify(program: "Module") -> Callable[..., Awaitable[Any]]:
     """
     Wraps a DSPy program so that it can be called asynchronously. This is useful for running a
     program in parallel with another task (e.g., another DSPy program).
@@ -40,7 +40,12 @@ def asyncify(program: "Module") -> Callable[[Any, Any], Awaitable[Any]]:
 
     Returns:
         An async function: An async function that, when awaited, runs the program in a worker thread.
-            The current thread's configuration context is inherited for each call.
+            The current thread's configuration context is inherited for each call. The wrapper
+            forwards every positional/keyword argument the original program accepts, so the
+            wrapped callable is typed as ``Callable[..., Awaitable[Any]]`` rather than the
+            previous fixed-arity ``Callable[[Any, Any], Awaitable[Any]]`` that triggered
+            Pyright ``reportCallIssue`` on any call with more or fewer than two positional
+            arguments (#9058).
     """
 
     async def async_program(*args, **kwargs) -> Any:

--- a/tests/utils/test_asyncify.py
+++ b/tests/utils/test_asyncify.py
@@ -50,3 +50,38 @@ async def test_asyncify():
     await verify_asyncify(4, 10)
     await verify_asyncify(8, 15)
     await verify_asyncify(8, 30)
+
+
+def test_asyncify_return_type_is_variadic_callable():
+    """Regression for #9058: `dspy.asyncify`'s return type annotation was
+    `Callable[[Any, Any], Awaitable[Any]]`, claiming the wrapped function
+    takes exactly two positional arguments. Pyright then raised
+    `reportCallIssue: Expected 2 positional arguments` on any call shape
+    other than exactly-two-args. Verify the annotation accepts variadic
+    arguments via `Callable[..., Awaitable[Any]]`."""
+    # `program: "Module"` is a forward ref behind `TYPE_CHECKING`, so
+    # `typing.get_type_hints` can't resolve the function's annotations at
+    # runtime. The bug is in the *return* annotation, which only references
+    # public typing names — read it from `__annotations__` and evaluate
+    # just that piece.
+    import typing
+
+    raw = dspy.asyncify.__annotations__["return"]
+    if isinstance(raw, str):
+        return_hint = eval(
+            raw,
+            {
+                **vars(typing),
+                "Any": typing.Any,
+                "Awaitable": typing.Awaitable,
+                "Callable": typing.Callable,
+            },
+        )
+    else:
+        return_hint = raw
+
+    args = getattr(return_hint, "__args__", None)
+    assert args is not None, f"return_hint has no __args__: {return_hint!r}"
+    assert args[0] is Ellipsis, (
+        f"asyncify return type should accept variadic args (...), got first arg: {args[0]!r}"
+    )


### PR DESCRIPTION
## Summary

Closes #9058.

`dspy.asyncify`'s return annotation was `Callable[[Any, Any], Awaitable[Any]]`, claiming the wrapped function takes exactly two positional arguments. Pyright then raised `reportCallIssue: Expected 2 positional arguments` on any call shape that wasn't exactly-two-args — including the documented `optimized_module_async(question=...)` shape from the README, breaking type-checked CI builds.

## Fix

Use `Callable[..., Awaitable[Any]]`. The wrapper already forwards `*args, **kwargs` to the underlying program, so a variadic signature is what callers should see. Pure annotation change with no runtime behavior diff. Docstring updated to call out the prior pitfall.

## Test plan

- [x] `test_asyncify_return_type_is_variadic_callable` reads the function's `__annotations__["return"]` (the `program: "Module"` parameter is a `TYPE_CHECKING` forward ref so `get_type_hints` can't resolve the function-level hints at runtime) and asserts the return type's first `__args__` element is `Ellipsis`, i.e. variadic.
- [x] Existing `test_asyncify` runtime test still passes.