### PR TITLE
fix(dspy): prevent Image.__repr__ crash on URLs containing 'base64' substring

### DIFF
--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -109,7 +109,7 @@ class Image(Type):
         return self.serialize_model()
 
     def __repr__(self):
-        if "base64" in self.url:
+        if "base64," in self.url:
             len_base64 = len(self.url.split("base64,")[1])
             image_type = self.url.split(";")[0].split("/")[-1]
             return f"Image(url=data:image/{image_type};base64,<IMAGE_BASE_64_ENCODED({len_base64!s})>)"

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -462,6 +462,13 @@ def test_image_repr():
     assert str(pil_image).endswith("<<CUSTOM-TYPE-END-IDENTIFIER>>")
     assert "base64" in str(pil_image)
 
+    # A plain URL that merely contains the substring "base64" (but is not a
+    # base64 data URI) must not crash __repr__. Previously the guard checked for
+    # "base64" while the body split on "base64,", raising IndexError.
+    tricky_url = "https://cdn.example.com/base64-banner.jpg"
+    tricky_image = dspy.Image(tricky_url)
+    assert repr(tricky_image) == f"Image(url='{tricky_url}')"
+
 
 def test_from_methods_warn(tmp_path):
     """Deprecated from_* methods emit warnings"""


### PR DESCRIPTION
## 📝 Changes Description

`Image.__repr__` crashed with `IndexError` for any `Image` whose `url` merely contains the substring
`base64` without the `base64,` delimiter.

The data-URI branch is guarded by `if "base64" in self.url:` but its body splits on `"base64,"`:

```python
def __repr__(self):
    if "base64" in self.url:
        len_base64 = len(self.url.split("base64,")[1])   # IndexError when "base64," is absent
        ...
```

So a perfectly valid non-data-URI such as `dspy.Image(url="https://cdn.example.com/base64-banner.jpg")`
made `repr(image)` raise. Because `__repr__` is invoked during logging, debugging, and error
formatting, this breaks exactly when a developer is trying to inspect state.

**Fix:** align the guard with the delimiter the body actually splits on (`"base64,"`), so the branch
only runs for genuine base64 data URIs and otherwise falls through to the plain-URL representation.

- `dspy/adapters/types/image.py`: `if "base64" in self.url:` → `if "base64," in self.url:`
- `tests/signatures/test_adapter_image.py`: extended `test_image_repr` with a regression case for a
  URL containing the `base64` substring (fails with `IndexError` before the fix, passes after).

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

None. Scoped to a one-token guard fix; no behavior change for valid base64 data URIs or ordinary URLs.
