### PR TITLE
fix(python_interpreter): serialize inf/-inf/nan as valid Python literals

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -12,6 +12,7 @@ import inspect
 import json
 import keyword
 import logging
+import math
 import os
 import subprocess
 import threading
@@ -480,6 +481,10 @@ class PythonInterpreter:
         elif isinstance(value, bool):
             # Must check bool before int since bool is a subclass of int
             return "True" if value else "False"
+        elif isinstance(value, float) and not math.isfinite(value):
+            # str(inf/-inf/nan) returns bare words ("inf", "nan") that are not valid
+            # Python literals; wrap them so they evaluate correctly in the sandbox.
+            return f"float('{value}')"
         elif isinstance(value, (int, float)):
             return str(value)
         elif isinstance(value, (list, tuple)):

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -31,6 +31,23 @@ def test_user_variable_definitions():
         assert result == 5, "User variable assignment should work"
 
 
+def test_non_finite_float_variables():
+    """Regression test: inf/-inf/nan variables must be injected as valid Python literals.
+
+    str(float("inf")) is the bare word "inf", which is not a valid Python name, so
+    injecting it as `x = inf` previously raised NameError in the sandbox.
+    """
+    with PythonInterpreter() as interpreter:
+        inf_code = "result = 1 if x == float('inf') else 0\nresult"
+        assert interpreter.execute(inf_code, variables={"x": float("inf")}) == 1
+
+        neg_inf_code = "result = 1 if x == float('-inf') else 0\nresult"
+        assert interpreter.execute(neg_inf_code, variables={"x": float("-inf")}) == 1
+
+        nan_code = "import math\nresult = 1 if math.isnan(x) else 0\nresult"
+        assert interpreter.execute(nan_code, variables={"x": float("nan")}) == 1
+
+
 def test_rejects_python_keywords_as_variable_names():
     """Test that Python keywords are rejected as variable names."""
     with PythonInterpreter() as interpreter:


### PR DESCRIPTION
### What

Non-finite float variables (`float('inf')`, `float('-inf')`, `float('nan')`) passed to `PythonInterpreter` are serialized to invalid Python and break inside the sandbox.

### Why it happens

`_serialize_value` used `str()` for floats. For the three non-finite values, `str()` returns the bare words `inf` / `-inf` / `nan`, which are not valid Python names. `_inject_variables` prepends the assignment to the executed code, so the sandbox receives `x = inf` and raises `NameError: name 'inf' is not defined`. (`repr()` has the same problem.)

### Impact

- **Direct API:** `interp("print(x)", variables={"x": float("inf")})` raises `CodeInterpreterError`/`NameError`.
- **RLM:** a float input field with an inf/nan value reaches `_serialize_value` via `RLM.forward -> _execute_code -> repl.execute(..., variables=...)`. Since the assignment is injected at the top of every executed block and `_execute_code` catches the error, the failure is silent — the input becomes inaccessible and RLM degrades to the extract fallback.

### Change

Wrap non-finite floats as `float('...')` before the generic `str()` path:

```python
elif isinstance(value, float) and not math.isfinite(value):
    return f"float('{value}')"
elif isinstance(value, (int, float)):
    return str(value)
```

Normal floats and ints are unchanged.

### Tests

Added `test_non_finite_float_variables`, which injects `inf`, `-inf`, and `nan` and asserts they arrive intact (comparisons inside the sandbox return finite ints, avoiding the separate question of JSON-serializing non-finite floats on output).

Verified locally that the serializer produces valid literals evaluating back to the correct values for `inf`, `-inf`, `nan`, and overflow (`1e309`); `ruff check` passes. The sandbox test itself runs under the `deno` marker in CI.

Fixes #9990.

### Disclosure

I used AI-assisted tooling while investigating and implementing this. I reviewed and verified every line, traced the reachability myself, and take ownership of the change.
