### PR TITLE
fix(tool): exclude default args from required in format_as_litellm_function_call

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -158,7 +158,7 @@ class Tool(Type):
                 "parameters": {
                     "type": "object",
                     "properties": self.args,
-                    "required": list(self.args.keys()),
+                    "required": [k for k in self.args if "default" not in self.args[k]],
                 },
             },
         }

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -689,6 +689,39 @@ def test_tool_convert_input_schema_to_tool_args_lang_chain():
 
 
 
+def test_format_as_litellm_function_call_required_excludes_defaults():
+    """Args with default values must NOT appear in the 'required' list (issue #9882)."""
+
+    def look_up(query: str, state: str = "fresh") -> str:
+        """Look something up."""
+        return f"{query}:{state}"
+
+    tool = Tool(look_up)
+    schema = tool.format_as_litellm_function_call()
+    params = schema["function"]["parameters"]
+
+    # 'query' has no default → must be required
+    assert "query" in params["required"]
+    # 'state' has a default → must NOT be required
+    assert "state" not in params["required"]
+    # The default value itself must still be present in properties
+    assert params["properties"]["state"]["default"] == "fresh"
+
+
+def test_format_as_litellm_function_call_all_required_when_no_defaults():
+    """When no args have defaults, all should appear in 'required'."""
+
+    def add(x: int, y: int) -> int:
+        """Add two numbers."""
+        return x + y
+
+    tool = Tool(add)
+    schema = tool.format_as_litellm_function_call()
+    params = schema["function"]["parameters"]
+
+    assert set(params["required"]) == {"x", "y"}
+
+
 def test_tool_call_execute():
     def get_weather(city: str) -> str:
         return f"The weather in {city} is sunny"


### PR DESCRIPTION
## Summary

Closes #9882

`format_as_litellm_function_call` built `"required": list(self.args.keys())`, which marks **every** argument as required — including ones that have Python default values and therefore have a `"default"` key in their schema (set by `_parse_function`).  This violates the [OpenAI function-calling spec](https://platform.openai.com/docs/guides/function-calling) and causes LLMs to treat optional parameters as mandatory.

### Root cause

```python
# before (line 161)
"required": list(self.args.keys()),
```

`_parse_function` already writes `args[k]["default"] = default_values[k]` for parameters that have a default, so the fix is a one-line filter:

```python
# after
"required": [k for k in self.args if "default" not in self.args[k]],
```

## Changes

| File | Change |
|------|--------|
| `dspy/adapters/types/tool.py` | Filter `required` to exclude args whose schema has a `"default"` key |
| `tests/adapters/test_tool.py` | Add `test_format_as_litellm_function_call_required_excludes_defaults` and `test_format_as_litellm_function_call_all_required_when_no_defaults` |

## Test plan

- [x] `test_format_as_litellm_function_call_required_excludes_defaults` — asserts that an arg **with** a default is absent from `required` and that `default` is still present in `properties`
- [x] `test_format_as_litellm_function_call_all_required_when_no_defaults` — asserts that when **no** args have defaults, all appear in `required` (no regression)
- [x] Full `tests/adapters/test_tool.py` suite: **39/39 passed**