### PR TITLE
feat: add tool call exact match metric

### DIFF
--- a/dspy/evaluate/__init__.py
+++ b/dspy/evaluate/__init__.py
@@ -1,12 +1,13 @@
 from dspy.evaluate.auto_evaluation import CompleteAndGrounded, SemanticF1
 from dspy.evaluate.evaluate import Evaluate, EvaluationResult
-from dspy.evaluate.metrics import EM, answer_exact_match, answer_passage_match, normalize_text
+from dspy.evaluate.metrics import EM, answer_exact_match, answer_passage_match, normalize_text, tool_call_exact_match
 
 __all__ = [
     "EM",
     "normalize_text",
     "answer_exact_match",
     "answer_passage_match",
+    "tool_call_exact_match",
     "Evaluate",
     "SemanticF1",
     "CompleteAndGrounded",

--- a/dspy/evaluate/metrics.py
+++ b/dspy/evaluate/metrics.py
@@ -323,16 +323,15 @@ def _freeze_tool_call_arg(value):
         return ("dict", tuple((key, _freeze_tool_call_arg(value[key])) for key in sorted(value)))
     if isinstance(value, list):
         return ("list", tuple(_freeze_tool_call_arg(item) for item in value))
-    return (type(value).__qualname__, value)
+    return (type(value), value)
 
 
 def _tool_call_counter(value):
     try:
         tool_calls = ToolCalls.model_validate(value).tool_calls
+        return Counter((tool_call.name, _freeze_tool_call_arg(tool_call.args)) for tool_call in tool_calls)
     except Exception:
         return None
-
-    return Counter((tool_call.name, _freeze_tool_call_arg(tool_call.args)) for tool_call in tool_calls)
 
 
 def tool_call_exact_match(example, pred, trace=None):

--- a/dspy/evaluate/metrics.py
+++ b/dspy/evaluate/metrics.py
@@ -5,6 +5,7 @@ import string
 import unicodedata
 from collections import Counter
 
+from dspy.adapters.types import ToolCalls
 from dspy.dsp.utils.utils import print_message
 
 
@@ -315,6 +316,44 @@ def answer_exact_match(example, pred, trace=None, frac=1.0):
         return _answer_match(pred.answer, example.answer, frac=frac)
 
     raise ValueError(f"Invalid answer type: {type(example.answer)}")
+
+
+def _freeze_tool_call_arg(value):
+    if isinstance(value, dict):
+        return ("dict", tuple((key, _freeze_tool_call_arg(value[key])) for key in sorted(value)))
+    if isinstance(value, list):
+        return ("list", tuple(_freeze_tool_call_arg(item) for item in value))
+    return (type(value).__qualname__, value)
+
+
+def _tool_call_counter(value):
+    try:
+        tool_calls = ToolCalls.model_validate(value).tool_calls
+    except Exception:
+        return None
+
+    return Counter((tool_call.name, _freeze_tool_call_arg(tool_call.args)) for tool_call in tool_calls)
+
+
+def tool_call_exact_match(example, pred, trace=None):
+    """Return whether predicted tool calls exactly match labeled tool calls.
+
+    The comparison accepts any value supported by `dspy.ToolCalls`, ignores provider-generated
+    call IDs and tool call results, and treats multiple calls as an order-independent multiset.
+    Tool names and argument structures must match exactly; no fuzzy matching or type coercion is
+    applied.
+    """
+    example_tool_calls = getattr(example, "tool_calls", None)
+    pred_tool_calls = getattr(pred, "tool_calls", None)
+    if example_tool_calls is None or pred_tool_calls is None:
+        return False
+
+    example_counter = _tool_call_counter(example_tool_calls)
+    pred_counter = _tool_call_counter(pred_tool_calls)
+    if example_counter is None or pred_counter is None:
+        return False
+
+    return example_counter == pred_counter
 
 
 def answer_passage_match(example, pred, trace=None):

--- a/tests/evaluate/test_metrics.py
+++ b/tests/evaluate/test_metrics.py
@@ -1,7 +1,7 @@
 # FILEPATH: /Users/ahle/repos/dspy/tests/evaluate/test_metrics.py
 
 import dspy
-from dspy.evaluate.metrics import answer_exact_match
+from dspy.evaluate.metrics import answer_exact_match, tool_call_exact_match
 from dspy.predict import Predict
 
 
@@ -33,3 +33,69 @@ def test_answer_exact_match_no_match():
     pred = Predict("question -> answer")
     pred.answer = "3"
     assert not answer_exact_match(example, pred)
+
+
+def test_tool_call_exact_match_ignores_call_ids_and_order():
+    example = dspy.Example(
+        tool_calls=dspy.ToolCalls.from_dict_list(
+            [
+                {"id": "gold-1", "name": "search", "args": {"query": "DSPy", "limit": 5}},
+                {"id": "gold-2", "name": "lookup", "args": {"id": "42"}},
+            ]
+        )
+    )
+    pred = dspy.Prediction(
+        tool_calls=dspy.ToolCalls.from_dict_list(
+            [
+                {"id": "pred-2", "name": "lookup", "args": {"id": "42"}},
+                {"id": "pred-1", "name": "search", "args": {"query": "DSPy", "limit": 5}},
+            ]
+        )
+    )
+
+    assert tool_call_exact_match(example, pred)
+
+
+def test_tool_call_exact_match_accepts_provider_shaped_dicts():
+    example = dspy.Example(
+        tool_calls=[
+            {
+                "id": "call-gold",
+                "type": "function",
+                "function": {"name": "search", "arguments": '{"query": "DSPy"}'},
+            }
+        ]
+    )
+    pred = dspy.Prediction(tool_calls=dspy.ToolCalls.from_dict_list([{"name": "search", "args": {"query": "DSPy"}}]))
+
+    assert tool_call_exact_match(example, pred)
+
+
+def test_tool_call_exact_match_counts_duplicate_calls():
+    example = dspy.Example(
+        tool_calls=dspy.ToolCalls.from_dict_list(
+            [
+                {"name": "search", "args": {"query": "DSPy"}},
+                {"name": "search", "args": {"query": "DSPy"}},
+            ]
+        )
+    )
+    pred = dspy.Prediction(tool_calls=dspy.ToolCalls.from_dict_list([{"name": "search", "args": {"query": "DSPy"}}]))
+
+    assert not tool_call_exact_match(example, pred)
+
+
+def test_tool_call_exact_match_requires_exact_argument_values():
+    example = dspy.Example(tool_calls=dspy.ToolCalls.from_dict_list([{"name": "search", "args": {"limit": 5}}]))
+    pred = dspy.Prediction(tool_calls=dspy.ToolCalls.from_dict_list([{"name": "search", "args": {"limit": "5"}}]))
+
+    assert not tool_call_exact_match(example, pred)
+
+
+def test_tool_call_exact_match_is_exported_from_evaluate():
+    from dspy.evaluate import tool_call_exact_match as exported_metric
+
+    example = dspy.Example(tool_calls=dspy.ToolCalls.from_dict_list([{"name": "search", "args": {"query": "DSPy"}}]))
+    pred = dspy.Prediction(tool_calls=dspy.ToolCalls.from_dict_list([{"name": "search", "args": {"query": "DSPy"}}]))
+
+    assert exported_metric(example, pred)

--- a/tests/evaluate/test_metrics.py
+++ b/tests/evaluate/test_metrics.py
@@ -92,6 +92,17 @@ def test_tool_call_exact_match_requires_exact_argument_values():
     assert not tool_call_exact_match(example, pred)
 
 
+def test_tool_call_exact_match_returns_false_for_unhashable_argument_values():
+    example = dspy.Example(
+        tool_calls=dspy.ToolCalls(tool_calls=[dspy.ToolCalls.ToolCall(name="search", args={"tags": {"dspy"}})])
+    )
+    pred = dspy.Prediction(
+        tool_calls=dspy.ToolCalls(tool_calls=[dspy.ToolCalls.ToolCall(name="search", args={"tags": {"dspy"}})])
+    )
+
+    assert not tool_call_exact_match(example, pred)
+
+
 def test_tool_call_exact_match_is_exported_from_evaluate():
     from dspy.evaluate import tool_call_exact_match as exported_metric
 


### PR DESCRIPTION
## Summary
- Adds `tool_call_exact_match(example, pred, trace=None)` for deterministic comparison of `dspy.ToolCalls`.
- Accepts any shape supported by `ToolCalls.model_validate`, ignores provider-generated call IDs and `ToolCallResults`, and compares tool names plus argument structures exactly.
- Treats multiple calls as an order-independent multiset so parallel-call ordering does not affect correctness while duplicate calls remain significant.
- Exports the metric from `dspy.evaluate`.

Closes #9961.

## Test Plan
- `uv run --with pytest pytest tests/evaluate/test_metrics.py -q`
  - Before the implementation, collection failed because `tool_call_exact_match` was missing.
- `uv run --with ruff ruff check dspy/evaluate/metrics.py dspy/evaluate/__init__.py tests/evaluate/test_metrics.py`
- `uv run --with ruff ruff format --check dspy/evaluate/metrics.py dspy/evaluate/__init__.py tests/evaluate/test_metrics.py`
