### PR TITLE
fix(adapters): coerce non-string Literal members in parse_value

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -170,7 +170,8 @@ def parse_value(value, annotation):
             if v in allowed:
                 return v
 
-        raise ValueError(f"{value!r} is not one of {allowed!r}")
+            # Coerce string forms of non-string members (e.g. "2" for Literal[1, 2, 3]) below.
+            value = v
 
     if not isinstance(value, str):
         return TypeAdapter(annotation).validate_python(value)

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -77,6 +77,16 @@ def test_parse_value_literal():
         parse_value("invalid", Literal["option1", "option2"])
 
 
+def test_parse_value_literal_non_string_members():
+    # Text adapters yield literal values as strings; coerce them to the member type.
+    assert parse_value("2", Literal[1, 2, 3]) == 2
+    assert parse_value('"2"', Literal[1, 2, 3]) == 2
+    assert parse_value("True", Literal[True, False]) is True
+
+    with pytest.raises(ValueError):
+        parse_value("42", Literal[1, 2, 3])
+
+
 def test_parse_value_union():
     # Test Union with None (Optional)
     assert parse_value("test", Optional[str]) == "test"


### PR DESCRIPTION
---
parse_value rejects Literal[int] / Literal[bool] output fields coming from a text adapter (ChatAdapter, XMLAdapter). The value arrives as a string, so Literal[1, 2, 3] gets "2", which the Literal branch checks for membership and rejects before it reaches the coercion path (json_repair -> TypeAdapter) below. String literals work, which hid it.

parse_value("2", Literal[1, 2, 3])   # ValueError: '2' is not one of (1, 2, 3)

With XMLAdapter (or ChatAdapter without JSON fallback) it's a hard AdapterParseError for that field — e.g. rating scales like Literal[1, 2, 3, 4, 5]. Regression from #8143.

Fix: let non-matching literals fall through to the same coercion every other type uses; non-members still fail via pydantic. Added a test.

Used Claude Code to help find this: I reproduced it, traced it to #8143, and verified the fix myself.

---