### PR TITLE
Preserve Predict.config across dump_state/load_state

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -86,6 +86,7 @@ class Predict(Module, Parameter):
 
         state["signature"] = self.signature.dump_state()
         state["lm"] = self.lm.dump_state() if self.lm else None
+        state["config"] = dict(self.config)  # copy so mutating the dumped state can't alter self.config
         return state
 
     def load_state(self, state: dict, *, allow_unsafe_lm_state: bool = False) -> "Predict":

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -92,6 +92,28 @@ def test_lm_after_dump_and_load_state():
     assert new_instance.lm.dump_state() == expected_lm_state
 
 
+def test_config_after_dump_and_load_state():
+    # Per-predictor generation config must survive a save/load round-trip.
+    # Regression: dump_state did not serialize self.config, so it was lost on load.
+    predict_instance = Predict("question -> answer", max_tokens=1234, n=4)
+    assert predict_instance.config == {"max_tokens": 1234, "n": 4}
+
+    dumped_state = predict_instance.dump_state()
+    assert "config" in dumped_state
+
+    new_instance = Predict("question -> answer")
+    new_instance.load_state(dumped_state)
+    assert new_instance.config == {"max_tokens": 1234, "n": 4}
+
+    # Backward compatibility: state files saved before this change (no "config" key)
+    # must still load without error, leaving the config untouched.
+    legacy_state = dict(dumped_state)
+    del legacy_state["config"]
+    legacy_instance = Predict("question -> answer")
+    legacy_instance.load_state(legacy_state)
+    assert legacy_instance.config == {}
+
+
 def test_base_lm_dump_state_ignores_internal_class_marker_kwarg():
     lm = CustomStateLM(model="custom-model", deployment="prod", **{LM_CLASS_STATE_KEY: "malicious.module.LM"})
 


### PR DESCRIPTION
## Summary

`Predict.dump_state` serializes `traces`, `train`, `demos`, `signature`, and `lm`, but **not**
`self.config`. So per-predictor generation settings passed to `Predict(...)` (e.g. `max_tokens`, `n`,
and any other LM kwargs) are silently lost on `dump_state` / `load_state` — a reloaded `Predict` comes
back with `config = {}`.

## Reproduce

```python
import dspy
p = dspy.Predict("question -> answer", max_tokens=1234, n=4)
print(p.config)                       # {'max_tokens': 1234, 'n': 4}
state = p.dump_state()
print("config" in state)              # False
p2 = dspy.Predict("question -> answer")
p2.load_state(state)
print(p2.config)                      # {}   <- config dropped
```

## Fix

Serialize `config` in `dump_state`:

```python
state["config"] = self.config
```

`load_state` already restores any non-excluded key through its generic `setattr` loop, so no change
is needed there. State files saved before this change (which lack a `"config"` key) still load
unchanged — the loop simply doesn't set it.

## Tests

`tests/predict/test_predict.py::test_config_after_dump_and_load_state` — fail-before: `config` missing
from dumped state / `config == {}` after load; pass-after: `config == {"max_tokens": 1234, "n": 4}`.
Includes a backward-compat case (legacy state without `"config"` loads without error). Full
`tests/predict` suite passes. No LM/GPU needed.
