### PR TITLE
Preserve input/label split when copying an Example

### DIFF
--- a/dspy/primitives/example.py
+++ b/dspy/primitives/example.py
@@ -111,6 +111,12 @@ class Example:
         # Initialize from a base Example if provided
         if base and isinstance(base, type(self)):
             self._store = base._store.copy()
+            # Preserve the input/label split so copy()/without()/Example(base=...)
+            # don't silently break .inputs()/.labels() on the new instance.
+            # Use getattr: subclasses such as Prediction don't keep _input_keys.
+            base_input_keys = getattr(base, "_input_keys", None)
+            if base_input_keys is not None:
+                self._input_keys = set(base_input_keys)
 
         # Initialize from a dict if provided
         elif base and isinstance(base, dict):

--- a/tests/primitives/test_example.py
+++ b/tests/primitives/test_example.py
@@ -120,6 +120,36 @@ def test_example_copy_without():
         _ = without_a.a
 
 
+def test_example_copy_preserves_input_keys():
+    """copy()/without() must preserve the input/label split.
+
+    Regression: the input keys were reset to None on copy, so .inputs()/.labels()
+    raised on any copied Example (and Example(base=other) lost the split too).
+    """
+    example = Example(question="q", answer="a").with_inputs("question")
+
+    copied = example.copy(answer="b")
+    assert copied._input_keys == {"question"}
+    assert copied.inputs().toDict() == {"question": "q"}
+    assert copied.labels().toDict() == {"answer": "b"}
+
+    # without() routes through copy(); the split must survive for remaining fields.
+    no_extra = example.copy(source="web").without("source")
+    assert no_extra._input_keys == {"question"}
+    assert no_extra.inputs().toDict() == {"question": "q"}
+
+    # Constructing directly from an Example base also preserves the split.
+    assert Example(base=example)._input_keys == {"question"}
+
+
+def test_prediction_copy_does_not_require_input_keys():
+    # Example subclasses (e.g. Prediction) don't keep _input_keys; copy() must not crash.
+    import dspy
+
+    copied = dspy.Prediction(answer="a").copy(answer="b")
+    assert copied.answer == "b"
+
+
 def test_example_to_dict():
     example = Example(a=1, b=2)
     assert example.toDict() == {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary

`Example.copy()`, `Example.without()`, and `Example(base=existing_example)` all route through
`Example.__init__`, which copies `_store` but leaves `_input_keys = None`. As a result a copied
`Example` loses the input/label split set by `.with_inputs()` — `.inputs()` then raises and
`.labels()` breaks.

## Reproduce (no LM)

```python
import dspy
ex = dspy.Example(question="q", answer="a").with_inputs("question")
print(ex.inputs().keys())          # ['question']  ✓
cp = ex.copy(answer="b")
print(cp.inputs().keys())          # ValueError: Inputs have not been set for this example.
```

This matters because optimizers/evaluators copy examples (e.g. `BootstrapFewShot`, demo handling)
and rely on `.inputs()`/`.labels()`. `with_inputs()` only works because it *re-sets* `_input_keys`
after the internal `copy()`; a plain `.copy()` does not.

## Fix

In `Example.__init__`, when `base` is an `Example`, inherit its `_input_keys` (as a fresh `set` to
avoid aliasing). `with_inputs()` still overrides it explicitly, so its behavior is unchanged;
`inputs()`/`labels()` build from a **dict** base and are unaffected.

## Tests

`tests/primitives/test_example.py::test_example_copy_preserves_input_keys` — fail-before:
`copied._input_keys is None`; pass-after: `{"question"}`, and `.inputs()` / `.labels()` / `without()`
work on the copy. Full `test_example` / `test_module` / `signatures` (136) and `predict` /
`teleprompt` (270) pass. CPU-only, no GPU.

(Out of scope: the same `__init__` branch also doesn't carry `_demos` from an Example base; left
alone here to keep this focused on the `_input_keys` data-loss bug.)
