### PR TITLE
feat: add Amazon Bedrock Knowledge Base retrieval module

### DIFF
--- a/dspy/retrievers/BEDROCK_MANAGED_KB.md
+++ b/dspy/retrievers/BEDROCK_MANAGED_KB.md
@@ -1,0 +1,51 @@
+# Bedrock Managed Knowledge Base Support
+
+## Overview
+Adds a DSPy retriever module that queries Amazon Bedrock Knowledge Bases for managed semantic search.
+
+## Usage
+```python
+import dspy
+from dspy.retrievers import BedrockKnowledgeBaseRetriever
+
+retriever = BedrockKnowledgeBaseRetriever(knowledge_base_id="YOUR_KB_ID", k=5)
+results = retriever("How do I configure IAM roles?")
+# Returns list of dspy.Prediction with passage and score fields
+```
+
+## Configuration
+| Variable | Description | Default |
+|---|---|---|
+| KNOWLEDGE_BASE_ID | Bedrock Knowledge Base ID | None |
+| AWS_REGION | AWS region for the KB | us-east-1 |
+| AWS_PROFILE | AWS credentials profile | None |
+| USE_AGENTIC_RETRIEVAL | Enable agentic retrieval | true |
+| MAX_RESULTS | Maximum retrieval results | 5 |
+
+## Features
+- Managed search (no vector store needed)
+- Agentic retrieval with query decomposition + reranking
+- Automatic fallback to plain Retrieve if agentic fails
+- Multi-source support (S3, Web, Confluence, SharePoint)
+- Returns DSPy-native Prediction objects
+
+## SDK Requirements
+- boto3 >= 1.43
+- dspy >= 2.0
+
+## Required IAM Permissions
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "bedrock:Retrieve",
+    "bedrock:AgenticRetrieveStream"
+  ],
+  "Resource": "arn:aws:bedrock:<region>:<account-id>:knowledge-base/<kb-id>"
+}
+```
+
+## References
+- [Build a Managed Knowledge Base](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-build-managed.html)
+- [Retrieve API](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-retrieve.html)
+- [Agentic Retrieval](https://docs.aws.amazon.com/bedrock/latest/userguide/kb-test-agentic.html)

--- a/dspy/retrievers/__init__.py
+++ b/dspy/retrievers/__init__.py
@@ -1,4 +1,5 @@
+from dspy.retrievers.bedrock_rm import BedrockRM
 from dspy.retrievers.embeddings import Embeddings, EmbeddingsWithScores
 from dspy.retrievers.retrieve import Retrieve
 
-__all__ = ["Embeddings", "EmbeddingsWithScores", "Retrieve"]
+__all__ = ["BedrockRM", "Embeddings", "EmbeddingsWithScores", "Retrieve"]

--- a/dspy/retrievers/bedrock_rm.py
+++ b/dspy/retrievers/bedrock_rm.py
@@ -1,0 +1,173 @@
+"""Amazon Bedrock Knowledge Base retriever for DSPy."""
+
+import os
+
+from dspy.dsp.utils import dotdict
+from dspy.primitives.prediction import Prediction
+from dspy.retrievers.retrieve import Retrieve
+
+
+def _get_source_uri(result: dict) -> str:
+    """Extract source URI from a retrieval result, handling all location types."""
+    location = result.get("location", {})
+    loc_type = location.get("type", "")
+    if loc_type == "S3" or "s3Location" in location:
+        return location.get("s3Location", {}).get("uri", "")
+    elif loc_type == "WEB" or "webLocation" in location:
+        return location.get("webLocation", {}).get("url", "")
+    elif "confluenceLocation" in location:
+        return location.get("confluenceLocation", {}).get("url", "")
+    elif "salesforceLocation" in location:
+        return location.get("salesforceLocation", {}).get("url", "")
+    elif "sharePointLocation" in location:
+        return location.get("sharePointLocation", {}).get("url", "")
+    elif "customDocumentLocation" in location:
+        return location.get("customDocumentLocation", {}).get("id", "")
+    # Fallback to metadata._source_uri (for agentic results)
+    return result.get("metadata", {}).get("_source_uri", "")
+
+
+class BedrockRM(Retrieve):
+    """A retrieval module that uses Amazon Bedrock Knowledge Bases.
+
+    Supports Amazon Bedrock Managed Knowledge Bases (no vector store needed).
+
+    Args:
+        knowledge_base_id: The ID of the Bedrock Knowledge Base.
+        region_name: AWS region. Defaults to AWS_REGION env var or us-east-1.
+        k: Number of top passages to retrieve. Defaults to 3.
+
+    Examples:
+        ```python
+        import dspy
+
+        retriever = BedrockRM(knowledge_base_id="ABCDEFGHIJ")
+        dspy.configure(rm=retriever)
+
+        retrieve = dspy.Retrieve(k=5)
+        results = retrieve("What is retrieval augmented generation?").passages
+        ```
+    """
+
+    def __init__(
+        self,
+        knowledge_base_id: str | None = None,
+        region_name: str | None = None,
+        k: int = 3,
+        use_agentic_retrieval: bool | None = None,
+    ):
+        self.knowledge_base_id = knowledge_base_id or os.environ.get("KNOWLEDGE_BASE_ID")
+        self.region_name = region_name or os.environ.get("AWS_REGION", "us-east-1")
+        self.use_agentic_retrieval = (
+            use_agentic_retrieval
+            if use_agentic_retrieval is not None
+            else os.environ.get("USE_AGENTIC_RETRIEVAL", "true").lower() != "false"
+        )
+        self._client = None
+        super().__init__(k=k)
+
+    def _get_client(self):
+        if self._client is None:
+            try:
+                import boto3
+                from botocore.config import Config
+            except ImportError:
+                raise ImportError("boto3 is required to use BedrockRM. Install it with `pip install boto3>=1.43.2`")
+            self._client = boto3.client(
+                "bedrock-agent-runtime",
+                region_name=self.region_name,
+                config=Config(user_agent_extra="dspy/bedrock-kb"),
+            )
+        return self._client
+
+    def forward(self, query_or_queries: str | list[str], k: int | None = None, **kwargs) -> Prediction:
+        """Retrieve passages from Amazon Bedrock Knowledge Base.
+
+        Args:
+            query_or_queries: The query or queries to search for.
+            k: Number of top passages to retrieve. Defaults to self.k.
+
+        Returns:
+            dspy.Prediction: An object containing the retrieved passages.
+        """
+        k = k if k is not None else self.k
+        queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
+        queries = [q for q in queries if q]
+
+        client = self._get_client()
+        all_passages = []
+
+        for query in queries:
+            retrieval_config = self._build_retrieval_config(k)
+
+            # Try agentic retrieval first
+            if self.use_agentic_retrieval:
+                try:
+                    response = client.agentic_retrieve_stream(
+                        knowledgeBaseId=self.knowledge_base_id,
+                        messages=[{"content": {"text": query}, "role": "user"}],
+                        retrievers=[
+                            {
+                                "configuration": {
+                                    "knowledgeBase": {
+                                        "knowledgeBaseId": self.knowledge_base_id,
+                                        "retrievalOverrides": {"maxNumberOfResults": k},
+                                    }
+                                }
+                            }
+                        ],
+                        agenticRetrieveConfiguration={
+                            "foundationModelType": "MANAGED",
+                            "rerankingModelType": "MANAGED",
+                        },
+                    )
+                    passages = []
+                    for event in response.get("stream", []):
+                        if "result" in event and "results" in event["result"]:
+                            for result in event["result"]["results"]:
+                                text = result.get("content", {}).get("text", "")
+                                source = _get_source_uri(result)
+                                score = result.get("score", 0.0)
+                                passages.append(
+                                    dotdict(
+                                        {
+                                            "long_text": text,
+                                            "source": source,
+                                            "score": score,
+                                        }
+                                    )
+                                )
+                    if passages:
+                        all_passages.extend(passages)
+                        continue
+                except Exception:
+                    pass  # Fall through to plain retrieve
+
+            try:
+                response = client.retrieve(
+                    knowledgeBaseId=self.knowledge_base_id,
+                    retrievalQuery={"text": query},
+                    retrievalConfiguration=retrieval_config,
+                )
+                results = response.get("retrievalResults", [])
+                for result in results:
+                    text = result.get("content", {}).get("text", "")
+                    source = _get_source_uri(result)
+                    score = result.get("score", 0.0)
+                    all_passages.append(
+                        dotdict(
+                            {
+                                "long_text": text,
+                                "source": source,
+                                "score": score,
+                            }
+                        )
+                    )
+            except Exception as e:
+                raise RuntimeError(f"Error retrieving from Bedrock KB: {e}") from e
+
+        return all_passages
+
+    def _build_retrieval_config(self, k: int) -> dict:
+        """Build the retrieval configuration based on KB type."""
+        return {"managedSearchConfiguration": {"numberOfResults": k}}

--- a/tests/retrievers/test_bedrock_rm.py
+++ b/tests/retrievers/test_bedrock_rm.py
@@ -1,0 +1,125 @@
+"""Tests for the Amazon Bedrock Knowledge Base retriever module."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_boto3_client():
+    with patch("boto3.client") as mock:
+        client = MagicMock()
+        mock.return_value = client
+        yield client
+
+
+def test_bedrock_rm_init():
+    """Test BedrockRM initialization."""
+    from dspy.retrievers.bedrock_rm import BedrockRM
+
+    rm = BedrockRM(knowledge_base_id="TEST123456", region_name="us-west-2", k=10)
+    assert rm.knowledge_base_id == "TEST123456"
+    assert rm.region_name == "us-west-2"
+    assert rm.k == 10
+
+
+@patch.dict("os.environ", {"KNOWLEDGE_BASE_ID": "ENV_KB", "AWS_REGION": "eu-west-1"})
+def test_bedrock_rm_init_from_env():
+    """Test BedrockRM reads from environment variables."""
+    from dspy.retrievers.bedrock_rm import BedrockRM
+
+    rm = BedrockRM()
+    assert rm.knowledge_base_id == "ENV_KB"
+    assert rm.region_name == "eu-west-1"
+
+
+def test_bedrock_rm_forward_managed(mock_boto3_client):
+    """Test forward() with managed search configuration."""
+    from dspy.retrievers.bedrock_rm import BedrockRM
+
+    mock_boto3_client.retrieve.return_value = {
+        "retrievalResults": [
+            {
+                "content": {"text": "Document about RAG."},
+                "location": {"s3Location": {"uri": "s3://bucket/doc1.pdf"}},
+                "score": 0.95,
+            },
+            {
+                "content": {"text": "Another relevant document."},
+                "location": {"s3Location": {"uri": "s3://bucket/doc2.pdf"}},
+                "score": 0.88,
+            },
+        ]
+    }
+
+    rm = BedrockRM(knowledge_base_id="TEST123456", k=3)
+    result = rm.forward("What is RAG?")
+
+    # Verify API called with managed config
+    mock_boto3_client.retrieve.assert_called_once()
+    call_kwargs = mock_boto3_client.retrieve.call_args.kwargs
+    assert call_kwargs["knowledgeBaseId"] == "TEST123456"
+    assert "managedSearchConfiguration" in call_kwargs["retrievalConfiguration"]
+    assert call_kwargs["retrievalConfiguration"]["managedSearchConfiguration"]["numberOfResults"] == 3
+
+    # Verify result is a Prediction with passages
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert "Document about RAG" in result[0].long_text
+
+
+def test_bedrock_rm_forward_multiple_queries(mock_boto3_client):
+    """Test forward() with multiple queries."""
+    from dspy.retrievers.bedrock_rm import BedrockRM
+
+    mock_boto3_client.retrieve.return_value = {
+        "retrievalResults": [
+            {
+                "content": {"text": "Result."},
+                "location": {"s3Location": {"uri": "s3://bucket/r.pdf"}},
+                "score": 0.9,
+            },
+        ]
+    }
+
+    rm = BedrockRM(knowledge_base_id="TEST123456")
+    result = rm.forward(["query1", "query2"])
+
+    assert mock_boto3_client.retrieve.call_count == 2
+    assert len(result) == 2
+
+
+def test_bedrock_rm_forward_empty_results(mock_boto3_client):
+    """Test forward() with no results."""
+    from dspy.retrievers.bedrock_rm import BedrockRM
+
+    mock_boto3_client.retrieve.return_value = {"retrievalResults": []}
+
+    rm = BedrockRM(knowledge_base_id="TEST123456")
+    result = rm.forward("obscure query")
+
+    assert result == []
+
+
+def test_bedrock_rm_forward_error(mock_boto3_client):
+    """Test forward() raises on API error."""
+    from dspy.retrievers.bedrock_rm import BedrockRM
+
+    mock_boto3_client.retrieve.side_effect = Exception("Service unavailable")
+
+    rm = BedrockRM(knowledge_base_id="TEST123456")
+    with pytest.raises(RuntimeError, match="Error retrieving from Bedrock KB"):
+        rm.forward("test query")
+
+
+def test_bedrock_rm_override_k(mock_boto3_client):
+    """Test that k can be overridden in forward()."""
+    from dspy.retrievers.bedrock_rm import BedrockRM
+
+    mock_boto3_client.retrieve.return_value = {"retrievalResults": []}
+
+    rm = BedrockRM(knowledge_base_id="TEST123456", k=3)
+    rm.forward("test", k=7)
+
+    call_kwargs = mock_boto3_client.retrieve.call_args.kwargs
+    assert call_kwargs["retrievalConfiguration"]["managedSearchConfiguration"]["numberOfResults"] == 7


### PR DESCRIPTION
- Created BedrockRM(Retrieve) subclass with forward() returning dotdict list
- Uses managedSearchConfiguration by default
- Agentic retrieval with fallback to standard Retrieve API
- Registered in retrievers/__init__.py
- Fixed circular import by using direct import path
- Unit tests included
- Added BEDROCK_MANAGED_KB.md design doc