### PR TITLE
fix(streaming): deliver status messages from dspy.Parallel worker threads

### DIFF
--- a/dspy/dsp/utils/settings.py
+++ b/dspy/dsp/utils/settings.py
@@ -21,6 +21,7 @@ DEFAULT_CONFIG = dotdict(
     callbacks=[],
     async_max_workers=8,
     send_stream=None,
+    send_stream_loop=None,
     disable_history=False,
     track_usage=False,
     usage_tracker=None,

--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -31,9 +31,20 @@ def sync_send_to_stream(stream, message):
         await stream.send(message)
 
     try:
-        asyncio.get_running_loop()
+        running_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        running_loop = None
 
-        # If we're in an event loop, offload to a new thread with its own event loop
+    # Status callbacks fire on worker threads: the anyio worker thread that runs an
+    # asyncified program, or a plain ThreadPoolExecutor thread spawned by dspy.Parallel.
+    # Neither has a running loop. Deliver on the loop that owns the stream (captured by
+    # streamify); run_coroutine_threadsafe works from any thread other than that loop's own.
+    stream_loop = settings.send_stream_loop
+    if running_loop is None and stream_loop is not None and stream_loop.is_running():
+        return asyncio.run_coroutine_threadsafe(_send(), stream_loop).result()
+
+    if running_loop is not None:
+        # Called from within an event loop: offload to a new thread with its own loop.
         def run_in_new_loop():
             new_loop = asyncio.new_event_loop()
             asyncio.set_event_loop(new_loop)
@@ -45,9 +56,9 @@ def sync_send_to_stream(stream, message):
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             future = executor.submit(run_in_new_loop)
             return future.result()
-    except RuntimeError:
-        # Not in an event loop, safe to use a new event loop in this thread
-        return anyio.from_thread.run(_send)
+
+    # No running loop and no captured stream loop: fall back to the anyio worker-thread portal.
+    return anyio.from_thread.run(_send)
 
 
 class StatusMessageProvider:

--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -41,7 +41,15 @@ def sync_send_to_stream(stream, message):
     # streamify); run_coroutine_threadsafe works from any thread other than that loop's own.
     stream_loop = settings.send_stream_loop
     if running_loop is None and stream_loop is not None and stream_loop.is_running():
-        return asyncio.run_coroutine_threadsafe(_send(), stream_loop).result()
+        future = asyncio.run_coroutine_threadsafe(_send(), stream_loop)
+        try:
+            # Bounded wait: if the stream loop shuts down (e.g. the consumer stops
+            # iterating) after the is_running() check, the future never resolves and
+            # this worker thread would hang. On timeout the message is dropped instead.
+            return future.result(timeout=60)
+        except concurrent.futures.TimeoutError:
+            future.cancel()
+            raise
 
     if running_loop is not None:
         # Called from within an event loop: offload to a new thread with its own loop.

--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -45,7 +45,9 @@ def sync_send_to_stream(stream, message):
         try:
             # Bounded wait: if the stream loop shuts down (e.g. the consumer stops
             # iterating) after the is_running() check, the future never resolves and
-            # this worker thread would hang. On timeout the message is dropped instead.
+            # this worker thread would hang. On timeout we cancel and re-raise; the
+            # callback layer swallows it, so the message is dropped rather than the
+            # worker hanging.
             return future.result(timeout=60)
         except concurrent.futures.TimeoutError:
             future.cancel()

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -171,7 +171,18 @@ def streamify(
         callbacks.append(status_streaming_callback)
 
     async def generator(args, kwargs, stream: MemoryObjectSendStream):
-        with settings.context(send_stream=stream, callbacks=callbacks, stream_listeners=stream_listeners):
+        # Capture the loop that owns `stream` so status callbacks firing on worker
+        # threads (e.g. dspy.Parallel's ThreadPoolExecutor) can deliver back to it.
+        try:
+            stream_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            stream_loop = None
+        with settings.context(
+            send_stream=stream,
+            send_stream_loop=stream_loop,
+            callbacks=callbacks,
+            stream_listeners=stream_listeners,
+        ):
             prediction = await program(*args, **kwargs)
 
         await stream.send(prediction)

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -173,10 +173,7 @@ def streamify(
     async def generator(args, kwargs, stream: MemoryObjectSendStream):
         # Capture the loop that owns `stream` so status callbacks firing on worker
         # threads (e.g. dspy.Parallel's ThreadPoolExecutor) can deliver back to it.
-        try:
-            stream_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            stream_loop = None
+        stream_loop = asyncio.get_running_loop()
         with settings.context(
             send_stream=stream,
             send_stream_loop=stream_loop,

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -98,6 +98,39 @@ async def test_default_status_streaming():
 
 
 @pytest.mark.anyio
+async def test_status_streaming_under_parallel():
+    """Status messages emitted from dspy.Parallel worker threads must reach the stream.
+
+    dspy.Parallel runs each module on a plain ThreadPoolExecutor thread, which has no
+    running event loop and is not an anyio worker thread. The status callback there must
+    still deliver to the streaming loop; a regression drops the messages (see #9154).
+    """
+
+    class MyProgram(dspy.Module):
+        def __init__(self):
+            self.predict = dspy.Predict("question->answer")
+
+        def __call__(self, questions):
+            pairs = [(self.predict, dspy.Example(question=q).with_inputs("question")) for q in questions]
+            return dspy.Parallel(num_threads=2)(pairs)[0]
+
+    class MyStatusMessageProvider(StatusMessageProvider):
+        def module_start_status_message(self, instance, inputs):
+            if isinstance(instance, dspy.Predict):
+                return "Predict starting!"
+
+    lm = dspy.utils.DummyLM([{"answer": "red"}, {"answer": "blue"}])
+    with dspy.context(lm=lm):
+        program = dspy.streamify(MyProgram(), status_message_provider=MyStatusMessageProvider())
+        output = program(["sky", "grass"])
+
+        status_messages = [value async for value in output if isinstance(value, StatusMessage)]
+
+    assert len(status_messages) == 2
+    assert all(message.message == "Predict starting!" for message in status_messages)
+
+
+@pytest.mark.anyio
 async def test_custom_status_streaming():
     class MyProgram(dspy.Module):
         def __init__(self):


### PR DESCRIPTION
Fixes #9154.

## Problem

Status messages emitted from inside `dspy.Parallel` are silently dropped when the program is streamed with `dspy.streamify`.

`dspy.Parallel` runs each module on a plain `ThreadPoolExecutor` worker thread. That thread has no running event loop and is not an anyio worker thread, so when a status callback fires there, `sync_send_to_stream` falls through to `anyio.from_thread.run(_send)`, which requires an anyio worker thread with a blocking portal. It raises `RuntimeError: Not running inside an AnyIO worker thread`, the callback framework swallows it as a warning, and the message never reaches the stream.

Reproduced on `main` (`80fce4cc`) with `DummyLM`, no network: a `Predict` streamed directly delivers its status message; the same `Predict` driven through `dspy.Parallel` delivers zero. `settings.send_stream` is correctly propagated into the worker threads, so the only missing piece is a way to deliver to the streaming loop from a thread that isn't an anyio worker.

## Fix

- `streamify`'s `generator` captures the event loop that owns the stream into a new `settings.send_stream_loop`.
- `sync_send_to_stream` delivers via `asyncio.run_coroutine_threadsafe(_send(), stream_loop)` when it is called from a worker thread (no running loop) and the stream loop is available. `run_coroutine_threadsafe` works from any thread other than the loop's own, so it covers both the anyio worker thread used for serial streaming and the plain `ThreadPoolExecutor` threads used by `dspy.Parallel`.
- The in-loop path (offload to a new thread) and the final `anyio.from_thread.run` fallback are preserved for callers outside a streamify context.

Serial streaming behavior is unchanged.

## Verification

- New regression test `test_status_streaming_under_parallel`: fails on `main` (0 status messages, with the `Not running inside an AnyIO worker thread` warning) and passes on this branch (both `Parallel` workers' status messages delivered).
- Existing `tests/streaming/test_streaming.py` passes (the two `litellm_test_server` cases error only because that fixture needs `litellm[proxy]`/`websockets` in my local env, unrelated to this change).

Analysis and implementation done with AI assistance.
