### PR TITLE
Fix: Evaluate straggler infinite loop and shutdown race condition

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -78,6 +78,7 @@ class Evaluate:
         display_table: bool | int = False,
         max_errors: int | None = None,
         provide_traceback: bool | None = None,
+        timeout: float | None = None,
         failure_score: float = 0.0,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
@@ -106,6 +107,7 @@ class Evaluate:
         self.display_table = display_table
         self.max_errors = max_errors
         self.provide_traceback = provide_traceback
+        self.timeout = timeout
         self.failure_score = failure_score
         self.save_as_csv = save_as_csv
         self.save_as_json = save_as_json
@@ -125,6 +127,7 @@ class Evaluate:
         callback_metadata: dict[str, Any] | None = None,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        timeout: float | None = None,
     ) -> EvaluationResult:
         """
         Args:
@@ -153,19 +156,24 @@ class Evaluate:
         display_table = display_table if display_table is not None else self.display_table
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
+        timeout = timeout if timeout is not None else self.timeout
 
         if callback_metadata:
             logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
 
         tqdm.tqdm._instances.clear()
 
-        executor = ParallelExecutor(
-            num_threads=num_threads,
-            disable_progress_bar=not display_progress,
-            max_errors=(self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
-            provide_traceback=self.provide_traceback,
-            compare_results=True,
-        )
+        executor_kwargs = {
+            "num_threads": num_threads,
+            "disable_progress_bar": not display_progress,
+            "max_errors": (self.max_errors if self.max_errors is not None else dspy.settings.max_errors),
+            "provide_traceback": self.provide_traceback,
+            "compare_results": True,
+        }
+        if timeout is not None:
+            executor_kwargs["timeout"] = timeout
+
+        executor = ParallelExecutor(**executor_kwargs)
 
         def process_item(example):
             prediction = program(**example.inputs())

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -227,6 +227,7 @@ class ParallelExecutor:
                                             submission_counter += 1
                                         except RuntimeError as e:
                                             if "shutdown" in str(e).lower():
+                                                self.cancel_jobs.set()
                                                 break
                                             raise
 

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -110,6 +110,7 @@ class ParallelExecutor:
         start_time_map = {}
         start_time_lock = threading.Lock()
         resubmitted = set()
+        resubmitted_count = {}
 
         # This is the worker function each thread will run.
         def worker(parent_overrides, submission_id, index, item):
@@ -205,20 +206,29 @@ class ParallelExecutor:
                         for f in list(not_done):
                             if f not in resubmitted:
                                 sid, idx, item = futures_map[f]
+                                if resubmitted_count.get(idx, 0) >= 1:
+                                    continue
                                 with start_time_lock:
                                     st = start_time_map.get(sid, None)
                                 if st and (now - st) >= self.timeout:
                                     resubmitted.add(f)
-                                    nf = executor.submit(
-                                        worker,
-                                        parent_overrides,
-                                        submission_counter,
-                                        idx,
-                                        item,
-                                    )
-                                    futures_map[nf] = (submission_counter, idx, item)
-                                    futures_set.add(nf)
-                                    submission_counter += 1
+                                    resubmitted_count[idx] = resubmitted_count.get(idx, 0) + 1
+                                    if not self.cancel_jobs.is_set():
+                                        try:
+                                            nf = executor.submit(
+                                                worker,
+                                                parent_overrides,
+                                                submission_counter,
+                                                idx,
+                                                item,
+                                            )
+                                            futures_map[nf] = (submission_counter, idx, item)
+                                            futures_set.add(nf)
+                                            submission_counter += 1
+                                        except RuntimeError as e:
+                                            if "shutdown" in str(e).lower():
+                                                break
+                                            raise
 
                 pbar.close()
 


### PR DESCRIPTION
# Fix: ParallelExecutor Infinite Straggler Loop & Shutdown Race Condition

Fixes [[#9574](https://github.com/stanfordnlp/dspy/issues/9574)]

## Problem

When an evaluation task hangs past the 120-second timeout, `ParallelExecutor` flags it as a straggler and submits a duplicate task to the thread pool to try to get it done. If that duplicate *also* takes longer than 120 seconds, it gets flagged as a straggler too, and a third task is spawned. This repeats indefinitely.

The result:

- The thread pool fills up with duplicate tasks.
- Requests stay hung, and no new tasks can be processed.
- If the evaluator eventually tries to shut down (either normally or via `Ctrl+C`), it calls `executor.shutdown(wait=False)`.
- The straggler logic never checked whether the executor was already shutting down before submitting the next retry, so `executor.submit()` throws immediately:

  ```
  RuntimeError: cannot schedule new futures after shutdown
  ```

This crashes the process instead of shutting down gracefully.

## Root Cause

Two separate issues compound each other:

1. **No cap on straggler retries** — a task that keeps timing out spawns an unbounded number of duplicate submissions.
2. **No shutdown check before `submit()`** — once the executor starts shutting down, any in-flight straggler logic that tries to submit a new task crashes with an unhandled `RuntimeError`.

## Solution

### 1. Expose the timeout
Added a `timeout` parameter to `dspy.Evaluate.__init__` and `dspy.Evaluate.__call__`, threaded down into `ParallelExecutor`. Users running complex, long-running evaluations can now raise the straggler timeout threshold instead of having it hardcoded, preventing false-positive straggler detection.

### 2. Cap straggler retries
Added a `resubmitted_count` dictionary to `ParallelExecutor` that tracks how many times each item has been resubmitted. Retries are now capped at **exactly 1** per item, eliminating the infinite resubmission loop and the resulting thread pool saturation.

### 3. Guard against the shutdown race condition
Wrapped the straggler `executor.submit()` call in a `try / except RuntimeError` block. If a submit is attempted while the executor is shutting down (or has already shut down), the exception is now caught gracefully and the loop breaks instead of crashing the program.

## Impact

- No more unbounded duplicate task submission during hung evaluations.
- Thread pools no longer saturate with straggler retries.
- Clean, non-crashing shutdown on `Ctrl+C` or normal evaluator exit.
- Users can tune the straggler timeout for legitimately long-running eval tasks.

## Testing

Reproduced the issue locally with a script that simulates hanging evaluation tasks exceeding the straggler timeout, confirmed the original `RuntimeError` on shutdown, then verified the fix resolves it under the same conditions.

> **Note:** Per DSPy's AI contribution guidelines, I paired with an AI coding assistant to investigate the root cause, write the reproduction script, and test this fix locally.