### PR TITLE
fix(tool): exclude defaulted args from required in function-calling schema

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -158,7 +158,7 @@ class Tool(Type):
                 "parameters": {
                     "type": "object",
                     "properties": self.args,
-                    "required": list(self.args.keys()),
+                    "required": [k for k in self.args if "default" not in self.args[k]],
                 },
             },
         }

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -1165,7 +1165,7 @@ def test_chat_adapter_format_exact_messages_and_lm_kwargs_with_native_tool_calli
                              "parameters": {"type": "object",
                                             "properties": {"query": {"type": "string"},
                                                            "k": {"type": "integer", "default": 3}},
-                                            "required": ["query", "k"]}}}]}
+                                            "required": ["query"]}}}]}
     assert lm_kwargs == expected_lm_kwargs
 
 

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -604,7 +604,7 @@ def test_json_adapter_format_exact_messages_and_lm_kwargs_with_native_tool_calli
                              "parameters": {"type": "object",
                                             "properties": {"query": {"type": "string"},
                                                            "k": {"type": "integer", "default": 3}},
-                                            "required": ["query", "k"]}}}]}
+                                            "required": ["query"]}}}]}
     assert lm_kwargs == expected_lm_kwargs
 
 def test_json_adapter_format_exact_messages_with_tool_calls_output_demo():

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -146,6 +146,19 @@ def test_tool_from_function():
     assert tool.args["y"]["default"] == "hello"
 
 
+def test_format_as_litellm_function_call_excludes_defaulted_args_from_required():
+    # `x` has no default and must be required; `y` has a default and must be optional.
+    tool = Tool(dummy_function)
+
+    function_call = tool.format_as_litellm_function_call()
+    parameters = function_call["function"]["parameters"]
+
+    assert parameters["required"] == ["x"]
+    assert "y" not in parameters["required"]
+    # The default is still advertised on the property itself.
+    assert parameters["properties"]["y"]["default"] == "hello"
+
+
 def test_tool_from_class():
     class Foo:
         def __init__(self, user_id: str):


### PR DESCRIPTION
## What
`Tool.format_as_litellm_function_call` listed *every* argument in `required`, including ones with default values. That contradicts the `default` already advertised on the property, and strict function-calling schemas reject a parameter that is simultaneously `required` and has a `default`.

## Change
Only arguments without a default are now listed in `required`. The signal already existed — `_parse_function` records `default` on each arg's schema — so this just reads it.

## Test
Added `test_format_as_litellm_function_call_excludes_defaulted_args_from_required` (this method had no test before). Builds a tool with one required + one defaulted arg and asserts only the required one appears in `required`. Confirmed it **fails on old code, passes with the fix**.

Fixes #9882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
