### PR TITLE
fix(cache): include endpoint in request identity

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -230,7 +230,7 @@ def request_cache(
         enable_memory_cache: Whether to enable in-memory cache at call time. If False, the memory cache will not be
             written to on new data.
     """
-    ignored_args_for_cache_key = ignored_args_for_cache_key or ["api_key", "api_base", "base_url"]
+    ignored_args_for_cache_key = ignored_args_for_cache_key or ["api_key"]
     # Deprecation notice
     if maxsize is not None:
         logger.warning(

--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -165,7 +165,7 @@ def _compute_embeddings(model, batch_inputs, caching=False, **kwargs):
         raise ValueError(f"`model` in `dspy.Embedder` must be a string or a callable, but got {type(model)}.")
 
 
-@request_cache(ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
+@request_cache(ignored_args_for_cache_key=["api_key"])
 def _cached_compute_embeddings(model, batch_inputs, caching=True, **kwargs):
     return _compute_embeddings(model, batch_inputs, caching=caching, **kwargs)
 
@@ -181,6 +181,6 @@ async def _acompute_embeddings(model, batch_inputs, caching=False, **kwargs):
         raise ValueError(f"`model` in `dspy.Embedder` must be a string or a callable, but got {type(model)}.")
 
 
-@request_cache(ignored_args_for_cache_key=["api_key", "api_base", "base_url"])
+@request_cache(ignored_args_for_cache_key=["api_key"])
 async def _cached_acompute_embeddings(model, batch_inputs, caching=True, **kwargs):
     return await _acompute_embeddings(model, batch_inputs, caching=caching, **kwargs)

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -170,7 +170,7 @@ class LM(BaseLM):
             self._warned_zero_temp_rollout = True
 
     def _get_cached_completion_fn(self, completion_fn, cache):
-        ignored_args_for_cache_key = ["api_key", "api_base", "base_url"]
+        ignored_args_for_cache_key = ["api_key"]
         if cache:
             completion_fn = request_cache(
                 cache_arg_name="request",

--- a/tests/clients/test_cache.py
+++ b/tests/clients/test_cache.py
@@ -291,6 +291,34 @@ def test_request_cache_decorator_with_ignored_args_for_cache_key(cache):
         assert result3 != result4
 
 
+@pytest.mark.parametrize("endpoint_key", ["api_base", "base_url"])
+def test_request_cache_default_uses_endpoint_but_ignores_api_key(cache, endpoint_key):
+    from dspy.clients.cache import request_cache
+
+    calls = []
+    endpoint_a = "https://endpoint-a.example/v1"
+    endpoint_b = "https://endpoint-b.example/v1"
+
+    with patch("dspy.cache", cache):
+
+        @request_cache()
+        def test_function(**kwargs):
+            calls.append(kwargs.copy())
+            return kwargs[endpoint_key]
+
+        first = test_function(**{endpoint_key: endpoint_a, "api_key": "key-a"})
+        cached = test_function(**{endpoint_key: endpoint_a, "api_key": "key-b"})
+        second_endpoint = test_function(**{endpoint_key: endpoint_b, "api_key": "key-b"})
+
+    assert first == endpoint_a
+    assert cached == endpoint_a
+    assert second_endpoint == endpoint_b
+    assert [(call[endpoint_key], call["api_key"]) for call in calls] == [
+        (endpoint_a, "key-a"),
+        (endpoint_b, "key-b"),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_request_cache_decorator_async(cache):
     """Test the request_cache decorator with async functions."""

--- a/tests/clients/test_embedding.py
+++ b/tests/clients/test_embedding.py
@@ -59,6 +59,32 @@ def test_litellm_embedding(cache):
         np.testing.assert_allclose(result, mock_embeddings)
 
 
+@pytest.mark.parametrize("endpoint_key", ["api_base", "base_url"])
+def test_embedding_cache_uses_endpoint_but_ignores_api_key(cache, endpoint_key):
+    endpoint_a = "https://endpoint-a.example/v1"
+    endpoint_b = "https://endpoint-b.example/v1"
+    calls = []
+
+    def fake_embedding(**kwargs):
+        calls.append(kwargs.copy())
+        value = 1.0 if kwargs[endpoint_key] == endpoint_a else 2.0
+        return MockEmbeddingResponse([[value]])
+
+    with patch("litellm.embedding", side_effect=fake_embedding):
+        embedding = Embedder("text-embedding-ada-002", caching=True)
+        first = embedding(["hello"], **{endpoint_key: endpoint_a, "api_key": "key-a"})
+        cached = embedding(["hello"], **{endpoint_key: endpoint_a, "api_key": "key-b"})
+        second_endpoint = embedding(["hello"], **{endpoint_key: endpoint_b, "api_key": "key-b"})
+
+    np.testing.assert_allclose(first, [[1.0]])
+    np.testing.assert_allclose(cached, [[1.0]])
+    np.testing.assert_allclose(second_endpoint, [[2.0]])
+    assert [(call[endpoint_key], call["api_key"]) for call in calls] == [
+        (endpoint_a, "key-a"),
+        (endpoint_b, "key-b"),
+    ]
+
+
 def test_callable_embedding(cache):
     inputs = ["hello", "world", "test"]
 
@@ -151,6 +177,33 @@ async def test_async_embedding():
 
         assert len(result) == len(inputs)
         np.testing.assert_allclose(result, mock_embeddings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("endpoint_key", ["api_base", "base_url"])
+async def test_async_embedding_cache_uses_endpoint_but_ignores_api_key(cache, endpoint_key):
+    endpoint_a = "https://endpoint-a.example/v1"
+    endpoint_b = "https://endpoint-b.example/v1"
+    calls = []
+
+    async def fake_embedding(**kwargs):
+        calls.append(kwargs.copy())
+        value = 1.0 if kwargs[endpoint_key] == endpoint_a else 2.0
+        return MockEmbeddingResponse([[value]])
+
+    with patch("litellm.aembedding", side_effect=fake_embedding):
+        embedding = Embedder("text-embedding-ada-002", caching=True)
+        first = await embedding.acall(["hello"], **{endpoint_key: endpoint_a, "api_key": "key-a"})
+        cached = await embedding.acall(["hello"], **{endpoint_key: endpoint_a, "api_key": "key-b"})
+        second_endpoint = await embedding.acall(["hello"], **{endpoint_key: endpoint_b, "api_key": "key-b"})
+
+    np.testing.assert_allclose(first, [[1.0]])
+    np.testing.assert_allclose(cached, [[1.0]])
+    np.testing.assert_allclose(second_endpoint, [[2.0]])
+    assert [(call[endpoint_key], call["api_key"]) for call in calls] == [
+        (endpoint_a, "key-a"),
+        (endpoint_b, "key-b"),
+    ]
 
 
 def test_call_caching_false_overrides_instance_true(cache):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -16,6 +16,7 @@ from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response_reasoning_item import Summary
 
 import dspy
+from dspy.clients.cache import Cache
 from dspy.utils.usage_tracker import track_usage
 
 
@@ -98,6 +99,40 @@ def test_dspy_cache(litellm_test_server, tmp_path):
     assert len(usage_tracker.usage_data) == 0
 
     dspy.cache = original_cache
+
+
+@pytest.mark.parametrize("endpoint_key", ["api_base", "base_url"])
+def test_lm_cache_uses_endpoint_but_ignores_api_key(monkeypatch, endpoint_key):
+    endpoint_a = "https://endpoint-a.example/v1"
+    endpoint_b = "https://endpoint-b.example/v1"
+    calls = []
+
+    def fake_completion(*, request, num_retries, cache):
+        calls.append(request.copy())
+        return ModelResponse(
+            choices=[Choices(message=Message(content=request[endpoint_key]))],
+            model=request["model"],
+        )
+
+    monkeypatch.setattr(
+        dspy,
+        "cache",
+        Cache(enable_disk_cache=False, enable_memory_cache=True, disk_cache_dir=None),
+    )
+    monkeypatch.setattr("dspy.clients.lm.litellm_completion", fake_completion)
+    lm = dspy.LM(model="openai/dspy-test-model")
+
+    first = lm("Query", **{endpoint_key: endpoint_a, "api_key": "key-a"})
+    cached = lm("Query", **{endpoint_key: endpoint_a, "api_key": "key-b"})
+    second_endpoint = lm("Query", **{endpoint_key: endpoint_b, "api_key": "key-b"})
+
+    assert first == [endpoint_a]
+    assert cached == [endpoint_a]
+    assert second_endpoint == [endpoint_b]
+    assert [(call[endpoint_key], call["api_key"]) for call in calls] == [
+        (endpoint_a, "key-a"),
+        (endpoint_b, "key-b"),
+    ]
 
 
 def test_disabled_cache_skips_cache_key(monkeypatch):


### PR DESCRIPTION
## 1. Issue / repro

DSPy treats identical prompts sent to different endpoints as the same cached request:

```python
lm("Query", api_base="https://endpoint-a.example/v1")
lm("Query", api_base="https://endpoint-b.example/v1")
```

If both endpoints expose the same model name, the second call can return endpoint A's cached response without contacting endpoint B. The same collision affects `base_url` and hosted embeddings.

## 2. Why this is the root cause

`request_cache` hashes the request after removing ignored fields. DSPy explicitly removed both endpoint aliases:

```python
ignored_args_for_cache_key = ["api_key", "api_base", "base_url"]
```

That makes these requests identical from the cache's perspective:

```text
key(model, prompt, endpoint A) == key(model, prompt, endpoint B)
```

An endpoint is a semantic request input: model aliases are not globally unique across custom, local, Azure, or proxy deployments.

## 3. How we know the fix addresses the root cause

The regressions use fake backends whose output is determined solely by the endpoint. Each test verifies:

1. Endpoint A invokes the backend.
2. Endpoint A with a different API key is a cache hit.
3. Endpoint B invokes the backend and returns B's result.

This is covered for `api_base` and `base_url` at all four cache boundaries: generic `request_cache`, `dspy.LM`, synchronous embeddings, and asynchronous embeddings. The eight parameterized cases fail with the old ignore lists and pass with this change.

## 4. Why this is the concise fix

The production change is four one-line edits. It does not add endpoint normalization, a cache migration, another cache layer, or provider-specific routing. Every boundary follows one rule: ignore credentials, but hash semantic request inputs.

## 5. Context needed to validate the change

DSPy stores entries under a SHA-256 digest of the transformed request; the raw endpoint is not persisted as the cache key. LM sync/async calls share one cache wrapper, while embeddings have separate sync and async decorators.

Requests without an explicit endpoint keep their existing identity. Requests with an endpoint safely cold-miss older entries.

## 6. What the fix does

```diff
- ignored_args_for_cache_key = ["api_key", "api_base", "base_url"]
+ ignored_args_for_cache_key = ["api_key"]
```

After the change:

```text
key(model, prompt, endpoint A) != key(model, prompt, endpoint B)
```

## Verification

- 8 focused endpoint/credential regression cases passed.
- 38 broader cache/LM/Embedder tests passed.
- Pre-commit and `git diff --check` passed.

## Scope and limitations

- Explicit `api_base` and `base_url` fields are covered. Endpoints resolved only from LiteLLM globals or environment variables are outside this change.
- API keys remain intentionally excluded, preserving credential rotation and the current cache contract. Gateways that route different backends by API key should isolate caches per tenant.
- Equivalent URL spellings can produce harmless cache misses, never incorrect cross-endpoint hits.
