### PR TITLE
Match fields by name in Signature.load_state

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -526,6 +526,7 @@ class Signature(BaseModel, metaclass=SignatureMeta):
         for field in cls.fields:
             state["fields"].append(
                 {
+                    "name": field,
                     "prefix": cls.fields[field].json_schema_extra["prefix"],
                     "description": cls.fields[field].json_schema_extra["desc"],
                 }
@@ -538,9 +539,21 @@ class Signature(BaseModel, metaclass=SignatureMeta):
         signature_copy = Signature(deepcopy(cls.fields), cls.instructions)
 
         signature_copy.instructions = state["instructions"]
-        for field, saved_field in zip(signature_copy.fields.values(), state["fields"], strict=False):
-            field.json_schema_extra["prefix"] = saved_field["prefix"]
-            field.json_schema_extra["desc"] = saved_field["description"]
+        saved_fields = state["fields"]
+        if saved_fields and all("name" in saved_field for saved_field in saved_fields):
+            # Match by field name so a reordered (or differently-sized) target signature
+            # is restored correctly rather than by position.
+            saved_by_name = {saved_field["name"]: saved_field for saved_field in saved_fields}
+            for name, field in signature_copy.fields.items():
+                saved_field = saved_by_name.get(name)
+                if saved_field is not None:
+                    field.json_schema_extra["prefix"] = saved_field["prefix"]
+                    field.json_schema_extra["desc"] = saved_field["description"]
+        else:
+            # Backward compatibility: state saved before field names were serialized.
+            for field, saved_field in zip(signature_copy.fields.values(), saved_fields, strict=False):
+                field.json_schema_extra["prefix"] = saved_field["prefix"]
+                field.json_schema_extra["desc"] = saved_field["description"]
 
         return signature_copy
 

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -250,10 +250,12 @@ def test_dump_and_load_state():
         "instructions": "I am just an instruction.",
         "fields": [
             {
+                "name": "sentence",
                 "prefix": "Sentence:",
                 "description": "I am an innocent input!",
             },
             {
+                "name": "sentiment",
                 "prefix": "Sentiment:",
                 "description": "${sentiment}",
             },
@@ -277,6 +279,53 @@ def test_dump_and_load_state():
     assert CustomSignature2.instructions == "I am a malicious instruction."
     assert CustomSignature2.fields["sentence"].json_schema_extra["desc"] == "I am an malicious input!"
     assert CustomSignature2.fields["sentiment"].json_schema_extra["prefix"] == "Sentiment:"
+
+
+def test_load_state_matches_fields_by_name():
+    # load_state must restore each saved field's prefix/desc onto the field with the
+    # SAME name, even when the target signature declares its fields in a different
+    # order. Regression: it assigned by position, corrupting reordered signatures.
+    class Source(dspy.Signature):
+        """Source instruction."""
+
+        question = dspy.InputField(desc="the question")
+        context = dspy.InputField(desc="the context")
+        answer = dspy.OutputField(desc="the answer")
+
+    state = Source.dump_state()
+
+    class Target(dspy.Signature):
+        """Target instruction."""
+
+        context = dspy.InputField(desc="orig context")
+        question = dspy.InputField(desc="orig question")
+        answer = dspy.OutputField(desc="orig answer")
+
+    loaded = Target.load_state(state)
+    assert loaded.fields["question"].json_schema_extra["desc"] == "the question"
+    assert loaded.fields["context"].json_schema_extra["desc"] == "the context"
+    assert loaded.fields["answer"].json_schema_extra["desc"] == "the answer"
+
+
+def test_load_state_backward_compatible_without_names():
+    # Legacy state files saved before field names were serialized must still load
+    # (positionally, as before).
+    class Sig(dspy.Signature):
+        """Instr."""
+
+        question = dspy.InputField(desc="q")
+        answer = dspy.OutputField(desc="a")
+
+    legacy_state = {
+        "instructions": "Instr.",
+        "fields": [
+            {"prefix": "Q:", "description": "d0"},
+            {"prefix": "A:", "description": "d1"},
+        ],
+    }
+    loaded = Sig.load_state(legacy_state)
+    assert loaded.fields["question"].json_schema_extra["desc"] == "d0"
+    assert loaded.fields["answer"].json_schema_extra["desc"] == "d1"
 
 
 def test_typed_signatures_basic_types():


### PR DESCRIPTION
## Summary

`Signature.dump_state` serializes each field's `prefix`/`description` **positionally**, with no field
name, and `Signature.load_state` restores them with a positional `zip`:

```python
# dump_state
state["fields"].append({"prefix": ..., "description": ...})   # no name
# load_state
for field, saved_field in zip(signature_copy.fields.values(), state["fields"], strict=False):
    field.json_schema_extra["prefix"] = saved_field["prefix"]
    field.json_schema_extra["desc"] = saved_field["description"]
```

So loading a saved state into a signature whose fields are declared in a **different order** silently
swaps prefixes/descriptions between fields, and a different field count drops or misaligns them.

## Reproduce

```python
import dspy

class Source(dspy.Signature):
    """Source instruction."""
    question = dspy.InputField(desc="the question")
    context  = dspy.InputField(desc="the context")
    answer   = dspy.OutputField(desc="the answer")

state = Source.dump_state()

class Target(dspy.Signature):
    """Target instruction."""
    context  = dspy.InputField(desc="orig context")
    question = dspy.InputField(desc="orig question")
    answer   = dspy.OutputField(desc="orig answer")

loaded = Target.load_state(state)
print(loaded.fields["question"].json_schema_extra["desc"])  # "the context"  <- wrong (swapped)
```

## Fix

Serialize the field `name` in `dump_state` and match by name in `load_state`, with a **positional
fallback** when the state lacks names so older saved state files still load:

```python
# dump_state: {"name": field, "prefix": ..., "description": ...}
# load_state: if every saved field has a "name", assign by name; else fall back to the positional zip.
```

## Tests

`tests/signatures/test_signature.py`:
- `test_load_state_matches_fields_by_name` — fail-before: `question` gets `"the context"`; pass-after:
  each field keeps its own prefix/desc across a reordered target signature.
- `test_load_state_backward_compatible_without_names` — legacy state (no `name`) still loads positionally.
- Existing `test_dump_and_load_state` updated for the added `name` key.

Full `tests/signatures` (49) and `tests/predict` (197) pass. No LM/GPU needed.
