### PR TITLE
fix(tool): stabilize open args schema across Pydantic versions

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -264,7 +264,7 @@ class ToolCalls(Type):
     class ToolCall(Type):
         id: str | None = None
         name: str
-        args: dict[str, Any]
+        args: dict[str, Any] = pydantic.Field(json_schema_extra={"additionalProperties": True})
 
         @classmethod
         def __get_pydantic_json_schema__(cls, core_schema: Any, handler: Any) -> dict[str, Any]:

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -470,6 +470,7 @@ def test_tool_calls_json_schema_omits_internal_id_field():
 
     assert "tool_call_results" not in schema["properties"]
     assert "id" not in schema["$defs"]["ToolCall"]["properties"]
+    assert schema["$defs"]["ToolCall"]["properties"]["args"]["additionalProperties"] is True
     assert schema["$defs"]["ToolCall"]["required"] == ["name", "args"]
 
 


### PR DESCRIPTION
## Summary

Make `ToolCall.args` emit one canonical open-object schema across DSPy's supported Pydantic versions. This removes the remaining two Pydantic-related failures from PR #10000's minimum-direct graph.

## 1. Issue / repro

The same DSPy type produces different schema text across supported Pydantic versions.

Pydantic 2.7.2 emits:

```json
{"args": {"title": "Args", "type": "object"}}
```

Current Pydantic emits:

```json
{"args": {"additionalProperties": true, "title": "Args", "type": "object"}}
```

Both schemas allow arbitrary tool argument names, but DSPy embeds the literal schema into adapter messages. The minimum graph therefore produces different prompts and fails two exact message tests.

## 2. Why this is the root cause

`ToolCall.args` is intentionally an open mapping:

```python
args: dict[str, Any]
```

Older Pydantic relies on JSON Schema's default open-object behavior; newer Pydantic writes that behavior explicitly. DSPy then uses the generated schema in LM requests, and those requests form part of the cache identity. A semantically irrelevant dependency-version detail therefore changes both the prompt and cache key.

The openness contract belongs on `args`, not in adapter-specific formatting or version checks.

## 3. How we know this fixes the root cause

The field now declares its existing contract explicitly:

```python
args: dict[str, Any] = pydantic.Field(
    json_schema_extra={"additionalProperties": True}
)
```

With this annotation, Pydantic 2.7.2 and current Pydantic emit the same schema. The two previously failing exact-message tests pass at the minimum version, and the current locked behavior is unchanged.

## 4. Why this is the concise fix

The production change is one field annotation. The regression is one assertion on the generated schema.

It does not:

- raise the Pydantic floor for a semantically equivalent rendering difference;
- add a Pydantic version branch;
- normalize every generated schema globally;
- loosen the exact adapter-message tests;
- add a cache migration or fallback.

## 5. Context needed to validate the change

In JSON Schema, omitting `additionalProperties` and setting it to `true` have the same open-object behavior. This change makes that behavior explicit at the DSPy type boundary.

Users on current Pydantic see no prompt change. Users on older supported Pydantic converge to the current canonical prompt and may incur one expected cache miss; runtime validation and serialization do not change.

`ToolCall`'s existing schema hook still owns removal of its internal `id` field. This field metadata owns only the independent `args` openness contract.

## 6. What the fix does

1. Adds explicit `additionalProperties: true` schema metadata to `ToolCall.args`.
2. Asserts that contract in the existing focused ToolCalls schema test.

## Verification

- Pydantic 2.7.2: 144 Tool/ChatAdapter/JSONAdapter tests passed.
- Locked Pydantic 2.12.4: the same 144 tests passed.
- Repository pre-commit hooks — passed.
- `git diff --check origin/main...HEAD` — passed.

## Scope

One commit. Two files. Two insertions, one deletion.
