### PR TITLE
fix(rlm): preserve input mutations across iterations

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -435,15 +435,10 @@ class RLM(Module):
         if missing:
             raise ValueError(f"Missing required inputs: {sorted(missing)}")
 
-    def _prepare_serializable_vars(
+    def _initialize_inputs(
         self, input_args: dict[str, Any], repl: CodeInterpreter,
-    ) -> dict[str, Any]:
-        """Inject SandboxSerializable values into the interpreter.
-
-        For each SandboxSerializable value in input_args, serializes it and
-        executes setup + assignment code in the interpreter. Returns the
-        remaining non-serializable args (for per-iteration use).
-        """
+    ) -> None:
+        """Initialize the interpreter namespace once for this RLM run."""
         repl.start()
         regular_args = {}
         for name, value in input_args.items():
@@ -475,7 +470,8 @@ class RLM(Module):
             code_lines.append(assignment)
             repl.execute("\n".join(code_lines), variables=payload_vars)
 
-        return regular_args
+        if regular_args:
+            repl.execute("pass", variables=regular_args)
 
     # =========================================================================
     # CodeInterpreter Lifecycle
@@ -653,11 +649,10 @@ class RLM(Module):
         self,
         repl: CodeInterpreter,
         code: str,
-        input_args: dict[str, Any],
     ) -> Any:
         """Execute code in the interpreter, returning the result or an error string."""
         try:
-            return repl.execute(code, variables=dict(input_args))
+            return repl.execute(code)
         except (CodeExecutionError, SyntaxError) as e:
             return f"[Error] {e}"
 
@@ -667,7 +662,6 @@ class RLM(Module):
         variables: list[REPLVariable],
         history: REPLHistory,
         iteration: int,
-        input_args: dict[str, Any],
         output_field_names: list[str],
     ) -> Prediction | REPLHistory:
         """Execute one iteration. Returns Prediction if done, else updated REPLHistory."""
@@ -689,7 +683,7 @@ class RLM(Module):
             code = action.code
             result = f"[Error] {e}"
             return self._process_execution_result(action, code, result, history, output_field_names)
-        result = self._execute_code(repl, code, input_args)
+        result = self._execute_code(repl, code)
         return self._process_execution_result(action, code, result, history, output_field_names)
 
     # =========================================================================
@@ -719,12 +713,12 @@ class RLM(Module):
         variables = self._build_variables(**input_args)
 
         with self._interpreter_context(execution_tools, interpreter) as repl:
-            regular_args = self._prepare_serializable_vars(input_args, repl)
+            self._initialize_inputs(input_args, repl)
             history: REPLHistory = REPLHistory(max_output_chars=self.max_output_chars)
 
             for iteration in range(self.max_iters):
                 result: Prediction | REPLHistory = self._execute_iteration(
-                    repl, variables, history, iteration, regular_args, output_field_names
+                    repl, variables, history, iteration, output_field_names
                 )
                 if isinstance(result, Prediction):
                     return result
@@ -760,7 +754,6 @@ class RLM(Module):
         variables: list[REPLVariable],
         history: REPLHistory,
         iteration: int,
-        input_args: dict[str, Any],
         output_field_names: list[str],
     ) -> Prediction | REPLHistory:
         """Async version: Execute one iteration."""
@@ -782,7 +775,7 @@ class RLM(Module):
             code = pred.code
             result = f"[Error] {e}"
             return self._process_execution_result(pred, code, result, history, output_field_names)
-        result = self._execute_code(repl, code, input_args)
+        result = self._execute_code(repl, code)
         return self._process_execution_result(pred, code, result, history, output_field_names)
 
     async def aforward(self, interpreter: CodeInterpreter | None = None, /, **input_args) -> Prediction:
@@ -808,12 +801,12 @@ class RLM(Module):
         variables = self._build_variables(**input_args)
 
         with self._interpreter_context(execution_tools, interpreter) as repl:
-            regular_args = self._prepare_serializable_vars(input_args, repl)
+            self._initialize_inputs(input_args, repl)
             history = REPLHistory(max_output_chars=self.max_output_chars)
 
             for iteration in range(self.max_iters):
                 result = await self._aexecute_iteration(
-                    repl, variables, history, iteration, regular_args, output_field_names
+                    repl, variables, history, iteration, output_field_names
                 )
                 if isinstance(result, Prediction):
                     return result

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -327,7 +327,7 @@ class TestRLMInitialization:
             query: str = dspy.InputField()
             answer: str = dspy.OutputField()
 
-        mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
+        mock = MockInterpreter(responses=["", FinalOutput({"answer": "done"})])
         rlm = RLM(QA)
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
@@ -361,8 +361,8 @@ class TestRLMInitialization:
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
         ])
-        default_mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
-        explicit_mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
+        default_mock = MockInterpreter(responses=["", FinalOutput({"answer": "done"})])
+        explicit_mock = MockInterpreter(responses=["", FinalOutput({"answer": "done"})])
 
         rlm.forward(default_mock, query="uses default")
         rlm.forward(explicit_mock, context=["caller context"], query="uses caller value")
@@ -502,7 +502,7 @@ class TestRLMInitialization:
 
 class TestRLMInterpreterLifecycle:
     def test_interpreter_remains_available_as_signature_input(self):
-        factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "CPython"})])
+        factory = MockInterpreterFactory(responses=["", FinalOutput({"answer": "CPython"})])
         rlm = RLM("interpreter -> answer", max_iters=1, interpreter_factory=factory)
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return input", "code": "SUBMIT(interpreter)"},
@@ -515,7 +515,7 @@ class TestRLMInterpreterLifecycle:
 
     @pytest.mark.asyncio
     async def test_factory_creates_and_shuts_down_one_interpreter_per_call(self):
-        factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "42"})])
+        factory = MockInterpreterFactory(responses=["", FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=1, interpreter_factory=factory)
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
@@ -537,7 +537,9 @@ class TestRLMInterpreterLifecycle:
         factory = MockInterpreterFactory()
         interpreter = MockInterpreter(
             responses=[
+                "",
                 FinalOutput({"answer": "first"}),
+                "",
                 FinalOutput({"answer": "second"}),
             ]
         )
@@ -553,6 +555,12 @@ class TestRLMInterpreterLifecycle:
             assert sync_result.answer == "first"
             assert async_result.answer == "second"
             assert factory.instances == []
+            assert interpreter.call_history[:4] == [
+                ("pass", {"query": "sync"}),
+                ("SUBMIT(answer)", {}),
+                ("pass", {"query": "async"}),
+                ("SUBMIT(answer)", {}),
+            ]
             assert interpreter.execute("print('still open')") == ""
         finally:
             interpreter.shutdown()
@@ -815,7 +823,7 @@ class TestRLMCallMethod:
 
     def test_call_is_alias_for_forward(self):
         """Test that __call__ is an alias for forward()."""
-        mock = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
+        mock = MockInterpreter(responses=["", FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=3)
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
@@ -831,6 +839,7 @@ class TestRLMMaxIterationsFallback:
     def test_max_iters_triggers_extract(self):
         """Test that reaching max_iters uses extract fallback."""
         mock = MockInterpreter(responses=[
+            "",
             "exploring...",
             "still exploring...",
             "more exploring...",
@@ -860,6 +869,7 @@ class TestRLMToolExceptions:
             raise RuntimeError("Tool failed!")
 
         mock = MockInterpreter(responses=[
+            "",
             CodeExecutionError("RuntimeError: Tool failed!"),
             FinalOutput({"answer": "recovered"}),
         ])
@@ -875,6 +885,7 @@ class TestRLMToolExceptions:
     def test_runtime_error_history_uses_stripped_code(self):
         """Runtime execution failures should preserve stripped code in history."""
         mock = MockInterpreter(responses=[
+            "",
             CodeExecutionError("NameError: name 'x' is not defined"),
             FinalOutput({"answer": "recovered"}),
         ])
@@ -892,6 +903,7 @@ class TestRLMToolExceptions:
     def test_syntax_error_from_execute_is_recoverable(self):
         """SyntaxError from interpreter.execute should be surfaced as an iteration error."""
         mock = MockInterpreter(responses=[
+            "",
             SyntaxError("invalid syntax"),
             FinalOutput({"answer": "recovered"}),
         ])
@@ -908,6 +920,7 @@ class TestRLMToolExceptions:
     def test_syntax_error_from_strip_code_fences_is_recoverable(self):
         """SyntaxError raised by _strip_code_fences (e.g. non-Python fence tag) should be recoverable."""
         mock = MockInterpreter(responses=[
+            "",
             FinalOutput({"answer": "recovered"}),
         ])
         rlm = RLM("query -> answer", max_iters=5)
@@ -1207,7 +1220,7 @@ class TestRLMAsyncMock:
     @pytest.mark.asyncio
     async def test_aforward_basic(self):
         """Test aforward() returns Prediction with expected output (MockInterpreter)."""
-        mock = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
+        mock = MockInterpreter(responses=["", FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=3)
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
@@ -1219,7 +1232,7 @@ class TestRLMAsyncMock:
     @pytest.mark.asyncio
     async def test_aforward_int_output_mock(self):
         """Test aforward() returns int when signature expects int (MockInterpreter)."""
-        mock = MockInterpreter(responses=[FinalOutput({"count": 42})])
+        mock = MockInterpreter(responses=["", FinalOutput({"count": 42})])
         rlm = RLM("query -> count: int", max_iters=3)
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return count", "code": "SUBMIT(42)"},
@@ -1233,6 +1246,7 @@ class TestRLMAsyncMock:
     async def test_aforward_multi_iteration_mock(self):
         """Test aforward() handles multiple iterations before SUBMIT (MockInterpreter)."""
         mock = MockInterpreter(responses=[
+            "",
             "explored data",
             FinalOutput({"answer": "done"}),
         ])
@@ -1258,7 +1272,7 @@ class TestRLMTypeCoercionMock:
     ])
     def test_type_coercion(self, output_field, output_type, final_value, code, expected):
         """Test RLM type coercion for various types (MockInterpreter)."""
-        mock = MockInterpreter(responses=[FinalOutput({output_field: final_value})])
+        mock = MockInterpreter(responses=["", FinalOutput({output_field: final_value})])
         rlm = RLM(f"query -> {output_field}: {output_type}", max_iters=3)
         rlm.generate_action = make_mock_predictor([
             {"reasoning": "Return value", "code": code},
@@ -1270,6 +1284,7 @@ class TestRLMTypeCoercionMock:
     def test_type_error_retries(self):
         """Test RLM retries when type validation fails (MockInterpreter)."""
         mock = MockInterpreter(responses=[
+            "",
             FinalOutput({"answer": "maybe"}),  # Invalid for Literal
             FinalOutput({"answer": "yes"}),    # Valid
         ])
@@ -1459,6 +1474,17 @@ class TestRLMWithDummyLM:
             result = rlm.forward(numbers=[1, 2, 3, 4, 5])
 
             assert result.total == 15
+
+    def test_input_mutations_persist_between_iterations(self):
+        """Input variables share the same persistent namespace as generated variables."""
+        with dummy_lm_context([
+            {"reasoning": "Extend the input", "code": "numbers.append(4)\nprint(numbers)"},
+            {"reasoning": "Return the updated sum", "code": "SUBMIT(sum(numbers))"},
+        ]):
+            rlm = RLM("numbers: list[int] -> total: int", max_iters=3)
+            result = rlm.forward(numbers=[1, 2, 3])
+
+        assert result.total == 10
 
     def test_with_tool_e2e(self):
         """Test RLM calling a host-side tool through the sandbox."""
@@ -1659,41 +1685,32 @@ class TestBuildVariablesWithSerializable:
         assert "plain text" in variables[0].preview
 
 
-class TestPrepareSerializableVars:
-    """Tests for _prepare_serializable_vars with MockInterpreter."""
+class TestInitializeInputs:
+    """Tests for one-time interpreter input initialization."""
 
-    def test_separates_serializable_from_regular(self):
-        """Serializable values are injected; regular values are returned."""
-        mock = MockInterpreter(responses=["", FinalOutput({"answer": "42"})])
+    def test_initializes_serializable_and_regular_inputs_once(self):
+        mock = MockInterpreter(responses=["", ""])
         rlm = RLM("data, query -> answer", max_iters=3)
 
         stub = _StubSerializable("payload")
 
-        # Manually call _prepare_serializable_vars
         rlm._inject_execution_context(mock, rlm._prepare_execution_tools())
-        regular = rlm._prepare_serializable_vars({"data": stub, "query": "hello"}, mock)
+        rlm._initialize_inputs({"data": stub, "query": "hello"}, mock)
 
-        # Regular args should only contain non-serializable values
-        assert "query" in regular
-        assert regular["query"] == "hello"
-        assert "data" not in regular
-
-        # MockInterpreter should have received an execute call for the setup
-        assert mock.call_count == 1
+        assert mock.call_count == 2
         code, variables = mock.call_history[0]
         assert "import json" in code
         assert "_raw_data" in variables
+        assert mock.call_history[1] == ("pass", {"query": "hello"})
 
-    def test_no_serializable_returns_all(self):
-        """When no SandboxSerializable values exist, all args are returned."""
-        mock = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
+    def test_regular_inputs_are_initialized_once(self):
+        mock = MockInterpreter(responses=["", ""])
         rlm = RLM("query -> answer", max_iters=3)
 
         rlm._inject_execution_context(mock, rlm._prepare_execution_tools())
-        regular = rlm._prepare_serializable_vars({"query": "hello"}, mock)
+        rlm._initialize_inputs({"query": "hello"}, mock)
 
-        assert regular == {"query": "hello"}
-        assert mock.call_count == 0
+        assert mock.call_history == [("pass", {"query": "hello"})]
 
     def test_binary_payload_uses_base64_transport(self):
         """Non-UTF8 bytes should be transported via base64 and decoded in sandbox code."""
@@ -1702,12 +1719,13 @@ class TestPrepareSerializableVars:
 
         payload = _BinarySerializable()
         rlm._inject_execution_context(mock, rlm._prepare_execution_tools())
-        rlm._prepare_serializable_vars({"data": payload, "query": "hello"}, mock)
+        rlm._initialize_inputs({"data": payload, "query": "hello"}, mock)
 
-        assert mock.call_count == 1
+        assert mock.call_count == 2
         code, variables = mock.call_history[0]
         assert "_raw_data = base64.b64decode(_raw_data_base64)" in code
         assert variables["_raw_data_base64"] == base64.b64encode(b"\xff\xfe\xfd").decode("ascii")
+        assert mock.call_history[1] == ("pass", {"query": "hello"})
 
     def test_large_payload_not_inlined_in_code(self):
         """Large payloads should ride in the variables kwarg, not the code string.
@@ -1716,7 +1734,7 @@ class TestPrepareSerializableVars:
         subsequent prompt and could blow past sandbox limits. The transport
         contract is: code stays small, payload travels as a named variable.
         """
-        mock = MockInterpreter(responses=[""])
+        mock = MockInterpreter(responses=["", ""])
         rlm = RLM("data, query -> answer")
 
         large_text = "x" * (2 * 1024 * 1024)  # 2 MB UTF-8 payload
@@ -1735,19 +1753,21 @@ class TestPrepareSerializableVars:
                 return f"LargeText({len(large_text)} chars)"
 
         rlm._inject_execution_context(mock, rlm._prepare_execution_tools())
-        rlm._prepare_serializable_vars({"data": _LargeText(), "query": "hi"}, mock)
+        rlm._initialize_inputs({"data": _LargeText(), "query": "hi"}, mock)
 
-        assert mock.call_count == 1
+        assert mock.call_count == 2
         code, variables = mock.call_history[0]
         # Payload must be in variables, not the code string.
         assert variables["_raw_data"] == large_text
+        assert mock.call_history[1] == ("pass", {"query": "hi"})
         assert large_text not in code
         assert len(code) < 1000
 
     def test_forward_with_serializable(self):
         """Full forward() pass with a SandboxSerializable input."""
         mock = MockInterpreter(responses=[
-            "",  # setup execution for _prepare_serializable_vars
+            "",  # serializable setup
+            "",  # regular input initialization
             FinalOutput({"answer": "done"}),
         ])
         rlm = RLM("data, query -> answer", max_iters=3)
@@ -1759,8 +1779,8 @@ class TestPrepareSerializableVars:
         result = rlm.forward(mock, data=stub, query="test")
         assert result.answer == "done"
 
-        # First call should be the serializable setup, second should be the iteration
-        assert mock.call_count == 2
+        # Setup and ordinary inputs run once before model-generated code.
+        assert mock.call_count == 3
 
 
 @pytest.mark.deno
@@ -1787,7 +1807,7 @@ class TestLargeSerializableRoundTrip:
         with PythonInterpreter(tools={}) as interp:
             rlm = RLM("data -> answer")
             rlm._inject_execution_context(interp, rlm._prepare_execution_tools())
-            rlm._prepare_serializable_vars({"data": _LargeText()}, interp)
+            rlm._initialize_inputs({"data": _LargeText()}, interp)
             result = interp.execute("print(len(data)); print(data[:6])")
 
         assert str(len(large_text)) in result


### PR DESCRIPTION
> **Stack:** this PR is one commit on top of #10034, the restored defaults child of #10020. GitHub should therefore show one focused review diff: initialize fully validated/defaulted inputs once per interpreter session.
>
> The lifecycle prerequisites are already on `main`: #10018 makes interpreter loss terminal, and #10022 gives each invocation a fresh interpreter unless the caller explicitly supplies one.

## 1. Issue / repro

RLM tells the model that interpreter state persists between iterations, but ordinary signature inputs are currently re-injected before every generated snippet.

```python
# input
numbers = [1, 2, 3]

# iteration 1
numbers.append(4)

# iteration 2
SUBMIT(sum(numbers))
```

On `main`, this returns `6`, not `10`: immediately before iteration two, RLM silently restores `numbers` to `[1, 2, 3]`.

## 2. Why this is the root cause

Every generated snippet currently crosses this boundary:

```python
repl.execute(code, variables=dict(input_args))
```

`variables=` assigns into the live interpreter namespace immediately before execution. Repeating it overwrites mutations from earlier iterations. That contradicts both public expectations:

- `CodeInterpreter` state persists across `execute()` calls;
- the RLM prompt says, “State persists between iterations.”

`SandboxSerializable` inputs already initialize before the model loop. Ordinary inputs are the only input form coupled to every iteration.

## 3. How we know the fix addresses the root cause

The regression uses real Deno/Pyodide:

1. initialize `numbers=[1, 2, 3]`;
2. append `4` in one model iteration;
3. sum `numbers` in the next iteration.

Untouched behavior returns `6`; this branch returns `10`.

Unit tests also inspect the exact execution order:

```python
[
    ("pass", {"query": "sync"}),       # initialize once
    ("SUBMIT(answer)", {}),             # generated code gets no reinjection
]
```

The same contract is tested for sync, async, factory-created interpreters, caller-owned sequential reuse, literal and zero-argument factory defaults from #10034, and `SandboxSerializable` payloads.

## 4. Why this is the concise fix

Input injection moves to the existing session-initialization boundary, and `input_args` disappears from the per-iteration call chain:

```python
self._initialize_inputs(input_args, repl)

# Every model iteration uses the namespace already owned by the session.
repl.execute(code)
```

Ordinary inputs use one explicit initialization call:

```python
repl.execute("pass", variables=regular_args)
```

There is no state flag, first-iteration branch, reset switch, retry path, or second namespace abstraction. The fix relies on the persistence guarantee the interpreter already exposes.

## 5. Context needed to validate the change

RLM has two different “variable” concepts:

- `REPLVariable` is prompt metadata describing what the model can access;
- `execute(..., variables=...)` mutates the live interpreter namespace.

This PR changes only the second. Prompt metadata, tools, output coercion, model calls, and healthy max-iteration extraction are untouched.

The stack order matters: #10020 first validates names, then #10034 binds defaults, and this PR initializes that complete input dictionary exactly once.

## 6. What the fix does in the code

- Renames the private serializable-preparation helper to `_initialize_inputs` because it now initializes both input forms.
- Preserves existing `SandboxSerializable` setup and payload transport.
- Injects ordinary inputs once before the sync or async iteration loop.
- Stops threading `input_args` through iteration helpers.
- Executes generated snippets against the persistent session namespace.

## Compatibility boundaries and downsides

- **Input mutations now persist intentionally.** Code relying on the undocumented per-turn reset will produce different results; reset-on-every-turn contradicted the stated session contract.
- **One initialization execution is added.** Runs with ordinary inputs call `execute("pass", variables=...)` before model-generated code. Scripted test interpreters must account for it.
- **Custom interpreters must persist injected variables.** That is the existing `CodeInterpreter` state contract; implementations exposing `variables=` for only one call are incompatible with persistent RLM execution.
- **Initialization failures occur before iteration one.** Generated code cannot repair a failed host-side input assignment.
- **Caller-owned interpreters are only safe for sequential reuse.** #10022 already documents that boundary; concurrent calls need distinct interpreter instances.
- **A dead session is not rebuilt.** #10018 deliberately makes process/protocol loss terminal, so one-time inputs cannot disappear behind a restart.
- **No public signature, LM provider, adapter, tool, output, or serializable-transport behavior changes.**

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — `146 passed, 2 skipped`
- real Deno mutation regression — returns `10`; old behavior returns `6`
- repository pre-commit hooks on both changed files — passed
- `git diff --check` — passed
- review diff over #10034 is exactly one commit and two files
