### PR TITLE
fix(miprov2): guard randrange against empty range when max_bootstrapped_demos=0

### DIFF
--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -391,7 +391,7 @@ def create_n_fewshot_demo_sets(
         else:
             # shuffled few-shot
             rng.shuffle(trainset_copy)
-            size = rng.randint(min_num_samples, max_bootstrapped_demos)
+            size = rng.randint(min_num_samples, max(min_num_samples, max_bootstrapped_demos))
 
             teleprompter = BootstrapFewShot(
                 metric=metric,


### PR DESCRIPTION
Fixes #9938

## Problem

When running MIPROv2 optimization with `max_bootstrapped_demos=0`, the optimizer crashes with:
```
ValueError: empty range for randrange() (1, 0)
```

In `dspy/teleprompt/utils.py` line 394, `rng.randint(min_num_samples, max_bootstrapped_demos)` is called with `min_num_samples=1` (default) and `max_bootstrapped_demos=0`, producing an empty range `[1, 0]`.

## What changed

Added `max(min_num_samples, max_bootstrapped_demos)` to ensure the upper bound is never less than the lower bound:

```python
# Before:
size = rng.randint(min_num_samples, max_bootstrapped_demos)

# After:
size = rng.randint(min_num_samples, max(min_num_samples, max_bootstrapped_demos))
```

When `max_bootstrapped_demos=0`, this becomes `randint(1, 1) = 1`, using 1 bootstrapped demo instead of crashing.

## Validation

- No behavior change when `max_bootstrapped_demos > 0` (normal case)
- Prevents crash when `max_bootstrapped_demos=0`
- The `zeroshot` override issue mentioned in the issue is a separate design concern