### PR TITLE
fix: correct typos in comments and error messages

### DIFF
--- a/dspy/clients/openai.py
+++ b/dspy/clients/openai.py
@@ -48,7 +48,7 @@ class OpenAIProvider(Provider):
     @staticmethod
     def is_provider_model(model: str) -> bool:
         if model.startswith("openai/") or model.startswith("ft:"):
-            # Althought it looks strange, `ft:` is a unique identifer for openai finetuned models in litellm context:
+            # Although it looks strange, `ft:` is a unique identifier for openai finetuned models in litellm context:
             # https://github.com/BerriAI/litellm/blob/cd893134b7974d9f21477049a373b469fff747a5/litellm/utils.py#L4495
             return True
 

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -162,7 +162,7 @@ class ProgramOfThought(Module):
         if not error:
             output, error = self._execute_code(code)
         hop = 1
-        # Retying code generation and execution until no error or reach max_iters
+        # Retrying code generation and execution until no error or reach max_iters
         while error is not None:
             logger.error(f"Error in code execution: {error}")
             if hop == self.max_iters:

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -227,7 +227,7 @@ class StreamListener:
                 # the end_identifier for all LMs.
                 token = self.field_end_queue.get()
 
-            # TODO: Put adapter streaming handling into individial classes, e.g., `JSONAdapterStreamListener`,
+            # TODO: Put adapter streaming handling into individual classes, e.g., `JSONAdapterStreamListener`,
             # `ChatAdapterStreamListener`, `XMLAdapterStreamListener` instead of having many adhoc code in the
             # `StreamListener` class.
             if isinstance(settings.adapter, JSONAdapter):


### PR DESCRIPTION
Fixed minor spelling errors across three core modules. These were present in comments and error messages and had no impact on functionality.

Changes:
- dspy/predict/openai.py line 51: "Althought" → "Although", "identifer" → "identifier"
- dspy/predict/program_of_thought.py line 165: "Retying" → "Retrying"
- dspy/streaming/streaming_listener.py line 230: "individial" → "individual"

No logic changes, no functional changes — purely spelling corrections in non-executable text.