### PR TITLE
fix: GroundedProposer ignores hand-labeled demos (sub-issue 4 of #9938)

### DIFF
--- a/dspy/propose/grounded_proposer.py
+++ b/dspy/propose/grounded_proposer.py
@@ -153,16 +153,19 @@ class GenerateModuleInstruction(dspy.Module):
         tip=None,
     ):
         def gather_examples_from_sets(candidate_sets, max_examples):
-            """Helper function to gather up to augmented examples from given sets."""
+            """Helper function to gather up to max_examples from given sets.
+
+            Yields rendered example strings for both bootstrapped (augmented) demos
+            and hand-labeled demos, since both are valid context for instruction proposal.
+            """
             count = 0
             for candidate_set in candidate_sets:
                 for example in candidate_set:
-                    if "augmented" in example.keys():
-                        fields_to_use = get_signature(program.predictors()[pred_i]).fields
-                        yield create_example_string(fields_to_use, example)
-                        count += 1
-                        if count >= max_examples:
-                            return
+                    fields_to_use = get_signature(program.predictors()[pred_i]).fields
+                    yield create_example_string(fields_to_use, example)
+                    count += 1
+                    if count >= max_examples:
+                        return
 
         # Construct full program demo or single module demo depending on settings
         basic_instruction = get_signature(program.predictors()[pred_i]).instructions

--- a/tests/propose/test_grounded_proposer.py
+++ b/tests/propose/test_grounded_proposer.py
@@ -63,3 +63,71 @@ def test_propose_instruction_for_predictor(demo_candidates):
     )
     assert result == "instruction"
     assert prompt_model.last_copy_kwargs["temperature"] == 0.7
+
+
+def test_labeled_demos_included_in_task_demos():
+    """Regression test: labeled (non-augmented) demos must appear in task_demos context.
+
+    gather_examples_from_sets previously required the "augmented" key, which only
+    bootstrapped demos carry. Hand-labeled examples from the training set never have
+    this key, so they were silently excluded. When max_bootstrapped_demos=0 and only
+    labeled demos exist, task_demos always collapsed to "No task demos provided.",
+    giving the instruction proposer no context about the task.
+    """
+
+    class SharedHistoryDummyLM(DummyLM):
+        """DummyLM whose copies share the parent's history list for post-call inspection."""
+
+        def copy(self, **kwargs):
+            clone = super().copy(**kwargs)
+            clone.history = self.history  # share list reference
+            return clone
+
+    prompt_model = SharedHistoryDummyLM([{"proposed_instruction": "instruction"}] * 20)
+    program = Predict("question -> answer")
+
+    # A labeled example WITHOUT the "augmented" key, as produced from a training set.
+    labeled_example = dspy.Example(question="What is 2+2?", answer="4")
+    assert "augmented" not in labeled_example.keys(), "setup: labeled_example must not have 'augmented'"
+
+    # Two demo candidate sets so demo_set_i=1 avoids the demo_set_i==0 shortcircuit.
+    demo_candidates = [
+        [
+            [labeled_example],  # set 0 — adjacent set used when demo_set_i=1
+            [labeled_example],  # set 1 — current set
+        ]
+    ]
+
+    proposer = GroundedProposer(
+        prompt_model=prompt_model,
+        program=program,
+        trainset=[],
+        use_dataset_summary=False,
+        program_aware=False,
+        use_task_demos=True,
+        use_instruct_history=False,
+        verbose=False,
+    )
+
+    proposer.propose_instruction_for_predictor(
+        program=program,
+        predictor=None,
+        pred_i=0,
+        demo_candidates=demo_candidates,
+        demo_set_i=1,
+        trial_logs={},
+        tip=None,
+    )
+
+    assert len(prompt_model.history) > 0, "LM must have been called"
+    full_prompt = " ".join(
+        str(m.get("content", "")) for m in prompt_model.history[-1]["messages"]
+    )
+    assert "What is 2+2?" in full_prompt, (
+        "Labeled demo ('What is 2+2?') must appear in the task_demos context sent to the "
+        "instruction proposer. If missing, gather_examples_from_sets is still filtering out "
+        "non-augmented examples."
+    )
+    assert "No task demos provided." not in full_prompt, (
+        "task_demos must contain the labeled example rather than the fallback message."
+    )


### PR DESCRIPTION
## Summary

Closes sub-issue 4 of #9938 (MIPROv2 crashes / produces wrong results when `max_bootstrapped_demos=0`).

### The bug

`GenerateModuleInstruction.forward()` contains a nested helper `gather_examples_from_sets` that filters candidate examples with:

```python
if "augmented" in example.keys():
```

The `"augmented"` key is only ever set on **bootstrapped** demos (see `BootstrapFewShot._bootstrap_one_example`, which does `dspy.Example(augmented=True, ...)`). Hand-labeled examples from the training set are appended to `predictor.demos` as plain `dspy.Example` objects with no `"augmented"` key.

**Concrete consequence**: when `max_bootstrapped_demos=0` and only labeled demos exist in `demo_candidates`, `gather_examples_from_sets` yields nothing, `task_demos` is an empty string, and the fallback fires:

```python
if not task_demos.strip() or demo_set_i == 0:
    task_demos = "No task demos provided."
```

The instruction proposer LM is given zero task context even though the caller explicitly provided labeled examples.

### The fix

Remove the `"augmented"` guard so the function yields all examples — both bootstrapped and hand-labeled. Both are equally valid as context for instruction proposal. The one-line removal is the entire change to production code.

### Verification

Added `test_labeled_demos_included_in_task_demos` in `tests/propose/test_grounded_proposer.py`:
- Constructs `demo_candidates` containing only labeled examples (no `"augmented"` key)
- Uses `demo_set_i=1` to bypass the `demo_set_i == 0` shortcircuit
- Asserts the labeled example text appears in the final prompt sent to the proposer LM
- Asserts "No task demos provided." is absent from that prompt

All 5 tests in `tests/propose/test_grounded_proposer.py` pass.

**Before fix**: `gather_examples_from_sets` yields 0 examples for labeled-only demo sets.  
**After fix**: yields the rendered example string (e.g. `"Question: What is 2+2?\nAnswer: 4"`).

This is one of four sub-issues in #9938; sub-issue 1 (randrange crash) was addressed by #9939.