### PR TITLE
docs: make pull request evidence reviewable

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,14 +1,39 @@
-## 📝 Changes Description
+## What changed
 
-This MR/PR contains the following changes:
-...
+<!-- Describe the behavior change and the code that implements it. Code samples
+are welcome when they make the before/after behavior easier to see. -->
 
-## ✅ Contributor Checklist
+## Why
 
-- [] Pre-Commit checks are passing (locally and remotely)
-- [] Title of your PR / MR corresponds to the required format
-- [] Commit message follows required format {label}(dspy): {message}
+<!-- Link the issue or include a minimal reproduction. For fixes, explain the
+root cause—not only the symptom—and any historical constraint that made this
+boundary difficult to maintain. -->
 
-## ⚠️ Warnings
+## Why this fix
 
-Anything we should be aware of ?
+<!-- Explain why the change addresses the root cause and why it is the smallest
+complete fix. Note alternatives considered when the choice is not obvious. -->
+
+## Verification
+
+<!-- List exact commands and results. For fixes, include failing evidence before
+the change and passing evidence after it when practical. -->
+
+## Review context
+
+<!-- Call out context, tradeoffs, compatibility impact, or follow-up work a
+reviewer needs to validate this change. -->
+
+## Contributor checklist
+
+- [ ] I ran the relevant tests and pre-commit checks.
+- [ ] I added or updated tests, or explained why tests are not needed.
+- [ ] I kept this PR focused and listed follow-up work separately.
+
+### Dependency changes
+
+<!-- Delete this section when the PR does not change a dependency contract. -->
+
+- [ ] The full dependency graph resolves at the proposed minimum and at current/latest versions.
+- [ ] A shipped runtime path fails below the proposed floor and passes at it.
+- [ ] Published metadata and lock metadata agree, without unrelated lock updates.


### PR DESCRIPTION
## What changed

Replace DSPy's 2024 pull-request template with a concise evidence-first structure:

```text
What changed → Why → Why this fix → Verification → Review context
```

The contributor checklist now uses valid GitHub task-list syntax and includes a short conditional checklist for dependency-contract changes.

## Why

The current template has three practical problems:

```markdown
- [] Pre-Commit checks are passing
- [] Title ... corresponds to the required format
- [] Commit message follows required format ...
```

1. `- []` does not render as a GitHub checkbox; valid syntax is `- [ ]`.
2. The required title and commit formats are not documented in `CONTRIBUTING.md`.
3. The template asks what changed, but not for the reproduction, root cause, boundary evidence, or context needed to validate it.

The file was added in January 2024 and has not been revised since.

## Why this fix

The new prompts map directly to the questions a reviewer must answer:

| Prompt | Review question |
| --- | --- |
| What changed | What does the code actually do? |
| Why | What is the issue and root cause? |
| Why this fix | Does it address that cause, and is it the smallest complete change? |
| Verification | What failed before and passes now? |
| Review context | What tradeoffs or compatibility constraints matter? |

Guidance is kept inside HTML comments, so it helps an author compose the PR without rendering boilerplate in the finished description.

Dependency changes get three additional gates: a real minimum/current resolution, a shipped runtime boundary, and agreement between published and lock metadata. The section explicitly tells authors to delete it when irrelevant.

## Verification

- Repository pre-commit hooks passed.
- `git diff --check origin/main...HEAD` passed.
- All checklist items use GitHub's `- [ ]` task-list syntax.
- The requirements claimed by the old checklist were compared against `CONTRIBUTING.md`; neither is documented there.

## Review context

This changes contributor guidance only. It does not add policy enforcement, alter CI, or require every PR to be a bug fix. Prompts explain what evidence is useful while leaving authors room to say why a section does not apply.

## Scope

One commit. One Markdown file. No runtime, test, or workflow changes.
