### PR TITLE
fix(evaluate): expose timeout/straggler_limit and harden straggler resubmission (#9574)

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -79,7 +79,7 @@ class Evaluate:
         max_errors: int | None = None,
         provide_traceback: bool | None = None,
         failure_score: float = 0.0,
-        timeout: int = 120,
+        timeout: float = 120,
         straggler_limit: int = 3,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
@@ -97,7 +97,7 @@ class Evaluate:
                 stopping evaluation. If ``None``, inherits from ``dspy.settings.max_errors``.
             provide_traceback (Optional[bool]): Whether to provide traceback information during evaluation.
             failure_score (float): The default score to use if evaluation fails due to an exception.
-            timeout (int): Per-example straggler timeout, in seconds, passed to the underlying
+            timeout (float): Per-example straggler timeout, in seconds, passed to the underlying
                 parallel executor. When fewer than ``straggler_limit`` examples remain, any that
                 have been running for longer than ``timeout`` are resubmitted once. Set to ``0``
                 to disable straggler resubmission entirely, which is useful for long-running

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -79,6 +79,8 @@ class Evaluate:
         max_errors: int | None = None,
         provide_traceback: bool | None = None,
         failure_score: float = 0.0,
+        timeout: int = 120,
+        straggler_limit: int = 3,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
         **kwargs,
@@ -95,6 +97,13 @@ class Evaluate:
                 stopping evaluation. If ``None``, inherits from ``dspy.settings.max_errors``.
             provide_traceback (Optional[bool]): Whether to provide traceback information during evaluation.
             failure_score (float): The default score to use if evaluation fails due to an exception.
+            timeout (int): Per-example straggler timeout, in seconds, passed to the underlying
+                parallel executor. When fewer than ``straggler_limit`` examples remain, any that
+                have been running for longer than ``timeout`` are resubmitted once. Set to ``0``
+                to disable straggler resubmission entirely, which is useful for long-running
+                evaluations whose examples legitimately exceed the default 120s. Defaults to 120.
+            straggler_limit (int): The maximum number of remaining examples for which straggler
+                resubmission is considered. Defaults to 3.
             save_as_csv (Optional[str]): The file name where the csv will be saved.
             save_as_json (Optional[str]): The file name where the json will be saved.
 
@@ -107,6 +116,8 @@ class Evaluate:
         self.max_errors = max_errors
         self.provide_traceback = provide_traceback
         self.failure_score = failure_score
+        self.timeout = timeout
+        self.straggler_limit = straggler_limit
         self.save_as_csv = save_as_csv
         self.save_as_json = save_as_json
 
@@ -165,6 +176,8 @@ class Evaluate:
             max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
             provide_traceback=self.provide_traceback,
             compare_results=True,
+            timeout=self.timeout,
+            straggler_limit=self.straggler_limit,
         )
 
         def process_item(example):

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -209,13 +209,25 @@ class ParallelExecutor:
                                     st = start_time_map.get(sid, None)
                                 if st and (now - st) >= self.timeout:
                                     resubmitted.add(f)
-                                    nf = executor.submit(
-                                        worker,
-                                        parent_overrides,
-                                        submission_counter,
-                                        idx,
-                                        item,
-                                    )
+                                    try:
+                                        nf = executor.submit(
+                                            worker,
+                                            parent_overrides,
+                                            submission_counter,
+                                            idx,
+                                            item,
+                                        )
+                                    except RuntimeError:
+                                        # The pool is shutting down (e.g. interpreter
+                                        # teardown on long evals). Resubmission is
+                                        # best-effort: skip it rather than crash the
+                                        # whole evaluation with "cannot schedule new
+                                        # futures after shutdown".
+                                        continue
+                                    # Mark the resubmission itself as already
+                                    # resubmitted so we honor "at most once per item"
+                                    # even if it later becomes a straggler too.
+                                    resubmitted.add(nf)
                                     futures_map[nf] = (submission_counter, idx, item)
                                     futures_set.add(nf)
                                     submission_counter += 1

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -208,13 +208,25 @@ class ParallelExecutor:
                                     st = start_time_map.get(sid, None)
                                 if st and (now - st) >= self.timeout:
                                     resubmitted.add(f)
-                                    nf = executor.submit(
-                                        worker,
-                                        parent_overrides,
-                                        submission_counter,
-                                        idx,
-                                        item,
-                                    )
+                                    try:
+                                        nf = executor.submit(
+                                            worker,
+                                            parent_overrides,
+                                            submission_counter,
+                                            idx,
+                                            item,
+                                        )
+                                    except RuntimeError:
+                                        # The pool is shutting down (e.g. interpreter
+                                        # teardown on long evals). Resubmission is
+                                        # best-effort: skip it rather than crash the
+                                        # whole evaluation with "cannot schedule new
+                                        # futures after shutdown".
+                                        continue
+                                    # Mark the resubmission itself as already
+                                    # resubmitted so we honor "at most once per item"
+                                    # even if it later becomes a straggler too.
+                                    resubmitted.add(nf)
                                     futures_map[nf] = (submission_counter, idx, item)
                                     futures_set.add(nf)
                                     submission_counter += 1

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -33,6 +33,39 @@ def test_evaluate_initialization():
     assert ev.metric == answer_exact_match
     assert ev.num_threads is None
     assert not ev.display_progress
+    # Straggler controls default to the previous hard-coded ParallelExecutor values.
+    assert ev.timeout == 120
+    assert ev.straggler_limit == 3
+
+
+def test_evaluate_forwards_straggler_controls_to_executor():
+    """`timeout` and `straggler_limit` set on Evaluate must reach the ParallelExecutor,
+    so long-running evals can disable straggler resubmission (timeout=0)."""
+    dspy.configure(lm=DummyLM({"What is 1+1?": {"answer": "2"}}))
+    devset = [new_example("What is 1+1?", "2")]
+    program = Predict("question -> answer")
+
+    captured = {}
+
+    class FakeExecutor:
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+
+        def execute(self, function, data):
+            return [function(example) for example in data]
+
+    ev = Evaluate(
+        devset=devset,
+        metric=answer_exact_match,
+        display_progress=False,
+        timeout=0,
+        straggler_limit=5,
+    )
+    with patch("dspy.evaluate.evaluate.ParallelExecutor", FakeExecutor):
+        ev(program)
+
+    assert captured["timeout"] == 0
+    assert captured["straggler_limit"] == 5
 
 
 def test_evaluate_call():

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -1,3 +1,4 @@
+import collections
 import threading
 import time
 
@@ -154,6 +155,62 @@ def test_sequential_tracks_failed_indices_and_exceptions():
     assert str(executor.exceptions_map[2]) == "test error for 3"
     assert isinstance(executor.exceptions_map[4], RuntimeError)
     assert str(executor.exceptions_map[4]) == "test error for 5"
+
+
+def test_straggler_resubmission_completes_without_error():
+    """A task slower than the straggler timeout should still resolve (via resubmission)
+    rather than crashing the executor."""
+    def task(item):
+        time.sleep(1.3 if item == 0 else 0.01)
+        return item
+
+    data = [0, 1, 2]
+    executor = ParallelExecutor(num_threads=3, timeout=0.2, straggler_limit=3, disable_progress_bar=True)
+    results = executor.execute(task, data)
+
+    assert results == [0, 1, 2]
+
+
+def test_straggler_resubmitted_at_most_once_per_item():
+    """A persistently slow straggler must not be resubmitted unboundedly: the
+    "at most once per item" invariant means the task is invoked at most twice."""
+    calls = collections.Counter()
+    lock = threading.Lock()
+
+    def task(item):
+        with lock:
+            calls[item] += 1
+        # item 0 stays slow long enough for its resubmission to also become a
+        # straggler; without the fix it would be resubmitted again and again.
+        time.sleep(2.6 if item == 0 else 0.01)
+        return item
+
+    data = [0, 1, 2]
+    executor = ParallelExecutor(num_threads=4, timeout=0.2, straggler_limit=3, disable_progress_bar=True)
+    results = executor.execute(task, data)
+
+    assert results == [0, 1, 2]
+    assert calls[0] <= 2, f"straggler resubmitted more than once (invoked {calls[0]} times)"
+
+
+def test_timeout_zero_disables_straggler_resubmission():
+    """With timeout=0, straggler resubmission is disabled: a slow task is invoked
+    exactly once and the eval still completes."""
+    calls = collections.Counter()
+    lock = threading.Lock()
+
+    def task(item):
+        with lock:
+            calls[item] += 1
+        time.sleep(1.3 if item == 0 else 0.01)
+        return item
+
+    data = [0, 1, 2]
+    executor = ParallelExecutor(num_threads=4, timeout=0, straggler_limit=3, disable_progress_bar=True)
+    results = executor.execute(task, data)
+
+    assert results == [0, 1, 2]
+    assert calls[0] == 1
 
 
 def test_sequential_compare_results():

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -1,3 +1,4 @@
+import collections
 import threading
 import time
 from unittest import mock
@@ -171,6 +172,62 @@ def test_sequential_tracks_failed_indices_and_exceptions():
     assert str(executor.exceptions_map[2]) == "test error for 3"
     assert isinstance(executor.exceptions_map[4], RuntimeError)
     assert str(executor.exceptions_map[4]) == "test error for 5"
+
+
+def test_straggler_resubmission_completes_without_error():
+    """A task slower than the straggler timeout should still resolve (via resubmission)
+    rather than crashing the executor."""
+    def task(item):
+        time.sleep(1.3 if item == 0 else 0.01)
+        return item
+
+    data = [0, 1, 2]
+    executor = ParallelExecutor(num_threads=3, timeout=0.2, straggler_limit=3, disable_progress_bar=True)
+    results = executor.execute(task, data)
+
+    assert results == [0, 1, 2]
+
+
+def test_straggler_resubmitted_at_most_once_per_item():
+    """A persistently slow straggler must not be resubmitted unboundedly: the
+    "at most once per item" invariant means the task is invoked at most twice."""
+    calls = collections.Counter()
+    lock = threading.Lock()
+
+    def task(item):
+        with lock:
+            calls[item] += 1
+        # item 0 stays slow long enough for its resubmission to also become a
+        # straggler; without the fix it would be resubmitted again and again.
+        time.sleep(2.6 if item == 0 else 0.01)
+        return item
+
+    data = [0, 1, 2]
+    executor = ParallelExecutor(num_threads=4, timeout=0.2, straggler_limit=3, disable_progress_bar=True)
+    results = executor.execute(task, data)
+
+    assert results == [0, 1, 2]
+    assert calls[0] <= 2, f"straggler resubmitted more than once (invoked {calls[0]} times)"
+
+
+def test_timeout_zero_disables_straggler_resubmission():
+    """With timeout=0, straggler resubmission is disabled: a slow task is invoked
+    exactly once and the eval still completes."""
+    calls = collections.Counter()
+    lock = threading.Lock()
+
+    def task(item):
+        with lock:
+            calls[item] += 1
+        time.sleep(1.3 if item == 0 else 0.01)
+        return item
+
+    data = [0, 1, 2]
+    executor = ParallelExecutor(num_threads=4, timeout=0, straggler_limit=3, disable_progress_bar=True)
+    results = executor.execute(task, data)
+
+    assert results == [0, 1, 2]
+    assert calls[0] == 1
 
 
 def test_sequential_compare_results():


### PR DESCRIPTION
## 📝 Changes Description

Fixes #9574.

`dspy.Evaluate` instantiated `ParallelExecutor` with the hard-coded default `timeout=120`, with no way to override it (`evaluate.py` did not pass `timeout`/`straggler_limit` through). On long-running evaluations whose examples legitimately take longer than 120s, the straggler logic resubmits work and can crash the whole evaluation with `RuntimeError: cannot schedule new futures after shutdown`.

This PR:

1. **Exposes `timeout` and `straggler_limit` on `dspy.Evaluate`** (`__init__`), forwarded to `ParallelExecutor`. Defaults are unchanged (`120` / `3`), so behavior is backwards-compatible. Setting `timeout=0` disables straggler resubmission entirely — the recommended setting for long evals (the executor already guards this path with `if 0 < self.timeout`).

2. **Hardens `ParallelExecutor._execute_parallel`:**
   - Wraps the straggler `executor.submit(...)` in `try/except RuntimeError`, so a pool that is shutting down no longer crashes the evaluation; resubmission is treated as best-effort.
   - Adds the resubmitted future to `resubmitted`, honoring the existing `# We resubmit at most once per item.` invariant even if the resubmission itself later becomes a straggler.

3. **Tests** (all passing locally):
   - `tests/utils/test_parallelizer.py`: completion under a tight straggler timeout, at-most-once resubmission, and `timeout=0` disabling resubmission.
   - `tests/evaluate/test_evaluate.py`: default values and that `timeout`/`straggler_limit` are forwarded to the executor.

### Reproduction

The straggler resubmission mechanism (and the "resubmit at most once" violation when a resubmission itself becomes a straggler) was reproduced in isolation before fixing. With `timeout=0`, the straggler path is skipped entirely and long examples are no longer resubmitted.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally) — `ruff check` is clean on the changed lines; new tests pass
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

The new straggler tests use short `time.sleep`-based timing (run 3× locally with no flakiness). Defaults are preserved, so this is a non-breaking change.