### PR TITLE
Revise Deno installation instructions in RLM.md

### DIFF
--- a/docs/docs/api/modules/RLM.md
+++ b/docs/docs/api/modules/RLM.md
@@ -36,9 +36,11 @@ print(result.answer)
 
 RLM relies on [Deno](https://deno.land/) and [Pyodide](https://pyodide.org/) to create a local WASM sandbox for secure Python execution.
 
-You can install Deno with: `curl -fsSL https://deno.land/install.sh | sh` on macOS and Linux. See the [Deno Installation Docs](https://docs.deno.com/runtime/getting_started/installation/) for more details. Make sure to accept the prompt when it asks to add it to your shell profile. 
+You can install Deno with: `brew install deno` on MacOS or `curl -fsSL https://deno.land/install.sh | sh` on MacOS and Linux. See the [Deno Installation Docs](https://docs.deno.com/runtime/getting_started/installation/) for more details. Make sure to accept the prompt when it asks to add it to your shell profile. 
 
 After you have installed Deno, **Make sure to restart your shell.**
+
+Deno may get confused by existing `package.json` files it happens to find; use the environment variable `DENO_NO_PACKAGE_JSON=1` to ignore `package.json` entirely and resolve `npm:pyodide` from its own cache, which is what DSPy expects.
 
 Then you can run `dspy.RLM`.
 


### PR DESCRIPTION
Updated Deno installation instructions for MacOS to add details about `package.json`. When run from a project that already has unrelated NPM packages, Deno will be confused until `DENO_NO_PACKAGE_JSON=1` is set. Tested with Deno 1.x and 2.x on MacOS.