### PR TITLE
fix(adapters): resolve enum output fields for int-valued and Optional-wrapped enums

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -143,6 +143,12 @@ def find_enum_member(enum, identifier):
     if identifier in enum.__members__:
         return enum[identifier]
 
+    # Adapters surface field values as text, so a non-string member value (e.g. an int-valued
+    # enum) arrives as its string form. Match against the stringified member value as a fallback.
+    for member in enum:
+        if str(member.value) == str(identifier):
+            return member
+
     raise ValueError(f"{identifier} is not a valid name or value for the enum {enum.__name__}")
 
 
@@ -174,6 +180,18 @@ def parse_value(value, annotation):
 
     if not isinstance(value, str):
         return TypeAdapter(annotation).validate_python(value)
+
+    # Optional/Union-wrapped enums (e.g. `Grade | None`) should resolve enum names and values the
+    # same way a bare enum does, instead of only matching the raw value through pydantic. Restrict
+    # to unions whose non-None members are all enums, to avoid altering mixed unions like `str | Grade`.
+    if origin in (Union, types.UnionType):
+        non_none_args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        if non_none_args and all(isinstance(arg, enum.EnumMeta) for arg in non_none_args):
+            for enum_arg in non_none_args:
+                try:
+                    return find_enum_member(enum_arg, value)
+                except ValueError:
+                    pass
 
     if origin in (Union, types.UnionType) and type(None) in get_args(annotation) and str in get_args(annotation):
         # Handle union annotations, e.g., `str | None`, `Optional[str]`, `Union[str, int, None]`, etc.

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -1,5 +1,6 @@
 # ruff: noqa: UP007
 
+import enum
 from typing import Literal, Optional, Union
 
 import pytest
@@ -75,6 +76,50 @@ def test_parse_value_literal():
     # Test invalid literal
     with pytest.raises(ValueError):
         parse_value("invalid", Literal["option1", "option2"])
+
+
+class Grade(enum.Enum):
+    A = 1
+    B = 2
+
+
+class Color(enum.Enum):
+    RED = "red"
+    GREEN = "green"
+
+
+class AutoValued(enum.Enum):
+    X = enum.auto()
+    Y = enum.auto()
+
+
+def test_parse_value_enum():
+    # Int-valued enum: adapters surface the value as text, so "2" must resolve to Grade.B
+    assert parse_value("2", Grade) is Grade.B
+    assert parse_value(2, Grade) is Grade.B
+
+    # String-valued enum: match by value and by member name
+    assert parse_value("red", Color) is Color.RED
+    assert parse_value("RED", Color) is Color.RED
+
+    # Auto-valued enum: match by member name
+    assert parse_value("X", AutoValued) is AutoValued.X
+
+    # Out-of-set values still raise
+    with pytest.raises(ValueError):
+        parse_value("99", Grade)
+
+
+def test_parse_value_optional_enum():
+    # Optional/Union-wrapped enums must resolve names and values the same way a bare enum does
+    assert parse_value("2", Grade | None) is Grade.B
+    assert parse_value("B", Grade | None) is Grade.B
+    assert parse_value("RED", Color | None) is Color.RED
+    assert parse_value("red", Grade | Color) is Color.RED
+
+    # Out-of-set values still raise
+    with pytest.raises(ValueError):
+        parse_value("99", Grade | None)
 
 
 def test_parse_value_union():


### PR DESCRIPTION
### What

Enum output fields fail to parse under `ChatAdapter` (and other text-based adapters) in two cases, even when the model answers correctly:

- **Int-valued enums:** the value arrives as text (`"2"`), but never matches the int member value (`2`) or the member name.
- **`Optional[Enum]` / `Enum | None`:** a bare enum accepts the member *name* or value, but the Optional path skips `find_enum_member` and falls through to pydantic (value-only), losing name resolution.

### Why it happens

- `find_enum_member` matched only exact member value or member name.
- `parse_value` routed only **bare** enums through `find_enum_member`; for Union-wrapped enums `get_origin` is `Union`, so it fell through to pydantic.

This is the enum analog of the int-valued `Literal` gap in #9932.

### Change

- `find_enum_member`: after the exact value/name checks, fall back to matching `str(member.value) == str(identifier)`.
- `parse_value`: when the annotation is a Union whose non-`None` members are all enums, route the value through `find_enum_member`.

String-valued enums, mixed unions (e.g. `str | Grade`), and out-of-set values are unaffected.

### Tests

Added `test_parse_value_enum` and `test_parse_value_optional_enum` covering int/string/auto-valued enums, name and value matching, Optional/Union wrapping, and out-of-set raises. The full `tests/adapters` suite passes locally; `ruff check` adds no new findings.

Fixes #9994.

### Disclosure

I used AI-assisted tooling while investigating and implementing this. I reviewed and verified every line, reproduced the behavior, and take ownership of the change.
