### PR TITLE
fix(predict): reject reserved output field names in `ReAct`/`ReActV2` (#9853)

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -41,6 +41,14 @@ class ReAct(Module):
         self.signature = signature = ensure_signature(signature)
         self.max_iters = max_iters
 
+        # `trajectory` is attached to every returned `Prediction`; a user output field with that
+        # name would collide with the keyword argument and raise an opaque TypeError mid-forward.
+        if "trajectory" in signature.output_fields:
+            raise ValueError(
+                "ReAct reserves the output field name `trajectory` for its own metadata. "
+                "Please rename the conflicting field in your signature."
+            )
+
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
         tools = {tool.name: tool for tool in tools}
 

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -21,10 +21,22 @@ if TYPE_CHECKING:
 
 @experimental
 class ReActV2(Module):
+    # Field names ReActV2 attaches to every returned `Prediction`. A user output field with one
+    # of these names would collide with the keyword arguments below and raise an opaque TypeError
+    # mid-`forward()`, so we reject it up front.
+    _RESERVED_OUTPUT_FIELDS = ("history", "termination_reason")
+
     def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
         super().__init__()
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
+
+        reserved = [name for name in self._RESERVED_OUTPUT_FIELDS if name in self.signature.output_fields]
+        if reserved:
+            raise ValueError(
+                f"ReActV2 reserves the output field name(s) {', '.join(reserved)} for its own metadata. "
+                "Please rename the conflicting field(s) in your signature."
+            )
 
         user_tools = [tool if isinstance(tool, Tool) else Tool(tool) for tool in tools]
         self.tools = {tool.name: tool for tool in user_tools}

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -10,6 +10,14 @@ from dspy.utils.dummies import DummyLM
 from dspy.utils.exceptions import ContextWindowExceededError
 
 
+def test_react_rejects_reserved_trajectory_output_field():
+    # Regression test for #9853: a clear error must be raised at construction instead of an
+    # opaque TypeError mid-forward when a user output field named `trajectory` collides with
+    # the `trajectory=...` keyword ReAct attaches to every Prediction.
+    with pytest.raises(ValueError, match="reserves the output field name `trajectory`"):
+        dspy.ReAct("question -> answer, trajectory: str", tools=[])
+
+
 @pytest.mark.extra
 def test_tool_observation_preserves_custom_type():
     pytest.importorskip("PIL.Image")

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -1,3 +1,5 @@
+import pytest
+
 import dspy
 from dspy.dsp.utils.utils import dotdict
 
@@ -13,6 +15,14 @@ def test_react_v2_submit_tool_returns_original_output_fields():
 
     assert react.tools["submit"](answer="Paris") == {"answer": "Paris"}
     assert "tool_call_results" not in react.react.signature.input_fields
+
+
+@pytest.mark.parametrize("reserved", ["history", "termination_reason"])
+def test_react_v2_rejects_reserved_output_field_names(reserved):
+    # Regression test for #9853: a clear error must be raised at construction instead of an
+    # opaque TypeError mid-forward when a user output field collides with ReActV2's metadata.
+    with pytest.raises(ValueError, match="reserves the output field name"):
+        dspy.ReActV2(f"question -> answer, {reserved}: str", tools=[])
 
 
 def test_react_v2_text_mock_lm_loop_records_inputs_once():


### PR DESCRIPTION
## 📝 Changes Description

Fixes #9853.

`ReActV2` attaches `history` and `termination_reason` to every returned `Prediction` (and `ReAct` attaches `trajectory`). If a user's signature declared an output field with one of those names, the `Prediction(**final_outputs, history=...)` call sites collided and raised an opaque `TypeError: got multiple values for keyword argument` partway through `forward()` — after work had already been done.

This validates the signature at construction time and raises a clear `ValueError` naming the conflicting field, for both `ReActV2` (`history`, `termination_reason`) and `ReAct` (`trajectory`).

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally) — `ruff check` clean; react tests pass
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Signatures that previously declared a reserved output field name now fail fast at construction with a clear error instead of crashing mid-`forward()`. Prepared with the assistance of an AI agent; verified locally (the issue's reproduction + react test suites + `ruff`).