### PR TITLE
test(mcp): declare the hello tool's actual return type

### DIFF
--- a/tests/utils/resources/mcp_server.py
+++ b/tests/utils/resources/mcp_server.py
@@ -21,7 +21,7 @@ def add(a: int, b: int) -> int:
 
 
 @mcp.tool()
-def hello(names: list[str]) -> str:
+def hello(names: list[str]) -> list[str]:
     """Greet people"""
     return [f"Hello, {name}!" for name in names]
 


### PR DESCRIPTION
## What changed

Correct the return annotation on DSPy's FastMCP `hello` test tool:

```diff
-def hello(names: list[str]) -> str:
+def hello(names: list[str]) -> list[str]:
     return [f"Hello, {name}!" for name in names]
```

## Why

The latest dependency-range run exposed this failure under MCP 1.28.1:

```text
Error executing tool hello: 1 validation error for helloOutput
result
  Input should be a valid string
  input_value=['Hello, Bob!', 'Hello, Tom!']
```

The function says it returns `str`, but it returns `list[str]` and the existing test has always expected that list.

## Why this fix

Current MCP generates and validates a structured output schema from a FastMCP tool's return annotation. With `-> str`, it correctly generates `{result: string}` and rejects the list before DSPy's MCP converter receives anything.

With `-> list[str]`, MCP generates `{result: array[string]}` and the existing DSPy conversion path succeeds unchanged.

This fixes the false contract at its source. Alternatives such as pinning MCP, ignoring `isError`, disabling structured output, or adding a converter fallback would hide an invalid tool declaration.

## Verification

- Locked MCP 1.9.4: `tests/utils/test_mcp.py` — passed.
- Latest MCP 1.28.1: `tests/utils/test_mcp.py` — passed.
- Latest environment: `uv pip check` — passed.
- Repository pre-commit hooks — passed.
- `git diff --check origin/main...HEAD` — passed.
- The unpatched failure is independently reproduced by the latest job in [PR #10000](https://github.com/stanfordnlp/dspy/pull/10000).

## Review context

This changes a test server fixture only. It does not change DSPy runtime behavior or its MCP dependency range. The corrected annotation is compatible with both the locked and latest MCP versions.

## Scope

One commit. One annotation. One insertion and one deletion.
