### PR TITLE
fix: preserve format/detail/video_metadata on file blocks and media_type on video blocks

### DIFF
--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -340,7 +340,9 @@ def binary_to_openai(binary: LMBinaryPart) -> dict[str, Any]:
         file_data["file_id"] = binary.file_id
     if binary.filename is not None:
         file_data["filename"] = binary.filename
-    if binary.media_type != "application/octet-stream":
+    if binary.data is None and binary.path is None and binary.media_type != "application/octet-stream":
+        # file_id and url sources carry no MIME information of their own; data
+        # and path sources already embed it in the emitted data URI.
         file_data["format"] = binary.media_type
     if binary.detail is not None:
         file_data["detail"] = binary.detail

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -340,6 +340,12 @@ def binary_to_openai(binary: LMBinaryPart) -> dict[str, Any]:
         file_data["file_id"] = binary.file_id
     if binary.filename is not None:
         file_data["filename"] = binary.filename
+    if binary.media_type != "application/octet-stream":
+        file_data["format"] = binary.media_type
+    if binary.detail is not None:
+        file_data["detail"] = binary.detail
+    if binary.video_metadata is not None:
+        file_data["video_metadata"] = binary.video_metadata
     return {"type": "file", "file": file_data}
 
 

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -137,6 +137,8 @@ class LMBinaryPart(LMSourcePart):
     type: Literal["binary"] = "binary"
     media_type: str = "application/octet-stream"
     filename: str | None = None
+    detail: Literal["low", "high", "auto"] | None = None
+    video_metadata: dict[str, Any] | None = None
 
 
 class LMToolCallPart(LMBasePart):
@@ -1691,6 +1693,8 @@ def _history_part_as_openai_content(part: LMPart) -> dict[str, Any]:
                     "file_id": part.file_id,
                     "filename": part.filename,
                     "media_type": part.media_type,
+                    "detail": part.detail,
+                    "video_metadata": part.video_metadata,
                 }.items()
                 if value is not None
             },
@@ -1888,14 +1892,22 @@ def _audio_dict_to_part(audio: dict[str, Any]) -> LMAudioPart:
 
 
 def _binary_dict_to_part(file: dict[str, Any]) -> LMBinaryPart:
+    common = {
+        "filename": file.get("filename"),
+        "detail": file.get("detail"),
+        "video_metadata": file.get("video_metadata"),
+    }
+    media_format = file.get("format")
     if file.get("file_data") is not None:
         media_type, data = _split_data_uri(file["file_data"])
-        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"))
+        return LMBinaryPart(data=data, media_type=media_format or media_type, **common)
     if file.get("data") is not None:
         media_type, data = _split_data_uri(file["data"])
-        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"))
+        return LMBinaryPart(data=data, media_type=media_format or media_type, **common)
     if file.get("file_id") is not None:
-        return LMBinaryPart(file_id=file["file_id"], filename=file.get("filename"))
+        if media_format is not None:
+            common["media_type"] = media_format
+        return LMBinaryPart(file_id=file["file_id"], **common)
     raise ValueError("Binary content block requires data, file_data, or file_id.")
 
 

--- a/tests/clients/test_openai_format.py
+++ b/tests/clients/test_openai_format.py
@@ -23,6 +23,14 @@ def test_binary_part_emits_format_detail_and_video_metadata():
     ]
 
 
+def test_binary_part_with_inline_data_keeps_media_type_in_data_uri_only():
+    part = LMBinaryPart(data="YWJj", media_type="video/webm")
+
+    assert part_to_openai_blocks(part) == [
+        {"type": "file", "file": {"file_data": "data:video/webm;base64,YWJj"}}
+    ]
+
+
 def test_binary_part_omits_format_for_default_media_type():
     part = LMBinaryPart(file_id="file-abc123", filename="document.bin")
 

--- a/tests/clients/test_openai_format.py
+++ b/tests/clients/test_openai_format.py
@@ -1,0 +1,72 @@
+from dspy.clients.openai_format import part_to_openai_blocks
+from dspy.core.types import LMBinaryPart, LMMessage, LMVideoPart
+
+
+def test_binary_part_emits_format_detail_and_video_metadata():
+    part = LMBinaryPart(
+        file_id="https://generativelanguage.googleapis.com/v1beta/files/abc123",
+        media_type="video/webm",
+        detail="high",
+        video_metadata={"fps": 1.0},
+    )
+
+    assert part_to_openai_blocks(part) == [
+        {
+            "type": "file",
+            "file": {
+                "file_id": "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+                "format": "video/webm",
+                "detail": "high",
+                "video_metadata": {"fps": 1.0},
+            },
+        }
+    ]
+
+
+def test_binary_part_omits_format_for_default_media_type():
+    part = LMBinaryPart(file_id="file-abc123", filename="document.bin")
+
+    assert part_to_openai_blocks(part) == [
+        {"type": "file", "file": {"file_id": "file-abc123", "filename": "document.bin"}}
+    ]
+
+
+def test_file_content_block_round_trips_through_openai_blocks():
+    block = {
+        "type": "file",
+        "file": {
+            "file_id": "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+            "format": "video/webm",
+            "detail": "high",
+            "video_metadata": {"fps": 1.0},
+        },
+    }
+    part = LMMessage(role="user", content=[block]).parts[0]
+
+    assert part_to_openai_blocks(part) == [block]
+
+
+def test_video_part_keeps_media_type_as_file_format():
+    part = LMVideoPart(
+        file_id="https://generativelanguage.googleapis.com/v1beta/files/abc123",
+        media_type="video/webm",
+    )
+
+    assert part_to_openai_blocks(part) == [
+        {
+            "type": "file",
+            "file": {
+                "file_id": "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+                "format": "video/webm",
+            },
+        }
+    ]
+
+
+def test_video_content_block_keeps_media_type_when_emitted_to_openai():
+    block = {"type": "video", "video": {"file_id": "files/abc123", "media_type": "video/webm"}}
+    part = LMMessage(role="user", content=[block]).parts[0]
+
+    assert part_to_openai_blocks(part) == [
+        {"type": "file", "file": {"file_id": "files/abc123", "format": "video/webm"}}
+    ]

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -3,6 +3,7 @@ import pytest
 
 from dspy.core.types import (
     LMAudioPart,
+    LMBinaryPart,
     LMConfig,
     LMDocumentPart,
     LMHistoryEntry,
@@ -140,6 +141,42 @@ def test_video_data_round_trips_through_history_messages():
     assert isinstance(round_tripped, LMVideoPart)
     assert round_tripped.data == "YWJj"
     assert round_tripped.media_type == "video/mp4"
+
+
+def test_file_content_block_preserves_format_detail_and_video_metadata():
+    message = LMMessage(
+        role="user",
+        content=[
+            {
+                "type": "file",
+                "file": {
+                    "file_id": "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+                    "format": "video/webm",
+                    "detail": "high",
+                    "video_metadata": {"fps": 1.0},
+                },
+            }
+        ],
+    )
+
+    part = message.parts[0]
+    assert isinstance(part, LMBinaryPart)
+    assert part.file_id == "https://generativelanguage.googleapis.com/v1beta/files/abc123"
+    assert part.media_type == "video/webm"
+    assert part.detail == "high"
+    assert part.video_metadata == {"fps": 1.0}
+
+
+def test_file_content_block_format_overrides_data_uri_media_type():
+    message = LMMessage(
+        role="user",
+        content=[{"type": "file", "file": {"file_data": "data:application/octet-stream;base64,YWJj", "format": "video/webm"}}],
+    )
+
+    part = message.parts[0]
+    assert isinstance(part, LMBinaryPart)
+    assert part.data == "YWJj"
+    assert part.media_type == "video/webm"
 
 
 def test_document_source_url_stays_url_and_round_trips_through_history_messages():


### PR DESCRIPTION
Fixes #9898
Fixes #9899


## Problem

The typed LMPart normalization layer drops fields from media content blocks in two places.

For #9898, a file content block like

{"type": "file", "file": {"file_id": "...", "format": "video/webm", "detail": "high", "video_metadata": {"fps": 1.0}}}

comes back out as {"type": "file", "file": {"file_id": "..."}}. The parse step (_binary_dict_to_part) never stored format, detail, or video_metadata on LMBinaryPart, so the emit step (binary_to_openai) had nothing to re-emit. These fields exist on litellm's ChatCompletionFileObjectFile and are consumed by AI Studio and Vertex. Losing format forces litellm to HTTP-fetch the URL just to infer the MIME type.

For #9899, a video block keeps its media_type during parsing, but the emit path (video_to_openai -> binary_to_openai) produced a file block with no MIME information at all.

## Fix

* Add optional detail and video_metadata fields to LMBinaryPart, mirroring litellm's ChatCompletionFileObjectFile.
* _binary_dict_to_part now preserves detail and video_metadata, and maps an explicit format into media_type. An explicit format wins over the MIME type parsed from a data URI, matching litellm precedence.
* binary_to_openai re-emits detail and video_metadata, and emits media_type as file.format whenever it is not the generic application/octet-stream default. Video parts are funneled through binary_to_openai, so this also fixes the lost video media_type.
* The inspect-history surface (_history_part_as_openai_content) includes the new fields.

Behavior for file blocks without MIME information is unchanged: no format key is emitted for the default application/octet-stream.

## Before / after (repro scripts from the issues)

#9898

emitted : {"file_id": ".../files/abc123", "format": "video/webm", "detail": "high", "video_metadata": {"fps": 1.0}}
before  : {"file_id": ".../files/abc123"}
after   : {"file_id": ".../files/abc123", "format": "video/webm", "detail": "high", "video_metadata": {"fps": 1.0}}

#9899

emitted : {"type": "video", "video": {"file_id": ".../files/abc123", "media_type": "video/webm"}}
before  : {"type": "file", "file": {"file_id": ".../files/abc123"}}
after   : {"type": "file", "file": {"file_id": ".../files/abc123", "format": "video/webm"}}

## Tests

* New tests/clients/test_openai_format.py: field round-trip through part_to_openai_blocks, format omitted for the default media type, and video media_type emitted as file.format.
* Parse-side tests in tests/core/test_types.py: field preservation, and explicit format overriding the data-URI MIME type.
* tests/core, tests/clients, tests/adapters, and tests/signatures pass locally. The only failures are pre-existing Windows environment issues that also fail on an unmodified main checkout.


Heads up that #9900 addresses the same two issues. Main difference in approach: this PR keeps the existing file block wire format and puts the MIME type in litellm's documented file.format field instead of emitting a new video block type, and stores the preserved fields as typed attributes on LMBinaryPart. Happy to go with whichever direction you prefer.