### PR TITLE
ci: test dependency range boundaries weekly

### DIFF
--- a/.github/workflows/dependency-range.yml
+++ b/.github/workflows/dependency-range.yml
@@ -1,0 +1,108 @@
+name: Dependency Range
+
+on:
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/dependency-range.yml
+
+permissions: {}
+
+jobs:
+  dependency-range:
+    name: Dependencies (${{ matrix.profile }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - profile: minimum-direct
+            resolution: lowest-direct
+          - profile: latest
+            resolution: highest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: "0.11.2"
+          enable-cache: true
+          cache-dependency-glob: pyproject.toml
+
+      - name: Create environment
+        run: uv venv .venv
+
+      - name: Resolve ${{ matrix.profile }} dependencies
+        env:
+          PROFILE: ${{ matrix.profile }}
+          RESOLUTION: ${{ matrix.resolution }}
+        run: |
+          uv pip compile pyproject.toml \
+            --extra dev \
+            --extra test_extras \
+            --resolution "$RESOLUTION" \
+            --python .venv/bin/python \
+            --refresh \
+            --no-sources \
+            --output-file "$RUNNER_TEMP/requirements-$PROFILE.txt"
+
+          uv pip sync \
+            --strict \
+            --python .venv/bin/python \
+            "$RUNNER_TEMP/requirements-$PROFILE.txt"
+
+          uv pip install \
+            --python .venv/bin/python \
+            --no-deps \
+            --editable .
+
+          uv pip check --python .venv/bin/python
+          uv pip list --python .venv/bin/python
+
+      - name: Run non-live tests
+        env:
+          PROFILE: ${{ matrix.profile }}
+        run: |
+          set +e
+          uv run --frozen --no-sync pytest -q tests/ --extra --deno 2>&1 \
+            | tee "$RUNNER_TEMP/pytest-$PROFILE.log"
+          TEST_STATUS=${PIPESTATUS[0]}
+          set -e
+
+          {
+            echo "## Dependencies ($PROFILE)"
+            echo
+            if [ "$TEST_STATUS" -eq 0 ]; then
+              echo "✅ Non-live test suite passed."
+            else
+              echo "❌ Non-live test suite failed."
+              echo
+              echo '```text'
+              if ! grep -E '^(FAILED|ERROR) |[0-9]+ failed, [0-9]+ passed' "$RUNNER_TEMP/pytest-$PROFILE.log"; then
+                tail -n 20 "$RUNNER_TEMP/pytest-$PROFILE.log"
+              fi
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$TEST_STATUS"


### PR DESCRIPTION
## Summary

DSPy's existing CI varies Python 3.10–3.14 while installing one checked-in dependency graph. That proves the lock works, but it does not verify either end of DSPy's published dependency ranges.

This PR adds one independent dependency-range workflow with two profiles:

```yaml
- profile: minimum-direct
  resolution: lowest-direct
- profile: latest
  resolution: highest
```

It runs every Monday, on manual dispatch, and when a pull request changes `pyproject.toml`, `uv.lock`, or the workflow itself.

## 1. Issue / repro

The current Python matrix always installs from `uv.lock`:

```yaml
uv sync --extra dev
uv run pytest tests/
```

It therefore does not answer either dependency-contract question:

1. Does the lowest resolver-compatible set of DSPy's direct requirements work?
2. Does a fresh install of the newest allowed packages still work today?

The first hosted dependency-range run also exposed a reporting bug. Both profiles had real pytest failures, but both PR checks appeared green because step-level `continue-on-error` rewrote their final conclusions to success. `gh pr checks` reported no failures; the only signal was a warning inside the job log/summary.

## 2. Why this is the root cause

Python-version coverage and dependency-range coverage are independent axes.

There is also a subtle uv boundary: project-level `uv sync` and `uv run` normally synchronize from `uv.lock`. A job can request another resolution and then silently restore locked packages before testing. The dependency workflow must never consume that lock.

For reporting, a failed compatibility suite must retain a failed job conclusion. Whether that check blocks a merge is repository policy; converting the failure to success inside the workflow destroys the signal itself.

## 3. How we know the workflow tests and reports the intended graphs

Each profile compiles directly from publishable `pyproject.toml` metadata:

```bash
uv pip compile pyproject.toml \
  --extra dev \
  --extra test_extras \
  --resolution "$RESOLUTION" \
  --refresh \
  --no-sources \
  --output-file "$RUNNER_TEMP/requirements-$PROFILE.txt"
```

The workflow syncs that exact result and prevents the test command from restoring `uv.lock`:

```bash
uv pip sync --strict "$RUNNER_TEMP/requirements-$PROFILE.txt"
uv pip check
uv run --frozen --no-sync pytest -q tests/ --extra --deno
```

The compiled requirements and installed packages are printed. Each job summary shows the final pytest count and every failing test name. The test command now returns its real exit status all the way to the job, so compatibility failures are visible as failed `Dependencies (...)` checks on the PR.

## 4. Why this is the concise version

The PR adds one workflow file and two jobs on one representative Python version.

It deliberately does not:

- multiply dependency profiles by the existing five-version Python matrix;
- change runtime code, dependency bounds, or `uv.lock`;
- change the existing locked CI jobs;
- publish a custom Check Run or require write permissions;
- add a new test framework or dependency.

The existing matrix owns Python compatibility. This workflow owns dependency-range drift. GitHub's native failed-check UI owns visibility.

## 5. Context needed to validate the rollout

`lowest-direct` means the lowest compatible versions of DSPy's direct requirements with current compatible transitive dependencies. It avoids the mostly artificial environment produced by minimizing every transitive package.

Both fresh graphs resolve and pass `uv pip check`. The corrected hosted run exposed five compatibility failures:

- Minimum: Pydantic 2.7.2 renders two semantically equivalent tool schemas differently from the locked version, and unbounded `langchain-core` resolves to 0.0.1 without `langchain_core.tools`.
- Latest: LiteLLM 1.92.0 adds nullable `caller` and `namespace` fields to its normalized function-call dictionary.

These jobs are not configured as required status checks, so the repository can still merge during an incident. The five baseline failures are now resolved, and the rebased hosted run passes both profiles. Any future red dependency-range run is therefore new compatibility drift rather than accepted noise.

The rollout fixes that debt in reviewable boundaries rather than hiding it here:

- #10004 declares the real LangChain Core floor and clears two minimum failures. Merged.
- #10012 makes the open ToolCall argument schema stable across Pydantic versions and clears the other two minimum failures. Merged.
- #10014 omits absent provider fields at the Responses boundary and clears the latest failure. Merged.

## 6. What the workflow does

For each profile it:

1. Creates a fresh Python 3.11 environment.
2. Resolves from `pyproject.toml`, independently of `uv.lock`.
3. Synchronizes the exact compiled graph.
4. Installs DSPy without re-resolving dependencies.
5. Runs `uv pip check` and prints installed versions.
6. Runs the complete non-live suite, including extra and Deno tests.
7. Writes exact failure counts and names to the job summary.
8. Preserves pytest's exit status so compatibility failures remain visible on the PR checks surface.

## Verification

- `actionlint .github/workflows/dependency-range.yml` — passed.
- `zizmor .github/workflows/dependency-range.yml` — no findings.
- `pre-commit run --files .github/workflows/dependency-range.yml` — passed.
- Both hosted graphs compiled, installed, and passed `uv pip check`.
- Corrected hosted minimum-direct suite: 1,114 passed, 206 skipped, 2 xfailed, 4 compatibility failures.
- Corrected hosted latest suite: 1,117 passed, 206 skipped, 2 xfailed, 1 compatibility failure.
- Both failures appear as red `Dependencies (...)` checks on the PR, while GitHub still reports the PR mergeable and no dependency check is required.
- Hosted evidence: https://github.com/stanfordnlp/dspy/actions/runs/29255689364
- Combined local minimum-direct graph with all three fixes: 1,120 passed, 206 skipped, 2 xfailed.
- Combined local latest graph with all three fixes: 1,120 passed, 206 skipped, 2 xfailed.
- Exact LiteLLM 1.92.0 / OpenAI 2.45.0 focused boundary matrix: 3 passed.
- Final rebased hosted minimum-direct graph: 1,128 passed, 206 skipped, 2 xfailed.
- Final rebased hosted latest graph: 1,128 passed, 206 skipped, 2 xfailed.
- Final hosted evidence: https://github.com/stanfordnlp/dspy/actions/runs/29265650259
- Standard CI also passed on the same head, including Python 3.10–3.14, Real LM, builds, workflow lint, and security scanning.
- `git diff --check origin/main...HEAD` — clean.

## Stack tracker

| Tracker head | Included compatibility fixes | Minimum-direct | Latest | Hosted run |
| --- | --- | --- | --- | --- |
| `9fd4a55c7` | #10004, #10012, #10014 merged into `main` | ✅ 1,128 passed | ✅ 1,128 passed | [29265650259](https://github.com/stanfordnlp/dspy/actions/runs/29265650259) |

## Scope

One commit. One new workflow file. No code, metadata, or lock changes.

