### PR TITLE
fix(adapters): stop custom Type docstrings leaking into prompts via nested annotations (#9251)

### DIFF
--- a/dspy/adapters/types/base_type.py
+++ b/dspy/adapters/types/base_type.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import re
 from typing import TYPE_CHECKING, Any, Optional, get_args, get_origin
@@ -40,6 +41,19 @@ class Type(pydantic.BaseModel):
     def description(cls) -> str:
         """Description of the custom type"""
         return ""
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, core_schema: Any, handler: pydantic.GetJsonSchemaHandler) -> dict[str, Any]:
+        json_schema = handler(core_schema)
+        # Pydantic embeds the class docstring as the schema "description". For DSPy custom types the
+        # docstring is developer documentation (often containing full code examples), not LLM
+        # instructions, and it leaks into adapter prompts whenever the type appears in a composite
+        # annotation, e.g. `list[dspy.Code]` (see #9251). Strip it; LLM-facing guidance belongs in
+        # `description()`. Descriptions set explicitly (not derived from the docstring) are preserved.
+        docstring = inspect.cleandoc(cls.__doc__) if cls.__doc__ else None
+        if docstring and json_schema.get("description") == docstring:
+            json_schema.pop("description")
+        return json_schema
 
     @classmethod
     def extract_custom_type_from_annotation(cls, annotation):

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -1,5 +1,4 @@
 import json
-import re
 from typing import Literal
 from unittest import mock
 
@@ -788,8 +787,7 @@ def test_chat_adapter_format_exact_messages_with_citations_output_demo():
                  '\n'
                  '[[ ## citations ## ]]\n'
                  '{citations}        # note: the value you produce must adhere to the JSON schema: '
-                 '{"type": "object", "$defs": {"Citation": {"type": "object", "description": '
-                 '"Individual citation with character location information.", "properties": {"type": '
+                 '{"type": "object", "$defs": {"Citation": {"type": "object", "properties": {"type": '
                  '{"type": "string", "default": "char_location", "title": "Type"}, "cited_text": '
                  '{"type": "string", "title": "Cited Text"}, "document_index": {"type": "integer", '
                  '"title": "Document Index"}, "document_title": {"anyOf": [{"type": "string"}, '
@@ -798,32 +796,7 @@ def test_chat_adapter_format_exact_messages_with_citations_output_demo():
                  '"integer", "title": "Start Char Index"}, "supported_text": {"anyOf": [{"type": '
                  '"string"}, {"type": "null"}], "default": null, "title": "Supported Text"}}, '
                  '"required": ["cited_text", "document_index", "start_char_index", "end_char_index"], '
-                 '"title": "Citation"}}, "description": "Experimental: This class may change or be '
-                 'removed in a future release without warning (introduced in v3.0.4).\\n\\nCitations '
-                 'extracted from an LM response with source references.\\n\\n    This type represents '
-                 'citations returned by language models that support\\n    citation extraction, '
-                 "particularly Anthropic's Citations API through LiteLLM.\\n    Citations include the "
-                 'quoted text and source information.\\n\\n    Examples:\\n        ```python\\n        '
-                 'import os\\n        import dspy\\n        from dspy.signatures import '
-                 'Signature\\n        from dspy.experimental import Citations, Document\\n        '
-                 'os.environ[\\"ANTHROPIC_API_KEY\\"] = \\"YOUR_ANTHROPIC_API_KEY\\"\\n\\n        '
-                 "class AnswerWithSources(Signature):\\n            '''Answer questions using provided "
-                 "documents with citations.'''\\n            documents: list[Document] = "
-                 'dspy.InputField()\\n            question: str = dspy.InputField()\\n            '
-                 'answer: str = dspy.OutputField()\\n            citations: Citations = '
-                 'dspy.OutputField()\\n\\n        # Create documents to provide as sources\\n        '
-                 'docs = [\\n            Document(\\n                data=\\"The Earth orbits the Sun '
-                 'in an elliptical path.\\",\\n                title=\\"Basic Astronomy '
-                 'Facts\\"\\n            ),\\n            Document(\\n                data=\\"Water '
-                 'boils at 100°C at standard atmospheric pressure.\\",\\n                '
-                 'title=\\"Physics Fundamentals\\",\\n                metadata={\\"author\\": \\"Dr. '
-                 'Smith\\", \\"year\\": 2023}\\n            )\\n        ]\\n\\n        # Use with a '
-                 'model that supports citations like Claude\\n        lm = '
-                 'dspy.LM(\\"anthropic/claude-opus-4-1-20250805\\")\\n        predictor = '
-                 'dspy.Predict(AnswerWithSources)\\n        result = predictor(documents=docs, '
-                 'question=\\"What temperature does water boil?\\", lm=lm)\\n\\n        for citation '
-                 'in result.citations.citations:\\n            print(citation.format())\\n        '
-                 '```\\n    ", "properties": {"citations": {"type": "array", "items": {"$ref": '
+                 '"title": "Citation"}}, "properties": {"citations": {"type": "array", "items": {"$ref": '
                  '"#/$defs/Citation"}, "title": "Citations"}}, "required": ["citations"], "title": '
                  '"Citations"}\n'
                  '\n'
@@ -845,16 +818,6 @@ def test_chat_adapter_format_exact_messages_with_citations_output_demo():
                  "Respond with the corresponding output fields, starting with the field `[[ ## "
                  "citations ## ]]` (must be formatted as a valid Python Citations), and then ending "
                  "with the marker for `[[ ## completed ## ]]`."}]
-    def normalize_citations_schema_description(content):
-        return re.sub(
-            r'"description": ".*?", "properties":',
-            '"description": "<CITATIONS_SCHEMA_DESCRIPTION>", "properties":',
-            content,
-        )
-
-    messages[0]["content"] = normalize_citations_schema_description(messages[0]["content"])
-    expected_messages[0]["content"] = normalize_citations_schema_description(expected_messages[0]["content"])
-
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs

--- a/tests/adapters/test_code.py
+++ b/tests/adapters/test_code.py
@@ -61,3 +61,58 @@ The code is a simple print statement.
 """
     code = dspy.Code(code=dirty_code_with_reasoning)
     assert code.code == "print('Hello, world!')"
+
+
+def test_nested_code_annotation_does_not_leak_docstring_into_prompt():
+    """Regression test for #9251: `dspy.Code`'s class docstring (which contains full code
+    examples) must not leak into the prompt via the pydantic JSON schema when the type
+    appears inside a composite annotation such as `list[dspy.Code]`."""
+
+    class CodeSnippets(dspy.Signature):
+        question: str = dspy.InputField()
+        snippets: list[dspy.Code] = dspy.OutputField()
+
+    messages = dspy.ChatAdapter().format(CodeSnippets, [], {"question": "reverse a string"})
+    system_content = messages[0]["content"]
+
+    # Docstring content (example code) must not appear in the prompt.
+    assert "sleepsort" not in system_content
+    assert "gpt-4o-mini" not in system_content
+    # The structural JSON schema for the list is still communicated.
+    assert "adhere to the JSON schema" in system_content
+    # The intended, LLM-facing type description is still present.
+    assert "Type description of Code" in system_content
+
+
+def test_explicit_json_schema_description_is_preserved_on_custom_types():
+    """The docstring-stripping hook must only remove descriptions derived from the class
+    docstring; explicitly configured schema descriptions are preserved."""
+    import pydantic
+
+    class DocumentedType(dspy.Type):
+        """Developer docstring that should not reach the schema."""
+
+        model_config = pydantic.ConfigDict(json_schema_extra={"description": "explicit description"})
+
+        value: str
+
+        def format(self):
+            return self.value
+
+    schema = pydantic.TypeAdapter(DocumentedType).json_schema()
+    assert schema.get("description") == "explicit description"
+
+
+def test_docstring_derived_description_is_stripped_from_custom_type_schema():
+    import pydantic
+
+    class DocstringOnlyType(dspy.Type):
+        """Developer docstring that should not reach the schema."""
+
+        value: str
+
+        def format(self):
+            return self.value
+
+    schema = pydantic.TypeAdapter(DocstringOnlyType).json_schema()
+    assert "description" not in schema

--- a/tests/adapters/test_code.py
+++ b/tests/adapters/test_code.py
@@ -87,7 +87,6 @@ def test_nested_code_annotation_does_not_leak_docstring_into_prompt():
 def test_explicit_json_schema_description_is_preserved_on_custom_types():
     """The docstring-stripping hook must only remove descriptions derived from the class
     docstring; explicitly configured schema descriptions are preserved."""
-    import pydantic
 
     class DocumentedType(dspy.Type):
         """Developer docstring that should not reach the schema."""

--- a/tests/adapters/test_code.py
+++ b/tests/adapters/test_code.py
@@ -103,8 +103,6 @@ def test_explicit_json_schema_description_is_preserved_on_custom_types():
 
 
 def test_docstring_derived_description_is_stripped_from_custom_type_schema():
-    import pydantic
-
     class DocstringOnlyType(dspy.Type):
         """Developer docstring that should not reach the schema."""
 


### PR DESCRIPTION

Fixes #9251 (the remaining nested-annotation case). 

DSPy custom types (subclasses of dspy.Type) often have developer-oriented docstrings with code examples. Pydantic includes a model's docstring as the JSON schema "description". When a custom type is nested inside another annotation (for example, list[dspy.Code]), translate_field_type falls back to embedding the JSON schema in the prompt, which causes that docstring to be exposed to the LLM. The existing check in translate_field_type only handles the bare dspy.Code case, so nested annotations still leak.

Instead of adding more special cases in translate_field_type, this fixes the issue at the source by overriding __get_pydantic_json_schema__ on the Type base class. The override removes the schema "description" only when it exactly matches the class docstring (after cleandoc), while leaving descriptions provided explicitly through json_schema_extra untouched. Since every schema for a Type subclass goes through this hook, the fix automatically covers nested uses such as list, dict, Optional, and future composite annotations.

Also adds regression tests covering the nested-annotation prompt and the strip/preserve behavior, and updates the Citations exact-message test now that its docstring is no longer included in the prompt.

Testing
- tests/adapters/: 233 passed, including 3 new regression tests.  
- The existing failures in tests/signatures/test_adapter_image.py are network-dependent and reproduce on clean main (verified with git stash).

Note for reviewers

The existing bare-Code special case in translate_field_type is left in place. Its purpose is different: when description() already fully describes the format, it avoids including the JSON schema altogether. This change addresses the underlying schema-generation issue on the Type base class, so it also covers Citations and future custom types, and allows removal of the normalize_citations_schema_description test workaround.