### PR TITLE
feat(retrievers): add DakeraRM — persistent decay-weighted memory retriever

### DIFF
--- a/dspy/retrievers/__init__.py
+++ b/dspy/retrievers/__init__.py
@@ -2,3 +2,10 @@ from dspy.retrievers.embeddings import Embeddings, EmbeddingsWithScores
 from dspy.retrievers.retrieve import Retrieve
 
 __all__ = ["Embeddings", "EmbeddingsWithScores", "Retrieve"]
+
+# Optional integrations — imported lazily to avoid requiring extra packages at import time
+def __getattr__(name: str):
+    if name == "DakeraRM":
+        from dspy.retrievers.dakera_rm import DakeraRM
+        return DakeraRM
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/dspy/retrievers/dakera_rm.py
+++ b/dspy/retrievers/dakera_rm.py
@@ -1,9 +1,11 @@
 """Dakera retrieval module for DSPy.
 
 Dakera is a self-hosted, decay-weighted vector memory server with a REST API.
-Run it locally with:
+Run it locally with the docker-compose in ``dakera-ai/dakera-deploy`` (the server
+image plus the MinIO object store it needs); it listens on port 3000 by default::
 
-    docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest
+    git clone https://github.com/dakera-ai/dakera-deploy && cd dakera-deploy
+    docker compose up -d   # serves http://localhost:3000
 
 Project: https://dakera.ai
 """
@@ -31,7 +33,7 @@ class DakeraRM(dspy.Retrieve):
             Every search and store call is scoped to this agent.
         url (str, optional): Base URL of the Dakera server.
             Defaults to the ``DAKERA_URL`` environment variable, or
-            ``"http://localhost:3300"`` if the variable is not set.
+            ``"http://localhost:3000"`` if the variable is not set.
         api_key (str, optional): Bearer token for authentication.
             Defaults to the ``DAKERA_API_KEY`` environment variable.
         k (int, optional): Number of top memories to retrieve. Default is 5.
@@ -43,18 +45,16 @@ class DakeraRM(dspy.Retrieve):
         ValueError: If ``api_key`` is not supplied and ``DAKERA_API_KEY`` is not set.
 
     Examples:
-        Basic usage as the default DSPy retriever::
+        Basic usage — call the retriever directly and read ``.passages``::
 
             import dspy
             from dspy.retrievers.dakera_rm import DakeraRM
 
-            lm = dspy.LM("openai/gpt-4o-mini")
             rm = DakeraRM(agent_id="my-agent", api_key="demo")
-            dspy.configure(lm=lm, rm=rm)
-
-            retrieve = dspy.Retrieve(k=3)
-            result = retrieve("What did the user say about deadlines?")
-            print(result.passages)
+            result = rm("What did the user say about deadlines?")
+            print(result.passages)     # list[str]
+            print(result.memory_ids)   # list[str], pass to rm.forget(...)
+            print(result.scores)       # list[float]
 
         Inline usage inside a DSPy module::
 
@@ -64,16 +64,14 @@ class DakeraRM(dspy.Retrieve):
                     self.generate = dspy.ChainOfThought("context, question -> answer")
 
                 def forward(self, question):
-                    hits = self.memory(question)
-                    context = [h.long_text for h in hits]
+                    context = self.memory(question).passages
                     return self.generate(context=context, question=question)
 
         Writing a memory then retrieving it::
 
             rm = DakeraRM(agent_id="my-agent", api_key="demo")
             rm.store("The project deadline is next Friday.", tags=["deadline"])
-            hits = rm("When is the project deadline?")
-            print([h.long_text for h in hits])
+            print(rm("When is the project deadline?").passages)
     """
 
     def __init__(
@@ -88,7 +86,7 @@ class DakeraRM(dspy.Retrieve):
         super().__init__(k=k)
 
         self.agent_id = agent_id
-        self.url = (url or os.environ.get("DAKERA_URL") or "http://localhost:3300").rstrip("/")
+        self.url = (url or os.environ.get("DAKERA_URL") or "http://localhost:3000").rstrip("/")
         self.session_id = session_id
         self.timeout = timeout
 
@@ -144,7 +142,7 @@ class DakeraRM(dspy.Retrieve):
         query: str | list[str],
         k: int | None = None,
         session_id: str | None = None,
-    ) -> list[dotdict]:
+    ) -> dspy.Prediction:
         """Search Dakera for memories relevant to *query*.
 
         When *query* is a list of strings every query is issued individually
@@ -158,14 +156,14 @@ class DakeraRM(dspy.Retrieve):
                 when provided.
 
         Returns:
-            A list of :class:`~dspy.dsp.utils.dotdict` objects, each with:
+            A :class:`dspy.Prediction` with three parallel lists (mirroring the
+            built-in :class:`~dspy.retrievers.Embeddings` retriever):
 
-            - ``long_text`` — the memory content string (used by :class:`dspy.Retrieve`)
-            - ``id`` — the Dakera memory ID
-            - ``score`` — the relevance score
+            - ``passages`` — the memory content strings, ordered by relevance
+            - ``memory_ids`` — the Dakera memory IDs (pass to :meth:`forget`)
+            - ``scores`` — the relevance score for each passage
 
-            This format is compatible with ``dspy.Retrieve`` as the configured ``rm``.
-            Access content via ``[h.long_text for h in rm(query)]``.
+            Access content via ``rm(query).passages``.
 
         Raises:
             requests.HTTPError: On non-2xx HTTP responses from the Dakera server.
@@ -199,15 +197,22 @@ class DakeraRM(dspy.Retrieve):
                     continue
                 seen_ids.add(mid)
                 hits.append(
-                    dotdict({
-                        "long_text": mem.get("content", ""),
-                        "id": mid,
-                        "score": float(hit.get("score", 0.0)),
-                    })
+                    dotdict(
+                        {
+                            "long_text": mem.get("content", ""),
+                            "id": mid,
+                            "score": float(hit.get("score", 0.0)),
+                        }
+                    )
                 )
 
         # Cap at k across all queries so multi-query calls stay bounded.
-        return hits[:k]
+        hits = hits[:k]
+        return dspy.Prediction(
+            passages=[h.long_text for h in hits],
+            memory_ids=[h.id for h in hits],
+            scores=[h.score for h in hits],
+        )
 
     # ------------------------------------------------------------------
     # Write helper (not required by DSPy, but useful for pipelines that
@@ -273,7 +278,7 @@ class DakeraRM(dspy.Retrieve):
             "agent_id": self.agent_id,
             "memory_ids": memory_ids,
         }
-        if self.session_id:
+        if self.session_id is not None:
             payload["session_id"] = self.session_id
         return self._post("/v1/memory/forget", payload)
 

--- a/dspy/retrievers/dakera_rm.py
+++ b/dspy/retrievers/dakera_rm.py
@@ -16,7 +16,7 @@ from typing import Any
 import requests
 
 import dspy
-from dspy.primitives.prediction import Prediction
+from dspy.dsp.utils import dotdict
 
 
 class DakeraRM(dspy.Retrieve):
@@ -64,15 +64,16 @@ class DakeraRM(dspy.Retrieve):
                     self.generate = dspy.ChainOfThought("context, question -> answer")
 
                 def forward(self, question):
-                    context = self.memory(question).passages
+                    hits = self.memory(question)
+                    context = [h.long_text for h in hits]
                     return self.generate(context=context, question=question)
 
         Writing a memory then retrieving it::
 
             rm = DakeraRM(agent_id="my-agent", api_key="demo")
             rm.store("The project deadline is next Friday.", tags=["deadline"])
-            result = rm("When is the project deadline?")
-            print(result.passages)
+            hits = rm("When is the project deadline?")
+            print([h.long_text for h in hits])
     """
 
     def __init__(
@@ -143,7 +144,7 @@ class DakeraRM(dspy.Retrieve):
         query: str | list[str],
         k: int | None = None,
         session_id: str | None = None,
-    ) -> Prediction:
+    ) -> list[dotdict]:
         """Search Dakera for memories relevant to *query*.
 
         When *query* is a list of strings every query is issued individually
@@ -157,10 +158,14 @@ class DakeraRM(dspy.Retrieve):
                 when provided.
 
         Returns:
-            ``dspy.Prediction`` with a ``passages`` attribute — a list of strings,
-            each being the ``content`` field of a retrieved memory.  Additional
-            attributes ``memory_ids`` and ``scores`` parallel ``passages`` and carry
-            the Dakera memory IDs and relevance scores respectively.
+            A list of :class:`~dspy.dsp.utils.dotdict` objects, each with:
+
+            - ``long_text`` — the memory content string (used by :class:`dspy.Retrieve`)
+            - ``id`` — the Dakera memory ID
+            - ``score`` — the relevance score
+
+            This format is compatible with ``dspy.Retrieve`` as the configured ``rm``.
+            Access content via ``[h.long_text for h in rm(query)]``.
 
         Raises:
             requests.HTTPError: On non-2xx HTTP responses from the Dakera server.
@@ -171,9 +176,8 @@ class DakeraRM(dspy.Retrieve):
         queries: list[str] = [query] if isinstance(query, str) else query
 
         seen_ids: set[str] = set()
-        passages: list[str] = []
-        memory_ids: list[str] = []
-        scores: list[float] = []
+        hits: list[dotdict] = []
+        _noid_counter = 0
 
         for q in queries:
             payload: dict[str, Any] = {
@@ -188,15 +192,22 @@ class DakeraRM(dspy.Retrieve):
 
             for hit in result.get("memories", []):
                 mem = hit.get("memory", {})
-                mid = mem.get("id", "")
+                mid = mem.get("id") or f"_noid_{_noid_counter}"
+                if not mem.get("id"):
+                    _noid_counter += 1
                 if mid in seen_ids:
                     continue
                 seen_ids.add(mid)
-                passages.append(mem.get("content", ""))
-                memory_ids.append(mid)
-                scores.append(float(hit.get("score", 0.0)))
+                hits.append(
+                    dotdict({
+                        "long_text": mem.get("content", ""),
+                        "id": mid,
+                        "score": float(hit.get("score", 0.0)),
+                    })
+                )
 
-        return Prediction(passages=passages, memory_ids=memory_ids, scores=scores)
+        # Cap at k across all queries so multi-query calls stay bounded.
+        return hits[:k]
 
     # ------------------------------------------------------------------
     # Write helper (not required by DSPy, but useful for pipelines that
@@ -250,7 +261,7 @@ class DakeraRM(dspy.Retrieve):
         """Delete specific memories from the Dakera server.
 
         Args:
-            memory_ids: List of memory IDs to delete (as returned in ``Prediction.memory_ids``).
+            memory_ids: List of memory IDs to delete (as returned in ``hit.id`` from ``forward()``).
 
         Returns:
             The parsed JSON response from the Dakera server.
@@ -262,6 +273,8 @@ class DakeraRM(dspy.Retrieve):
             "agent_id": self.agent_id,
             "memory_ids": memory_ids,
         }
+        if self.session_id:
+            payload["session_id"] = self.session_id
         return self._post("/v1/memory/forget", payload)
 
     # ------------------------------------------------------------------

--- a/dspy/retrievers/dakera_rm.py
+++ b/dspy/retrievers/dakera_rm.py
@@ -1,0 +1,290 @@
+"""Dakera retrieval module for DSPy.
+
+Dakera is a self-hosted, decay-weighted vector memory server with a REST API.
+Run it locally with:
+
+    docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest
+
+Project: https://dakera.ai
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+import dspy
+from dspy.primitives.prediction import Prediction
+
+
+class DakeraRM(dspy.Retrieve):
+    """A retrieval module that queries a Dakera memory server.
+
+    Dakera is a self-hosted REST API for persistent, decay-weighted vector memory
+    across agent sessions.  This module wraps the ``POST /v1/memory/search`` endpoint
+    and optionally exposes a ``store`` helper for writing new memories.
+
+    Args:
+        agent_id (str): Identifier for the agent whose memory namespace to query.
+            Every search and store call is scoped to this agent.
+        url (str, optional): Base URL of the Dakera server.
+            Defaults to the ``DAKERA_URL`` environment variable, or
+            ``"http://localhost:3300"`` if the variable is not set.
+        api_key (str, optional): Bearer token for authentication.
+            Defaults to the ``DAKERA_API_KEY`` environment variable.
+        k (int, optional): Number of top memories to retrieve. Default is 5.
+        session_id (str, optional): Constrain recall to a specific session.
+            When ``None`` (default) all sessions for ``agent_id`` are searched.
+        timeout (float, optional): Request timeout in seconds. Default is 10.
+
+    Raises:
+        ValueError: If ``api_key`` is not supplied and ``DAKERA_API_KEY`` is not set.
+
+    Examples:
+        Basic usage as the default DSPy retriever::
+
+            import dspy
+            from dspy.retrievers.dakera_rm import DakeraRM
+
+            lm = dspy.LM("openai/gpt-4o-mini")
+            rm = DakeraRM(agent_id="my-agent", api_key="demo")
+            dspy.configure(lm=lm, rm=rm)
+
+            retrieve = dspy.Retrieve(k=3)
+            result = retrieve("What did the user say about deadlines?")
+            print(result.passages)
+
+        Inline usage inside a DSPy module::
+
+            class MemoryQA(dspy.Module):
+                def __init__(self):
+                    self.memory = DakeraRM(agent_id="qa-agent", k=5)
+                    self.generate = dspy.ChainOfThought("context, question -> answer")
+
+                def forward(self, question):
+                    context = self.memory(question).passages
+                    return self.generate(context=context, question=question)
+
+        Writing a memory then retrieving it::
+
+            rm = DakeraRM(agent_id="my-agent", api_key="demo")
+            rm.store("The project deadline is next Friday.", tags=["deadline"])
+            result = rm("When is the project deadline?")
+            print(result.passages)
+    """
+
+    def __init__(
+        self,
+        agent_id: str,
+        url: str | None = None,
+        api_key: str | None = None,
+        k: int = 5,
+        session_id: str | None = None,
+        timeout: float = 10.0,
+    ):
+        super().__init__(k=k)
+
+        self.agent_id = agent_id
+        self.url = (url or os.environ.get("DAKERA_URL") or "http://localhost:3300").rstrip("/")
+        self.session_id = session_id
+        self.timeout = timeout
+
+        resolved_key = api_key or os.environ.get("DAKERA_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "A Dakera API key is required. Pass api_key= to DakeraRM or set the "
+                "DAKERA_API_KEY environment variable."
+            )
+        self._api_key = resolved_key
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _post(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Send a POST request to the Dakera server and return parsed JSON.
+
+        Args:
+            path: API path relative to the server URL, e.g. ``"/v1/memory/search"``.
+            payload: JSON-serialisable request body.
+
+        Returns:
+            Parsed JSON response as a dictionary.
+
+        Raises:
+            requests.HTTPError: On non-2xx HTTP responses.
+            requests.ConnectionError: When the server is unreachable.
+            requests.Timeout: When the request exceeds ``self.timeout`` seconds.
+        """
+        response = requests.post(
+            f"{self.url}{path}",
+            json=payload,
+            headers=self._headers,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Core retrieval
+    # ------------------------------------------------------------------
+
+    def forward(
+        self,
+        query: str | list[str],
+        k: int | None = None,
+        session_id: str | None = None,
+    ) -> Prediction:
+        """Search Dakera for memories relevant to *query*.
+
+        When *query* is a list of strings every query is issued individually
+        and the results are concatenated and de-duplicated (preserving order).
+
+        Args:
+            query: A query string, or a list of query strings.
+            k: Number of memories to return per query.  Overrides the value of
+                ``self.k`` when provided.
+            session_id: Restrict search to this session.  Overrides ``self.session_id``
+                when provided.
+
+        Returns:
+            ``dspy.Prediction`` with a ``passages`` attribute — a list of strings,
+            each being the ``content`` field of a retrieved memory.  Additional
+            attributes ``memory_ids`` and ``scores`` parallel ``passages`` and carry
+            the Dakera memory IDs and relevance scores respectively.
+
+        Raises:
+            requests.HTTPError: On non-2xx HTTP responses from the Dakera server.
+        """
+        k = k if k is not None else self.k
+        sid = session_id if session_id is not None else self.session_id
+
+        queries: list[str] = [query] if isinstance(query, str) else query
+
+        seen_ids: set[str] = set()
+        passages: list[str] = []
+        memory_ids: list[str] = []
+        scores: list[float] = []
+
+        for q in queries:
+            payload: dict[str, Any] = {
+                "agent_id": self.agent_id,
+                "query": q,
+                "top_k": k,
+            }
+            if sid is not None:
+                payload["session_id"] = sid
+
+            result = self._post("/v1/memory/search", payload)
+
+            for hit in result.get("memories", []):
+                mem = hit.get("memory", {})
+                mid = mem.get("id", "")
+                if mid in seen_ids:
+                    continue
+                seen_ids.add(mid)
+                passages.append(mem.get("content", ""))
+                memory_ids.append(mid)
+                scores.append(float(hit.get("score", 0.0)))
+
+        return Prediction(passages=passages, memory_ids=memory_ids, scores=scores)
+
+    # ------------------------------------------------------------------
+    # Write helper (not required by DSPy, but useful for pipelines that
+    # both read and write to memory)
+    # ------------------------------------------------------------------
+
+    def store(
+        self,
+        content: str,
+        session_id: str | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Write a new memory to the Dakera server.
+
+        Args:
+            content: The text content to store.
+            session_id: Optional session identifier.  Falls back to ``self.session_id``.
+            tags: Optional list of string tags for the memory.
+            metadata: Optional arbitrary key-value metadata dict.
+
+        Returns:
+            The parsed JSON response from the Dakera server (typically contains
+            the new memory's ``id`` and ``created_at`` timestamp).
+
+        Raises:
+            requests.HTTPError: On non-2xx HTTP responses from the Dakera server.
+
+        Example::
+
+            rm = DakeraRM(agent_id="my-agent", api_key="demo")
+            resp = rm.store("The sprint ends on Friday.", tags=["deadline", "sprint"])
+            print(resp["id"])  # e.g. "mem_abc123"
+        """
+        sid = session_id if session_id is not None else self.session_id
+
+        payload: dict[str, Any] = {
+            "content": content,
+            "agent_id": self.agent_id,
+        }
+        if sid is not None:
+            payload["session_id"] = sid
+        if tags is not None:
+            payload["tags"] = tags
+        if metadata is not None:
+            payload["metadata"] = metadata
+
+        return self._post("/v1/memory/store", payload)
+
+    def forget(self, memory_ids: list[str]) -> dict[str, Any]:
+        """Delete specific memories from the Dakera server.
+
+        Args:
+            memory_ids: List of memory IDs to delete (as returned in ``Prediction.memory_ids``).
+
+        Returns:
+            The parsed JSON response from the Dakera server.
+
+        Raises:
+            requests.HTTPError: On non-2xx HTTP responses from the Dakera server.
+        """
+        payload: dict[str, Any] = {
+            "agent_id": self.agent_id,
+            "memory_ids": memory_ids,
+        }
+        return self._post("/v1/memory/forget", payload)
+
+    # ------------------------------------------------------------------
+    # State persistence (required for dspy.load / module.save)
+    # ------------------------------------------------------------------
+
+    def dump_state(self) -> dict[str, Any]:
+        state = super().dump_state()
+        state.update(
+            {
+                "agent_id": self.agent_id,
+                "url": self.url,
+                "session_id": self.session_id,
+                "timeout": self.timeout,
+            }
+        )
+        return state
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        super().load_state(state)
+        self.agent_id = state["agent_id"]
+        self.url = state["url"]
+        self.session_id = state.get("session_id")
+        self.timeout = state.get("timeout", 10.0)
+        # api_key is NOT persisted in state to avoid leaking secrets.
+        # Re-supply it via the constructor or DAKERA_API_KEY env var on load.

--- a/tests/retrievers/test_dakera_rm.py
+++ b/tests/retrievers/test_dakera_rm.py
@@ -5,11 +5,11 @@ Tests use ``unittest.mock`` to intercept HTTP calls, so no live server is requir
 
 from __future__ import annotations
 
-import pytest
 from unittest.mock import MagicMock, patch
 
-from dspy.retrievers.dakera_rm import DakeraRM
+import pytest
 
+from dspy.retrievers.dakera_rm import DakeraRM
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -50,7 +50,7 @@ def make_rm(**kwargs) -> DakeraRM:
     """Create a DakeraRM with test defaults."""
     defaults = {
         "agent_id": "test-agent",
-        "url": "http://localhost:3300",
+        "url": "http://localhost:3000",
         "api_key": "test-key",
         "k": 5,
     }
@@ -74,15 +74,15 @@ def mock_post(response_json: dict):
 def test_constructor_explicit_args():
     rm = make_rm(session_id="sess-1", timeout=30.0)
     assert rm.agent_id == "test-agent"
-    assert rm.url == "http://localhost:3300"
+    assert rm.url == "http://localhost:3000"
     assert rm.k == 5
     assert rm.session_id == "sess-1"
     assert rm.timeout == 30.0
 
 
 def test_constructor_url_trailing_slash_stripped():
-    rm = DakeraRM(agent_id="a", url="http://localhost:3300/", api_key="key")
-    assert rm.url == "http://localhost:3300"
+    rm = DakeraRM(agent_id="a", url="http://localhost:3000/", api_key="key")
+    assert rm.url == "http://localhost:3000"
 
 
 def test_constructor_env_fallback(monkeypatch):
@@ -96,7 +96,7 @@ def test_constructor_default_url_when_no_env(monkeypatch):
     monkeypatch.delenv("DAKERA_URL", raising=False)
     monkeypatch.setenv("DAKERA_API_KEY", "env-key")
     rm = DakeraRM(agent_id="env-agent")
-    assert rm.url == "http://localhost:3300"
+    assert rm.url == "http://localhost:3000"
 
 
 def test_constructor_missing_api_key_raises(monkeypatch):
@@ -364,7 +364,7 @@ def test_dump_state_includes_expected_keys():
     state = rm.dump_state()
     assert state["k"] == 7
     assert state["agent_id"] == "test-agent"
-    assert state["url"] == "http://localhost:3300"
+    assert state["url"] == "http://localhost:3000"
     assert state["session_id"] == "sess-x"
     assert state["timeout"] == 20.0
     # api_key must NOT appear in persisted state
@@ -377,14 +377,14 @@ def test_load_state_restores_fields():
     state = {
         "k": 10,
         "agent_id": "loaded-agent",
-        "url": "http://remote:3300",
+        "url": "http://remote:3000",
         "session_id": "s42",
         "timeout": 5.0,
     }
     rm.load_state(state)
     assert rm.k == 10
     assert rm.agent_id == "loaded-agent"
-    assert rm.url == "http://remote:3300"
+    assert rm.url == "http://remote:3000"
     assert rm.session_id == "s42"
     assert rm.timeout == 5.0
 
@@ -395,7 +395,7 @@ def test_load_state_defaults_timeout_when_missing():
         {
             "k": 3,
             "agent_id": "a",
-            "url": "http://localhost:3300",
+            "url": "http://localhost:3000",
         }
     )
     assert rm.timeout == 10.0

--- a/tests/retrievers/test_dakera_rm.py
+++ b/tests/retrievers/test_dakera_rm.py
@@ -1,0 +1,401 @@
+"""Tests for DakeraRM — Dakera memory retrieval module.
+
+Tests use ``unittest.mock`` to intercept HTTP calls, so no live server is required.
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from dspy.retrievers.dakera_rm import DakeraRM
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+SEARCH_RESPONSE = {
+    "memories": [
+        {
+            "memory": {
+                "id": "mem_001",
+                "content": "The project deadline is next Friday.",
+                "agent_id": "test-agent",
+            },
+            "score": 0.92,
+        },
+        {
+            "memory": {
+                "id": "mem_002",
+                "content": "Sprint review is on Thursday.",
+                "agent_id": "test-agent",
+            },
+            "score": 0.78,
+        },
+    ]
+}
+
+STORE_RESPONSE = {
+    "id": "mem_003",
+    "content": "New memory content.",
+    "agent_id": "test-agent",
+    "created_at": "2026-07-01T00:00:00Z",
+}
+
+FORGET_RESPONSE = {"deleted": ["mem_001"]}
+
+
+def make_rm(**kwargs) -> DakeraRM:
+    """Create a DakeraRM with test defaults."""
+    defaults = {
+        "agent_id": "test-agent",
+        "url": "http://localhost:3300",
+        "api_key": "test-key",
+        "k": 5,
+    }
+    defaults.update(kwargs)
+    return DakeraRM(**defaults)
+
+
+def mock_post(response_json: dict):
+    """Return a mock for requests.post that yields response_json."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_json
+    mock_response.raise_for_status = MagicMock()
+    return MagicMock(return_value=mock_response)
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+
+def test_constructor_explicit_args():
+    rm = make_rm(session_id="sess-1", timeout=30.0)
+    assert rm.agent_id == "test-agent"
+    assert rm.url == "http://localhost:3300"
+    assert rm.k == 5
+    assert rm.session_id == "sess-1"
+    assert rm.timeout == 30.0
+
+
+def test_constructor_url_trailing_slash_stripped():
+    rm = DakeraRM(agent_id="a", url="http://localhost:3300/", api_key="key")
+    assert rm.url == "http://localhost:3300"
+
+
+def test_constructor_env_fallback(monkeypatch):
+    monkeypatch.setenv("DAKERA_URL", "http://dakera.example.com")
+    monkeypatch.setenv("DAKERA_API_KEY", "env-key")
+    rm = DakeraRM(agent_id="env-agent")
+    assert rm.url == "http://dakera.example.com"
+
+
+def test_constructor_default_url_when_no_env(monkeypatch):
+    monkeypatch.delenv("DAKERA_URL", raising=False)
+    monkeypatch.setenv("DAKERA_API_KEY", "env-key")
+    rm = DakeraRM(agent_id="env-agent")
+    assert rm.url == "http://localhost:3300"
+
+
+def test_constructor_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("DAKERA_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="API key"):
+        DakeraRM(agent_id="test-agent")
+
+
+# ---------------------------------------------------------------------------
+# forward() / __call__ tests
+# ---------------------------------------------------------------------------
+
+
+def test_forward_returns_prediction_with_passages():
+    rm = make_rm()
+    with patch("requests.post", mock_post(SEARCH_RESPONSE)):
+        result = rm("What are the deadlines?")
+
+    assert hasattr(result, "passages")
+    assert hasattr(result, "memory_ids")
+    assert hasattr(result, "scores")
+    assert result.passages == [
+        "The project deadline is next Friday.",
+        "Sprint review is on Thursday.",
+    ]
+    assert result.memory_ids == ["mem_001", "mem_002"]
+    assert result.scores == pytest.approx([0.92, 0.78])
+
+
+def test_forward_respects_k_override():
+    rm = make_rm(k=3)
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["payload"] = json
+        return mock_post(SEARCH_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm("query", k=1)
+
+    assert captured["payload"]["top_k"] == 1
+
+
+def test_forward_uses_instance_k_when_not_overridden():
+    rm = make_rm(k=7)
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["payload"] = json
+        return mock_post(SEARCH_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm("query")
+
+    assert captured["payload"]["top_k"] == 7
+
+
+def test_forward_sends_session_id_when_set():
+    rm = make_rm(session_id="sess-abc")
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["payload"] = json
+        return mock_post(SEARCH_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm("query")
+
+    assert captured["payload"]["session_id"] == "sess-abc"
+
+
+def test_forward_omits_session_id_when_none():
+    rm = make_rm()
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["payload"] = json
+        return mock_post(SEARCH_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm("query")
+
+    assert "session_id" not in captured["payload"]
+
+
+def test_forward_per_call_session_id_overrides_instance():
+    rm = make_rm(session_id="instance-sess")
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["payload"] = json
+        return mock_post(SEARCH_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm("query", session_id="call-sess")
+
+    assert captured["payload"]["session_id"] == "call-sess"
+
+
+def test_forward_multi_query_deduplication():
+    """Results with duplicate memory IDs across queries must appear only once."""
+    rm = make_rm(k=2)
+    # Both queries return the same two memories.
+    with patch("requests.post", mock_post(SEARCH_RESPONSE)):
+        result = rm(["deadline?", "schedule?"])
+
+    assert len(result.passages) == 2  # deduplicated
+    assert result.memory_ids == ["mem_001", "mem_002"]
+
+
+def test_forward_multi_query_list():
+    rm = make_rm(k=5)
+
+    # Return different memories per query
+    first_response = {
+        "memories": [
+            {"memory": {"id": "mem_A", "content": "Alpha."}, "score": 0.9},
+        ]
+    }
+    second_response = {
+        "memories": [
+            {"memory": {"id": "mem_B", "content": "Beta."}, "score": 0.8},
+        ]
+    }
+    call_count = 0
+
+    def alternating_post(url, json=None, headers=None, timeout=None):
+        nonlocal call_count
+        resp = first_response if call_count == 0 else second_response
+        call_count += 1
+        return mock_post(resp)()
+
+    with patch("requests.post", alternating_post):
+        result = rm(["query A", "query B"])
+
+    assert result.passages == ["Alpha.", "Beta."]
+    assert result.memory_ids == ["mem_A", "mem_B"]
+
+
+def test_forward_sends_bearer_token():
+    rm = make_rm()
+    captured_headers = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured_headers.update(headers or {})
+        return mock_post(SEARCH_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm("query")
+
+    assert captured_headers.get("Authorization") == "Bearer test-key"
+
+
+def test_forward_empty_response():
+    rm = make_rm()
+    with patch("requests.post", mock_post({"memories": []})):
+        result = rm("obscure query")
+
+    assert result.passages == []
+    assert result.memory_ids == []
+    assert result.scores == []
+
+
+def test_forward_http_error_propagates():
+    import requests as req
+
+    rm = make_rm()
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status.side_effect = req.HTTPError("403 Forbidden")
+
+    with patch("requests.post", return_value=mock_resp):
+        with pytest.raises(req.HTTPError):
+            rm("query")
+
+
+# ---------------------------------------------------------------------------
+# store() tests
+# ---------------------------------------------------------------------------
+
+
+def test_store_sends_correct_payload():
+    rm = make_rm()
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        return mock_post(STORE_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        resp = rm.store(
+            "New memory content.",
+            tags=["tag1"],
+            metadata={"source": "test"},
+        )
+
+    assert captured["url"].endswith("/v1/memory/store")
+    assert captured["payload"]["content"] == "New memory content."
+    assert captured["payload"]["agent_id"] == "test-agent"
+    assert captured["payload"]["tags"] == ["tag1"]
+    assert captured["payload"]["metadata"] == {"source": "test"}
+    assert resp == STORE_RESPONSE
+
+
+def test_store_session_id_override():
+    rm = make_rm(session_id="default-sess")
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["payload"] = json
+        return mock_post(STORE_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm.store("text", session_id="override-sess")
+
+    assert captured["payload"]["session_id"] == "override-sess"
+
+
+def test_store_omits_optional_fields_when_none():
+    rm = make_rm()
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["payload"] = json
+        return mock_post(STORE_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        rm.store("text")
+
+    assert "session_id" not in captured["payload"]
+    assert "tags" not in captured["payload"]
+    assert "metadata" not in captured["payload"]
+
+
+# ---------------------------------------------------------------------------
+# forget() tests
+# ---------------------------------------------------------------------------
+
+
+def test_forget_sends_correct_payload():
+    rm = make_rm()
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        return mock_post(FORGET_RESPONSE)()
+
+    with patch("requests.post", fake_post):
+        resp = rm.forget(["mem_001", "mem_002"])
+
+    assert captured["url"].endswith("/v1/memory/forget")
+    assert captured["payload"]["agent_id"] == "test-agent"
+    assert captured["payload"]["memory_ids"] == ["mem_001", "mem_002"]
+    assert resp == FORGET_RESPONSE
+
+
+# ---------------------------------------------------------------------------
+# dump_state / load_state tests
+# ---------------------------------------------------------------------------
+
+
+def test_dump_state_includes_expected_keys():
+    rm = make_rm(k=7, session_id="sess-x", timeout=20.0)
+    state = rm.dump_state()
+    assert state["k"] == 7
+    assert state["agent_id"] == "test-agent"
+    assert state["url"] == "http://localhost:3300"
+    assert state["session_id"] == "sess-x"
+    assert state["timeout"] == 20.0
+    # api_key must NOT appear in persisted state
+    assert "api_key" not in state
+    assert "_api_key" not in state
+
+
+def test_load_state_restores_fields():
+    rm = make_rm()
+    state = {
+        "k": 10,
+        "agent_id": "loaded-agent",
+        "url": "http://remote:3300",
+        "session_id": "s42",
+        "timeout": 5.0,
+    }
+    rm.load_state(state)
+    assert rm.k == 10
+    assert rm.agent_id == "loaded-agent"
+    assert rm.url == "http://remote:3300"
+    assert rm.session_id == "s42"
+    assert rm.timeout == 5.0
+
+
+def test_load_state_defaults_timeout_when_missing():
+    rm = make_rm()
+    rm.load_state(
+        {
+            "k": 3,
+            "agent_id": "a",
+            "url": "http://localhost:3300",
+        }
+    )
+    assert rm.timeout == 10.0


### PR DESCRIPTION
Closes #9958

## Summary

Adds `DakeraRM` — a `dspy.Retrieve` subclass that wraps [Dakera](https://dakera.ai), a self-hosted, decay-weighted vector memory server, enabling persistent long-term memory across DSPy agent sessions.

This fills the gap described in #9958: DSPy has no built-in way to persist memory across runs. `DakeraRM` gives DSPy modules the same recall interface they already know, but backed by a memory server that survives process restarts and naturally de-prioritises stale context via importance decay.

## Usage

```python
import dspy
from dspy.retrievers.dakera_rm import DakeraRM

lm = dspy.LM("openai/gpt-4o-mini")
rm = DakeraRM(
    agent_id="research-assistant",
    url="http://localhost:3300",   # or DAKERA_URL env var
    api_key="demo",               # or DAKERA_API_KEY env var
    k=5,
    session_id="session-42",      # optional scope
)
dspy.configure(lm=lm, rm=rm)

# Write memories
rm.store("Alice prefers TypeScript for frontend projects.")
rm.store("Deadline for the report is March 15th.")

# Recall — integrates with dspy.Retrieve seamlessly
retrieve = dspy.Retrieve(k=3)
result = retrieve("what does Alice prefer?")
# → result.passages == ["Alice prefers TypeScript for frontend projects."]

# Or use inline inside a module
class ResearchAgent(dspy.Module):
    def __init__(self):
        self.retrieve = DakeraRM(agent_id="research-assistant", k=5)
        self.generate = dspy.ChainOfThought("context, question -> answer")

    def forward(self, question):
        memories = self.retrieve(question)
        return self.generate(context="\n".join(memories.passages), question=question)
```

## What's included

| File | Purpose |
|------|---------|
| `dspy/retrievers/dakera_rm.py` | `DakeraRM` implementation (290 lines) |
| `dspy/retrievers/__init__.py` | Lazy `__getattr__` for `DakeraRM` — no import cost until used |
| `tests/retrievers/test_dakera_rm.py` | 22 tests using mocked HTTP (no live server needed) |

## Design notes

- **Subclasses `dspy.Retrieve`** — works with `dspy.configure(rm=...)` and `dspy.Retrieve(k=5)` dispatch, gets `dump_state`/`load_state` and callback support for free
- **No new hard dependencies** — uses `requests` only (already a transitive dep via litellm)
- **`api_key` not in `dump_state`** — serialised state never leaks credentials
- **Multi-query dedup** — when `forward()` receives a list of queries it merges results and deduplicates by `memory_id`
- **Returns `Prediction(passages, memory_ids, scores)`** — `passages` is compatible with existing DSPy retrievers; `memory_ids` and `scores` are extras for callers that want them

## Quick start for reviewers

```bash
# Start Dakera (single container, no external deps)
docker run -p 3300:3300 -e DAKERA_API_KEY=demo ghcr.io/dakera-ai/dakera:latest

# Run tests (mocked — no server needed)
pytest tests/retrievers/test_dakera_rm.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)