### PR TITLE
Fix Document.format() emitting an invalid source type for PDFs

### DIFF
--- a/dspy/adapters/types/document.py
+++ b/dspy/adapters/types/document.py
@@ -64,10 +64,12 @@ class Document(Type):
         Returns:
             A list containing the document block in the format expected by citation-enabled language models.
         """
+        # PDFs use a base64 source; only text/plain uses a text source.
+        source_type = "base64" if self.media_type == "application/pdf" else "text"
         document_block = {
             "type": "document",
             "source": {
-                "type": "text",
+                "type": source_type,
                 "media_type": self.media_type,
                 "data": self.data
             },

--- a/tests/adapters/test_document.py
+++ b/tests/adapters/test_document.py
@@ -55,3 +55,17 @@ def test_document_format():
     assert doc_block["source"]["data"] == "The sky is blue."
     assert doc_block["title"] == "Color Facts"
     assert doc_block["citations"]["enabled"] is True
+
+
+def test_document_format_pdf_uses_base64_source():
+    doc = Document(
+        data="base64pdfdata",
+        media_type="application/pdf",
+    )
+
+    doc_block = doc.format()[0]
+
+    # PDF documents must use a base64 source, not a text source.
+    assert doc_block["source"]["type"] == "base64"
+    assert doc_block["source"]["media_type"] == "application/pdf"
+    assert doc_block["source"]["data"] == "base64pdfdata"


### PR DESCRIPTION
The `Document` type advertises PDF support via `media_type: Literal["text/plain", "application/pdf"]`, but `format()` hardcodes the source type as `"text"` regardless:

```python
"source": {"type": "text", "media_type": self.media_type, "data": self.data}
```

Anthropic's document blocks require `source.type == "base64"` for `application/pdf` (only `text/plain` uses `source.type == "text"`), so `Document(data=<base64>, media_type="application/pdf").format()` currently produces a block the API rejects, and the advertised PDF path is broken.

Fix is one line: pick the source type from `media_type`.

```python
source_type = "base64" if self.media_type == "application/pdf" else "text"
```

I added a PDF case to `tests/adapters/test_document.py`. The existing `test_document_with_all_fields` builds a PDF `Document` but never calls `format()`, which is why this slipped through. `pytest tests/adapters/test_document.py` gives 5 passed; the new test fails on `main`.