### PR TITLE
feat(clients): add Together AI fine-tuning provider

### DIFF
--- a/dspy/clients/togetherai.py
+++ b/dspy/clients/togetherai.py
@@ -23,6 +23,8 @@ class TrainingJobTogether(TrainingJob):
         self.job_id = job_id  # Together's fine-tune job id, set once we start the job
 
     def status(self):
+        if self.job_id is None:
+            return None  # no job started yet, so there's nothing to check
         # Lazy import: `together` is an optional dependency, only needed by people
         # who actually use Together fine-tuning (see databricks.py for the same pattern).
         try:

--- a/dspy/clients/togetherai.py
+++ b/dspy/clients/togetherai.py
@@ -1,0 +1,111 @@
+import json
+import logging
+import os
+import time
+import uuid
+from typing import Any
+
+from dspy.clients.provider import Provider, TrainingJob
+from dspy.clients.utils_finetune import TrainDataFormat, get_finetune_directory
+
+logger = logging.getLogger(__name__)
+
+
+class TrainingJobTogether(TrainingJob):
+    """A claim ticket for a Together AI fine-tuning job.
+
+    Fine-tuning runs for minutes/hours, so instead of blocking we hold the
+    job's id and expose `status()` to ask Together how it's going.
+    """
+
+    def __init__(self, job_id: str | None = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.job_id = job_id  # Together's fine-tune job id, set once we start the job
+
+    def status(self):
+        # Lazy import: `together` is an optional dependency, only needed by people
+        # who actually use Together fine-tuning (see databricks.py for the same pattern).
+        try:
+            from together import Together
+        except ImportError:
+            raise ImportError(
+                "To use Together fine-tuning, please install the together package via `pip install together`."
+            )
+        client = Together()  # reads TOGETHER_API_KEY from the environment
+        return client.fine_tuning.retrieve(id=self.job_id).status
+
+
+class TogetherProvider(Provider):
+    # Tells DSPy: yes, this provider can fine-tune, and here's the ticket type it hands out.
+    finetunable = True
+    TrainingJob = TrainingJobTogether
+
+    @staticmethod
+    def is_provider_model(model: str) -> bool:
+        # The "bouncer": Together models are named with a "together_ai/" prefix.
+        return model.startswith("together_ai/")
+
+    @staticmethod
+    def finetune(
+        job: "TrainingJobTogether",
+        model: str,
+        train_data: list[dict[str, Any]],
+        train_data_format: TrainDataFormat | str | None = "chat",
+        train_kwargs: dict[str, Any] | None = None,
+    ) -> str:
+        train_kwargs = train_kwargs or {}
+
+        # --- Step 1: validate/normalize the data format ---
+        # Together infers the actual format from the file, but we reject unknown
+        # formats early so the user gets a clear error instead of a confusing API one.
+        if isinstance(train_data_format, str):
+            if train_data_format == "chat":
+                train_data_format = TrainDataFormat.CHAT
+            elif train_data_format == "completion":
+                train_data_format = TrainDataFormat.COMPLETION
+            else:
+                raise ValueError(
+                    f"String `train_data_format` must be 'chat' or 'completion', but received: {train_data_format}."
+                )
+
+        # Lazy import (same optional-dependency pattern as status()).
+        try:
+            from together import Together
+        except ImportError:
+            raise ImportError(
+                "To use Together fine-tuning, please install the together package via `pip install together`."
+            )
+        client = Together()
+
+        # --- Step 2: save data to a local .jsonl, then upload it to Together ---
+        logger.info("Uploading training data to Together...")
+        file_path = _save_data_to_jsonl(train_data)
+        train_file = client.files.upload(file=file_path, purpose="fine-tune")
+
+        # --- Step 3: create the fine-tune job; store its id on the claim ticket ---
+        logger.info("Starting Together fine-tuning job...")
+        ft = client.fine_tuning.create(training_file=train_file.id, model=model, **train_kwargs)
+        job.job_id = ft.id
+
+        # --- Step 4: poll until the job completes or fails ---
+        while True:
+            status = job.status()
+            if status == "completed":
+                logger.info("Together fine-tuning job completed successfully!")
+                break
+            elif status in ("error", "cancelled"):
+                raise ValueError(f"Together fine-tuning job {job.job_id} ended with status: {status}.")
+            time.sleep(60)
+
+        # --- Step 5: return the fine-tuned model's name, DSPy-prefixed ---
+        output_name = client.fine_tuning.retrieve(id=job.job_id).x_model_output_name
+        return f"together_ai/{output_name}"
+
+
+def _save_data_to_jsonl(train_data: list[dict[str, Any]]) -> str:
+    """Write the training examples to a local JSONL file and return its path."""
+    file_path = os.path.join(get_finetune_directory(), f"togetherai_{uuid.uuid4()}.jsonl")
+    with open(file_path, "w") as f:
+        for item in train_data:
+            f.write(json.dumps(item) + "\n")
+    return os.path.abspath(file_path)

--- a/dspy/clients/togetherai.py
+++ b/dspy/clients/togetherai.py
@@ -48,6 +48,12 @@ class TogetherProvider(Provider):
         return model.startswith("together_ai/")
 
     @staticmethod
+    def _remove_provider_prefix(model: str) -> str:
+        # Together's API wants the bare model name, so strip DSPy's "together_ai/" routing prefix.
+        provider_prefix = "together_ai/"
+        return model.replace(provider_prefix, "")
+
+    @staticmethod
     def finetune(
         job: "TrainingJobTogether",
         model: str,
@@ -55,6 +61,7 @@ class TogetherProvider(Provider):
         train_data_format: TrainDataFormat | str | None = "chat",
         train_kwargs: dict[str, Any] | None = None,
     ) -> str:
+        model = TogetherProvider._remove_provider_prefix(model)
         train_kwargs = train_kwargs or {}
 
         # --- Step 1: normalize the format label, then validate the data matches it ---

--- a/dspy/clients/togetherai.py
+++ b/dspy/clients/togetherai.py
@@ -6,7 +6,7 @@ import uuid
 from typing import Any
 
 from dspy.clients.provider import Provider, TrainingJob
-from dspy.clients.utils_finetune import TrainDataFormat, get_finetune_directory
+from dspy.clients.utils_finetune import TrainDataFormat, get_finetune_directory, validate_data_format
 
 logger = logging.getLogger(__name__)
 
@@ -55,9 +55,8 @@ class TogetherProvider(Provider):
     ) -> str:
         train_kwargs = train_kwargs or {}
 
-        # --- Step 1: validate/normalize the data format ---
-        # Together infers the actual format from the file, but we reject unknown
-        # formats early so the user gets a clear error instead of a confusing API one.
+        # --- Step 1: normalize the format label, then validate the data matches it ---
+        # First the "spelling check": reject unknown format words early.
         if isinstance(train_data_format, str):
             if train_data_format == "chat":
                 train_data_format = TrainDataFormat.CHAT
@@ -67,6 +66,9 @@ class TogetherProvider(Provider):
                 raise ValueError(
                     f"String `train_data_format` must be 'chat' or 'completion', but received: {train_data_format}."
                 )
+        # Then "open the box": check each training example actually matches the format.
+        if train_data_format is not None:
+            validate_data_format(train_data, train_data_format)
 
         # Lazy import (same optional-dependency pattern as status()).
         try:
@@ -77,10 +79,13 @@ class TogetherProvider(Provider):
             )
         client = Together()
 
-        # --- Step 2: save data to a local .jsonl, then upload it to Together ---
+        # --- Step 2: save data to a local .jsonl, upload it, then clean up the local copy ---
         logger.info("Uploading training data to Together...")
         file_path = _save_data_to_jsonl(train_data)
-        train_file = client.files.upload(file=file_path, purpose="fine-tune")
+        try:
+            train_file = client.files.upload(file=file_path, purpose="fine-tune")
+        finally:
+            os.remove(file_path)  # the local file was only needed for the upload
 
         # --- Step 3: create the fine-tune job; store its id on the claim ticket ---
         logger.info("Starting Together fine-tuning job...")
@@ -99,6 +104,8 @@ class TogetherProvider(Provider):
 
         # --- Step 5: return the fine-tuned model's name, DSPy-prefixed ---
         output_name = client.fine_tuning.retrieve(id=job.job_id).x_model_output_name
+        if not output_name:
+            raise ValueError(f"Together fine-tuning job {job.job_id} completed but returned no model name.")
         return f"together_ai/{output_name}"
 
 

--- a/dspy/clients/togetherai.py
+++ b/dspy/clients/togetherai.py
@@ -51,7 +51,7 @@ class TogetherProvider(Provider):
     def _remove_provider_prefix(model: str) -> str:
         # Together's API wants the bare model name, so strip DSPy's "together_ai/" routing prefix.
         provider_prefix = "together_ai/"
-        return model.replace(provider_prefix, "")
+        return model.removeprefix(provider_prefix)
 
     @staticmethod
     def finetune(

--- a/tests/clients/test_togetherai.py
+++ b/tests/clients/test_togetherai.py
@@ -14,6 +14,13 @@ def test_is_provider_model():
     assert TogetherProvider.is_provider_model("openai/my-together_ai-clone") is False
 
 
+def test_remove_provider_prefix_strips_only_leading_prefix():
+    # Normal case: the "together_ai/" routing prefix is stripped off the front.
+    assert TogetherProvider._remove_provider_prefix("together_ai/meta-llama/Llama-3-8b") == "meta-llama/Llama-3-8b"
+    # Edge case: a "together_ai/" appearing mid-string is left alone (only the leading prefix is removed).
+    assert TogetherProvider._remove_provider_prefix("org/together_ai/model") == "org/together_ai/model"
+
+
 def test_status_returns_none_before_job_starts():
     # No job started yet (job_id is None) → status() returns None instead of hitting the API.
     assert TrainingJobTogether().status() is None

--- a/tests/clients/test_togetherai.py
+++ b/tests/clients/test_togetherai.py
@@ -1,0 +1,39 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+from dspy.clients.togetherai import TogetherProvider, TrainingJobTogether
+
+
+def test_is_provider_model():
+    # A real Together model → True.
+    assert TogetherProvider.is_provider_model("together_ai/meta-llama/Llama-3-8b") is True
+    # A non-Together model → False.
+    assert TogetherProvider.is_provider_model("openai/gpt-4o") is False
+    # Contains "together_ai" but not at the start → False (guards against startswith -> contains).
+    assert TogetherProvider.is_provider_model("openai/my-together_ai-clone") is False
+
+
+def test_finetune_returns_prefixed_model_name(monkeypatch):
+    # 1. Build a fake Together client that answers only the calls finetune() makes.
+    fake_client = MagicMock()
+    fake_client.files.upload.return_value.id = "file-abc"  # Step 2: upload → file id
+    fake_client.fine_tuning.create.return_value.id = "job-xyz"  # Step 3: create → job id
+    fake_client.fine_tuning.retrieve.return_value.status = "completed"  # Step 4: poll → "completed"
+    fake_client.fine_tuning.retrieve.return_value.x_model_output_name = "my-model"  # Step 5: retrieve → name
+
+    # 2. Patch `together` so finetune()'s `from together import Together` grabs our fake.
+    fake_together = types.ModuleType("together")
+    fake_together.Together = lambda *a, **k: fake_client
+    monkeypatch.setitem(sys.modules, "together", fake_together)
+
+    # 3. Call the real finetune() — it runs its full logic against the fake.
+    job = TrainingJobTogether()
+    result = TogetherProvider.finetune(
+        job=job,
+        model="together_ai/meta-llama/Llama-3-8b",
+        train_data=[{"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}],
+    )
+
+    # 4. It should return the fine-tuned model's name, DSPy-prefixed.
+    assert result == "together_ai/my-model"

--- a/tests/clients/test_togetherai.py
+++ b/tests/clients/test_togetherai.py
@@ -14,6 +14,11 @@ def test_is_provider_model():
     assert TogetherProvider.is_provider_model("openai/my-together_ai-clone") is False
 
 
+def test_status_returns_none_before_job_starts():
+    # No job started yet (job_id is None) → status() returns None instead of hitting the API.
+    assert TrainingJobTogether().status() is None
+
+
 def test_finetune_returns_prefixed_model_name(monkeypatch):
     # 1. Build a fake Together client that answers only the calls finetune() makes.
     fake_client = MagicMock()

--- a/tests/clients/test_togetherai.py
+++ b/tests/clients/test_togetherai.py
@@ -42,3 +42,6 @@ def test_finetune_returns_prefixed_model_name(monkeypatch):
 
     # 4. It should return the fine-tuned model's name, DSPy-prefixed.
     assert result == "together_ai/my-model"
+
+    # 5. What went OUT: create() should get the BARE model name, "together_ai/" prefix stripped.
+    assert fake_client.fine_tuning.create.call_args.kwargs["model"] == "meta-llama/Llama-3-8b"


### PR DESCRIPTION
## What
Adds `TogetherProvider`, a fine-tuning provider for Together AI, mirroring `dspy/clients/databricks.py`.

## Details
`finetune()` saves training data to JSONL, uploads it, creates a Together fine-tune job, polls until it completes (raises on error/cancelled), and returns the model as `together_ai/<name>`. `together` is imported lazily (optional dependency). `TrainingJobTogether.status()` reports job status, and `is_provider_model()` recognizes `together_ai/` model names.

## Tests
`tests/clients/test_togetherai.py` — a pure-logic test for `is_provider_model`, plus a mocked test that runs the full `finetune()` flow against a fake `together` client (no live API calls; runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
