### PR TITLE
lm: fix KeyError in _check_truncation for reasoning models (GPT-5, o-series)

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -435,11 +435,12 @@ class LM(BaseLM):
 
     def _check_truncation(self, results):
         if self.model_type != "responses" and any(c.finish_reason == "length" for c in results["choices"]):
+            token_limit = self.kwargs.get("max_tokens") or self.kwargs.get("max_completion_tokens")
             logger.warning(
-                f"LM response was truncated due to exceeding max_tokens={self.kwargs['max_tokens']}. "
+                f"LM response was truncated due to exceeding max_tokens={token_limit}. "
                 "You can inspect the latest LM interactions with `dspy.inspect_history()`. "
                 "To avoid truncation, consider passing a larger max_tokens when setting up dspy.LM. "
-                f"You may also consider increasing the temperature (currently {self.kwargs['temperature']}) "
+                f"You may also consider increasing the temperature (currently {self.kwargs.get('temperature')}) "
                 " if the reason for truncation is repetition."
             )
 


### PR DESCRIPTION
## Problem

`LM._check_truncation()` crashes with `KeyError: 'max_tokens'` when using OpenAI reasoning models (GPT-5, o1, o3, o4-mini, etc.).

**Root cause:** `_get_initial_kwargs()` correctly stores `max_completion_tokens` instead of `max_tokens` for reasoning models, but `_check_truncation()` directly accesses `self.kwargs['max_tokens']` and `self.kwargs['temperature']` — both raise `KeyError` when the response is truncated (`finish_reason == "length"`).

```python
# BEFORE (crashes for reasoning models):
f"LM response was truncated due to exceeding max_tokens={self.kwargs['max_tokens']}. "
f"...temperature (currently {self.kwargs['temperature']}) "

# AFTER (safe for all models):
token_limit = self.kwargs.get("max_tokens") or self.kwargs.get("max_completion_tokens")
f"LM response was truncated due to exceeding max_tokens={token_limit}. "
f"...temperature (currently {self.kwargs.get('temperature')}) "
```

## Fix

- Use `.get()` with a fallback from `max_tokens` → `max_completion_tokens` for the token limit display
- Use `.get()` for `temperature` to avoid `KeyError` when temperature is not set

## Reproduces

Any call to a GPT-5 or o-series model where the response is truncated (`finish_reason == "length"`) will crash instead of logging the truncation warning.