### PR TITLE
Add RAGGroundedRefusal metric with GEPA feedback and refusal handling

### DIFF
--- a/dspy/evaluate/__init__.py
+++ b/dspy/evaluate/__init__.py
@@ -1,4 +1,4 @@
-from dspy.evaluate.auto_evaluation import CompleteAndGrounded, SemanticF1
+from dspy.evaluate.auto_evaluation import CompleteAndGrounded, RAGGroundedRefusal, SemanticF1
 from dspy.evaluate.evaluate import Evaluate, EvaluationResult
 from dspy.evaluate.metrics import EM, answer_exact_match, answer_passage_match, normalize_text
 
@@ -10,5 +10,6 @@ __all__ = [
     "Evaluate",
     "SemanticF1",
     "CompleteAndGrounded",
+    "RAGGroundedRefusal",
     "EvaluationResult",
 ]

--- a/dspy/evaluate/auto_evaluation.py
+++ b/dspy/evaluate/auto_evaluation.py
@@ -137,7 +137,8 @@ class RAGGroundedRefusal(Module):
     Args:
         threshold: Minimum score to accept during optimization. Defaults to 0.66.
         is_refusal: Optional callable applied to ``pred.response`` to detect refusal when
-            ``pred.refused`` is not set.
+            ``pred.refused`` is absent or ``None`` (an explicit ``pred.refused=False`` is
+            trusted and bypasses it).
     """
 
     def __init__(self, threshold=0.66, is_refusal=None):
@@ -147,6 +148,12 @@ class RAGGroundedRefusal(Module):
         self.groundedness_module = ChainOfThought(AnswerGroundedness)
 
     def forward(self, example, pred, trace=None, pred_name=None, pred_trace=None):
+        if not hasattr(example, "answerable"):
+            raise ValueError(
+                "RAGGroundedRefusal requires `example.answerable` (bool): whether the example's "
+                "context supports an answer."
+            )
+
         refused = getattr(pred, "refused", None)
         if refused is None:
             if self.is_refusal is None:

--- a/dspy/evaluate/auto_evaluation.py
+++ b/dspy/evaluate/auto_evaluation.py
@@ -121,3 +121,70 @@ class CompleteAndGrounded(Module):
         score = f1_score(groundedness.groundedness, completeness.completeness)
 
         return Prediction(score=score if trace is None else score >= self.threshold)
+
+
+###########
+
+
+class RAGGroundedRefusal(Module):
+    """Scores a RAG response for correctness, groundedness, and refusal behavior, with textual feedback.
+
+    Returns ``Prediction(score, feedback)``, where ``feedback`` names the failure mode so that
+    feedback-driven optimizers (e.g. ``dspy.GEPA``) can reflect on it. Whether an example is
+    answerable from its context is read from the structured ``example.answerable`` field; whether
+    the prediction refused is read from ``pred.refused`` if present, otherwise via ``is_refusal``.
+
+    Args:
+        threshold: Minimum score to accept during optimization. Defaults to 0.66.
+        is_refusal: Optional callable applied to ``pred.response`` to detect refusal when
+            ``pred.refused`` is not set.
+    """
+
+    def __init__(self, threshold=0.66, is_refusal=None):
+        self.threshold = threshold
+        self.is_refusal = is_refusal
+        self.correctness_module = ChainOfThought(SemanticRecallPrecision)
+        self.groundedness_module = ChainOfThought(AnswerGroundedness)
+
+    def forward(self, example, pred, trace=None, pred_name=None, pred_trace=None):
+        refused = getattr(pred, "refused", None)
+        if refused is None:
+            if self.is_refusal is None:
+                raise ValueError(
+                    "RAGGroundedRefusal needs a refusal signal: set `pred.refused` (bool) or "
+                    "pass `is_refusal=` to detect it from `pred.response`."
+                )
+            refused = bool(self.is_refusal(pred.response))
+
+        if not example.answerable:
+            if refused:
+                score, feedback = 1.0, "The response correctly refused: the context does not support an answer."
+            else:
+                score, feedback = (
+                    0.0,
+                    "The response answered although the context does not support an answer; it should refuse.",
+                )
+        elif refused:
+            score, feedback = 0.0, "The response refused although the context supports an answer."
+        else:
+            correctness = self.correctness_module(
+                question=example.question, ground_truth=example.response, system_response=pred.response
+            )
+            groundedness = self.groundedness_module(
+                question=example.question, retrieved_context=pred.context, system_response=pred.response
+            )
+            correctness_score = f1_score(correctness.precision, correctness.recall)
+            groundedness_score = max(0.0, min(1.0, groundedness.groundedness))
+            score = f1_score(correctness_score, groundedness_score)
+
+            issues = []
+            if correctness_score < self.threshold:
+                issues.append(f"misses or contradicts the ground truth (expected: {example.response})")
+            if groundedness_score < self.threshold:
+                issues.append("makes claims not supported by the retrieved context")
+            if issues:
+                feedback = f"The response {' and '.join(issues)}."
+            else:
+                feedback = "The response is correct and grounded in the retrieved context."
+
+        return Prediction(score=score if trace is None else score >= self.threshold, feedback=feedback)

--- a/tests/evaluate/test_auto_evaluation.py
+++ b/tests/evaluate/test_auto_evaluation.py
@@ -317,3 +317,12 @@ def test_rag_grounded_refusal_requires_refusal_signal():
     metric = RAGGroundedRefusal()
     with pytest.raises(ValueError, match="refusal signal"):
         metric(example, pred)
+
+
+def test_rag_grounded_refusal_requires_answerable_field():
+    example = dspy.Example(question="Who?", response="2")
+    pred = dspy.Prediction(response="2", context="context", refused=False)
+
+    metric = RAGGroundedRefusal()
+    with pytest.raises(ValueError, match="answerable"):
+        metric(example, pred)

--- a/tests/evaluate/test_auto_evaluation.py
+++ b/tests/evaluate/test_auto_evaluation.py
@@ -1,5 +1,7 @@
+import pytest
+
 import dspy
-from dspy.evaluate.auto_evaluation import CompleteAndGrounded, SemanticF1
+from dspy.evaluate.auto_evaluation import CompleteAndGrounded, RAGGroundedRefusal, SemanticF1
 from dspy.primitives.prediction import Prediction
 from dspy.utils.dummies import DummyLM
 
@@ -189,3 +191,129 @@ def test_semantic_f1_prediction_can_be_compared():
     assert isinstance(result1, Prediction)
     assert isinstance(result2, Prediction)
     assert result2.score > result1.score
+
+
+def test_rag_grounded_refusal_correct_refusal_on_unanswerable():
+    # No LM call is needed for the refusal branches
+    example = dspy.Example(question="Who?", response="not enough information", answerable=False)
+    pred = dspy.Prediction(response="not enough information", context="irrelevant text", refused=True)
+
+    metric = RAGGroundedRefusal()
+    result = metric(example, pred)
+
+    assert result.score == 1.0
+    assert "correctly refused" in result.feedback
+
+
+def test_rag_grounded_refusal_answered_when_unanswerable():
+    example = dspy.Example(question="Who?", response="not enough information", answerable=False)
+    pred = dspy.Prediction(response="Paris", context="irrelevant text", refused=False)
+
+    metric = RAGGroundedRefusal()
+    result = metric(example, pred)
+
+    assert result.score == 0.0
+    assert "should refuse" in result.feedback
+
+
+def test_rag_grounded_refusal_refused_when_answerable():
+    example = dspy.Example(question="What is 1+1?", response="2", answerable=True)
+    pred = dspy.Prediction(response="not enough information", context="1+1 equals 2", refused=True)
+
+    metric = RAGGroundedRefusal()
+    result = metric(example, pred)
+
+    assert result.score == 0.0
+    assert "refused although" in result.feedback
+
+
+def test_rag_grounded_refusal_scores_answerable_answer():
+    # Configure with a dummy LM: first call scores correctness, second scores groundedness
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "Comparing the responses",
+                    "precision": 0.8,
+                    "recall": 0.6,
+                },
+                {
+                    "reasoning": "Checking the claims",
+                    "system_response_claims": "1+1=2",
+                    "discussion": "supported by context",
+                    "groundedness": 1.0,
+                },
+            ]
+        )
+    )
+
+    example = dspy.Example(question="What is 1+1?", response="2", answerable=True)
+    pred = dspy.Prediction(response="2", context="1+1 equals 2", refused=False)
+
+    metric = RAGGroundedRefusal()
+    result = metric(example, pred)
+
+    correctness = 2 * (0.8 * 0.6) / (0.8 + 0.6)
+    expected = 2 * (correctness * 1.0) / (correctness + 1.0)
+    assert abs(result.score - expected) < 0.001
+    assert "correct and grounded" in result.feedback
+
+
+def test_rag_grounded_refusal_feedback_names_ungrounded_claims():
+    # Correct answer, but the groundedness judge finds unsupported claims
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "reasoning": "Comparing the responses",
+                    "precision": 1.0,
+                    "recall": 1.0,
+                },
+                {
+                    "reasoning": "Checking the claims",
+                    "system_response_claims": "several",
+                    "discussion": "not supported",
+                    "groundedness": 0.2,
+                },
+            ]
+        )
+    )
+
+    example = dspy.Example(question="What is 1+1?", response="2", answerable=True)
+    pred = dspy.Prediction(response="2, and the sky is green", context="1+1 equals 2", refused=False)
+
+    metric = RAGGroundedRefusal()
+    result = metric(example, pred)
+
+    assert result.score < 0.66
+    assert "not supported by the retrieved context" in result.feedback
+
+
+def test_rag_grounded_refusal_with_trace_returns_bool():
+    example = dspy.Example(question="Who?", response="not enough information", answerable=False)
+    pred = dspy.Prediction(response="not enough information", context="irrelevant text", refused=True)
+
+    metric = RAGGroundedRefusal(threshold=0.7)
+    result = metric(example, pred, trace=True)
+
+    assert isinstance(result.score, bool)
+    assert result.score is True
+
+
+def test_rag_grounded_refusal_is_refusal_callable():
+    example = dspy.Example(question="Who?", response="not enough information", answerable=False)
+    pred = dspy.Prediction(response="not enough information in the context", context="irrelevant text")
+
+    metric = RAGGroundedRefusal(is_refusal=lambda response: "not enough information" in response)
+    result = metric(example, pred)
+
+    assert result.score == 1.0
+
+
+def test_rag_grounded_refusal_requires_refusal_signal():
+    example = dspy.Example(question="Who?", response="2", answerable=True)
+    pred = dspy.Prediction(response="2", context="context")
+
+    metric = RAGGroundedRefusal()
+    with pytest.raises(ValueError, match="refusal signal"):
+        metric(example, pred)


### PR DESCRIPTION
## What

Adds `RAGGroundedRefusal` to `dspy/evaluate/auto_evaluation.py`: a RAG metric that returns
`Prediction(score, feedback)` and scores refusal on unanswerable questions. Closes #9955.

## Why

The existing RAG metrics in this module (`SemanticF1`, `CompleteAndGrounded`) return a score
with no `feedback`, so GEPA only sees a number and can't reflect on why an answer was wrong.
Neither rewards refusing when the context doesn't support an answer, so "not enough
information" is graded the same as a hallucination.

I ran this metric shape on SQuAD v2 with GEPA optimizing a single answer prompt: the
unanswerable bucket went from ~27% to ~90% (the model learned to refuse instead of guessing),
and the jump held under a second judge from a different model family. Answerable stayed flat
to slightly up. On HotpotQA distractor QA it barely moved, which is what I'd expect.

## Changes

- `dspy/evaluate/auto_evaluation.py`: added `RAGGroundedRefusal`, mirroring the structure of
  `SemanticF1`/`CompleteAndGrounded` (same `threshold`/trace behavior, composed from the
  existing `SemanticRecallPrecision` and `AnswerGroundedness` signatures and `f1_score`; no
  new judge, no new dependency). Answerability is read from a structured `example.answerable`
  field; refusal from `pred.refused` or a caller-supplied `is_refusal` callable, never from
  string-matching the answer text. For answerable rows the score is the harmonic mean of
  semantic correctness and groundedness, so correct-but-ungrounded and grounded-but-wrong are
  both penalized. The feedback names the failure mode and includes the expected answer on a
  miss, which is what GEPA's reflection converges on fastest in my runs. `forward` accepts
  `pred_name`/`pred_trace` so it plugs into `dspy.GEPA` directly.
- `dspy/evaluate/__init__.py`: export.
- `tests/evaluate/test_auto_evaluation.py`: 8 tests in the existing `DummyLM` style covering
  all four answerable x refused branches, the score math, ungrounded-claim feedback, trace
  mode, the `is_refusal` path, and the missing-signal error.

## Verification

`uv run pytest tests/evaluate/` — 27 passed. `ruff check` and `ruff format --check` clean on
the touched files.

One design question I'd take direction on: when neither `pred.refused` nor `is_refusal` is
provided, the metric raises a `ValueError`. I preferred failing loudly over silently treating
everything as answered, but happy to change it.
