### PR TITLE
Fix parse_value for int-valued Literal fields in ChatAdapter

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -170,6 +170,13 @@ def parse_value(value, annotation):
             if v in allowed:
                 return v
 
+            # Non-string members (e.g. `Literal[1, 2, 3]`) never equal the raw
+            # text emitted by adapters that surface every field as a string, so
+            # fall back to matching on the stringified member.
+            for member in allowed:
+                if not isinstance(member, str) and v == str(member):
+                    return member
+
         raise ValueError(f"{value!r} is not one of {allowed!r}")
 
     if not isinstance(value, str):

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -77,6 +77,23 @@ def test_parse_value_literal():
         parse_value("invalid", Literal["option1", "option2"])
 
 
+def test_parse_value_literal_non_string_members():
+    # Adapters that surface fields as text (e.g. ChatAdapter) emit the value of
+    # an int-valued Literal as a string, which must still resolve to the member.
+    assert parse_value("1", Literal[1, 2, 3]) == 1
+    assert parse_value("2", Literal[1, 2, 3]) == 2
+    assert parse_value("'1'", Literal[1, 2, 3]) == 1
+
+    # Mixed int/str literal: an exact string match wins, otherwise fall back to
+    # the stringified non-string member.
+    assert parse_value("bar", Literal[1, "bar"]) == "bar"
+    assert parse_value("1", Literal[1, "bar"]) == 1
+
+    # Values outside the allowed set still raise.
+    with pytest.raises(ValueError):
+        parse_value("4", Literal[1, 2, 3])
+
+
 def test_parse_value_union():
     # Test Union with None (Optional)
     assert parse_value("test", Optional[str]) == "test"


### PR DESCRIPTION
## What

`parse_value` raised `ValueError` for output fields typed as an int-valued `Literal`, e.g. `Literal[1, 2, 3]`.

Adapters that surface every field as text (notably `ChatAdapter`) hand the field value to `parse_value` as a **string** (`"1"`). For a `Literal`, `parse_value` only compared the raw/stripped string against the allowed members, so a non-string member (`1`) never matched `"1"` and the call raised:

```
ValueError: '1' is not one of (1, 2, 3)
```

This is the scalar form of the long-standing problem reported in #1870 (`List[Literal[1, 0]]`).

## Fix

In the `Literal` branch of `parse_value`, after the existing exact-match attempts, fall back to matching the stripped string against the **stringified form** of each non-string member, returning the original typed member:

```python
for member in allowed:
    if not isinstance(member, str) and v == str(member):
        return member
```

- Exact string matches still take precedence (`Literal[1, "bar"]` + `"bar"` → `"bar"`).
- Out-of-set values still raise (`"4"` for `Literal[1, 2, 3]`).
- Only non-string members are stringified, so string literals are unaffected.

## Tests

Added `test_parse_value_literal_non_string_members` covering int-only and mixed int/str literals, including the out-of-set raise.

```
# new test fails on main (proves the bug):
tests/adapters/test_adapter_utils.py::test_parse_value_literal_non_string_members
  ValueError: '1' is not one of (1, 2, 3)

# with the fix:
$ pytest tests/adapters/test_adapter_utils.py -q
7 passed

# regression check:
$ pytest tests/adapters/test_chat_adapter.py tests/adapters/test_adapter_utils.py -q
76 passed
```

`ruff format` clean; no new `ruff check` findings on the changed lines.

Related: #1870