### PR TITLE
Fix JSONAdapter fallback for JSON-mode-only models; preserve Responses tool-call transcripts

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -58,12 +58,15 @@ class JSONAdapter(ChatAdapter):
 
         has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
 
-        supports_structured = lm.supports_response_schema
-
-        if _has_open_ended_mapping(signature) or (
-            not self.use_native_function_calling and has_tool_calls
+        if (
+            _has_open_ended_mapping(signature)
+            or (not self.use_native_function_calling and has_tool_calls)
+            or not lm.supports_response_schema
         ):
-            # Only fallback when structured output is fundamentally impossible
+            # Fall back to JSON mode when structured-output cannot be used:
+            # - signature contains open-ended mapping types (e.g. dict[str, Any])
+            # - native function calling is disabled while `ToolCalls` is present
+            # - the LLM does not support structured/schema mode
             lm_kwargs["response_format"] = {"type": "json_object"}
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -58,9 +58,12 @@ class JSONAdapter(ChatAdapter):
 
         has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
 
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
-            # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
-            # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
+        supports_structured = lm.supports_response_schema
+
+        if _has_open_ended_mapping(signature) or (
+            not self.use_native_function_calling and has_tool_calls
+        ):
+            # Only fallback when structured output is fundamentally impossible
             lm_kwargs["response_format"] = {"type": "json_object"}
             return call_fn(lm, lm_kwargs, signature, demos, inputs)
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -12,6 +12,7 @@ from anyio.streams.memory import MemoryObjectSendStream
 
 import dspy
 from dspy.clients._litellm import get_litellm, is_litellm_context_window_error
+from dspy.clients.openai_format import responses_tool_output_text
 from dspy.clients.cache import request_cache
 from dspy.clients.openai import OpenAIProvider
 from dspy.clients.provider import Provider, ReinforceJob, TrainingJob
@@ -110,6 +111,13 @@ class LM(BaseLM):
             callbacks=callbacks,
             **kwargs,
         )
+
+        # Validate model_type early to avoid an unbound `completion` later in `forward()`.
+        if self.model_type not in {"chat", "text", "responses"}:
+            raise LMConfigurationError(
+                f"Unsupported model_type {self.model_type!r}; expected 'chat', 'text', or 'responses'.",
+                model=self.model,
+            )
 
         self.provider = provider or self.infer_provider()
         self.finetuning_model = finetuning_model
@@ -627,15 +635,51 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     if "messages" in request:
         input_items = []
         for msg in request.pop("messages"):
+            role = msg.get("role", "user")
             content_blocks = []
             c = msg.get("content")
             if isinstance(c, str):
                 content_blocks.append({"type": "input_text", "text": c})
             elif isinstance(c, list):
-                # Convert each content item from Chat API format to Responses API format
                 for item in c:
                     content_blocks.append(_convert_content_item_to_responses_format(item))
-            input_items.append({"role": msg.get("role", "user"), "content": content_blocks})
+
+            # Handle tool-result messages from tools (tool -> function_call_output)
+            if role == "tool":
+                # For tool outputs, emit a function_call_output item with optional call_id/name
+                output_text = responses_tool_output_text(c)
+                item: dict[str, Any] = {"type": "function_call_output", "output": output_text}
+                if msg.get("tool_call_id") is not None:
+                    item["call_id"] = msg.get("tool_call_id")
+                if msg.get("name") is not None:
+                    item["name"] = msg.get("name")
+                input_items.append(item)
+                continue
+
+            # For assistant messages that include tool_calls, we may omit the assistant content
+            # item if content is None and tool_calls are present (Responses API expects separate
+            # function_call items for each tool call).
+            has_tool_calls = bool(msg.get("tool_calls"))
+            if content_blocks or role != "assistant" or not has_tool_calls:
+                item = {"role": role, "content": content_blocks}
+                if msg.get("name") is not None:
+                    item["name"] = msg.get("name")
+                input_items.append(item)
+
+            # Emit function_call items for assistant tool calls
+            if role == "assistant" and has_tool_calls:
+                for tool_call in msg.get("tool_calls"):
+                    function = tool_call.get("function", {})
+                    func_item: dict[str, Any] = {
+                        "type": "function_call",
+                        "name": function.get("name", ""),
+                        "arguments": function.get("arguments", "{}"),
+                    }
+                    call_id = tool_call.get("id") or tool_call.get("call_id")
+                    if call_id is not None:
+                        func_item["call_id"] = call_id
+                    input_items.append(func_item)
+
         request["input"] = input_items
     # Convert `reasoning_effort` to reasoning format supported by the Responses API
     if "reasoning_effort" in request:

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1514,6 +1514,38 @@ def test_responses_api_preserves_multi_message_structure():
     assert result["input"][3]["content"] == [{"type": "input_text", "text": "And 3+3?"}]
 
 
+def test_convert_chat_request_preserves_tool_calls_and_results():
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "model": "openai/gpt-5-mini",
+        "messages": [
+            {"role": "user", "content": "What is the weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})},
+                        "id": "call_1",
+                    }
+                ],
+            },
+            {"role": "tool", "content": '{"temperature": "22 C"}', "tool_call_id": "call_1", "name": "get_weather"},
+        ],
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+    inputs = result["input"]
+
+    # Should include a function_call item for the assistant tool call
+    assert any(item.get("type") == "function_call" and item.get("name") == "get_weather" for item in inputs)
+
+    # Should include a function_call_output for the tool result with the matching call_id
+    assert any(item.get("type") == "function_call_output" and item.get("call_id") == "call_1" for item in inputs)
+
+
 def test_responses_api_with_image_input():
     api_response = make_response(
         output_blocks=[


### PR DESCRIPTION
Summary: Improve structured-output fallback clarity, add defensive model_type validation, and ensure assistant tool-calls and tool-result messages are preserved when converting chat requests to the Responses API.

Why: Prevent accidental attempts to use structured/schema mode on LMs that only support JSON-mode; avoid confusing runtime errors from invalid model_type; and avoid losing tool-call metadata when sending Requests to Responses-style backends.