### PR TITLE
fix(dspy): unregister cloudpickle pickle-by-value after save

### DIFF
--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -280,9 +280,14 @@ class Settings:
             "execution of arbitrary code during deserialization, you should only load files from "
             "verified sources within a trusted environment."
         )
+        modules_to_serialize = modules_to_serialize or []
+        # Only unregister the modules we register here, so we restore
+        # cloudpickle's global registry to its prior state without clobbering
+        # any modules the caller had already registered by value themselves.
+        already_registered = cloudpickle.list_registry_pickle_by_value()
+        registered_by_us = [module for module in modules_to_serialize if module.__name__ not in already_registered]
         try:
-            modules_to_serialize = modules_to_serialize or []
-            for module in modules_to_serialize:
+            for module in registered_by_us:
                 cloudpickle.register_pickle_by_value(module)
 
             exclude_keys = exclude_keys or []
@@ -294,6 +299,9 @@ class Settings:
                 f"Saving failed with error: {e}. Please remove the non-picklable attributes from the values "
                 "in the `dspy.settings`."
             )
+        finally:
+            for module in registered_by_us:
+                cloudpickle.unregister_pickle_by_value(module)
 
     @classmethod
     def load(cls, path: str, allow_pickle: bool = False) -> dict[str, Any]:

--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -285,7 +285,11 @@ class Settings:
         # cloudpickle's global registry to its prior state without clobbering
         # any modules the caller had already registered by value themselves.
         already_registered = cloudpickle.list_registry_pickle_by_value()
-        registered_by_us = [module for module in modules_to_serialize if module.__name__ not in already_registered]
+        # Dedupe by identity: passing the same module twice would make the
+        # second unregister_pickle_by_value in the finally block raise ValueError.
+        registered_by_us = list(dict.fromkeys(
+            module for module in modules_to_serialize if module.__name__ not in already_registered
+        ))
         try:
             for module in registered_by_us:
                 cloudpickle.register_pickle_by_value(module)

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -212,9 +212,14 @@ class BaseModule:
                 path.mkdir(parents=True)
             logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
                           'this, prefer saving using json format using module.save("module.json").')
+            modules_to_serialize = modules_to_serialize or []
+            # Only unregister the modules we register here, so we restore
+            # cloudpickle's global registry to its prior state without clobbering
+            # any modules the caller had already registered by value themselves.
+            already_registered = cloudpickle.list_registry_pickle_by_value()
+            registered_by_us = [module for module in modules_to_serialize if module.__name__ not in already_registered]
             try:
-                modules_to_serialize = modules_to_serialize or []
-                for module in modules_to_serialize:
+                for module in registered_by_us:
                     cloudpickle.register_pickle_by_value(module)
 
                 with open(path / "program.pkl", "wb") as f:
@@ -224,6 +229,9 @@ class BaseModule:
                     f"Saving failed with error: {e}. Please remove the non-picklable attributes from your DSPy program, "
                     "or consider using state-only saving by setting `save_program=False`."
                 )
+            finally:
+                for module in registered_by_us:
+                    cloudpickle.unregister_pickle_by_value(module)
             with open(path / "metadata.json", "wb") as f:
                 f.write(orjson.dumps(metadata, option=orjson.OPT_INDENT_2 | orjson.OPT_APPEND_NEWLINE))
 

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -217,7 +217,11 @@ class BaseModule:
             # cloudpickle's global registry to its prior state without clobbering
             # any modules the caller had already registered by value themselves.
             already_registered = cloudpickle.list_registry_pickle_by_value()
-            registered_by_us = [module for module in modules_to_serialize if module.__name__ not in already_registered]
+            # Dedupe by identity: passing the same module twice would make the
+            # second unregister_pickle_by_value in the finally block raise ValueError.
+            registered_by_us = list(dict.fromkeys(
+                module for module in modules_to_serialize if module.__name__ not in already_registered
+            ))
             try:
                 for module in registered_by_us:
                     cloudpickle.register_pickle_by_value(module)

--- a/tests/primitives/test_base_module.py
+++ b/tests/primitives/test_base_module.py
@@ -188,6 +188,37 @@ class MyModule(dspy.Module):
             sys.path.remove(str(tmp_path))
 
 
+def test_save_with_extra_modules_does_not_leak_pickle_by_value_registry(tmp_path):
+    """`save(modules_to_serialize=...)` must not permanently register modules for
+    pickling by value in cloudpickle's process-global registry.
+
+    Regression test: previously `save()` called ``cloudpickle.register_pickle_by_value``
+    but never unregistered, so the module stayed registered by value for the rest of
+    the process. That leaked global state across unrelated ``save``/``load`` calls
+    (and across tests), e.g. making a later ``load`` of a genuinely-missing module
+    succeed instead of raising ``ModuleNotFoundError``.
+    """
+    # Reuse an always-available module as the stand-in for the caller's module.
+    import json as some_module
+
+    import cloudpickle
+
+    program = dspy.Predict(dspy.Signature("q -> a"))
+
+    # 1. A module we register here must be gone from the registry afterwards.
+    assert some_module.__name__ not in cloudpickle.list_registry_pickle_by_value()
+    program.save(tmp_path / "prog", save_program=True, modules_to_serialize=[some_module])
+    assert some_module.__name__ not in cloudpickle.list_registry_pickle_by_value()
+
+    # 2. A module the caller registered themselves must be preserved (not clobbered).
+    cloudpickle.register_pickle_by_value(some_module)
+    try:
+        program.save(tmp_path / "prog2", save_program=True, modules_to_serialize=[some_module])
+        assert some_module.__name__ in cloudpickle.list_registry_pickle_by_value()
+    finally:
+        cloudpickle.unregister_pickle_by_value(some_module)
+
+
 def test_load_with_version_mismatch(tmp_path):
     from dspy.primitives.base_module import logger
 

--- a/tests/primitives/test_base_module.py
+++ b/tests/primitives/test_base_module.py
@@ -219,6 +219,28 @@ def test_save_with_extra_modules_does_not_leak_pickle_by_value_registry(tmp_path
         cloudpickle.unregister_pickle_by_value(some_module)
 
 
+def test_save_with_duplicate_modules_does_not_raise(tmp_path):
+    """Passing the same module twice in `modules_to_serialize` must not raise.
+
+    Regression test: `registered_by_us` used to be a plain list, so a duplicated
+    module was registered twice but the first `unregister_pickle_by_value` in the
+    `finally` block removed the entry, making the second unregister raise
+    `ValueError` — on the success path that blocked the `metadata.json` write.
+    """
+    import json as some_module
+
+    import cloudpickle
+
+    program = dspy.Predict(dspy.Signature("q -> a"))
+    program.save(
+        tmp_path / "prog",
+        save_program=True,
+        modules_to_serialize=[some_module, some_module],
+    )
+    assert some_module.__name__ not in cloudpickle.list_registry_pickle_by_value()
+    assert (tmp_path / "prog" / "metadata.json").exists()
+
+
 def test_load_with_version_mismatch(tmp_path):
     from dspy.primitives.base_module import logger
 

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -262,3 +262,19 @@ def callback(x):
         # Only need to clean up sys.path
         if str(tmp_path) in sys.path:
             sys.path.remove(str(tmp_path))
+
+
+def test_settings_save_with_duplicate_modules_does_not_raise(tmp_path):
+    """Passing the same module twice in `modules_to_serialize` must not raise.
+
+    Mirrors the `registered_by_us` deduplication in `dspy/settings.py`: without
+    dedup, the second `unregister_pickle_by_value` in the `finally` block raised
+    `ValueError` because the first call had already removed the entry.
+    """
+    import json as some_module
+
+    import cloudpickle
+
+    settings_path = tmp_path / "settings.pkl"
+    dspy.settings.save(settings_path, modules_to_serialize=[some_module, some_module])
+    assert some_module.__name__ not in cloudpickle.list_registry_pickle_by_value()


### PR DESCRIPTION
## 📝 Changes Description

`BaseModule.save(..., modules_to_serialize=...)` and `Settings.save(..., modules_to_serialize=...)` register the given modules with `cloudpickle.register_pickle_by_value(module)` but **never unregister them**.

`register_pickle_by_value` mutates cloudpickle's **process-global** `_PICKLE_BY_VALUE_MODULES` registry. Because nothing unregisters, every module passed to a save call stays registered by value for the rest of the interpreter session — a leaked global side effect.

### Root cause

`dspy/primitives/base_module.py` and `dspy/dsp/utils/settings.py` both did:

```python
for module in modules_to_serialize:
    cloudpickle.register_pickle_by_value(module)   # never undone
...
cloudpickle.dump(self, f)
```

There is no matching `unregister_pickle_by_value`, so the registration outlives the `save()` call.

### Impact

1. **Leaked global state in production.** After a single `save(..., modules_to_serialize=[m])`, module `m` pickles *by value* in every later, unrelated cloudpickle operation in the same process — a surprising, sticky side effect of a save call.
2. **Cross-test pollution.** `tests/utils/test_settings.py::test_settings_save_with_extra_modules` registers a `custom_module` by value, which then makes the independent `tests/primitives/test_base_module.py::test_save_with_extra_modules` fail:

```
FAILED tests/primitives/test_base_module.py::test_save_with_extra_modules
    with pytest.raises(ModuleNotFoundError):
E   Failed: DID NOT RAISE ModuleNotFoundError
```

The victim test expects loading a genuinely-missing module to raise `ModuleNotFoundError`, but the leaked by-value registration made cloudpickle embed the code, so the load unexpectedly succeeded.

Reproduce on `main`:

```console
$ python -m pytest -q \
    tests/utils/test_settings.py::test_settings_save_with_extra_modules \
    tests/primitives/test_base_module.py::test_save_with_extra_modules
1 failed, 1 passed
```

Minimal, no-test reproduction of the leak itself:

```python
import cloudpickle, dspy, tempfile, pathlib
import json as m
prog = dspy.Predict(dspy.Signature("q -> a"))
with tempfile.TemporaryDirectory() as d:
    prog.save(pathlib.Path(d) / "p", save_program=True, modules_to_serialize=[m])
print(cloudpickle.list_registry_pickle_by_value())   # -> {'json'}  (leaked!)
```

### The fix

Wrap the register/dump in `try/finally` and unregister in the `finally`. Only unregister the modules **this call** actually registered — computed by diffing against `cloudpickle.list_registry_pickle_by_value()` before registering — so we restore the registry to its prior state **without clobbering** modules the caller had already registered by value themselves. (`unregister_pickle_by_value` raises `ValueError` on an unregistered module, so this guard also keeps the cleanup safe.)

### Before / after

| Scenario | Before | After |
| --- | --- | --- |
| `list_registry_pickle_by_value()` after `save(modules_to_serialize=[m])` | `{'m'}` (leaked) | `set()` (restored) |
| `m` already registered by value by the caller, then `save(...)` | still `{'m'}` | still `{'m'}` (preserved) |
| `test_settings_save_with_extra_modules` then `test_save_with_extra_modules` | victim fails | both pass |

### Tests

Added `test_save_with_extra_modules_does_not_leak_pickle_by_value_registry`, which asserts the registry is clean after `save()` and that a pre-existing user registration is preserved. Verified it guards the bug:

```console
# with source fix reverted (test kept):
$ python -m pytest -q tests/primitives/test_base_module.py::test_save_with_extra_modules_does_not_leak_pickle_by_value_registry
1 failed        # AssertionError: registry leaked

# with the fix:
1 passed
```

Full affected suites are green, including the original failing cross-module sequence:

```console
$ python -m pytest -q tests/signatures tests/adapters tests/utils tests/primitives
482 passed, 52 skipped, 2 xfailed          # was "1 failed, 480 passed" on main
```

`ruff check` on the changed files reports only pre-existing findings (verified identical counts with the change stashed); the added lines introduce no new lint.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally): `ruff check` on changed files introduces no new findings
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format `{label}(dspy): {message}`

## ⚠️ Warnings

None. The change is additive cleanup with no behavior change to successful save/load output; it only stops leaking cloudpickle global state.
