### PR TITLE
fix(evaluate): raise descriptive ValueError on empty devset instead of ZeroDivisionError

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -154,6 +154,9 @@ class Evaluate:
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
 
+        if not devset:
+            raise ValueError("devset must contain at least one example, got an empty devset.")
+
         if callback_metadata:
             logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
 

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -423,3 +423,14 @@ def test_evaluate_save_as_csv_with_history():
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
 
+
+def test_evaluate_raises_on_empty_devset():
+    program = Predict("question -> answer")
+    ev = Evaluate(
+        devset=[],
+        metric=answer_exact_match,
+        display_progress=False,
+    )
+    with pytest.raises(ValueError, match="devset"):
+        ev(program)
+


### PR DESCRIPTION

Calling `Evaluate.__call__` with an empty `devset` currently raises a raw
`ZeroDivisionError` from inside the metric-summary logging line in
`dspy/evaluate/evaluate.py` (`ntotal = len(devset)` is used as a divisor with
no guard). The traceback points at a logging call and gives no indication
that an empty devset is the actual cause, which is confusing when a devset
ends up empty by accident (e.g. after upstream filtering).

On the closed PR #1193, a maintainer commented that `Evaluate` should still
raise in this case, but with a descriptive exception rather than an unguarded
`ZeroDivisionError`. There is no open issue tracking this; this PR reports and
fixes it directly.

This PR adds a guard at the top of `Evaluate.__call__`, right after `devset`
is resolved from either the call argument or `self.devset`, that raises
`ValueError("devset must contain at least one example, got an empty devset.")`
when `devset` is empty. No other behavior changes.

### Testing

- Added `tests/evaluate/test_evaluate.py::test_evaluate_raises_on_empty_devset`,
  written before the fix to confirm it fails with `ZeroDivisionError` on the
  current code, and passes once the guard is added.
- Ran the full `tests/evaluate/test_evaluate.py` file before and after the
  fix: 10 passed / 25 skipped before (new test failing), 11 passed / 25
  skipped after. The 25 skips are pre-existing `@pytest.mark.extra` cases
  unrelated to this change.
- Confirmed with a stash/pop of the source change only that the new test
  fails against unfixed code and passes again once the fix is restored.

### Diff

```
 dspy/evaluate/evaluate.py       |  3 +++
 tests/evaluate/test_evaluate.py | 11 +++++++++++
 2 files changed, 14 insertions(+)
```

## Notes from CONTRIBUTING.md

- CONTRIBUTING.md says: "For minor changes (simple bug fixes or documentation
  fixes), feel free to open a PR without discussion." This qualifies, so no
  issue was opened first.
- Style/lint: the project uses `ruff` via `pre-commit`; run `pre-commit run
  --files dspy/evaluate/evaluate.py tests/evaluate/test_evaluate.py` before
  submitting (not yet run in this pass; pre-commit was not installed in the
  scratch venv used for this local fix).
- Python 3.10+ is the stated minimum; the guard clause uses no version-specific
  syntax.
