### PR TITLE
fix: improve structured output fallback in JSONAdapter

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -58,9 +58,12 @@ class JSONAdapter(ChatAdapter):
 
         has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
 
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
-            # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
-            # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
+        supports_structured = lm.supports_response_schema
+
+        if _has_open_ended_mapping(signature) or (
+            not self.use_native_function_calling and has_tool_calls
+        ):
+            # Only fallback when structured output is fundamentally impossible
             lm_kwargs["response_format"] = {"type": "json_object"}
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 


### PR DESCRIPTION
Improves structured output fallback logic in JSONAdapter.
Ensures structured outputs are not prematurely downgraded to JSON mode.