### PR TITLE
fix: honor zero values in Dataset.reset_seeds

### DIFF
--- a/dspy/datasets/dataset.py
+++ b/dspy/datasets/dataset.py
@@ -39,12 +39,12 @@ class Dataset:
         dev_size: int | None = None,
         test_size: int | None = None,
     ) -> None:
-        self.train_size = train_size or self.train_size
-        self.train_seed = train_seed or self.train_seed
-        self.dev_size = dev_size or self.dev_size
-        self.dev_seed = eval_seed or self.dev_seed
-        self.test_size = test_size or self.test_size
-        self.test_seed = eval_seed or self.test_seed
+        self.train_size = train_size if train_size is not None else self.train_size
+        self.train_seed = train_seed if train_seed is not None else self.train_seed
+        self.dev_size = dev_size if dev_size is not None else self.dev_size
+        self.dev_seed = eval_seed if eval_seed is not None else self.dev_seed
+        self.test_size = test_size if test_size is not None else self.test_size
+        self.test_seed = eval_seed if eval_seed is not None else self.test_seed
 
         if hasattr(self, "_train_"):
             del self._train_

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -36,6 +36,30 @@ def csv_file():
         yield tmp_file.name
 
 
+def test_reset_seeds_accepts_zero():
+    dataset = Dataset(train_seed=5, train_size=10, eval_seed=5, dev_size=10, test_size=10)
+    dataset.reset_seeds(train_seed=0, train_size=0, eval_seed=0, dev_size=0, test_size=0)
+
+    assert dataset.train_seed == 0
+    assert dataset.train_size == 0
+    assert dataset.dev_seed == 0
+    assert dataset.dev_size == 0
+    assert dataset.test_seed == 0
+    assert dataset.test_size == 0
+
+
+def test_reset_seeds_keeps_existing_values_when_omitted():
+    dataset = Dataset(train_seed=5, train_size=10, eval_seed=7, dev_size=20, test_size=30)
+    dataset.reset_seeds(train_seed=1)
+
+    assert dataset.train_seed == 1
+    # Unspecified values should be left untouched.
+    assert dataset.train_size == 10
+    assert dataset.dev_seed == 7
+    assert dataset.dev_size == 20
+    assert dataset.test_size == 30
+
+
 @pytest.mark.extra
 def test_input_keys(csv_file):
     dataset = CSVDataset(csv_file, input_keys=["content", "question"])

--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -57,6 +57,7 @@ def test_reset_seeds_keeps_existing_values_when_omitted():
     assert dataset.train_size == 10
     assert dataset.dev_seed == 7
     assert dataset.dev_size == 20
+    assert dataset.test_seed == 7
     assert dataset.test_size == 30
 
 


### PR DESCRIPTION
`Dataset.reset_seeds` updates each seed/size with `value or self.value`. Since `0` is falsy, passing a valid `0` is silently dropped and the previous value is kept.

Repro:
```python
from dspy.datasets.dataset import Dataset
d = Dataset(train_seed=5, train_size=10)
d.reset_seeds(train_seed=0, train_size=0)
print(d.train_seed, d.train_size)  # prints "5 10", expected "0 0"
```

This affects anyone resetting to seed 0 (a common default) or requesting an empty split with size 0.

Fix: replace the `or` fallbacks with explicit `is not None` checks so `0` is applied while omitted (`None`) arguments still leave the existing value untouched. Added tests covering both the zero case and the omitted-argument behavior.