### PR TITLE
fix(syncify): reuse running loop instead of deprecated get_event_loop()

### DIFF
--- a/dspy/utils/syncify.py
+++ b/dspy/utils/syncify.py
@@ -18,7 +18,7 @@ def run_async(coro):
         import nest_asyncio
 
         nest_asyncio.apply()
-        return asyncio.get_event_loop().run_until_complete(coro)
+        return loop.run_until_complete(coro)
     else:
         return asyncio.run(coro)
 


### PR DESCRIPTION
## What

In `dspy/utils/syncify.py`, the running-loop branch of `run_async` already obtains the loop via `asyncio.get_running_loop()` a few lines above and checks `loop.is_running()`. It then calls `asyncio.get_event_loop().run_until_complete(coro)` — but `asyncio.get_event_loop()` is deprecated since Python 3.10 (and emits a `DeprecationWarning`).

Since we already hold the running loop in `loop`, this just calls `loop.run_until_complete(coro)` directly. Same behavior, no deprecated API.

## Why

- Removes a `DeprecationWarning` on Python 3.10+.
- Uses the loop we already resolved, so it's also slightly clearer.

No functional change.
