### PR TITLE
fix(adapters): normalize non-dict tool call arguments to an empty dict

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -736,6 +736,10 @@ def _provider_tool_call_to_tool_call_dict(tool_call: Any) -> dict[str, Any]:
     arguments = _provider_value(function, "arguments", {})
     if isinstance(arguments, str):
         parsed_arguments = json_repair.loads(arguments)
+        # json_repair.loads returns "" for empty or invalid input; a no-argument
+        # tool call (arguments="") must still normalize to an empty dict.
+        if not isinstance(parsed_arguments, dict):
+            parsed_arguments = {}
     elif isinstance(arguments, dict):
         parsed_arguments = arguments
     else:

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -491,7 +491,9 @@ def _normalize_tool_call_dict(data: dict[str, Any]) -> dict[str, Any]:
 
     if isinstance(arguments, str):
         arguments = json_repair.loads(arguments)
-    elif not isinstance(arguments, dict):
+    # json_repair.loads returns "" for empty or invalid input, so a no-argument
+    # tool call (arguments="") would otherwise leave a non-dict value here.
+    if not isinstance(arguments, dict):
         arguments = {}
 
     return {

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -753,3 +753,58 @@ def test_tool_call_execute_with_local_functions():
             globals().pop("local_add", None)
 
     main()
+
+
+@pytest.mark.parametrize(
+    "tool_call_dict",
+    [
+        {"name": "get_time", "arguments": ""},
+        {"name": "get_time", "args": ""},
+        {"type": "function", "function": {"name": "get_time", "arguments": ""}},
+        {"name": "get_time", "arguments": "   "},
+        {"name": "get_time", "arguments": "not json"},
+        {"name": "get_time", "arguments": "[1, 2]"},
+        {"name": "get_time", "arguments": "42"},
+    ],
+)
+def test_tool_calls_normalize_non_dict_arguments_to_empty_dict(tool_call_dict):
+    """A tool call whose ``arguments`` is not a JSON object (e.g. the empty string an
+    OpenAI-compatible provider emits for a no-argument call) must normalize to an empty
+    dict instead of crashing ToolCall validation."""
+    tool_calls = ToolCalls.from_dict_list([tool_call_dict])
+    assert tool_calls.tool_calls[0].name == "get_time"
+    assert tool_calls.tool_calls[0].args == {}
+
+    validated = ToolCalls.model_validate(tool_call_dict)
+    assert validated.tool_calls[0].args == {}
+
+
+def test_tool_calls_still_parse_valid_json_string_arguments():
+    """Well-formed JSON-string arguments continue to parse into a dict."""
+    tool_calls = ToolCalls.from_dict_list([{"name": "search", "arguments": '{"query": "hello"}'}])
+    assert tool_calls.tool_calls[0].args == {"query": "hello"}
+
+
+@pytest.mark.parametrize(
+    "arguments,expected",
+    [
+        ("", {}),
+        ("   ", {}),
+        ("not json", {}),
+        ("[1, 2]", {}),
+        (None, {}),
+        ('{"query": "hello"}', {"query": "hello"}),
+        ({"query": "hello"}, {"query": "hello"}),
+    ],
+)
+def test_provider_tool_call_to_tool_call_dict_normalizes_arguments(arguments, expected):
+    """The provider-response path (hit when an LM returns native tool calls) must also
+    coerce non-dict ``arguments`` to a dict so downstream ToolCall construction succeeds."""
+    from dspy.adapters.base import _provider_tool_call_to_tool_call_dict
+
+    normalized = _provider_tool_call_to_tool_call_dict(
+        {"id": "call_1", "function": {"name": "get_time", "arguments": arguments}}
+    )
+    assert normalized["name"] == "get_time"
+    assert normalized["args"] == expected
+    assert ToolCalls.ToolCall(**normalized).args == expected


### PR DESCRIPTION
### What & why

When a tool call's `arguments` is a string, it is parsed with `json_repair.loads`, which returns `""` (an empty string, not a dict) for empty or invalid input. An empty string is the canonical `arguments` value an OpenAI-compatible provider emits for a **no-argument tool call**, so parsing such a call currently raises `pydantic.ValidationError` because `ToolCall.args` must be a dict.

The dict-coercion guard was an `elif`, so it never ran after the string branch:

```python
if isinstance(arguments, str):
    arguments = json_repair.loads(arguments)
elif not isinstance(arguments, dict):   # never reached when arguments was a str
    arguments = {}
```

Minimal repro (no network / API key needed):

```python
import dspy

dspy.ToolCalls.model_validate(
    {"type": "function", "function": {"name": "get_time", "arguments": ""}}
)
# pydantic ValidationError: args
#   Input should be a valid dictionary [type=dict_type, input_value='', input_type=str]
```

The same omission exists on the provider-response path `_provider_tool_call_to_tool_call_dict` in `dspy/adapters/base.py`, which runs at `Adapter.parse` time when an LM returns native tool calls (`base.py:184`). So a model that calls a no-argument tool crashes the entire parse.

### Fix

Coerce any non-dict result to `{}` after `json_repair.loads` in both `_normalize_tool_call_dict` (public `ToolCalls` construction) and `_provider_tool_call_to_tool_call_dict` (native tool-call parsing). Well-formed JSON-object arguments are unaffected.

### Tests

Added coverage in `tests/adapters/test_tool.py` for both paths across empty-string, whitespace, non-JSON, and non-object-JSON (`"[1, 2]"`, `"42"`) inputs, plus a regression check that valid JSON-string arguments still parse into a dict. The full `tests/adapters/` suite passes.

Found by reading the code; no linked issue.
