### PR TITLE
fix(propose): handle None parent namespace for dynamic signatures

### DIFF
--- a/dspy/propose/utils.py
+++ b/dspy/propose/utils.py
@@ -172,13 +172,21 @@ def get_dspy_source_code(module):
             except TypeError:
                 continue
             if isinstance(item, Parameter):
-                if hasattr(item, "signature") and item.signature is not None and item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig" not in completed_set:
-                    try:
-                        header.append(inspect.getsource(item.signature))
-                        print(inspect.getsource(item.signature))
-                    except (TypeError, OSError):
-                        header.append(str(item.signature))
-                    completed_set.add(item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig")
+                if hasattr(item, "signature") and item.signature is not None:
+                    # Dynamically created signatures (e.g. dspy.Signature("q -> a")) may have
+                    # __pydantic_parent_namespace__ set to None, so fall back to the class name.
+                    parent_namespace = getattr(item.signature, "__pydantic_parent_namespace__", None)
+                    if parent_namespace and "signature_name" in parent_namespace:
+                        signature_key = parent_namespace["signature_name"] + "_sig"
+                    else:
+                        signature_key = item.signature.__name__ + "_sig"
+                    if signature_key not in completed_set:
+                        try:
+                            header.append(inspect.getsource(item.signature))
+                            print(inspect.getsource(item.signature))
+                        except (TypeError, OSError):
+                            header.append(str(item.signature))
+                        completed_set.add(signature_key)
             if isinstance(item, dspy.Module):
                 code = get_dspy_source_code(item).strip()
                 if code not in completed_set:

--- a/tests/propose/test_utils.py
+++ b/tests/propose/test_utils.py
@@ -1,0 +1,37 @@
+import dspy
+from dspy.propose.utils import get_dspy_source_code
+
+
+def test_get_dspy_source_code_with_dynamic_signature():
+    """Dynamically created signatures can leave ``__pydantic_parent_namespace__`` set
+    to ``None`` (for example on Python 3.14), and extracting their source code must not
+    crash with ``TypeError: 'NoneType' object is not subscriptable``."""
+
+    class DynamicProgram(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predict = dspy.Predict(dspy.Signature("question -> answer"))
+
+    program = DynamicProgram()
+    # Reproduce the state where pydantic leaves the parent namespace unset.
+    program.predict.signature.__pydantic_parent_namespace__ = None
+
+    source = get_dspy_source_code(program)
+    assert isinstance(source, str)
+
+
+def test_get_dspy_source_code_with_class_signature():
+    class QASignature(dspy.Signature):
+        """Answer the question."""
+
+        question = dspy.InputField()
+        answer = dspy.OutputField()
+
+    class QAProgram(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predict = dspy.Predict(QASignature)
+
+    source = get_dspy_source_code(QAProgram())
+    assert isinstance(source, str)
+    assert "QASignature" in source


### PR DESCRIPTION
Closes #9937.

  ## What
  `get_dspy_source_code` (in `dspy/propose/utils.py`) builds a dedup key from
  `item.signature.__pydantic_parent_namespace__["signature_name"]`. For dynamically
  created signatures — e.g. `dspy.Signature("question -> answer")` — that attribute can
  be `None`, so the subscript raises `TypeError: 'NoneType' object is not subscriptable`
  and crashes `MIPROv2` optimization for any program containing a dynamic signature.

  ## Root cause
  Dynamic signatures are built via `create_model(__base__=Signature)`. On Python 3.14,
  `SignatureMeta` sets `__pydantic_reset_parent_namespace__ = False` (to avoid a
  cloudpickle issue), and pydantic leaves `__pydantic_parent_namespace__` as `None` for
  these classes. The grounded proposer then subscripts `None` when collecting source code.

  ## Fix
  Read the parent namespace defensively and fall back to the signature class `__name__`
  when it is unavailable. For class-defined signatures `__name__` equals the existing
  `signature_name` value, so the dedup key — and therefore behavior — is unchanged on
  that path; only the previously-crashing dynamic-signature path changes.

  ## Tests
  Adds `tests/propose/test_utils.py`:
  - `test_get_dspy_source_code_with_dynamic_signature` reproduces the `None`
    parent-namespace state and asserts a string is returned instead of raising. It fails
    on `main` with the reported `TypeError` and passes with this change.
  - `test_get_dspy_source_code_with_class_signature` confirms the class-defined path is
    unaffected.
