### PR TITLE
fix(lm): omit absent Responses tool fields

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -873,7 +873,7 @@ class BaseLM:
                 for content_item in output_item.content:
                     text_outputs.append(content_item.text)
             elif output_item_type == "function_call":
-                tool_calls.append(output_item.model_dump())
+                tool_calls.append(output_item.model_dump(exclude_none=True))
             elif output_item_type == "reasoning":
                 if getattr(output_item, "content", None) and len(output_item.content) > 0:
                     for content_item in output_item.content:

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1214,9 +1214,21 @@ def test_lm_replaces_system_with_developer_role():
         assert mock_completion.call_args.kwargs["request"]["messages"][0]["role"] == "developer"
 
 
-def test_responses_api_tool_calls(litellm_test_server):
+@pytest.mark.parametrize(
+    ("provider_fields", "expected_provider_fields"),
+    [
+        ({}, {}),
+        ({"caller": None, "namespace": None}, {}),
+        (
+            {"caller": {"type": "direct"}, "namespace": "collaboration"},
+            {"caller": {"type": "direct"}, "namespace": "collaboration"},
+        ),
+    ],
+    ids=["legacy", "empty-provider-fields", "populated-provider-fields"],
+)
+def test_responses_api_tool_calls(litellm_test_server, provider_fields, expected_provider_fields):
     api_base, _ = litellm_test_server
-    expected_tool_call = {
+    base_tool_call = {
         "type": "function_call",
         "name": "get_weather",
         "arguments": json.dumps({"city": "Paris"}),
@@ -1224,10 +1236,10 @@ def test_responses_api_tool_calls(litellm_test_server):
         "status": "completed",
         "id": "call_1",
     }
-    expected_response = [{"tool_calls": [expected_tool_call]}]
+    expected_response = [{"tool_calls": [{**base_tool_call, **expected_provider_fields}]}]
 
     api_response = make_response(
-        output_blocks=[expected_tool_call],
+        output_blocks=[{**base_tool_call, **provider_fields}],
     )
 
     with mock.patch("litellm.responses", autospec=True, return_value=api_response) as dspy_responses:


### PR DESCRIPTION
## Summary

Keep DSPy's Responses API tool-call output stable when provider SDKs add new optional fields. This clears PR #10000's single latest-dependency failure.

## 1. Issue / repro

The first hosted latest-dependency run in #10000 resolved LiteLLM 1.92.0 and OpenAI 2.45.0. Their function-call model includes two optional fields:

```python
caller = None
namespace = None
```

DSPy currently returns them verbatim:

```python
{"name": "get_weather", ..., "caller": None, "namespace": None}
```

That changes the public tool-call dictionary even though the provider supplied no new information, breaking `test_responses_api_tool_calls` in the hosted run.

## 2. Why this is the root cause

`BaseLM._process_response()` forwards the provider model without a boundary policy:

```python
tool_calls.append(output_item.model_dump())
```

Any optional field added by OpenAI or LiteLLM therefore becomes a new DSPy output key, including fields whose value is only the default `None`.

The stable boundary is semantic: absent provider information should be absent from DSPy's dictionary; populated provider information should remain available.

## 3. How we know this fixes the root cause

The boundary now excludes model fields whose value is `None`:

```python
tool_calls.append(output_item.model_dump(exclude_none=True))
```

The regression covers all three relevant shapes:

| Provider model | DSPy output |
| --- | --- |
| Legacy model without new fields | Existing dictionary unchanged |
| New fields present as `None` | Empty fields omitted |
| New fields contain values | Values preserved |

The same three cases pass with both the locked older SDK pair and exact latest SDK pair.

## 4. Why this is the concise fix

The production change is one serialization option. It adds no SDK version check, provider allowlist, schema introspection, exception fallback, or loose assertion.

Filtering the two field names manually would require another code change whenever an SDK adds a different optional field. `exclude_none=True` expresses the actual boundary once.

## 5. Context needed to validate the change

OpenAI defines `caller` as execution-context metadata and `namespace` as function namespace metadata. A non-`None` value can be meaningful, so the fix deliberately preserves it.

PR #9672 previously applied this exact production fix only to Dependabot branch #9667; it never reached `main`. PR #9842 overlaps this code while pursuing a much broader typed-output migration. This change preserves today's public dictionary boundary and gives that future migration a focused regression to adapt.

## 6. What the fix does

1. Serializes Responses function calls with `exclude_none=True`.
2. Extends the existing integration test across legacy, empty-current, and populated-current provider fields.

## 7. Downsides and compatibility boundaries

This is an intentional normalized-output shape change, not a byte-for-byte serialization no-op. It applies only to `function_call` items returned through `model_type="responses"` on the legacy `BaseLM` output path (sync and async). Chat Completions, Responses message/reasoning items, outbound provider requests, and tool execution do not change. DSPy's typed Responses conversion is also unchanged; it already uses the same `exclude_none=True` policy.

The concrete compatibility break is for code that relies on `None` placeholder keys:

```python
# Before
{"type": "function_call", "name": "get_weather", ..., "status": None,
 "caller": None, "namespace": None}

# After
{"type": "function_call", "name": "get_weather", ...}

tool_call["status"]      # Can now raise KeyError when status is None.
tool_call.get("status")  # Still returns None for optional metadata.
```

`exclude_none=True` applies to all `None`-valued SDK model fields, not only `caller` and `namespace`. Existing optional fields such as `id` and `status`, nullable fields on nested SDK models, and future provider fields are omitted when empty. Exact-dictionary snapshots, key-set assertions, and direct indexing of optional metadata can therefore break. Non-`None` values are preserved, including `False`, `0`, empty strings, empty containers, and populated provider metadata. Tool `arguments` remains an opaque JSON string, so JSON `null` inside user arguments is untouched.

Required call fields (`arguments`, `call_id`, `name`, and `type`) are unchanged. [OpenAI's Responses input schema](https://github.com/openai/openai-python/blob/v2.45.0/src/openai/types/responses/response_function_tool_call_param.py) makes the omitted metadata fields optional, so the normalized call remains structurally valid when reused as an input item.

Missing and explicit provider `null` both already became the same `key: None` value in DSPy's old dictionary, so this does not discard a distinction that the existing public dictionary exposed; it changes that shared representation from an explicit placeholder to omission. If a future provider gives explicit `null` semantics distinct from absence, that distinction will not appear in the normalized legacy output. The raw provider response retained in LM history is unchanged.

We considered `exclude_unset=True`. It fixes the exact OpenAI 2.45 model when the SDK preserves which fields were present, but makes DSPy's output depend on how each LiteLLM provider adapter constructed its Pydantic model: an adapter that explicitly passes default `None` values would leak them again. Filtering `caller` and `namespace` by name is narrower but repeats this failure for the next optional SDK field. `exclude_none=True` instead defines one provider-neutral rule: optional metadata without a value is absent.

There is no provider-wire or cache-format change. Filtering happens after LiteLLM returns and after the raw response is cached; cache keys and stored values remain valid, although old cache hits are normalized with the new omission rule. The supported Pydantic range is v2-only, where this argument is available. Standard LiteLLM/OpenAI response models support it; a hand-written test double or custom response wrapper whose `model_dump()` rejects Pydantic keyword arguments would need to match that interface.

No provider-specific incompatibility was found. The exact boundary was checked against [OpenAI 1.75's function-call model](https://github.com/openai/openai-python/blob/v1.75.0/src/openai/types/responses/response_function_tool_call.py), [OpenAI 2.45's expanded model](https://github.com/openai/openai-python/blob/v2.45.0/src/openai/types/responses/response_function_tool_call.py), LiteLLM's provider-normalized Responses models, the minimum supported Pydantic API, and Python 3.10-3.14 in hosted CI.

## Verification

- Locked LiteLLM 1.68 / OpenAI 1.75: 3 passed.
- Exact LiteLLM 1.92 / OpenAI 2.45: 3 passed.
- Rebased locked dependency graph: 3 passed.
- Repository pre-commit hooks — passed.
- Hosted CI: 15 checks passed; Greptile 5/5 with no blocking issues.
- `git diff --check origin/main...HEAD` — passed.

## Scope

One commit. Two files. One production-line change plus a parameterized regression.
