### PR TITLE
fix(teleprompt): isolate BootstrapFinetune data by predictor

### DIFF
--- a/dspy/teleprompt/bootstrap_finetune.py
+++ b/dspy/teleprompt/bootstrap_finetune.py
@@ -176,11 +176,13 @@ class BootstrapFinetune(FinetuneTeleprompter):
         adapter = self.adapter[lm] or settings.adapter or ChatAdapter()
         data_format = infer_data_format(adapter)
         for item in trace_data:
-            for pred_ind, _ in enumerate(item["trace"]):
-                include_data = pred_ind is None or pred_ind == pred_ind
-                if include_data:
+            for trace_pred_ind, _ in enumerate(item["trace"]):
+                if pred_ind is None or trace_pred_ind == pred_ind:
                     call_data = build_call_data_from_trace(
-                        trace=item["trace"], pred_ind=pred_ind, adapter=adapter, exclude_demos=self.exclude_demos
+                        trace=item["trace"],
+                        pred_ind=trace_pred_ind,
+                        adapter=adapter,
+                        exclude_demos=self.exclude_demos,
                     )
                     data.append(call_data)
 

--- a/tests/teleprompt/test_bootstrap_finetune.py
+++ b/tests/teleprompt/test_bootstrap_finetune.py
@@ -19,6 +19,22 @@ examples = [
 trainset = [examples[0]]
 
 
+class TraceIdentityAdapter(dspy.ChatAdapter):
+    def format_finetune_data(self, signature, demos, inputs, outputs):
+        return {"inputs": inputs, "outputs": outputs}
+
+
+def make_two_predictor_trace():
+    return [
+        {
+            "trace": [
+                (Predict("input -> output"), {"input": "predictor-0"}, {"output": "zero"}),
+                (Predict("input -> output"), {"input": "predictor-1"}, {"output": "one"}),
+            ]
+        }
+    ]
+
+
 def test_bootstrap_finetune_initialization():
     """Test BootstrapFinetune initialization with various parameters."""
     bootstrap = BootstrapFinetune(metric=simple_metric)
@@ -79,3 +95,30 @@ def test_error_handling_missing_lm():
     except ValueError as e:
         assert "does not have an LM assigned" in str(e)
         assert "set_lm" in str(e)
+
+
+def test_prepare_finetune_data_filters_to_requested_predictor():
+    bootstrap = BootstrapFinetune(adapter=TraceIdentityAdapter(), exclude_demos=True)
+
+    data, _ = bootstrap._prepare_finetune_data(
+        trace_data=make_two_predictor_trace(),
+        lm=DummyLM([]),
+        pred_ind=1,
+    )
+
+    assert data == [{"inputs": {"input": "predictor-1"}, "outputs": {"output": "one"}}]
+
+
+def test_prepare_finetune_data_includes_all_predictors_without_filter():
+    bootstrap = BootstrapFinetune(adapter=TraceIdentityAdapter(), exclude_demos=True)
+
+    data, _ = bootstrap._prepare_finetune_data(
+        trace_data=make_two_predictor_trace(),
+        lm=DummyLM([]),
+        pred_ind=None,
+    )
+
+    assert sorted(data, key=lambda item: item["inputs"]["input"]) == [
+        {"inputs": {"input": "predictor-0"}, "outputs": {"output": "zero"}},
+        {"inputs": {"input": "predictor-1"}, "outputs": {"output": "one"}},
+    ]


### PR DESCRIPTION
## 1. Issue / repro

`BootstrapFinetune(multitask=False)` is supposed to build one fine-tuning dataset per predictor. Instead, every dataset currently contains traces from every predictor.

The filter is a tautology because the `pred_ind` argument is shadowed by the loop variable:

```python
for pred_ind, _ in enumerate(item["trace"]):
    include_data = pred_ind is None or pred_ind == pred_ind
```

For a two-predictor trace, asking for predictor 1 therefore returns both predictor 0 and predictor 1 examples.

## 2. Why this is the root cause

`compile()` deliberately passes `pred_ind=None` for multitask training and a concrete index for per-predictor training. `_prepare_finetune_data()` is the boundary that turns that index into training rows. Rebinding the argument inside that function erases the caller's selection before it is used.

## 3. How we know the fix addresses the root cause

The regression test uses a two-predictor trace and an identity adapter so the selected row is directly observable:

```python
data, _ = bootstrap._prepare_finetune_data(trace_data, lm, pred_ind=1)

assert data == [{
    "inputs": {"input": "predictor-1"},
    "outputs": {"output": "one"},
}]
```

A negative control passes `pred_ind=None` and verifies that both rows remain present for intentional multitask training.

## 4. Why this is the concise fix

The data model and call graph are already correct. The production change only gives the trace index its own name and compares it with the unchanged requested index. There is no new filtering layer or compatibility path.

## 5. Context needed to validate the change

- `multitask=True`: predictors sharing an LM intentionally train on all trace steps (`pred_ind=None`).
- `multitask=False`: each predictor gets a distinct job keyed by its concrete index.
- `build_call_data_from_trace()` already accepts the trace index and needs no change.

## 6. What the fix does

```diff
- for pred_ind, _ in enumerate(item["trace"]):
-     include_data = pred_ind is None or pred_ind == pred_ind
-     if include_data:
-         build_call_data_from_trace(..., pred_ind=pred_ind)
+ for trace_pred_ind, _ in enumerate(item["trace"]):
+     if pred_ind is None or trace_pred_ind == pred_ind:
+         build_call_data_from_trace(..., pred_ind=trace_pred_ind)
```

## Verification

```text
uv run --frozen pytest --deno -q tests/teleprompt/test_bootstrap_finetune.py
5 passed
```

Pre-commit and `git diff --check` also pass.

## Scope

Two files: the broken predicate and two focused regression tests. Fine-tuning submission, adapters, trace collection, and multitask behavior are unchanged.
