### PR TITLE
fix(clients): preserve provider-specific `file` block fields (#9898)

### DIFF
--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -340,6 +340,10 @@ def binary_to_openai(binary: LMBinaryPart) -> dict[str, Any]:
         file_data["file_id"] = binary.file_id
     if binary.filename is not None:
         file_data["filename"] = binary.filename
+    # Re-emit provider-specific fields (e.g. format, detail, video_metadata) that were preserved
+    # on the way in, without letting them overwrite the canonical keys computed above.
+    for key, value in binary.extra_file_fields.items():
+        file_data.setdefault(key, value)
     return {"type": "file", "file": file_data}
 
 

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -137,6 +137,9 @@ class LMBinaryPart(LMSourcePart):
     type: Literal["binary"] = "binary"
     media_type: str = "application/octet-stream"
     filename: str | None = None
+    # Provider-specific `file` block fields (e.g. `format`, `detail`, `video_metadata`) that are
+    # not modeled explicitly. They are preserved so they survive the round-trip to the LM.
+    extra_file_fields: dict[str, Any] = Field(default_factory=dict)
 
 
 class LMToolCallPart(LMBasePart):
@@ -1887,15 +1890,21 @@ def _audio_dict_to_part(audio: dict[str, Any]) -> LMAudioPart:
     raise ValueError("Audio content block requires data, url, file_id, or path.")
 
 
+_BINARY_FILE_RESERVED_KEYS = frozenset({"file_data", "data", "file_id", "filename"})
+
+
 def _binary_dict_to_part(file: dict[str, Any]) -> LMBinaryPart:
+    # Preserve any provider-specific fields (e.g. format, detail, video_metadata) so they are
+    # not silently dropped on the way back out to the LM.
+    extra = {key: value for key, value in file.items() if key not in _BINARY_FILE_RESERVED_KEYS}
     if file.get("file_data") is not None:
         media_type, data = _split_data_uri(file["file_data"])
-        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"))
+        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"), extra_file_fields=extra)
     if file.get("data") is not None:
         media_type, data = _split_data_uri(file["data"])
-        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"))
+        return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"), extra_file_fields=extra)
     if file.get("file_id") is not None:
-        return LMBinaryPart(file_id=file["file_id"], filename=file.get("filename"))
+        return LMBinaryPart(file_id=file["file_id"], filename=file.get("filename"), extra_file_fields=extra)
     raise ValueError("Binary content block requires data, file_data, or file_id.")
 
 

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -3,6 +3,7 @@ import pytest
 
 from dspy.core.types import (
     LMAudioPart,
+    LMBinaryPart,
     LMConfig,
     LMDocumentPart,
     LMHistoryEntry,
@@ -140,6 +141,31 @@ def test_video_data_round_trips_through_history_messages():
     assert isinstance(round_tripped, LMVideoPart)
     assert round_tripped.data == "YWJj"
     assert round_tripped.media_type == "video/mp4"
+
+
+def test_file_block_preserves_provider_specific_fields():
+    """Regression test for #9898.
+
+    Provider-specific `file` fields (e.g. `format`, `detail`, `video_metadata`) must survive the
+    round-trip instead of being silently dropped during message normalization.
+    """
+    from dspy.clients.openai_format import message_to_openai_chat
+
+    block = {
+        "type": "file",
+        "file": {
+            "file_id": "file-123",
+            "format": "video/webm",
+            "detail": "high",
+            "video_metadata": {"fps": 1.0},
+        },
+    }
+    part = LMMessage(role="user", content=[block]).parts[0]
+    assert isinstance(part, LMBinaryPart)
+    assert part.extra_file_fields == {"format": "video/webm", "detail": "high", "video_metadata": {"fps": 1.0}}
+
+    emitted = message_to_openai_chat(LMMessage(role="user", parts=[part]))["content"][0]
+    assert emitted == block
 
 
 def test_document_source_url_stays_url_and_round_trips_through_history_messages():


### PR DESCRIPTION
## 📝 Changes Description

Fixes #9898.

An OpenAI/litellm `file` content block can carry provider-specific fields like `format`, `detail`, and `video_metadata` (defined on `litellm.types.llms.openai.ChatCompletionFileObjectFile` and consumed by AI Studio / Vertex). During message normalization through the typed `LMPart` layer, `_binary_dict_to_part` only captured `file_id`/`filename`, so those fields were silently dropped and never reached litellm. Losing `format`, for example, forces litellm to HTTP-fetch the URL to infer its MIME type.

This preserves any unmodeled `file` fields on a new `LMBinaryPart.extra_file_fields` mapping and re-emits them in `binary_to_openai` (using `setdefault`, so they never overwrite the canonical keys).

Verified with the issue's reproduction:

- before: `{"file_id": "..."}`
- after: `{"file_id": "...", "format": "video/webm", "detail": "high", "video_metadata": {"fps": 1.0}}`

This is the sibling of #9899 (video block losing `media_type`), which was handled separately.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally) — `ruff check` clean; `tests/core/test_types.py` passes
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Adds one field (`extra_file_fields`) to `LMBinaryPart`. Prepared with the assistance of an AI agent; verified locally (the issue's reproduction + tests + `ruff`).