### PR TITLE
fix(docstring): Fix max_iters default value in docstring of ReAct

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -25,7 +25,7 @@ class ReAct(Module):
         Args:
             signature: The signature of the module, which defines the input and output of the react module.
             tools (list[Callable]): A list of functions, callable objects, or `dspy.Tool` instances.
-            max_iters (Optional[int]): The maximum number of iterations to run. Defaults to 10.
+            max_iters (Optional[int]): The maximum number of iterations to run. Defaults to 20.
 
         Examples:
 


### PR DESCRIPTION
Small fix in the docstring of ReAct to update the default value of max_iters from 10 to 20, following the update in the __init__() function in PR #9162.