### PR TITLE
Flatten tools and tool_choice for the Responses API

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -46,10 +46,13 @@ def _get_litellm():
 
 def _is_openai_reasoning_model(model: str) -> bool:
     model_family = model.split("/")[-1].lower() if "/" in model else model.lower()
-    return re.match(
-        r"^(?:o[1345](?:-(?:mini|nano|pro))?(?:-\d{4}-\d{2}-\d{2})?|gpt-5(?!-chat)(?:-.*)?)$",
-        model_family,
-    ) is not None
+    return (
+        re.match(
+            r"^(?:o[1345](?:-(?:mini|nano|pro))?(?:-\d{4}-\d{2}-\d{2})?|gpt-5(?!-chat)(?:-.*)?)$",
+            model_family,
+        )
+        is not None
+    )
 
 
 class LM(BaseLM):
@@ -205,12 +208,7 @@ class LM(BaseLM):
         exc_cls = _lm_error_class_from_litellm_exception(exc) or _lm_error_class_from_status(status)
         return exc_cls(message, **metadata)
 
-    def forward(
-        self,
-        prompt: str | None = None,
-        messages: list[dict[str, Any]] | None = None,
-        **kwargs
-    ):
+    def forward(self, prompt: str | None = None, messages: list[dict[str, Any]] | None = None, **kwargs):
         """Call the configured LM synchronously.
 
         LiteLLM/provider exceptions are wrapped in DSPy's structured LM error
@@ -654,6 +652,18 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
         text = request.pop("text", {})
         request["text"] = {**text, "format": response_format}
 
+    # Flatten `tools` / `tool_choice` from Chat Completions shape
+    # (`{"type": "function", "function": {"name": ...}}`) to the flat shape the
+    # Responses API requires (`{"type": "function", "name": ..., "parameters": ...}`).
+    if "tools" in request:
+        request["tools"] = [
+            {"type": "function", **tool["function"]} if tool.get("type") == "function" and "function" in tool else tool
+            for tool in request["tools"]
+        ]
+    tool_choice = request.get("tool_choice")
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function" and "function" in tool_choice:
+        request["tool_choice"] = {"type": "function", **tool_choice["function"]}
+
     return request
 
 
@@ -704,9 +714,11 @@ def _add_dspy_identifier_to_headers(headers: dict[str, Any] | None = None):
         **headers,
     }
 
-#--------
+
+# --------
 # Errors
-#--------
+# --------
+
 
 def _safe_litellm_exception_class(name: str) -> type[Exception] | None:
     cls = getattr(_get_litellm(), name, None)

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -282,7 +282,9 @@ def test_lm_wraps_litellm_errors_with_metadata():
     response.status_code = 429
     response.headers = {"x-request-id": "req-123", "retry-after": "2.5"}
 
-    error = litellm.RateLimitError(message="too many requests", llm_provider="openai", model="gpt-4o", response=response)
+    error = litellm.RateLimitError(
+        message="too many requests", llm_provider="openai", model="gpt-4o", response=response
+    )
     wrapped = lm._wrap_litellm_exception(error)
 
     assert isinstance(wrapped, dspy.LMRateLimitError)
@@ -1328,6 +1330,44 @@ def test_api_key_not_saved_in_json():
         assert saved_state["lm"]["max_tokens"] == 100
 
 
+def test_responses_api_converts_tools_correctly():
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request_with_tools = {
+        "model": "openai/gpt-5-mini",
+        "messages": [{"role": "user", "content": "What is the weather?"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        "tool_choice": {"type": "function", "function": {"name": "get_weather"}},
+    }
+
+    result = _convert_chat_request_to_responses_request(request_with_tools)
+
+    # Responses API requires flat tool entries, not the Chat Completions
+    # nested {"function": {...}} shape.
+    assert len(result["tools"]) == 1
+    tool = result["tools"][0]
+    assert tool["type"] == "function"
+    assert tool["name"] == "get_weather"
+    assert tool["description"] == "Get the weather for a city"
+    assert tool["parameters"]["properties"] == {"city": {"type": "string"}}
+    assert "function" not in tool
+
+    assert result["tool_choice"] == {"type": "function", "name": "get_weather"}
+
+
 def test_responses_api_converts_images_correctly():
     from dspy.clients.lm import _convert_chat_request_to_responses_request
 
@@ -1704,9 +1744,7 @@ async def test_responses_api_with_none_usage_async():
                     "type": "message",
                     "role": "assistant",
                     "status": "incomplete",
-                    "content": [
-                        {"type": "output_text", "text": "Partial async response", "annotations": []}
-                    ],
+                    "content": [{"type": "output_text", "text": "Partial async response", "annotations": []}],
                 },
             ),
         ],


### PR DESCRIPTION
Fixes #9943

Using `dspy.LM(model_type="responses")` with native function calling fails every request with `Missing required parameter: 'tools[0].name'`. `_convert_chat_request_to_responses_request` converts `messages`, `reasoning_effort`, and `response_format` to the Responses API shape, but has no branch for `tools` / `tool_choice`. They are emitted in Chat Completions shape (`{"type": "function", "function": {"name": ..., "parameters": ...}}`) by `Tool.format_as_litellm_function_call`, whereas the Responses API expects the function fields flattened onto the tool (`{"type": "function", "name": ..., "parameters": ...}`).

This flattens `tools` entries and a function-typed `tool_choice` into the Responses shape, leaving any already-flat or non-function entries untouched.

Added `test_responses_api_converts_tools_correctly`, mirroring the existing `test_responses_api_converts_images_correctly`, which calls the converter directly and asserts the tool is flattened (`name`/`parameters` present, no nested `function` key) and `tool_choice` is flattened too. It fails on current main and passes with the change.
