### PR TITLE
Sample labeled demos independently per predictor in BootstrapFewShot

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -266,7 +266,7 @@ class BootstrapFewShot(Teleprompter):
             sample_size = min(self.max_labeled_demos - len(augmented_demos), len(raw_demos))
             sample_size = max(0, sample_size)
 
-            raw_demos = rng.sample(raw_demos, sample_size)
-            predictor.demos = augmented_demos + raw_demos
+            sampled_demos = rng.sample(raw_demos, sample_size)
+            predictor.demos = augmented_demos + sampled_demos
 
         return self.student

--- a/tests/teleprompt/test_bootstrap.py
+++ b/tests/teleprompt/test_bootstrap.py
@@ -36,6 +36,42 @@ class SimpleModule(dspy.Module):
         return self.predictor(**kwargs)
 
 
+class TwoPredictorModule(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.p1 = Predict("input -> output")
+        self.p2 = Predict("input -> output")
+
+    def forward(self, **kwargs):
+        return self.p2(**self.p1(**kwargs))
+
+
+def test_bootstrap_labeled_demos_sampled_independently_per_predictor():
+    # Each predictor must draw its labeled demos from the FULL validation pool.
+    # Regression: _train reassigned the shared `raw_demos` to the sampled subset
+    # inside the per-predictor loop, so later predictors sampled from the prior
+    # predictor's leftovers -- starving them when an earlier predictor consumed
+    # most of the pool via bootstrapped (augmented) demos.
+    student = TwoPredictorModule()
+    names = [name for name, _ in student.named_predictors()]
+    pool = [Example(input=f"q{i}", output=f"a{i}").with_inputs("input") for i in range(10)]
+    augmented = [Example(input=f"aug{i}", output=f"x{i}").with_inputs("input") for i in range(5)]
+
+    bootstrap = BootstrapFewShot(metric=simple_metric, max_bootstrapped_demos=5, max_labeled_demos=8)
+    bootstrap.student = student
+    bootstrap.validation = pool
+    # First predictor has 5 bootstrapped demos; second has none.
+    bootstrap.name2traces = {names[0]: list(augmented), names[1]: []}
+
+    bootstrap._train()
+
+    p1, p2 = (p for _, p in student.named_predictors())
+    # p1: 5 augmented + 3 labeled = 8
+    assert len(p1.demos) == 8
+    # p2: 0 augmented, so it must still get the full labeled quota from the full pool.
+    assert len(p2.demos) == 8
+
+
 def test_compile_with_predict_instances():
     # Create Predict instances for student and teacher
     # Note that dspy.Predict is not itself a module, so we can't use it directly here


### PR DESCRIPTION
## Summary

`BootstrapFewShot._train` reassigns the shared `raw_demos` pool to the sampled subset **inside** the
per-predictor loop:

```python
raw_demos = self.validation
for name, predictor in self.student.named_predictors():
    augmented_demos = self.name2traces[name][: self.max_bootstrapped_demos]
    sample_size = max(0, min(self.max_labeled_demos - len(augmented_demos), len(raw_demos)))
    raw_demos = rng.sample(raw_demos, sample_size)   # <-- shrinks the shared pool
    predictor.demos = augmented_demos + raw_demos
```

So each subsequent predictor samples from the *previous* predictor's leftovers rather than the full
validation pool. Two consequences:

1. Predictors get an identical, monotonically shrinking demo set instead of independent samples.
2. When an early predictor consumes most of the pool via bootstrapped (augmented) demos, later
   predictors are **starved** of labeled demos.

## Reproduce

A 2-predictor program where the first predictor has 5 bootstrapped demos (`max_bootstrapped_demos=5`,
`max_labeled_demos=8`) and a 10-example validation pool: the first predictor takes `5 + 3` labeled, and
the second predictor — which should still get 8 labeled from the full pool — receives only **3** (the
first predictor's leftovers).

## Fix

Sample into a fresh local variable so the full pool is reused for every predictor:

```python
sampled_demos = rng.sample(raw_demos, sample_size)
predictor.demos = augmented_demos + sampled_demos
```

Behavior-preserving for the single-predictor case.

## Tests

`tests/teleprompt/test_bootstrap.py::test_bootstrap_labeled_demos_sampled_independently_per_predictor`
— fail-before: second predictor gets 3 demos; pass-after: 8. Full `test_bootstrap.py` suite passes.
Deterministic (`random.Random(0)`), no LM/GPU needed.
