### PR TITLE
fix(openai): preserve non-not-found provider errors

### DIFF
--- a/dspy/clients/openai.py
+++ b/dspy/clients/openai.py
@@ -100,23 +100,23 @@ class OpenAIProvider(Provider):
         return model
 
     @staticmethod
-    def does_job_exist(job_id: str) -> bool:
+    def does_job_exist(job_id: str | None) -> bool:
+        if job_id is None:
+            return False
         try:
-            # TODO(nit): This call may fail for other reasons. We should check
-            # the error message to ensure that the job does not exist.
             openai.fine_tuning.jobs.retrieve(job_id)
             return True
-        except Exception:
+        except openai.NotFoundError:
             return False
 
     @staticmethod
-    def does_file_exist(file_id: str) -> bool:
+    def does_file_exist(file_id: str | None) -> bool:
+        if file_id is None:
+            return False
         try:
-            # TODO(nit): This call may fail for other reasons. We should check
-            # the error message to ensure that the file does not exist.
             openai.files.retrieve(file_id)
             return True
-        except Exception:
+        except openai.NotFoundError:
             return False
 
     @staticmethod

--- a/tests/clients/test_openai_provider.py
+++ b/tests/clients/test_openai_provider.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import httpx
+import openai
+import pytest
+
+from dspy.clients.openai import OpenAIProvider
+
+
+@pytest.mark.parametrize(
+    ("method_name", "resource_name"),
+    [
+        ("does_job_exist", "fine_tuning"),
+        ("does_file_exist", "files"),
+    ],
+)
+def test_provider_existence_checks_only_handle_not_found(monkeypatch, method_name, resource_name):
+    retrieve = Mock()
+    resource = SimpleNamespace(retrieve=retrieve)
+    if resource_name == "fine_tuning":
+        resource = SimpleNamespace(jobs=resource)
+    monkeypatch.setitem(openai.__dict__, resource_name, resource)
+    exists = getattr(OpenAIProvider, method_name)
+
+    assert exists("resource-id") is True
+    retrieve.assert_called_once_with("resource-id")
+
+    response = httpx.Response(404, request=httpx.Request("GET", "https://api.openai.com/resource"))
+    retrieve.side_effect = openai.NotFoundError("not found", response=response, body=None)
+    assert exists("missing-id") is False
+
+    response = httpx.Response(401, request=httpx.Request("GET", "https://api.openai.com/resource"))
+    retrieve.side_effect = openai.AuthenticationError("unauthorized", response=response, body=None)
+    with pytest.raises(openai.AuthenticationError):
+        exists("private-id")
+
+    retrieve.reset_mock()
+    retrieve.side_effect = None
+    assert exists(None) is False
+    retrieve.assert_not_called()


### PR DESCRIPTION
## Summary

- Treat a locally absent ID (`None`) as absent without calling OpenAI.
- Treat only an SDK-classified 404 (`openai.NotFoundError`) as remote absence.
- Preserve authentication, transport, rate-limit, server, and other unexpected provider failures.
- Cover the boundary symmetrically for jobs and files.

## Review dossier

### 1. Issue / repro

Before this PR, both existence probes used this shape:

```python
try:
    openai.fine_tuning.jobs.retrieve(job_id)
    return True
except Exception:
    return False
```

That makes a 401, timeout, rate limit, or server error indistinguishable from a 404.

This matters because the result controls whether cancellation and deletion happen:

```python
if OpenAIProvider.does_job_exist(self.provider_job_id):
    openai.fine_tuning.jobs.cancel(self.provider_job_id)

if OpenAIProvider.does_file_exist(self.provider_file_id):
    openai.files.delete(self.provider_file_id)
self.provider_file_id = None
```

If the lookup fails with a 401, the old helper returns `False`: remote cancel/delete is skipped, and the file path still clears its local provider ID. The same false negative in training-status lookup replaces the provider error with a misleading assertion:

```python
err_msg = f"Job with ID {job_id} does not exist."
assert OpenAIProvider.does_job_exist(job_id), err_msg
```

### 2. Why this is the root cause

The broad `except Exception` conflates two different outcomes:

- provider-confirmed 404: the resource is absent;
- any other retrieval failure: existence is unknown and the original failure matters.

The OpenAI SDK already classifies HTTP failures. `openai.NotFoundError` is the precise boundary for the first outcome.

### 3. How the regression proves it

One parametrized test exercises both helpers across the complete decision table:

| Input / SDK result | Expected behavior |
| --- | --- |
| successful retrieve | `True` |
| `NotFoundError` (404) | `False` |
| `AuthenticationError` (401) | original exception propagates |
| `None` ID | `False`, no SDK call |

The key negative case is explicit:

```python
retrieve.side_effect = openai.AuthenticationError(
    "unauthorized",
    response=response,
    body=None,
)
with pytest.raises(openai.AuthenticationError):
    exists("private-id")
```

Applied to the parent tree, this fails because the broad catch swallows the 401. It passes after narrowing the catch.

### 4. Why this is concise

The production change is limited to the two symmetric existence probes:

- one explicit `None` guard;
- one precise exception type;
- no retries, compatibility cascade, exception translation, or caller changes.

The two intentional fallback paths remain: a missing local ID and a provider-confirmed 404.

### 5. Context needed to validate it

These helpers are the OpenAI SDK boundary used by cancellation and training-status paths. The provider already uses the SDK's v1 resource APIs, so it should rely on the SDK's error classification instead of inferring absence from arbitrary failures.

`main` now declares `openai>=1.66.2`, the compatibility floor reviewed separately before this boundary change. The fresh minimum-direct graph resolves OpenAI 1.68.2, so `openai.NotFoundError` is present throughout the supported range; no compatibility fallback is needed here.

### 6. What the fix does

The complete job boundary is now:

```python
def does_job_exist(job_id: str | None) -> bool:
    if job_id is None:
        return False
    try:
        openai.fine_tuning.jobs.retrieve(job_id)
        return True
    except openai.NotFoundError:
        return False
```

`does_file_exist` applies the same boundary to `openai.files.retrieve`. Successful retrieval returns `True`; `None` and `NotFoundError` return `False`; every other SDK exception retains its original type and context.

## Verification

- Parent-tree negative control: the added regression fails because `AuthenticationError` does not propagate.
- `uv run --frozen pytest --deno -q tests/clients/test_openai_provider.py` — 2 passed.
- Rebased onto current `main`, including the supported OpenAI floor.
- `uv run --frozen pytest --deno -q tests/clients` — 136 passed, 21 skipped.
- `uv run --frozen ruff check dspy/clients/openai.py tests/clients/test_openai_provider.py` — passed.
- `git diff --check origin/main...agent/openai-existence-errors` — clean.

## Scope

One commit, two files: the provider boundary and its focused regression test.
