### PR TITLE
fix(adapter): preserve nested open mappings

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, get_origin
+from typing import Any
 
 import json_repair
 import pydantic
@@ -24,16 +24,48 @@ from dspy.utils.exceptions import AdapterParseError, LMError
 logger = logging.getLogger(__name__)
 
 
-def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
-    """
-    Check whether any output field in the signature has an open-ended mapping type,
-    such as dict[str, Any]. Structured Outputs require explicit properties, so such fields
-    are incompatible.
-    """
-    for field in signature.output_fields.values():
-        annotation = field.annotation
-        if get_origin(annotation) is dict:
+class _OpenEndedMappingError(ValueError):
+    """Raised when a response schema permits arbitrary object keys."""
+
+
+def _schema_has_open_ended_mapping(schema: Any) -> bool:
+    if not isinstance(schema, dict):
+        return False
+
+    schema_type = schema.get("type")
+    has_object_type = schema_type == "object" or (isinstance(schema_type, list) and "object" in schema_type)
+    has_object_keywords = any(
+        keyword in schema
+        for keyword in ("properties", "patternProperties", "additionalProperties", "propertyNames", "unevaluatedProperties")
+    )
+    if has_object_type or (schema_type is None and has_object_keywords):
+        if "patternProperties" in schema:
             return True
+        if "propertyNames" in schema and schema.get("additionalProperties") is not False:
+            return True
+        if schema.get("additionalProperties") not in (None, False):
+            return True
+        if schema.get("unevaluatedProperties") not in (None, False):
+            return True
+        if has_object_type and "properties" not in schema and schema.get("additionalProperties") is not False:
+            return True
+
+    for keyword in ("properties", "$defs", "definitions", "dependentSchemas"):
+        subschemas = schema.get(keyword)
+        if isinstance(subschemas, dict) and any(
+            _schema_has_open_ended_mapping(subschema) for subschema in subschemas.values()
+        ):
+            return True
+
+    for keyword in ("items", "contains", "additionalProperties", "unevaluatedProperties", "not", "if", "then", "else"):
+        if _schema_has_open_ended_mapping(schema.get(keyword)):
+            return True
+
+    for keyword in ("prefixItems", "allOf", "anyOf", "oneOf"):
+        subschemas = schema.get(keyword)
+        if isinstance(subschemas, list) and any(_schema_has_open_ended_mapping(subschema) for subschema in subschemas):
+            return True
+
     return False
 
 
@@ -58,7 +90,7 @@ class JSONAdapter(ChatAdapter):
 
         has_tool_calls = any(field.annotation == ToolCalls for field in signature.output_fields.values())
 
-        if _has_open_ended_mapping(signature) or (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
+        if (not self.use_native_function_calling and has_tool_calls) or not lm.supports_response_schema:
             # We found that structured output mode doesn't work well with dspy.ToolCalls as output field.
             # So we fall back to json mode if native function calling is disabled and ToolCalls is present.
             lm_kwargs["response_format"] = {"type": "json_object"}
@@ -81,6 +113,9 @@ class JSONAdapter(ChatAdapter):
                 signature, self.use_native_function_calling
             )
             lm_kwargs["response_format"] = structured_output_model
+            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+        except _OpenEndedMappingError:
+            lm_kwargs["response_format"] = {"type": "json_object"}
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except LMError:
             # Provider/backend failures should propagate; the fallback below is only for local structured-output
@@ -108,6 +143,9 @@ class JSONAdapter(ChatAdapter):
                 signature, self.use_native_function_calling
             )
             lm_kwargs["response_format"] = structured_output_model
+            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+        except _OpenEndedMappingError:
+            lm_kwargs["response_format"] = {"type": "json_object"}
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
         except LMError:
             # Provider/backend failures should propagate; the fallback below is only for local structured-output
@@ -237,18 +275,10 @@ def _get_structured_outputs_response_format(
     is compatible with OpenAI Structured Outputs (all objects have a "required" key listing every property,
     and additionalProperties is always false).
 
-    IMPORTANT: If any field's annotation is an open-ended mapping (e.g. dict[str, Any]), then a structured
-    schema cannot be generated since all properties must be explicitly declared. In that case, an exception
-    is raised so that the caller can fall back to using a plain "json_object" response_format.
+    IMPORTANT: If the generated schema contains an open-ended mapping (e.g. dict[str, Any]), then a structured
+    schema cannot be generated since all properties must be explicitly declared. In that case, an exception is
+    raised so that the caller can use a plain "json_object" response format.
     """
-    # Although we've already performed an early check, we keep this here as a final guard.
-    for name, field in signature.output_fields.items():
-        annotation = field.annotation
-        if get_origin(annotation) is dict:
-            raise ValueError(
-                f"Field '{name}' has an open-ended mapping type which is not supported by Structured Outputs."
-            )
-
     fields = {}
     for name, field in signature.output_fields.items():
         annotation = field.annotation
@@ -267,6 +297,9 @@ def _get_structured_outputs_response_format(
 
     # Generate the initial schema.
     schema = pydantic_model.model_json_schema()
+
+    if _schema_has_open_ended_mapping(schema):
+        raise _OpenEndedMappingError("Open-ended mappings are not supported by Structured Outputs.")
 
     # Remove any DSPy-specific metadata.
     for prop in schema.get("properties", {}).values():

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1,5 +1,6 @@
 import enum
-from typing import Literal
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal
 from unittest import mock
 
 import pydantic
@@ -7,6 +8,7 @@ import pytest
 from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
 from litellm.utils import ChatCompletionMessageToolCall, Choices, Function, Message, ModelResponse
 from openai.types.responses import ResponseOutputMessage
+from typing_extensions import TypedDict
 
 import dspy
 from tests.adapters.conftest import format_messages_and_lm_kwargs
@@ -757,6 +759,143 @@ def test_json_adapter_passes_structured_output_when_supported_by_model():
     assert response_format is not None
     assert issubclass(response_format, pydantic.BaseModel)
     assert response_format.model_fields.keys() == {"output1", "output2", "output3", "output4_unannotated"}
+
+
+@dataclass
+class _DataclassOutput:
+    metadata: dict[str, Any]
+
+
+class _PydanticOutput(pydantic.BaseModel):
+    metadata: dict[str, Any]
+
+
+class _TypedDictOutput(TypedDict):
+    metadata: dict[str, Any]
+
+
+class _ExtraAllowedOutput(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="allow")
+    value: str
+
+
+_PropertyNamesMap = Annotated[
+    dict[str, Any],
+    pydantic.WithJsonSchema({"type": "object", "properties": {}, "propertyNames": {"pattern": "^x"}}),
+]
+
+
+class _PropertyNamesOutput(pydantic.BaseModel):
+    data: _PropertyNamesMap
+
+
+_UnevaluatedPropertiesMap = Annotated[
+    dict[str, Any],
+    pydantic.WithJsonSchema(
+        {
+            "type": "object",
+            "properties": {"fixed": {"type": "string"}},
+            "additionalProperties": False,
+            "unevaluatedProperties": {"type": "string"},
+        }
+    ),
+]
+
+
+class _UnevaluatedPropertiesOutput(pydantic.BaseModel):
+    data: _UnevaluatedPropertiesMap
+
+
+_ImplicitObjectMap = Annotated[
+    dict[str, Any],
+    pydantic.WithJsonSchema({"additionalProperties": {"type": "string"}}),
+]
+
+
+class _ImplicitObjectOutput(pydantic.BaseModel):
+    data: _ImplicitObjectMap
+
+
+_NullableObjectMap = Annotated[
+    dict[str, Any] | None,
+    pydantic.WithJsonSchema(
+        {
+            "type": ["object", "null"],
+            "properties": {},
+            "additionalProperties": {"type": "string"},
+        }
+    ),
+]
+
+
+class _NullableObjectOutput(pydantic.BaseModel):
+    data: _NullableObjectMap
+
+
+class _FixedTypedDictOutput(TypedDict):
+    value: str
+
+
+class _ObjectShapedTypedDict(TypedDict):
+    type: str
+
+
+class _FixedDefaultOutput(pydantic.BaseModel):
+    value: _ObjectShapedTypedDict = {"type": "object"}
+
+
+class _FixedExampleOutput(pydantic.BaseModel):
+    value: str = pydantic.Field(json_schema_extra={"examples": [{"type": "object"}]})
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        list[dict[str, Any]],
+        _DataclassOutput,
+        _PydanticOutput,
+        _TypedDictOutput,
+        _ExtraAllowedOutput,
+        _PropertyNamesOutput,
+        _UnevaluatedPropertiesOutput,
+        _ImplicitObjectOutput,
+        _NullableObjectOutput,
+    ],
+    ids=[
+        "list",
+        "dataclass",
+        "pydantic",
+        "typed-dict",
+        "extra-allowed",
+        "property-names",
+        "unevaluated",
+        "implicit-object",
+        "nullable-object",
+    ],
+)
+def test_json_adapter_uses_json_mode_for_nested_open_mapping(annotation):
+    signature = dspy.Signature({"output": (annotation, dspy.OutputField())})
+    lm = mock.Mock(supported_params={"response_format"}, supports_response_schema=True)
+    lm_kwargs = {}
+    expected = [{"output": "value"}]
+
+    with mock.patch("dspy.adapters.json_adapter.ChatAdapter.__call__", return_value=expected):
+        result = dspy.JSONAdapter()(lm, lm_kwargs, signature, [], {})
+
+    assert result == expected
+    assert lm_kwargs["response_format"] == {"type": "json_object"}
+
+
+@pytest.mark.parametrize("annotation", [_FixedTypedDictOutput, _FixedDefaultOutput, _FixedExampleOutput])
+def test_json_adapter_keeps_structured_output_for_fixed_schema(annotation):
+    signature = dspy.Signature({"output": (annotation, dspy.OutputField())})
+    lm = mock.Mock(supported_params={"response_format"}, supports_response_schema=True)
+    lm_kwargs = {}
+
+    with mock.patch("dspy.adapters.json_adapter.ChatAdapter.__call__", return_value=[]) as call:
+        dspy.JSONAdapter()(lm, lm_kwargs, signature, [], {})
+
+    assert issubclass(call.call_args.args[1]["response_format"], pydantic.BaseModel)
 
 
 def test_json_adapter_not_using_structured_outputs_when_not_supported_by_model():


### PR DESCRIPTION
## 1. Issue / repro

`JSONAdapter` detects only a top-level `dict` as incompatible with Structured Outputs. Open mappings nested inside models, arrays, dataclasses, or `TypedDict`s are missed:

```python
class NestedOutput(pydantic.BaseModel):
    metadata: dict[str, Any]

class Signature(dspy.Signature):
    output: NestedOutput = dspy.OutputField()
```

Pydantic correctly emits an open object:

```json
{"type": "object", "additionalProperties": true}
```

DSPy's Structured Outputs normalization then silently rewrites it as an object that permits no keys:

```json
{"type": "object", "properties": {}, "required": [], "additionalProperties": false}
```

The request can succeed, but the response schema now contradicts the declared output type.

## 2. Why this is the root cause

The old preflight looks only at each direct Python annotation:

```python
get_origin(annotation) is dict
```

It cannot see mappings represented inside Pydantic `$defs`, array `items`, unions/compositions, dataclasses, `TypedDict`s, nullable objects, or custom schema applicators.

The generated JSON Schema is the actual provider boundary. It must be checked before `enforce_required()` mutates every object into a closed object.

## 3. How we know the fix addresses the root cause

The tests exercise the public adapter call and verify intentional `json_object` mode for:

- `list[dict[str, Any]]`
- nested dataclass, Pydantic, and `TypedDict` fields
- Pydantic `extra="allow"`
- `propertyNames` and `unevaluatedProperties`
- implicit object applicators with no `type`
- nullable schemas with `type: ["object", "null"]`

Negative controls verify that Structured Outputs remains selected for:

- fixed-key `TypedDict`
- a default value containing `{"type": "object"}`
- an example containing `{"type": "object"}`

Those last two prove the scanner follows schema-bearing keywords instead of interpreting arbitrary annotation data as schemas.

## 4. Why this is the concise fix

The generated schema is the single source of truth instead of accumulating Python-type special cases. The change adds:

- one schema predicate,
- one internal exception for this known incompatibility, and
- symmetric sync/async selection of JSON mode.

There is no new dependency, provider retry, endpoint-specific rule, or parsing change.

## 5. Context needed to validate the change

Structured Outputs requires object keys to be explicitly declared. Plain `json_object` mode supports arbitrary keys and is already JSONAdapter's established mode for output shapes Structured Outputs cannot express.

The check runs during local response-model construction, before the provider call. `LMError` still propagates; this does not retry a failed provider request in a different mode. Native `ToolCalls` are still excluded before schema generation.

## 6. What the fix does

Before:

```python
if get_origin(annotation) is dict:
    raise ValueError(...)
```

After:

```python
schema = pydantic_model.model_json_schema()

if _schema_has_open_ended_mapping(schema):
    raise _OpenEndedMappingError(...)
```

The adapter catches only that internal signal:

```python
except _OpenEndedMappingError:
    lm_kwargs["response_format"] = {"type": "json_object"}
    return super().__call__(...)
```

The model therefore makes exactly one request, in the mode that can represent its declared output.

## Verification

```text
uv run --frozen pytest --deno -q tests/adapters/test_json_adapter.py
50 passed

uv run --frozen pytest --deno -q tests/adapters
242 passed
```

Pre-commit and `git diff --check` pass. Independent adversarial schema review: 5/5.

## Scope

Two files. Fixed closed schemas keep the existing Structured Outputs path; provider errors, parsing, type validation, and non-schema-capable LMs are unchanged.
