### PR TITLE
fix(ChatAdapter): keep field-header offset on the stripped line in parse

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -219,11 +219,12 @@ class ChatAdapter(Adapter):
         sections = [(None, [])]
 
         for line in completion.splitlines():
-            match = field_header_pattern.match(line.strip())
+            stripped_line = line.strip()
+            match = field_header_pattern.match(stripped_line)
             if match:
                 # If the header pattern is found, split the rest of the line as content
                 header = match.group(1)
-                remaining_content = line[match.end() :].strip()
+                remaining_content = stripped_line[match.end() :].strip()
                 sections.append((header, [remaining_content] if remaining_content else []))
             else:
                 sections[-1][1].append(line)

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2648,6 +2648,27 @@ def test_chat_adapter_parses_float_with_underscores():
         assert result[0]["score"].score == 123456.789
 
 
+def test_chat_adapter_parse_handles_indented_field_header():
+    """
+    Regression test: when a field header line is indented (e.g. emitted inside a
+    markdown list or quoted block), ``parse`` matched the header against the
+    stripped line but sliced the original, unstripped line. This shifted the
+    slice start into the trailing ``## ]]`` marker and leaked marker characters
+    into the parsed value. The offset must be applied to the same stripped line.
+    """
+    adapter = dspy.ChatAdapter()
+    signature = dspy.Signature("question -> answer")
+
+    # Control: a non-indented header parses correctly.
+    assert adapter.parse(signature, "[[ ## answer ## ]] Paris") == {"answer": "Paris"}
+
+    # Indented header must not leak the ``]]`` marker into the value.
+    assert adapter.parse(signature, "  [[ ## answer ## ]] Paris") == {"answer": "Paris"}
+
+    # Indented header followed by the value on the next line.
+    assert adapter.parse(signature, "\t[[ ## answer ## ]]\nParis") == {"answer": "Paris"}
+
+
 def test_format_system_message():
     class MySignature(dspy.Signature):
         """Answer the question with multiple answers and scores"""


### PR DESCRIPTION
## What

`ChatAdapter.parse` matches the field-header pattern against `line.strip()` but then slices the original, unstripped `line` with `match.end()`:

```python
match = field_header_pattern.match(line.strip())   # offset is into the STRIPPED line
if match:
    header = match.group(1)
    remaining_content = line[match.end() :].strip()  # but slices the UNSTRIPPED line
```

When a header line has leading whitespace, `match.end()` (an offset into the stripped string) is applied to the longer unstripped string, so the slice starts inside the trailing `## ]]` marker and leaks marker characters into the value.

## Repro (before this change)

```python
import dspy
from dspy.adapters.chat_adapter import ChatAdapter

sig = dspy.Signature("question -> answer")
ad = ChatAdapter()

ad.parse(sig, "[[ ## answer ## ]] Paris")     # {'answer': 'Paris'}   (ok, no indent)
ad.parse(sig, "  [[ ## answer ## ]] Paris")   # {'answer': ']] Paris'} (leaked marker)
ad.parse(sig, "  [[ ## answer ## ]]\nParis")  # {'answer': ']]\nParis'}
```

LMs commonly indent markers (markdown lists, quoted/nested blocks), and `ChatAdapter` is the default adapter, so this is silent value corruption on the common path. For non-string fields it instead raises a spurious `AdapterParseError`.

## Fix

Match and slice the same stripped line so the offset is consistent. Non-header content lines are still appended unchanged, so multi-line values are unaffected.

## Tests

Added `test_chat_adapter_parse_handles_indented_field_header`, which fails on `main` and passes with this change. It covers a non-indented control, an indented header, and an indented header with the value on the next line. Found via code inspection; no existing test exercised an indented header.
