### PR TITLE
fix(clients): keep `media_type` on video content blocks in OpenAI format (#9899)

### DIFF
--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -314,17 +314,22 @@ def document_to_openai_blocks(document: LMDocumentPart) -> list[dict[str, Any]]:
 
 
 def video_to_openai(video: LMVideoPart) -> dict[str, Any]:
-    filename = os.path.basename(video.path) if video.path is not None else None
-    return binary_to_openai(
-        LMBinaryPart(
-            data=video.data,
-            url=video.url,
-            file_id=video.file_id,
-            path=video.path,
-            media_type=video.media_type,
-            filename=filename,
-        )
-    )
+    # Emit a `video` content block (symmetric with `_media_dict_to_video_part`) rather
+    # than collapsing into a `file` block, so `media_type` survives the round-trip.
+    # Without it, providers such as Gemini/Vertex must HTTP-fetch the source to infer
+    # the MIME type.
+    payload: dict[str, Any] = {"media_type": video.media_type}
+    if video.data is not None:
+        payload["data"] = data_uri(video.media_type, video.data)
+    elif video.path is not None:
+        payload["data"] = data_uri_from_path(video.path, fallback_media_type=video.media_type)
+    elif video.url is not None:
+        payload["url"] = video.url
+    elif video.file_id is not None:
+        payload["file_id"] = video.file_id
+    else:
+        raise ValueError("OpenAI-format video input requires data, path, url, or file_id.")
+    return {"type": "video", "video": payload}
 
 
 def binary_to_openai(binary: LMBinaryPart) -> dict[str, Any]:

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -142,6 +142,31 @@ def test_video_data_round_trips_through_history_messages():
     assert round_tripped.media_type == "video/mp4"
 
 
+def test_video_round_trips_through_openai_chat_messages():
+    """Regression test for #9899.
+
+    A video part must emit a `video` content block that keeps `media_type`, rather
+    than collapsing into a bare `file` block that drops it (which forces providers
+    such as Gemini/Vertex to HTTP-fetch the source to infer the MIME type).
+    """
+    from dspy.clients.openai_format import message_to_openai_chat
+
+    message = User(LMVideoPart(file_id="https://example.com/files/abc", media_type="video/webm"))
+    content = message_to_openai_chat(message)["content"]
+
+    assert content == [
+        {
+            "type": "video",
+            "video": {"media_type": "video/webm", "file_id": "https://example.com/files/abc"},
+        }
+    ]
+
+    round_tripped = LMMessage(role="user", content=content).parts[0]
+    assert isinstance(round_tripped, LMVideoPart)
+    assert round_tripped.media_type == "video/webm"
+    assert round_tripped.file_id == "https://example.com/files/abc"
+
+
 def test_document_source_url_stays_url_and_round_trips_through_history_messages():
     message = LMMessage(
         role="user",


### PR DESCRIPTION
## 📝 Changes Description

Fixes #9899.

`video_to_openai` collapsed an `LMVideoPart` into an `LMBinaryPart` and emitted a bare `{"type": "file", "file": {"file_id": ...}}` content block, silently dropping `media_type`. For a Gemini / Vertex Files URL this forces litellm to HTTP-fetch the source just to infer its MIME type, and can change how the media is handled downstream.

This PR makes `video_to_openai` emit a proper `video` content block (`{"type": "video", "video": {"media_type": ..., <source>: ...}}`), which is symmetric with the inbound `_media_dict_to_video_part` parser and the history serializer. As a result, `media_type` now survives the round-trip.

Verified with the issue's reproduction:

- before: `{"type": "file", "file": {"file_id": "..."}}`
- after: `{"type": "video", "video": {"media_type": "video/webm", "file_id": "..."}}`

A regression test covering the chat-message round-trip is included in `tests/core/test_types.py`.

> Note: the sibling issue #9898 (the `file` block dropping `format` / `detail` / `video_metadata`) is intentionally out of scope here, since it needs passthrough-field modeling on `LMBinaryPart` and is a larger change.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally) — `ruff check` clean on changed lines; new and existing `tests/core/test_types.py` pass
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Behavioral change: video inputs are now sent as `video` blocks rather than `file` blocks. This is the intended shape (it matches the inbound parser and history serializer), but is worth noting for anyone who relied on the previous `file` emission.