### PR TITLE
Extract public record_trace helper

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -44,6 +44,7 @@ from dspy.utils.logging_utils import configure_dspy_loggers, disable_logging, en
 from dspy.utils.asyncify import asyncify
 from dspy.utils.syncify import syncify
 from dspy.utils.saving import load
+from dspy.utils.trace import record_trace
 from dspy.streaming.streamify import streamify
 from dspy.utils.usage_tracker import track_usage
 

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -15,6 +15,7 @@ from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import Signature, ensure_signature
 from dspy.utils.callback import BaseCallback
 from dspy.utils.constants import IS_TYPE_UNDEFINED
+from dspy.utils.trace import record_trace
 
 logger = logging.getLogger(__name__)
 
@@ -232,11 +233,8 @@ class Predict(Module, Parameter):
 
     def _forward_postprocess(self, completions, signature, **kwargs):
         pred = Prediction.from_completions(completions, signature=signature)
-        if kwargs.pop("_trace", True) and settings.trace is not None and settings.max_trace_size > 0:
-            trace = settings.trace
-            if len(trace) >= settings.max_trace_size:
-                trace.pop(0)
-            trace.append((self, {**kwargs}, pred))
+        if kwargs.pop("_trace", True):
+            record_trace(self, kwargs, pred)
         return pred
 
     def _should_stream(self):

--- a/dspy/utils/trace.py
+++ b/dspy/utils/trace.py
@@ -1,0 +1,29 @@
+"""The optimizer-facing execution trace.
+
+When tracing is active (``dspy.settings.trace`` is a list), every predictor
+invocation appends one ``(predictor, inputs, prediction)`` tuple. Teleprompters
+(GEPA, MIPROv2, SIMBA, bootstrapping) mine these tuples to attribute examples
+and feedback to individual predictors. This tuple shape is a public contract:
+custom predictors that execute outside ``dspy.Predict`` (e.g. harness- or
+backend-based modules) should call :func:`record_trace` so optimizers can see
+their invocations.
+"""
+
+from typing import Any, Mapping
+
+from dspy.dsp.utils.settings import settings
+
+
+def record_trace(predictor: Any, inputs: Mapping[str, Any], prediction: Any) -> None:
+    """Append one ``(predictor, inputs, prediction)`` tuple to the active trace.
+
+    No-op when tracing is disabled. Enforces ``settings.max_trace_size`` as a
+    bounded FIFO. ``inputs`` is copied into a plain dict so later mutation of
+    the caller's kwargs cannot corrupt the trace.
+    """
+    if settings.trace is None or settings.max_trace_size <= 0:
+        return
+    trace = settings.trace
+    if len(trace) >= settings.max_trace_size:
+        trace.pop(0)
+    trace.append((predictor, dict(inputs), prediction))


### PR DESCRIPTION
## Summary

This extracts DSPy's internal trace append behavior into a public `dspy.record_trace(...)` helper.

The helper centralizes the logic for recording a `(predictor, inputs, prediction)` tuple into the active DSPy trace context. `Predict.forward` now uses that helper instead of appending to `settings.trace` directly, and the helper is exported from `dspy.__init__`.

## Impact

- Gives custom `Predict` subclasses and integrations a supported way to participate in DSPy tracing.
- Keeps existing `Predict.forward` trace behavior intact.
- Avoids each integration reaching into `settings.trace` directly.

## Validation

- `uv run pytest vendor/dspy/tests/predict/test_predict_extension.py -q`
- Downstream DSAG interop regression: `uv run pytest tests/test_dspy_gepa_interop.py -q`