### PR TITLE
Fix KeyError in _check_truncation for OpenAI reasoning models

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -435,8 +435,9 @@ class LM(BaseLM):
 
     def _check_truncation(self, results):
         if self.model_type != "responses" and any(c.finish_reason == "length" for c in results["choices"]):
+            max_tokens = self.kwargs.get("max_tokens", self.kwargs.get("max_completion_tokens"))
             logger.warning(
-                f"LM response was truncated due to exceeding max_tokens={self.kwargs['max_tokens']}. "
+                f"LM response was truncated due to exceeding max_tokens={max_tokens}. "
                 "You can inspect the latest LM interactions with `dspy.inspect_history()`. "
                 "To avoid truncation, consider passing a larger max_tokens when setting up dspy.LM. "
                 f"You may also consider increasing the temperature (currently {self.kwargs['temperature']}) "

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -440,6 +440,20 @@ def test_gpt_5_chat_not_reasoning_model():
     assert lm.kwargs["temperature"] == 0.7
 
 
+def test_check_truncation_handles_reasoning_models(monkeypatch):
+    """Reasoning models store max_completion_tokens, so a truncated response must not KeyError."""
+
+    def fake_completion(*, cache, num_retries, retry_strategy, **request):
+        return ModelResponse(
+            choices=[Choices(finish_reason="length", message=Message(role="assistant", content="Hi!"))],
+            usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            model="openai/gpt-5-nano",
+        )
+
+    monkeypatch.setattr(litellm, "completion", fake_completion)
+    assert dspy.LM("openai/gpt-5-nano")("Query") == ["Hi!"]
+
+
 def test_base_lm_init_uses_lm_defaults_and_isolates_callback_list():
     callbacks = [object()]
     lm = dspy.BaseLM("custom-model", callbacks=callbacks)


### PR DESCRIPTION
## Bug

Calling an OpenAI reasoning model (o-series or gpt-5*) crashes with `KeyError: 'max_tokens'` whenever a response is truncated (`finish_reason == "length"`).

## Root cause

`LM._get_initial_kwargs` stores the token budget as `max_completion_tokens` for reasoning models, not `max_tokens`.

But `LM._check_truncation` builds its warning with `self.kwargs['max_tokens']`. That key is absent for reasoning models, so the truncation-warning path itself raises `KeyError` and crashes `forward()` / `aforward()`.

## Fix

Look up the budget with a fallback:

`self.kwargs.get("max_tokens", self.kwargs.get("max_completion_tokens"))`

This is a one-line fix with no behavior change for non-reasoning models.

## Tests

Adds `test_check_truncation_handles_reasoning_models`.

The test mocks a `gpt-5-nano` call returning `finish_reason == "length"` and verifies that the call returns normally instead of raising `KeyError`.

This fails before the fix and passes after the fix.

## Notes

No existing open issue appears to track this. This is a latent consequence of the reasoning-model token-parameter handling. AI assistance was used to reproduce the issue, create the failing test, apply the minimal fix, and verify locally.
