### PR TITLE
fix: handle Perplexity Gemini response format (#9956)

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -626,6 +626,7 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     request = dict(request)
 
     model = request.get("model", "")
+
     provider = model.split("/", 1)[0] if "/" in model else "openai"
     if "messages" in request:
         input_items = []
@@ -635,27 +636,24 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
             if isinstance(c, str):
                 content_blocks.append({"type": "input_text", "text": c})
             elif isinstance(c, list):
-                # Convert each content item from Chat API format to Responses API format
                 for item in c:
                     content_blocks.append(_convert_content_item_to_responses_format(item))
             input_items.append({"role": msg.get("role", "user"), "content": content_blocks})
         request["input"] = input_items
-    # Convert `reasoning_effort` to reasoning format supported by the Responses API
     if "reasoning_effort" in request:
         effort = request.pop("reasoning_effort")
         request["reasoning"] = {"effort": effort, "summary": "auto"}
 
-    # Convert `response_format` to `text.format` for Responses API
     if "response_format" in request:
         response_format = request.pop("response_format")
-        if isinstance(response_format, type) and issubclass(response_format, pydantic.BaseModel):
-            response_format = {
-                "name": response_format.__name__,
-                "type": "json_schema",
-                "schema": response_format.model_json_schema(),
-            }
-
         if provider == "openai":
+            if isinstance(response_format, type) and issubclass(response_format, pydantic.BaseModel):
+                response_format = {
+                    "name": response_format.__name__,
+                    "type": "json_schema",
+                    "schema": response_format.model_json_schema(),
+                }
+
             text = request.pop("text", {})
             request["text"] = {**text, "format": response_format}
         else:

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -626,7 +626,7 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     request = dict(request)
 
     model = request.get("model", "")
-
+    # LiteLLM treats unprefixed models as OpenAI models by default.
     provider = model.split("/", 1)[0] if "/" in model else "openai"
     if "messages" in request:
         input_items = []
@@ -636,14 +636,17 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
             if isinstance(c, str):
                 content_blocks.append({"type": "input_text", "text": c})
             elif isinstance(c, list):
+                # Convert each content item from Chat API format to Responses API format
                 for item in c:
                     content_blocks.append(_convert_content_item_to_responses_format(item))
             input_items.append({"role": msg.get("role", "user"), "content": content_blocks})
         request["input"] = input_items
+    # Convert `reasoning_effort` to reasoning format supported by the Responses API
     if "reasoning_effort" in request:
         effort = request.pop("reasoning_effort")
         request["reasoning"] = {"effort": effort, "summary": "auto"}
 
+    # Convert `response_format` to `text.format` for Responses API
     if "response_format" in request:
         response_format = request.pop("response_format")
         if provider == "openai":

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -624,6 +624,9 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     Also see https://platform.openai.com/docs/api-reference/chat/create for the chat API specification.
     """
     request = dict(request)
+
+    model = request.get("model", "")
+    provider = model.split("/", 1)[0] if "/" in model else "openai"
     if "messages" in request:
         input_items = []
         for msg in request.pop("messages"):
@@ -651,8 +654,12 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
                 "type": "json_schema",
                 "schema": response_format.model_json_schema(),
             }
-        text = request.pop("text", {})
-        request["text"] = {**text, "format": response_format}
+
+        if provider == "openai":
+            text = request.pop("text", {})
+            request["text"] = {**text, "format": response_format}
+        else:
+            request["response_format"] = response_format
 
     return request
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -628,6 +628,7 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     model = request.get("model", "")
     # LiteLLM treats unprefixed models as OpenAI models by default.
     provider = model.split("/", 1)[0] if "/" in model else "openai"
+    _openai_compatible_providers = {"openai", "azure"}
     if "messages" in request:
         input_items = []
         for msg in request.pop("messages"):
@@ -649,7 +650,7 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
     # Convert `response_format` to `text.format` for Responses API
     if "response_format" in request:
         response_format = request.pop("response_format")
-        if provider == "openai":
+        if provider in _openai_compatible_providers:
             if isinstance(response_format, type) and issubclass(response_format, pydantic.BaseModel):
                 response_format = {
                     "name": response_format.__name__,

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1547,6 +1547,21 @@ def test_convert_chat_request_to_responses_request_preserves_pydantic_response_f
     assert "text" not in result
 
 
+def test_convert_chat_request_to_responses_request_azure_uses_text_format():
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "model": "azure/gpt-4o",
+        "messages": [{"role": "user", "content": "Return JSON"}],
+        "response_format": {"type": "json_object"},
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert result["text"]["format"] == {"type": "json_object"}
+    assert "response_format" not in result
+
+
 def test_responses_api_with_image_input():
     api_response = make_response(
         output_blocks=[

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1514,6 +1514,21 @@ def test_responses_api_preserves_multi_message_structure():
     assert result["input"][3]["content"] == [{"type": "input_text", "text": "And 3+3?"}]
 
 
+def test_convert_chat_request_to_responses_request_preserves_response_format_for_non_openai_models():
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "model": "perplexity/google/gemini-3.5-flash",
+        "messages": [{"role": "user", "content": "Return JSON"}],
+        "response_format": {"type": "json_object"},
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert result["response_format"] == {"type": "json_object"}
+    assert "text" not in result
+
+
 def test_responses_api_with_image_input():
     api_response = make_response(
         output_blocks=[

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1529,6 +1529,24 @@ def test_convert_chat_request_to_responses_request_preserves_response_format_for
     assert "text" not in result
 
 
+def test_convert_chat_request_to_responses_request_preserves_pydantic_response_format_for_non_openai():
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    class TestModel(pydantic.BaseModel):
+        answer: str
+
+    request = {
+        "model": "perplexity/google/gemini-3.5-flash",
+        "messages": [{"role": "user", "content": "Return JSON"}],
+        "response_format": TestModel,
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert result["response_format"] is TestModel
+    assert "text" not in result
+
+
 def test_responses_api_with_image_input():
     api_response = make_response(
         output_blocks=[


### PR DESCRIPTION
Fixes #9956

## Problem

Perplexity Gemini models routed through LiteLLM fail because DSPy converts
`response_format` into `text.format`, which is only supported by the OpenAI
Responses API.

For non-OpenAI providers, this produces an invalid request body:

```
invalid request body: json: unknown field "format"
```

## Changes

### `dspy/clients/lm.py`

- Updated `_convert_chat_request_to_responses_request()`.
- Added provider detection from the model name.
- Keep converting `response_format` → `text.format` only for OpenAI models.
- Preserve `response_format` directly for non-OpenAI providers such as Perplexity.

Before:

```
response_format
|
v
text.format
```

After:

```
OpenAI:
response_format → text.format

Non-OpenAI:
response_format stays unchanged
```

### `tests/clients/test_lm.py`

- Added a regression test:
  `test_convert_chat_request_to_responses_request_preserves_response_format_for_non_openai_models`
- Verifies that non-OpenAI providers keep `response_format` and do not create
  an invalid `text.format` field.

## Tests

```bash
uv run pytest tests/clients/test_lm.py
```

Result:

```
74 passed, 2 warnings
```