### PR TITLE
Add Predict instructions property

### DIFF
--- a/dspy/predict/parameter.py
+++ b/dspy/predict/parameter.py
@@ -1,2 +1,7 @@
 class Parameter:
-    pass
+    """Vestigial marker used by module traversal, state dumps, and deepcopy.
+
+    Not a public concept: the optimizer-facing predictor is ``dspy.Predict``,
+    and custom predictors subclass it. Kept only because ``named_parameters()``
+    and ``BaseModule.deepcopy`` key off it.
+    """

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -68,6 +68,22 @@ class Predict(Module, Parameter):
         self.train = []
         self.demos = []
 
+    @property
+    def instructions(self) -> str:
+        """The learned instruction text — the canonical optimizer read/write target.
+
+        Instructions are predictor state, not part of the signature contract;
+        this property keeps them addressable on the predictor while storing
+        them on the signature, so legacy code that reassigns ``.signature``
+        observes the same state. Subclasses that hold learned state elsewhere
+        (e.g. a non-LM execution backend) can override the pair.
+        """
+        return self.signature.instructions
+
+    @instructions.setter
+    def instructions(self, value: str) -> None:
+        self.signature = self.signature.with_instructions(value)
+
     def dump_state(self, json_mode=True):
         state_keys = ["traces", "train"]
         state = {k: getattr(self, k) for k in state_keys}

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -132,7 +132,10 @@ class Module(BaseModule, metaclass=ProgramMeta):
         """Return all named Predict modules in this module.
 
         Iterates through all parameters and returns those that are instances
-        of ``dspy.Predict``, along with their names.
+        of ``dspy.Predict``, along with their names. Custom predictors
+        (e.g. ones that execute outside the LM/adapter path) participate by
+        subclassing ``Predict`` and overriding ``forward``; optimizers only
+        rely on ``signature``, ``instructions``, ``demos``, and the trace.
 
         Returns:
             list[tuple[str, Predict]]: A list of (name, predictor) tuples

--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -114,7 +114,7 @@ class DspyGEPAResult:
 
     def to_dict(self) -> dict[str, Any]:
         cands = [
-            {name: pred.signature.instructions for name, pred in cand.named_predictors()}
+            {name: pred.instructions for name, pred in cand.named_predictors()}
             for cand in self.candidates
         ]
 
@@ -572,7 +572,7 @@ class GEPA(Teleprompter):
         )
 
         # Build the seed candidate: map each predictor name to its current instruction
-        seed_candidate = {name: pred.signature.instructions for name, pred in student.named_predictors()}
+        seed_candidate = {name: pred.instructions for name, pred in student.named_predictors()}
 
         gepa_result: GEPAResult = optimize(
             seed_candidate=seed_candidate,

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -141,7 +141,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
 
         for name, pred in new_prog.named_predictors():
             if name in candidate:
-                pred.signature = pred.signature.with_instructions(candidate[name])
+                pred.instructions = candidate[name]
 
         return new_prog
 

--- a/tests/predict/test_predict_extension.py
+++ b/tests/predict/test_predict_extension.py
@@ -1,0 +1,81 @@
+"""The optimizer-facing surface of Predict, as used by custom predictors.
+
+A custom predictor (e.g. one backed by an agent harness instead of the
+LM/adapter path) subclasses ``dspy.Predict`` and overrides ``forward``.
+Optimizers only rely on: discovery via ``named_predictors()``, the learned
+parameters ``instructions``/``demos``, and ``(predictor, inputs, prediction)``
+tuples in the trace. These tests pin that surface.
+"""
+
+import dspy
+from dspy.utils.trace import record_trace
+
+
+class BackendPredict(dspy.Predict):
+    """A Predict whose execution bypasses the LM/adapter path entirely."""
+
+    def forward(self, **kwargs):
+        pred = dspy.Prediction(answer=f"backend saw: {self.instructions}")
+        record_trace(self, kwargs, pred)
+        return pred
+
+
+class Program(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.qa = dspy.Predict("question -> answer")
+        self.backend = BackendPredict("question -> answer")
+
+
+def test_named_predictors_discovers_predict_subclasses():
+    program = Program()
+    names = [name for name, _ in program.named_predictors()]
+    assert names == ["qa", "backend"]
+
+
+def test_instructions_is_the_canonical_parameter():
+    pred = dspy.Predict("question -> answer")
+    pred.instructions = "Answer concisely."
+    assert pred.signature.instructions == "Answer concisely."
+    assert pred.instructions == "Answer concisely."
+
+    # Legacy signature reassignment stays observable through the property.
+    pred.signature = pred.signature.with_instructions("Answer verbosely.")
+    assert pred.instructions == "Answer verbosely."
+
+
+def test_backend_predict_runs_without_lm_or_adapter():
+    program = Program()
+    program.backend.instructions = "Be brief."
+    result = program.backend(question="hello")
+    assert result.answer == "backend saw: Be brief."
+
+
+def test_record_trace_matches_predict_tuple_shape():
+    program = Program()
+    with dspy.context(trace=[]):
+        program.backend(question="hello")
+        trace = dspy.settings.trace
+        assert len(trace) == 1
+        predictor, inputs, prediction = trace[0]
+        assert predictor is program.backend
+        assert inputs == {"question": "hello"}
+
+
+def test_record_trace_bounds_trace_size():
+    predictor = BackendPredict("question -> answer")
+    with dspy.context(trace=[], max_trace_size=3):
+        for i in range(5):
+            record_trace(predictor, {"i": i}, dspy.Prediction(answer=str(i)))
+        trace = dspy.settings.trace
+        assert len(trace) == 3
+        assert [t[1]["i"] for t in trace] == [2, 3, 4]
+
+
+def test_record_trace_noop_when_disabled():
+    predictor = BackendPredict("question -> answer")
+    with dspy.context(trace=None):
+        record_trace(predictor, {"q": "x"}, dspy.Prediction(answer="y"))
+    with dspy.context(trace=[], max_trace_size=0):
+        record_trace(predictor, {"q": "x"}, dspy.Prediction(answer="y"))
+        assert dspy.settings.trace == []


### PR DESCRIPTION
## Summary

This adds a public `Predict.instructions` property for reading and updating the instruction text associated with a predictor's signature.

The property gives optimizers and custom integrations a stable API for instruction-level edits without reaching into signature internals. The GEPA instruction update path now uses this property where appropriate.

## Impact

- Allows `predictor.instructions` reads and assignments on `dspy.Predict` instances.
- Preserves existing signature behavior while making instruction mutation explicit.
- Makes instruction edits easier for downstream optimizers and custom predictor subclasses.
- Adds focused tests for the new extension surface.

## Validation

- `uv run pytest vendor/dspy/tests/predict/test_predict_extension.py -q`
- Downstream DSAG test suite: `uv run pytest tests/`
- Downstream type check: `uv run pyright`