### PR TITLE
fix(signatures): raise clear error when fields shadow reserved DSPy attributes

### DIFF
--- a/docs/docs/diving-deeper/signatures-in-depth.md
+++ b/docs/docs/diving-deeper/signatures-in-depth.md
@@ -62,6 +62,14 @@ GEPA and the other instruction optimizers rewrite the Signature’s docstring. T
 
 Field names are part of the program’s public interface: caller code reads `result.haiku`, downstream modules look up `"haiku"` by name. An optimizer that renamed them would break the program around it. So name your fields carefully — the optimizer can’t fix `result` into `haiku` later. The same goes for field descriptions when you write them.
 
+### 10. A few field names are reserved
+
+`instructions`, `fields`, `input_fields`, `output_fields` and `signature` are properties on `SignatureMeta`, and a property is a data descriptor: it wins over the class `__dict__` during attribute lookup. So a field with one of those names could be declared but never read back — `MySignature.instructions` would return the docstring, not your field. Rather than let that fail confusingly downstream, `SignatureMeta.__new__` raises a `TypeError` naming the colliding field, for both the class form and the string form (`dspy.Signature("question -> instructions")`).
+
+`dspy.Predict` reserves a second, overlapping set: `lm`, `demos`, `config`, `signature` and `new_signature` are the privileged keyword arguments it pops off in `_forward_preprocess`, so an *input* field with one of those names would have its value swallowed instead of reaching the LM. `Predict` raises a `ValueError` when it is constructed with such a signature, and again if the signature is swapped out later (by an optimizer, or via a per-call `signature=` override). Output fields are unaffected — nothing pops them.
+
+The reserved set is derived from the metaclass at runtime rather than hardcoded, so it stays correct if a property is added to `SignatureMeta` later. Plain methods (`append`, `delete`, `with_instructions`, …) are *not* data descriptors, so fields may still be named after them. The fix in every case is to rename the field: `instructions` → `instructions_text`.
+
 ## API walkthrough
 
 Grouped by what you’re trying to do.
@@ -82,7 +90,7 @@ The actual constructor. Two input shapes: a string (parsed by `_parse_signature`
 A no-op on already-built Signature classes; runs `make_signature` on strings. Use it when writing a module that should accept either form. It doesn’t memoize, so don’t call it in a hot loop on the same string — every call constructs a new class.
 
 **`SignatureMeta`**  
-The metaclass behind `Signature`. You won’t subclass or instantiate it. What it does: parses docstrings into instructions, validates that every field is tagged `input` or `output`, infers missing `prefix=` values, and runs the custom-type frame walk during string parsing. Most “weird signature” errors originate here.
+The metaclass behind `Signature`. You won’t subclass or instantiate it. What it does: parses docstrings into instructions, validates that every field is tagged `input` or `output`, rejects field names reserved by DSPy (design decision 10), infers missing `prefix=` values, and runs the custom-type frame walk during string parsing. Most “weird signature” errors originate here.
 
 ### Introspecting a signature
 

--- a/docs/docs/getting-started/expanding-signatures.md
+++ b/docs/docs/getting-started/expanding-signatures.md
@@ -60,6 +60,8 @@ Our model doesn’t know we want a haiku, so it just makes a guess.
 
 Naming is the cheapest optimization in DSPy. A field called `research_request` will produce better completions than one called `request`, with no other changes. Signatures are easy to edit; take advantage.
 
+One constraint on naming: a handful of names are reserved by DSPy itself — `instructions`, `fields`, `input_fields`, `output_fields`, `signature`, and (for input fields) `lm`, `demos`, `config`, `new_signature`. DSPy raises an error naming the offending field if you use one, so you'll know right away; rename it (`instructions` → `instructions_text`) and carry on. See [Reserved names](../learn/programming/signatures.md#reserved-names).
+
 ## Typing your fields yields more reliable programs
 
 We can add more specificity to our task by *typing* our fields using the format `name: type`. For example, the signature `"location, mood, contains_pun: bool -> haiku"` accepts a boolean to indicate whether we want our poem to include a pun:

--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -235,6 +235,26 @@ predictor = dspy.Predict("number: int -> result: str")
 predictor(number="42")  # No warning
 ```
 
+## Reserved names
+
+A few names are reserved by DSPy and cannot be used as field names.
+
+**Reserved on every signature: `instructions`, `fields`, `input_fields`, `output_fields`, `signature`.** DSPy exposes
+these as properties on the signature class itself (that is how `MySignature.instructions` works), so a field of the
+same name would be hidden by the property and could never be read back. Creating such a signature raises a
+`TypeError`, whether you use the class-based or the inline form:
+
+```python
+dspy.Signature("question -> instructions")  # TypeError: ... collide with reserved DSPy signature attribute(s) ...
+```
+
+**Additionally reserved for `dspy.Predict` *input* fields: `lm`, `demos`, `config`, `signature`, `new_signature`.**
+`dspy.Predict` consumes these as keyword arguments (e.g. `predict(question=..., lm=my_lm)`), so an input field with
+one of these names would have its value swallowed and never reach the LM. Constructing the predictor raises a
+`ValueError`. Output fields are unaffected.
+
+In both cases the fix is to rename the field, for example `instructions` -> `instructions_text`.
+
 ## Using signatures to build modules & compiling them
 
 While signatures are convenient for prototyping with structured inputs/outputs, that's not the only reason to use them!

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -20,6 +20,24 @@ logger = logging.getLogger(__name__)
 
 UNSAFE_LM_STATE_KEYS = {"api_base", "base_url", "model_list"}
 
+# Keyword arguments that `dspy.Predict` consumes itself. An input field with one of these names would have its value
+# swallowed by `_forward_preprocess` and never reach the LM, so we reject such signatures instead.
+RESERVED_PREDICT_KWARGS = frozenset({"signature", "new_signature", "demos", "config", "lm"})
+
+
+def _validate_signature_input_fields(signature: type[Signature]) -> None:
+    colliding = sorted(name for name in signature.input_fields if name in RESERVED_PREDICT_KWARGS)
+    if not colliding:
+        return
+
+    fields_ = ", ".join(f"`{name}`" for name in colliding)
+    raise ValueError(
+        f"Signature input field(s) {fields_} collide with reserved `dspy.Predict` keyword argument(s) of the same "
+        f"name. Their values would be consumed by `dspy.Predict` and never reach the LM. Please rename the field(s), "
+        f"e.g. `{colliding[0]}` -> `{colliding[0]}_text`. Reserved keyword arguments: "
+        f"{', '.join(sorted(RESERVED_PREDICT_KWARGS))}."
+    )
+
 
 def _sanitize_lm_state(lm_state: dict, allow_unsafe_lm_state: bool) -> dict:
     if allow_unsafe_lm_state:
@@ -52,12 +70,19 @@ class Predict(Module, Parameter):
 
                 predict = dspy.Predict("q -> a", rollout_id=1, temperature=1.0)
                 predict(q="What is 1 + 52?", config={"rollout_id": 2, "temperature": 1.0})
+
+    Raises:
+        ValueError: If an *input* field of ``signature`` is named after one of the privileged keyword
+            arguments ``dspy.Predict`` consumes itself (``lm``, ``demos``, ``config``, ``signature``,
+            ``new_signature``). Such a field's value would be swallowed and never reach the language
+            model, so rename it, e.g. ``lm`` -> ``lm_text``. Output fields may use these names freely.
     """
 
     def __init__(self, signature: str | type[Signature], callbacks: list[BaseCallback] | None = None, **config):
         super().__init__(callbacks=callbacks)
         self.stage = random.randbytes(8).hex()
         self.signature = ensure_signature(signature)
+        _validate_signature_input_fields(self.signature)
         self.config = config
         self.reset()
 
@@ -140,8 +165,12 @@ class Predict(Module, Parameter):
 
     def _forward_preprocess(self, **kwargs):
         # Extract the three privileged keyword arguments.
-        assert "new_signature" not in kwargs, "new_signature is no longer a valid keyword argument."
+        if "new_signature" in kwargs:
+            raise ValueError("`new_signature` is no longer a valid keyword argument.")
         signature = ensure_signature(kwargs.pop("signature", self.signature))
+        # The signature may have been swapped out since `__init__` (by an optimizer, or via a per-call `signature=`
+        # override), so validate whichever signature we actually resolved.
+        _validate_signature_input_fields(signature)
         demos = kwargs.pop("demos", self.demos)
         config = {**self.config, **kwargs.pop("config", {})}
 
@@ -191,8 +220,7 @@ class Predict(Module, Parameter):
         extra_fields = [k for k in kwargs if k not in signature.input_fields]
         if extra_fields:
             logger.warning(
-                "Input contains fields not in signature. These fields will be ignored: %s. "
-                "Expected fields: %s.",
+                "Input contains fields not in signature. These fields will be ignored: %s. Expected fields: %s.",
                 extra_fields,
                 list(signature.input_fields.keys()),
             )
@@ -282,6 +310,7 @@ class Predict(Module, Parameter):
 
     def __repr__(self):
         return f"{self.__class__.__name__}({self.signature})"
+
 
 def _get_type_name(type_annotation) -> str:
     """Helper method to get the name for a type annotation."""
@@ -394,6 +423,7 @@ def _check_type(value: Any, expected: type) -> bool:
         return isinstance(value, expected)
 
     return False
+
 
 def serialize_object(obj):
     """

--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -13,6 +13,12 @@ If you are not sure if your input is a string representation, (like "input1, inp
 or a signature, you can use the ensure_signature function.
 
 For compatibility with the legacy dsp format, you can use the signature_to_template function.
+
+Reserved names: a signature field cannot be named `instructions`, `fields`, `input_fields`, `output_fields` or
+`signature`. DSPy exposes those names as properties on the signature class itself, so a field of the same name would
+be hidden by the property and silently ignored. Constructing such a signature raises a `TypeError`; rename the field
+(e.g. `instructions_text`) to fix it. Additionally, `dspy.Predict` reserves the keyword arguments `lm`, `demos`,
+`config`, `signature` and `new_signature`, so an *input* field may not use those names either.
 """
 
 import ast
@@ -36,6 +42,54 @@ def _default_instructions(cls) -> str:
     inputs_ = ", ".join([f"`{field}`" for field in cls.input_fields])
     outputs_ = ", ".join([f"`{field}`" for field in cls.output_fields])
     return f"Given the fields {inputs_}, produce the fields {outputs_}."
+
+
+_RESERVED_SIGNATURE_NAMES_CACHE: dict[type, frozenset[str]] = {}
+
+
+def _reserved_signature_names(metaclass: type) -> frozenset[str]:
+    """Return the field names that a signature cannot use, derived from the metaclass.
+
+    `SignatureMeta` exposes `instructions`, `fields`, `input_fields`, `output_fields` and `signature` as properties.
+    A property is a data descriptor, so it takes precedence over the class `__dict__` during attribute lookup: a
+    Pydantic field with one of these names can never be read back from the signature class. Deriving the set from the
+    metaclass at runtime keeps it correct if a property is added to `SignatureMeta` later.
+    """
+    reserved = _RESERVED_SIGNATURE_NAMES_CACHE.get(metaclass)
+    if reserved is None:
+        reserved = frozenset(
+            name
+            for name in dir(metaclass)
+            if not name.startswith("__") and hasattr(inspect.getattr_static(metaclass, name, None), "__set__")
+        )
+        _RESERVED_SIGNATURE_NAMES_CACHE[metaclass] = reserved
+    return reserved
+
+
+def _validate_reserved_names(
+    metaclass: type,
+    signature_name: str,
+    annotations: dict[str, Any],
+    namespace: dict[str, Any],
+) -> None:
+    """Raise if a signature declares a field whose name is reserved by DSPy.
+
+    Called for every signature, whether it is built from a class body or from the string form
+    (`dspy.Signature("question -> instructions")`), since both go through `SignatureMeta.__new__`.
+    """
+    reserved = _reserved_signature_names(metaclass)
+    declared = set(annotations) | {name for name, value in namespace.items() if isinstance(value, FieldInfo)}
+    colliding = sorted(declared & reserved)
+    if not colliding:
+        return
+
+    fields_ = ", ".join(f"`{name}`" for name in colliding)
+    raise TypeError(
+        f"Field(s) {fields_} in `{signature_name}` collide with reserved DSPy signature attribute(s) of the same "
+        f"name. DSPy exposes {fields_} as a property on every signature class, so the property would hide your "
+        f"InputField/OutputField and the field could never be read back. Please rename the field(s), e.g. "
+        f"`{colliding[0]}` -> `{colliding[0]}_text`. Reserved names: {', '.join(sorted(reserved))}."
+    )
 
 
 class SignatureMeta(type(BaseModel)):
@@ -142,6 +196,7 @@ class SignatureMeta(type(BaseModel)):
         if sys.version_info >= (3, 14):
             try:
                 import annotationlib
+
                 # Try to get from explicit __annotations__ first (e.g., from __future__ import annotations)
                 raw_annotations = namespace.get("__annotations__")
 
@@ -150,8 +205,7 @@ class SignatureMeta(type(BaseModel)):
                     annotate_func = annotationlib.get_annotate_from_class_namespace(namespace)
                     if annotate_func:
                         raw_annotations = annotationlib.call_annotate_function(
-                            annotate_func,
-                            format=annotationlib.Format.FORWARDREF
+                            annotate_func, format=annotationlib.Format.FORWARDREF
                         )
                     else:
                         raw_annotations = {}
@@ -166,12 +220,18 @@ class SignatureMeta(type(BaseModel)):
                 continue  # Don't add types to non-field attributes
             if not name.startswith("__") and name not in raw_annotations:
                 raw_annotations[name] = str
-                field.json_schema_extra[IS_TYPE_UNDEFINED] = True  # Mark that the type was originally undefined in the signature
+                field.json_schema_extra[IS_TYPE_UNDEFINED] = (
+                    True  # Mark that the type was originally undefined in the signature
+                )
         # Create ordered annotations dictionary that preserves field order
         ordered_annotations = {name: raw_annotations[name] for name in field_order if name in raw_annotations}
         # Add any remaining annotations that weren't in field_order
         ordered_annotations.update({k: v for k, v in raw_annotations.items() if k not in ordered_annotations})
         namespace["__annotations__"] = ordered_annotations
+
+        # Reject fields whose name is shadowed by a property on the metaclass. Pydantic would happily create the
+        # field, but it could never be read back from the signature class, which surfaces later as a confusing error.
+        _validate_reserved_names(mcs, signature_name, ordered_annotations, namespace)
 
         # On Python 3.14+, prevent Pydantic from capturing this frame's locals via
         # parent_frame_namespace(). Those locals include references to the __annotate__
@@ -307,9 +367,9 @@ class Signature(BaseModel, metaclass=SignatureMeta):
     def append_instructions(cls, instructions: str) -> type["Signature"]:
         """Return a new Signature class with identical fields and `instructions` appended to the existing instructions.
 
-        This method does not mutate `cls`. It constructs a fresh Signature 
-        using the existing instructions from `cls.instructions` followed 
-        by `instructions`, joined by a blank line. 
+        This method does not mutate `cls`. It constructs a fresh Signature
+        using the existing instructions from `cls.instructions` followed
+        by `instructions`, joined by a blank line.
         Unlike `with_instructions`, the existing instructions are preserved rather than replaced.
 
         Args:
@@ -576,6 +636,11 @@ def make_signature(
     Returns:
         A new signature class with the specified fields and instructions.
 
+    Raises:
+        TypeError: If a field is named after one of the properties DSPy exposes on every signature class
+            (`instructions`, `fields`, `input_fields`, `output_fields`, `signature`). The property would hide
+            the field, so it could never be read back; rename it, e.g. `instructions` -> `instructions_text`.
+
     Examples:
 
     ```
@@ -649,9 +714,9 @@ def _parse_signature(signature: str, names=None) -> dict[str, tuple[type, Any]]:
 
     input_fields = list(_parse_field_string(inputs_str, names))
     output_fields = list(_parse_field_string(outputs_str, names))
-    duplicate_field_names = sorted({field_name for field_name, *_ in input_fields}.intersection(
-        field_name for field_name, *_ in output_fields
-    ))
+    duplicate_field_names = sorted(
+        {field_name for field_name, *_ in input_fields}.intersection(field_name for field_name, *_ in output_fields)
+    )
     if duplicate_field_names:
         raise ValueError(
             "Input and output fields must have distinct names, but found duplicates: "
@@ -660,7 +725,7 @@ def _parse_signature(signature: str, names=None) -> dict[str, tuple[type, Any]]:
 
     fields = {}
     for field_name, field_type, is_type_undefined in input_fields:
-        fields[field_name] = (field_type, InputField(IS_TYPE_UNDEFINED= is_type_undefined))
+        fields[field_name] = (field_type, InputField(IS_TYPE_UNDEFINED=is_type_undefined))
     for field_name, field_type, _ in output_fields:
         fields[field_name] = (field_type, OutputField())
 
@@ -677,7 +742,9 @@ def _parse_field_string(field_string: str, names=None) -> Iterator[tuple[str, ty
 
     args = ast.parse(f"def f({field_string}): pass").body[0].args.args
     field_names: list[str] = [arg.arg for arg in args]
-    types_list: list[type] = [str if arg.annotation is None else _parse_type_node(arg.annotation, names) for arg in args]
+    types_list: list[type] = [
+        str if arg.annotation is None else _parse_type_node(arg.annotation, names) for arg in args
+    ]
     is_type_undefined: list[bool] = [True if arg.annotation is None else False for arg in args]
     return zip(field_names, types_list, is_type_undefined, strict=False)
 

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -880,6 +880,7 @@ def test_positional_arguments():
         "your signature input fields: 'question'. For example: `predict(question=input_value, ...)`."
     )
 
+
 def test_error_message_on_invalid_lm_setup():
     # No LM is loaded.
     with pytest.raises(ValueError, match="No LM is loaded"):
@@ -1061,6 +1062,7 @@ def test_per_module_history_disabled():
         program(question="What is the capital of France?")
     assert len(program.history) == 0
 
+
 def test_input_field_default_value():
     class SpyLM(dspy.LM):
         def __init__(self):
@@ -1084,11 +1086,13 @@ def test_input_field_default_value():
     user_message = lm.calls[0]["messages"][-1]["content"]
     assert "DEFAULT_CONTEXT" in user_message
 
+
 def log_test_helper():
     lm = DummyLM([{"answer": "test output"}])
     dspy.configure(lm=lm)
     dspy_logger = logging.getLogger("dspy")
     dspy_logger.propagate = True
+
 
 def test_extra_fields_warning(caplog):
     """Test that extra fields not in signature generate a warning."""
@@ -1154,6 +1158,7 @@ def test_warning_images(caplog):
         predict_instance(question="dog_image")
 
     assert "Type mismatch for field 'question': expected Image" in caplog.text
+
 
 def test_type_mismatch_warning(caplog):
     """Test that type mismatches in input fields generate a warning."""
@@ -1661,6 +1666,7 @@ def test_union_type_validation_string_signature(caplog):
 
     assert "Type mismatch for field 'mode'" in caplog.text
 
+
 @pytest.mark.parametrize("enable_type_warnings", [False, True])
 def test_basic_types_string_signature(caplog, enable_type_warnings):
     """Test type validation with basic types using string signatures."""
@@ -1690,6 +1696,7 @@ def test_basic_types_string_signature(caplog, enable_type_warnings):
     else:
         assert "Type mismatch" not in caplog.text
 
+
 def test_untyped_string_signature(caplog):
     """Test type validation with basic types using string signatures without type."""
     log_test_helper()
@@ -1716,6 +1723,7 @@ def test_untyped_class_signature(caplog):
         count = dspy.InputField()
         name = dspy.InputField()
         result = dspy.OutputField()
+
     predict_instance = Predict(TestSignature)
 
     # Test with correct types
@@ -1728,6 +1736,7 @@ def test_untyped_class_signature(caplog):
 
     assert "Type mismatch" not in caplog.text
 
+
 def test_string_to_list_signature(caplog):
     """Test type validation with string input field type where the module gets called with a list."""
     log_test_helper()
@@ -1737,6 +1746,7 @@ def test_string_to_list_signature(caplog):
         name: str = dspy.InputField()
         count = dspy.InputField()
         result = dspy.OutputField()
+
     predict_instance = Predict(TestSignature)
 
     caplog.clear()
@@ -1747,6 +1757,7 @@ def test_string_to_list_signature(caplog):
         predict_instance(name=["abc", "def", "geh"], count=123)
 
     assert "Type mismatch" not in caplog.text
+
 
 @pytest.mark.parametrize("enable_type_warnings", [False, True])
 def test_custom_signature_types(caplog, enable_type_warnings):
@@ -1780,3 +1791,41 @@ def test_custom_signature_types(caplog, enable_type_warnings):
         assert "Type mismatch for field 'query': expected Query" in caplog.text
     else:
         assert "Type mismatch" not in caplog.text
+
+
+@pytest.mark.parametrize("reserved_kwarg", ["lm", "demos", "config", "new_signature"])
+def test_predict_rejects_signature_input_field_colliding_with_reserved_kwarg(reserved_kwarg):
+    with pytest.raises(ValueError, match=f"Signature input field\\(s\\) `{reserved_kwarg}` collide with reserved"):
+        Predict(f"question, {reserved_kwarg} -> answer")
+
+
+@pytest.mark.parametrize("reserved_kwarg", ["lm", "demos", "config", "new_signature"])
+def test_predict_rejects_reserved_kwarg_in_per_call_signature_override(reserved_kwarg):
+    predict = Predict("question -> answer")
+    # Bypass the constructor check the way an optimizer would, by assigning the signature directly.
+    predict.signature = Signature(f"question, {reserved_kwarg} -> answer")
+
+    dspy.settings.configure(lm=DummyLM([{"answer": "blue"}]))
+    with pytest.raises(ValueError, match=f"Signature input field\\(s\\) `{reserved_kwarg}` collide with reserved"):
+        predict(question="What color is the sky?")
+
+
+def test_predict_allows_reserved_names_as_output_fields():
+    # Only input fields are consumed as keyword arguments, so outputs are unaffected.
+    predict = Predict("question -> lm, demos")
+    dspy.settings.configure(lm=DummyLM([{"lm": "a", "demos": "b"}]))
+
+    prediction = predict(question="What color is the sky?")
+    assert prediction.lm == "a"
+    assert prediction.demos == "b"
+
+
+def test_predict_passes_through_non_reserved_field_names():
+    lm = DummyLM([{"answer": "blue"}])
+    dspy.settings.configure(lm=lm)
+
+    predict = Predict("question, language_model -> answer")
+    prediction = predict(question="What color is the sky?", language_model="gpt-4")
+
+    assert prediction.answer == "blue"
+    assert "gpt-4" in str(lm.history[-1]["messages"])

--- a/tests/signatures/test_reserved_names.py
+++ b/tests/signatures/test_reserved_names.py
@@ -1,0 +1,83 @@
+"""Acceptance test for the reserved-name collision issue (stanfordnlp/dspy#658).
+
+Intent: a field name that collides with a DSPy accessor must never leave the user
+misled. Either the field works, or DSPy raises an error that NAMES THE COLLISION.
+What must not happen: an error that falsely blames the user's declaration, or a
+value that is silently swallowed before reaching the adapter.
+"""
+
+import pytest
+
+import dspy
+from dspy.utils.dummies import DummyLM
+
+SHADOWED = ["instructions", "fields", "signature", "input_fields", "output_fields"]
+RESERVED_KWARGS = ["demos", "config", "lm"]
+
+
+def _make_sig(name, kind="output"):
+    field = dspy.OutputField() if kind == "output" else dspy.InputField()
+    ann = {"question": str, name: str} if kind == "output" else {name: str, "answer": str}
+    ns = {"__annotations__": ann, "__doc__": "Doc here."}
+    if kind == "output":
+        ns["question"] = dspy.InputField()
+        ns[name] = field
+    else:
+        ns[name] = field
+        ns["answer"] = dspy.OutputField()
+    return type("ReservedSig", (dspy.Signature,), ns)
+
+
+@pytest.mark.parametrize("name", SHADOWED)
+def test_shadowing_field_name_is_not_misdiagnosed(name):
+    """Declaring a field that collides with a metaclass property must not produce
+    the misleading 'must be declared with InputField or OutputField' error."""
+    try:
+        sig = _make_sig(name, kind="output")
+    except Exception as e:
+        msg = str(e)
+        assert "json_schema_extra=None" not in msg, (
+            f"Field `{name}` WAS declared with OutputField, but DSPy reports it was not. "
+            f"The message blames the user's declaration instead of naming the collision "
+            f"with the reserved Signature attribute `{name}`. Got: {msg}"
+        )
+        # An error is acceptable only if it identifies the collision.
+        assert name in msg and any(k in msg.lower() for k in ("reserved", "shadow", "collide", "conflict")), (
+            f"Error for `{name}` does not identify the name collision. Got: {msg}"
+        )
+        return
+    # Otherwise the field must actually register.
+    assert name in sig.output_fields
+
+
+@pytest.mark.parametrize("name", RESERVED_KWARGS)
+def test_reserved_kwarg_is_not_silently_stolen(name):
+    """An input field named `demos`/`config`/`lm` must not have its value eaten by
+    Predict._forward_preprocess before it reaches the adapter."""
+    seen = {}
+
+    class SpyAdapter(dspy.ChatAdapter):
+        def __call__(self, lm, lm_kwargs, signature, demos, inputs, **kw):
+            seen.clear()
+            seen.update(inputs)
+            return [{"answer": "ok"}]
+
+    with dspy.context(lm=DummyLM([{"answer": "ok"}] * 3), adapter=SpyAdapter()):
+        sig = _make_sig(name, kind="input")
+        assert name in sig.input_fields  # signature-level validation permits these names
+        # The collision may legitimately be reported either when the Predict is constructed
+        # (fail-fast) or when it is called, so both are inside the `try`.
+        try:
+            predict = dspy.Predict(sig)
+            predict(**{name: "MY-VALUE"})
+        except Exception as e:
+            msg = str(e)
+            assert name in msg and any(k in msg.lower() for k in ("reserved", "shadow", "collide", "conflict")), (
+                f"Input field `{name}` was consumed as a privileged Predict kwarg and the "
+                f"resulting error does not explain the collision. Got: {msg}"
+            )
+            return
+        assert seen.get(name) == "MY-VALUE", (
+            f"Input field `{name}` never reached the adapter -- its value was silently "
+            f"popped by Predict._forward_preprocess. Adapter saw: {seen}"
+        )

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -133,8 +133,7 @@ def test_signature_instructions_none():
 
 
 def test_signature_from_dict():
-    signature = Signature(
-        {"input1": InputField(), "input2": InputField(), "output": OutputField()})
+    signature = Signature({"input1": InputField(), "input2": InputField(), "output": OutputField()})
     for k in ["input1", "input2", "output"]:
         assert k in signature.fields
         assert signature.fields[k].annotation == str
@@ -193,8 +192,7 @@ def test_order_preserved_with_mixed_annotations():
 
 
 def test_infer_prefix():
-    assert infer_prefix(
-        "someAttributeName42IsCool") == "Some Attribute Name 42 Is Cool"
+    assert infer_prefix("someAttributeName42IsCool") == "Some Attribute Name 42 Is Cool"
     assert infer_prefix("version2Update") == "Version 2 Update"
     assert infer_prefix("modelT45Enhanced") == "Model T 45 Enhanced"
     assert infer_prefix("someAttributeName") == "Some Attribute Name"
@@ -290,8 +288,7 @@ def test_typed_signatures_basic_types():
 
 
 def test_typed_signatures_generics():
-    sig = Signature(
-        "input_list: list[int], input_dict: dict[str, float] -> output_tuple: tuple[str, int]")
+    sig = Signature("input_list: list[int], input_dict: dict[str, float] -> output_tuple: tuple[str, int]")
     assert "input_list" in sig.input_fields
     assert sig.input_fields["input_list"].annotation == list[int]
     assert "input_dict" in sig.input_fields
@@ -301,8 +298,7 @@ def test_typed_signatures_generics():
 
 
 def test_typed_signatures_unions_and_optionals():
-    sig = Signature(
-        "input_opt: Optional[str], input_union: Union[int, None] -> output_union: Union[int, str]")
+    sig = Signature("input_opt: Optional[str], input_union: Union[int, None] -> output_union: Union[int, str]")
     assert "input_opt" in sig.input_fields
     # Optional[str] is actually Union[str, None]
     # Depending on the environment, it might resolve to Union[str, None] or Optional[str], either is correct.
@@ -340,8 +336,7 @@ def test_typed_signatures_any():
 
 
 def test_typed_signatures_nested():
-    sig = Signature(
-        "input_nested: list[Union[str, int]] -> output_nested: Tuple[int, Optional[float], list[str]]")
+    sig = Signature("input_nested: list[Union[str, int]] -> output_nested: Tuple[int, Optional[float], list[str]]")
     input_nested_ann = sig.input_fields["input_nested"].annotation
     assert getattr(input_nested_ann, "__origin__", None) is list
     assert len(input_nested_ann.__args__) == 1
@@ -402,18 +397,15 @@ def test_typed_signatures_complex_combinations():
     # Expecting list[str] and dict[str, Any]
     # Because sets don't preserve order, just check membership.
     # Find the list[str] arg
-    list_arg = next(a for a in possible_args if getattr(
-        a, "__origin__", None) is list)
-    dict_arg = next(a for a in possible_args if getattr(
-        a, "__origin__", None) is dict)
+    list_arg = next(a for a in possible_args if getattr(a, "__origin__", None) is list)
+    dict_arg = next(a for a in possible_args if getattr(a, "__origin__", None) is dict)
     assert list_arg.__args__ == (str,)
     k, v = dict_arg.__args__
     assert k == str and v == Any
 
 
 def test_make_signature_from_string():
-    sig = Signature(
-        "input1: int, input2: dict[str, int] -> output1: list[str], output2: Union[int, str]")
+    sig = Signature("input1: int, input2: dict[str, int] -> output1: list[str], output2: Union[int, str]")
     assert "input1" in sig.input_fields
     assert sig.input_fields["input1"].annotation == int
     assert "input2" in sig.input_fields
@@ -446,10 +438,7 @@ def test_basic_custom_type():
     class CustomType(pydantic.BaseModel):
         value: str
 
-    test_signature = dspy.Signature(
-        "input: CustomType -> output: str",
-        custom_types={"CustomType": CustomType}
-    )
+    test_signature = dspy.Signature("input: CustomType -> output: str", custom_types={"CustomType": CustomType})
 
     assert test_signature.input_fields["input"].annotation == CustomType
 
@@ -474,10 +463,9 @@ def test_custom_type_from_different_module():
     pred = dspy.Predict(test_signature)(input=path_obj)
     assert pred.output == "/test/path"
 
+
 def test_pep604_union_type_inline():
-    sig = Signature(
-        "input1: str | None, input2: None | int -> output_union: int | str"
-    )
+    sig = Signature("input1: str | None, input2: None | int -> output_union: int | str")
 
     # input1 and input2 test that both 'T | None' and 'None | T' are interpreted as Optional types,
     # regardless of the order of None in the union expression.
@@ -520,9 +508,7 @@ def test_pep604_union_type_inline_equivalence():
 
 
 def test_pep604_union_type_inline_nested():
-    sig = Signature(
-        "input: str | (int | float) | None -> output: str"
-    )
+    sig = Signature("input: str | (int | float) | None -> output: str")
     assert "input" in sig.input_fields
     input_annotation = sig.input_fields["input"].annotation
 
@@ -595,10 +581,7 @@ def test_pep604_union_type_with_custom_types():
     class CustomType(pydantic.BaseModel):
         value: str
 
-    sig = Signature(
-        "input: CustomType | None -> output: int | str",
-        custom_types={"CustomType": CustomType}
-    )
+    sig = Signature("input: CustomType | None -> output: int | str", custom_types={"CustomType": CustomType})
 
     assert sig.input_fields["input"].annotation == Union[CustomType, None]
     assert sig.output_fields["output"].annotation == Union[int, str]
@@ -614,6 +597,7 @@ def test_pep604_union_type_with_custom_types():
 def test_signature_cloudpickle_roundtrip():
     class MySignature(Signature):
         """Answer the question."""
+
         context: list[str] = InputField()
         question: str = InputField()
         answer: str = OutputField()
@@ -630,6 +614,7 @@ def test_signature_cloudpickle_roundtrip():
 def test_predict_cloudpickle_roundtrip():
     class QA(Signature):
         """Answer the question."""
+
         question: str = InputField()
         answer: str = OutputField()
 
@@ -638,3 +623,75 @@ def test_predict_cloudpickle_roundtrip():
     loaded = pickle.loads(data)
 
     assert list(loaded.signature.fields.keys()) == ["question", "answer"]
+
+
+RESERVED_SIGNATURE_NAMES = ["fields", "input_fields", "instructions", "output_fields", "signature"]
+
+
+@pytest.mark.parametrize("reserved_name", RESERVED_SIGNATURE_NAMES)
+def test_reserved_name_as_field_in_class_signature_raises(reserved_name):
+    with pytest.raises(TypeError, match=f"Field\\(s\\) `{reserved_name}` .* collide with reserved DSPy signature"):
+        type(
+            "ReservedSignature",
+            (Signature,),
+            {
+                "__annotations__": {"question": str, reserved_name: str},
+                "question": InputField(),
+                reserved_name: OutputField(),
+            },
+        )
+
+
+def test_reserved_name_as_field_in_class_body_raises():
+    with pytest.raises(TypeError, match="collide with reserved DSPy signature"):
+
+        class ReservedSignature(Signature):
+            question: str = InputField()
+            instructions: str = OutputField()
+
+
+@pytest.mark.parametrize("reserved_name", RESERVED_SIGNATURE_NAMES)
+def test_reserved_name_as_field_in_string_signature_raises(reserved_name):
+    with pytest.raises(TypeError, match=f"Field\\(s\\) `{reserved_name}` .* collide with reserved DSPy signature"):
+        Signature(f"question -> {reserved_name}")
+
+
+def test_reserved_name_error_explains_the_cause():
+    with pytest.raises(TypeError) as exc_info:
+        Signature("question -> instructions")
+
+    message = str(exc_info.value)
+    # The old error was a `TypeError: 'NoneType' object is not subscriptable` or a complaint about
+    # `json_schema_extra`, neither of which pointed at the actual problem.
+    assert "property" in message
+    assert "json_schema_extra" not in message
+    assert "instructions_text" in message
+
+
+def test_non_reserved_names_that_shadow_signature_methods_still_work():
+    # These are plain methods, not data descriptors, so a field of the same name is still readable. They must keep
+    # working: rejecting them would be a gratuitous breaking change.
+    usable_names = ["prepend", "append", "insert", "delete", "equals", "with_instructions", "dump_state"]
+
+    for name in usable_names:
+        signature = Signature(f"question -> {name}")
+        assert name in signature.output_fields
+
+    signature = Signature("question -> append")
+    extended = Signature.append.__func__(signature, "context", InputField(), str)
+    assert list(extended.fields.keys()) == ["question", "context", "append"]
+    assert list(signature.delete("append").fields.keys()) == ["question"]
+
+
+def test_signature_base_class_and_subclasses_still_construct():
+    assert Signature.fields == {}
+
+    class MySignature(Signature):
+        """Answer the question."""
+
+        question: str = InputField()
+        answer: str = OutputField()
+
+    assert list(MySignature.fields.keys()) == ["question", "answer"]
+    assert MySignature.instructions == "Answer the question."
+    assert list(Signature("question -> answer").fields.keys()) == ["question", "answer"]


### PR DESCRIPTION
## What

Declaring a signature field named `instructions` currently fails with a message that blames the user for something they didn't do:

```
TypeError: Field `instructions` in `Signature` must be declared with InputField or OutputField,
but field `instructions` has `field.json_schema_extra=None`
```

— even though the field *was* declared with `OutputField`. Worse, an input field named `demos` produces no error at all: its value is silently popped by `Predict._forward_preprocess` and never reaches the LM.

This PR makes both cases fail fast with an error that names the actual collision.

## Why the old error was misleading

`instructions`, `fields`, `input_fields`, `output_fields` and `signature` are **properties on `SignatureMeta`**. A property is a data descriptor, so it takes precedence over the class `__dict__` during attribute lookup — Pydantic's field collection does `getattr(cls, name)` and gets the property object back instead of the `FieldInfo`, hence `json_schema_extra=None`. The field could never have been read back from the class.

## Approach

- `signature.py` derives the reserved set from the metaclass at runtime — any non-dunder **data descriptor** on `SignatureMeta`. This is the mechanically correct criterion: it is exactly the set of names a field cannot survive, and it stays correct if a property is added later. It also explains why plain methods like `append`/`delete` keep working (non-data descriptors, shadowed by the class dict) — pinned by a test.
- `predict.py` rejects *input* fields colliding with `Predict`'s privileged kwargs (`signature`, `new_signature`, `demos`, `config`, `lm`), which would otherwise be silently swallowed.
- Docs updated to list the reserved names.

## Scope

This implements the minimal fix the thread converged on: *"we should at least make sure we document those reserved names well, and throw errors when the user unknowingly tries to use them."* It deliberately does **not** do the `dspy_`-prefix namespace migration discussed higher up — that is a breaking API change and a maintainer call.

### Known gap: `prediction`

`_forward_preprocess` (`predict.py:203`) also pops `prediction` into `config`, but **only** when its value is a `{"type": "content", "content": ...}` dict (the OpenAI predicted-outputs format). So an input field named `prediction` carrying that shape can still be silently swallowed — the exact failure mode this PR sets out to kill. I left it out of `RESERVED_PREDICT_KWARGS` because the pop is *conditional*: a `prediction: str` field passes through fine today, and unconditionally reserving the name would reject signatures that currently work.

**Proposed fix, if you want it in this PR:** the resolved `signature` is already in scope at that point, so the pop can simply defer to an explicit field declaration:

```python
if "prediction" in kwargs and "prediction" not in signature.input_fields:
    if (
        isinstance(kwargs["prediction"], dict)
        and kwargs["prediction"].get("type") == "content"
        and "content" in kwargs["prediction"]
    ):
        config["prediction"] = kwargs.pop("prediction")
```

This is backward compatible: signatures that do not declare a `prediction` field (i.e. everyone using predicted outputs today) behave identically, and `prediction: str` keeps working. It only changes the case that is currently broken — a declared `prediction` input field whose value happens to be dict-shaped now reaches the adapter instead of vanishing.

The tradeoff worth your call: it means a signature **cannot** both declare a `prediction` input field and use the predicted-outputs LM feature. Resolving in favor of the explicit signature declaration seems right (a declared field is more specific than an optional LM knob), but that is a product decision, so I have left it out pending your preference. Say the word and I will add it.

## Testing

Red→green verified against base: the reserved-name cases fail on `main` and pass with this change. `tests/signatures/` + `tests/predict/` → 214 passed, 2 xfailed, no regressions.

Addresses #658
