### PR TITLE
fix(rlm): make interpreter failures terminal

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -23,7 +23,7 @@ import pydantic
 import dspy
 from dspy.adapters.types.tool import Tool
 from dspy.adapters.utils import parse_value, translate_field_type
-from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeInterpreter, CodeInterpreterError, FinalOutput
+from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeExecutionError, CodeInterpreter, FinalOutput
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
 from dspy.primitives.python_interpreter import PythonInterpreter
@@ -587,7 +587,7 @@ class RLM(Module):
         """Execute code in the interpreter, returning the result or an error string."""
         try:
             return repl.execute(code, variables=dict(input_args))
-        except (CodeInterpreterError, SyntaxError) as e:
+        except (CodeExecutionError, SyntaxError) as e:
             return f"[Error] {e}"
 
     def _execute_iteration(
@@ -636,6 +636,7 @@ class RLM(Module):
 
         Raises:
             ValueError: If required input fields are missing
+            CodeInterpreterError: If interpreter setup, process, or protocol fails
         """
         self._validate_inputs(input_args)
 
@@ -721,6 +722,7 @@ class RLM(Module):
 
         Raises:
             ValueError: If required input fields are missing
+            CodeInterpreterError: If interpreter setup, process, or protocol fails
         """
         self._validate_inputs(input_args)
 

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -1,5 +1,5 @@
 from dspy.primitives.base_module import BaseModule
-from dspy.primitives.code_interpreter import CodeInterpreter, CodeInterpreterError, FinalOutput
+from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreter, CodeInterpreterError, FinalOutput
 from dspy.primitives.example import Example
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Completions, Prediction
@@ -8,6 +8,7 @@ from dspy.primitives.sandbox_serializable import SandboxSerializable
 
 __all__ = [
     "BaseModule",
+    "CodeExecutionError",
     "CodeInterpreter",
     "Completions",
     "Example",

--- a/dspy/primitives/code_interpreter.py
+++ b/dspy/primitives/code_interpreter.py
@@ -14,26 +14,17 @@ SIMPLE_TYPES = (str, int, float, bool, list, dict, type(None))
 
 
 class CodeInterpreterError(RuntimeError):
-    """Error raised during code interpretation.
+    """Base class for errors reported by a code interpreter.
 
-    This exception covers two distinct failure modes:
-
-    1. **Execution errors**: The sandbox ran user code that failed.
-       - NameError, TypeError, ValueError, etc.
-       - Tool call failures (unknown tool, tool raised exception)
-       - These are normal user code errors.
-
-    2. **Protocol errors**: Communication between host and sandbox failed.
-       - Malformed JSON from sandbox
-       - Sandbox process crashed or became unresponsive
-       - Invalid JSON-RPC message structure
-       - These may indicate a corrupted sandbox needing restart.
-
-    The error message typically includes the original error type (e.g., "NameError: ...")
-    which can help distinguish the failure mode.
-
-    Note: SyntaxError is raised separately (not wrapped) for invalid Python syntax.
+    A bare instance indicates a failure that submitted code cannot repair, such
+    as invalid host-side setup or a process/protocol failure. Recoverable
+    submitted-code failures use :class:`CodeExecutionError`. Implementations
+    should make process/protocol failures terminal for that interpreter session.
     """
+
+
+class CodeExecutionError(CodeInterpreterError):
+    """Recoverable error raised by code running in a healthy interpreter."""
 
 
 class FinalOutput:
@@ -104,7 +95,10 @@ class CodeInterpreter(Protocol):
         For pooling scenarios, call start() on multiple instances to have
         them ready before distributing work.
 
-        Calling start() multiple times should be safe (idempotent).
+        Calling start() multiple times before shutdown should be safe (idempotent).
+        If the underlying interpreter process exits, the session state is lost and
+        the implementation should raise CodeInterpreterError instead of silently
+        starting a new session.
         """
         ...
 
@@ -128,7 +122,8 @@ class CodeInterpreter(Protocol):
             - None: If no output was produced
 
         Raises:
-            CodeInterpreterError: On runtime errors (undefined vars, tool failures, etc.)
+            CodeExecutionError: On runtime errors in the submitted code or a called tool.
+            CodeInterpreterError: If host-side setup or the interpreter process/protocol fails.
             SyntaxError: On invalid Python syntax
 
         Note:

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -17,11 +17,11 @@ import os
 import subprocess
 import threading
 from os import PathLike
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 
-from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeInterpreterError, FinalOutput
+from dspy.primitives.code_interpreter import SIMPLE_TYPES, CodeExecutionError, CodeInterpreterError, FinalOutput
 
-__all__ = ["PythonInterpreter", "FinalOutput", "CodeInterpreterError"]
+__all__ = ["PythonInterpreter", "FinalOutput", "CodeExecutionError", "CodeInterpreterError"]
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +197,39 @@ class PythonInterpreter:
         self._request_id = 0
         self._owner_thread: int | None = None
         self._pending_large_vars = {}
+        self._session_ended = False
+
+    def _check_session_active(self) -> None:
+        if self._session_ended:
+            raise CodeInterpreterError(
+                "PythonInterpreter session has ended; create a new interpreter for a fresh session."
+            )
+
+    def _raise_terminal_error(self, message: str, cause: Exception | None = None) -> NoReturn:
+        """End an unusable interpreter session and report its process/protocol failure."""
+        self._session_ended = True
+        if self.deno_process is not None and self.deno_process.poll() is None:
+            try:
+                self.deno_process.terminate()
+            except ProcessLookupError:
+                pass
+            self.deno_process.wait()
+
+        error = CodeInterpreterError(message)
+        if cause is not None:
+            raise error from cause
+        raise error
+
+    def _write_message(self, message: str, context: str) -> None:
+        try:
+            self.deno_process.stdin.write(message + "\n")
+            self.deno_process.stdin.flush()
+        except BrokenPipeError as e:
+            self._raise_terminal_error(
+                f"Deno process stopped {context}; interpreter state was lost. "
+                "Create a new interpreter for a fresh session.",
+                e,
+            )
 
     def _check_thread_ownership(self) -> None:
         """Ensure this interpreter is only used from a single thread."""
@@ -267,8 +300,7 @@ class PythonInterpreter:
             virtual_path = f"/sandbox/{os.path.basename(str(path))}"
             host_path = _canonicalize_path(path)
             sync_msg = _jsonrpc_notification("sync_file", {"virtual_path": virtual_path, "host_path": host_path})
-            self.deno_process.stdin.write(sync_msg + "\n")
-            self.deno_process.stdin.flush()
+            self._write_message(sync_msg, "while syncing files")
 
     def _extract_parameters(self, fn: Callable) -> list[dict]:
         """Extract parameter info from a callable for sandbox registration."""
@@ -339,35 +371,41 @@ class PythonInterpreter:
             error_code = JSONRPC_APP_ERRORS.get(error_type, JSONRPC_APP_ERRORS["Unknown"])
             response = _jsonrpc_error(error_code, str(e), request_id, {"type": error_type})
 
-        self.deno_process.stdin.write(response + "\n")
-        self.deno_process.stdin.flush()
+        self._write_message(response, "while returning a tool result")
 
     def _ensure_deno_process(self) -> None:
-        if self.deno_process is None or self.deno_process.poll() is not None:
-            # Process identity changed (or process missing), so replay setup.
-            self._tools_registered = False
-            self._mounted_files = False
-            try:
-                self.deno_process = subprocess.Popen(
-                    self.deno_command,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    encoding="UTF-8",
-                    env=os.environ.copy()
-                )
-            except FileNotFoundError as e:
-                install_instructions = (
-                    "Deno executable not found. Please install Deno to proceed.\n"
-                    "Installation instructions:\n"
-                    "> curl -fsSL https://deno.land/install.sh | sh\n"
-                    "*or*, on macOS with Homebrew:\n"
-                    "> brew install deno\n"
-                    "For additional configurations: https://docs.deno.com/runtime/getting_started/installation/"
-                )
-                raise CodeInterpreterError(install_instructions) from e
-            self._health_check()
+        self._check_session_active()
+
+        if self.deno_process is not None:
+            exit_code = self.deno_process.poll()
+            if exit_code is None:
+                return
+            self._raise_terminal_error(
+                f"Deno process exited (code {exit_code}); interpreter state was lost. "
+                "Create a new interpreter for a fresh session."
+            )
+
+        try:
+            self.deno_process = subprocess.Popen(
+                self.deno_command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                encoding="UTF-8",
+                env=os.environ.copy()
+            )
+        except FileNotFoundError as e:
+            install_instructions = (
+                "Deno executable not found. Please install Deno to proceed.\n"
+                "Installation instructions:\n"
+                "> curl -fsSL https://deno.land/install.sh | sh\n"
+                "*or*, on macOS with Homebrew:\n"
+                "> brew install deno\n"
+                "For additional configurations: https://docs.deno.com/runtime/getting_started/installation/"
+            )
+            raise CodeInterpreterError(install_instructions) from e
+        self._health_check()
 
     _MAX_SKIP_LINES = 100
 
@@ -380,8 +418,8 @@ class PythonInterpreter:
         exit_code = self.deno_process.poll()
         if exit_code is not None:
             stderr = self.deno_process.stderr.read() if self.deno_process.stderr else ""
-            raise CodeInterpreterError(f"Deno exited (code {exit_code}) {context}: {stderr}")
-        raise CodeInterpreterError(f"No response {context}")
+            self._raise_terminal_error(f"Deno exited (code {exit_code}) {context}: {stderr}")
+        self._raise_terminal_error(f"No response {context}")
 
     def _parse_response_line(self, response_line: str, context: str) -> dict | None:
         """Parse a JSON-RPC line, returning None for non-JSON or malformed lines."""
@@ -404,8 +442,7 @@ class PythonInterpreter:
         self._request_id += 1
         request_id = self._request_id
         msg = _jsonrpc_request(method, params, request_id)
-        self.deno_process.stdin.write(msg + "\n")
-        self.deno_process.stdin.flush()
+        self._write_message(msg, context)
 
         skipped = 0
         while skipped <= self._MAX_SKIP_LINES:
@@ -416,18 +453,26 @@ class PythonInterpreter:
                 continue
 
             if response.get("id") != request_id:
-                raise CodeInterpreterError(f"Response ID mismatch {context}: expected {request_id}, got {response.get('id')}")
+                self._raise_terminal_error(
+                    f"Response ID mismatch {context}: expected {request_id}, got {response.get('id')}"
+                )
             if "error" in response:
-                raise CodeInterpreterError(f"Error {context}: {response['error'].get('message', 'Unknown error')}")
+                error = response["error"]
+                if not isinstance(error, dict):
+                    self._raise_terminal_error(f"Malformed error response {context}: {response}")
+                self._raise_terminal_error(f"Error {context}: {error.get('message', 'Unknown error')}")
+            if "result" not in response:
+                self._raise_terminal_error(f"Unexpected response {context}: {response}")
             return response
 
-        raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) {context}")
+        self._raise_terminal_error(f"Too many non-JSON lines ({skipped}) {context}")
 
     def _health_check(self) -> None:
         """Verify the subprocess is alive by executing a simple expression."""
         response = self._send_request("execute", {"code": "print(1+1)"}, "during health check")
-        if response.get("result", {}).get("output", "").strip() != "2":
-            raise CodeInterpreterError(f"Unexpected ping response: {response}")
+        result = response["result"]
+        if not isinstance(result, dict) or result.get("output", "").strip() != "2":
+            self._raise_terminal_error(f"Unexpected ping response: {response}")
 
     def _to_json_compatible(self, value: Any) -> Any:
         """Recursively convert Python values to JSON-compatible types."""
@@ -519,6 +564,7 @@ class PythonInterpreter:
         code: str,
         variables: dict[str, Any] | None = None,
     ) -> Any:
+        self._check_session_active()
         self._check_thread_ownership()
         variables = variables or {}
         code = self._inject_variables(code, variables)
@@ -533,18 +579,7 @@ class PythonInterpreter:
         self._request_id += 1
         execute_request_id = self._request_id
         input_data = _jsonrpc_request("execute", {"code": code}, execute_request_id)
-        try:
-            self.deno_process.stdin.write(input_data + "\n")
-            self.deno_process.stdin.flush()
-        except BrokenPipeError:
-            # If the process died, restart and try again once
-            self._ensure_deno_process()
-            self._mount_files()
-            self._register_tools()
-            for name, value in self._pending_large_vars.items():
-                self._inject_large_var(name, value)
-            self.deno_process.stdin.write(input_data + "\n")
-            self.deno_process.stdin.flush()
+        self._write_message(input_data, "during execution")
 
         # Read and handle messages until we get the final output.
         # Loop is needed because tool calls require back-and-forth communication.
@@ -565,8 +600,12 @@ class PythonInterpreter:
             # Handle success response
             if "result" in msg:
                 if msg.get("id") != execute_request_id:
-                    raise CodeInterpreterError(f"Response ID mismatch: expected {execute_request_id}, got {msg.get('id')}")
+                    self._raise_terminal_error(
+                        f"Response ID mismatch: expected {execute_request_id}, got {msg.get('id')}"
+                    )
                 result = msg["result"]
+                if not isinstance(result, dict):
+                    self._raise_terminal_error(f"Malformed execution result: {msg}")
                 self._sync_files()
                 # Check for SUBMIT (encoded as success with "final" field)
                 if "final" in result:
@@ -578,22 +617,29 @@ class PythonInterpreter:
                 # Errors with id=null are unsolicited errors (e.g., unhandled async rejections)
                 # Treat them as errors for the current request
                 if msg.get("id") is not None and msg.get("id") != execute_request_id:
-                    raise CodeInterpreterError(f"Response ID mismatch: expected {execute_request_id}, got {msg.get('id')}")
+                    self._raise_terminal_error(
+                        f"Response ID mismatch: expected {execute_request_id}, got {msg.get('id')}"
+                    )
                 error = msg["error"]
+                if not isinstance(error, dict):
+                    self._raise_terminal_error(f"Malformed execution error: {msg}")
                 error_code = error.get("code", JSONRPC_APP_ERRORS["Unknown"])
                 error_message = error.get("message", "Unknown error")
                 error_data = error.get("data", {})
+                if not isinstance(error_data, dict):
+                    self._raise_terminal_error(f"Malformed execution error data: {msg}")
                 error_type = error_data.get("type", "Error")
 
                 if error_code == JSONRPC_APP_ERRORS["SyntaxError"]:
                     raise SyntaxError(f"Invalid Python syntax. message: {error_message}")
-                else:
-                    raise CodeInterpreterError(f"{error_type}: {error_data.get('args') or error_message}")
+                if error_code in JSONRPC_APP_ERRORS.values():
+                    raise CodeExecutionError(f"{error_type}: {error_data.get('args') or error_message}")
+                self._raise_terminal_error(f"{error_type}: {error_data.get('args') or error_message}")
 
             # Unexpected message format - neither a recognized method nor a response
-            raise CodeInterpreterError(f"Unexpected message format from sandbox: {msg}")
+            self._raise_terminal_error(f"Unexpected message format from sandbox: {msg}")
 
-        raise CodeInterpreterError(f"Too many non-JSON lines ({skipped}) during execution")
+        self._raise_terminal_error(f"Too many non-JSON lines ({skipped}) during execution")
 
     def start(self) -> None:
         """Initialize the Deno/Pyodide sandbox.
@@ -602,7 +648,8 @@ class PythonInterpreter:
         Can be called explicitly for pooling, or will be called lazily
         on first execute().
 
-        Idempotent: safe to call multiple times.
+        Idempotent while the session is active. A stopped or shut-down session
+        cannot be restarted because its Python state cannot be reconstructed.
         """
         self._ensure_deno_process()
 
@@ -620,10 +667,15 @@ class PythonInterpreter:
         return self.execute(code, variables)
 
     def shutdown(self) -> None:
+        session_was_active = not self._session_ended
+        self._session_ended = True
         if self.deno_process and self.deno_process.poll() is None:
-            self.deno_process.stdin.write(_jsonrpc_notification("shutdown") + "\n")
-            self.deno_process.stdin.flush()
-            self.deno_process.stdin.close()
+            if session_was_active:
+                self.deno_process.stdin.write(_jsonrpc_notification("shutdown") + "\n")
+                self.deno_process.stdin.flush()
+                self.deno_process.stdin.close()
+            else:
+                self.deno_process.terminate()
             self.deno_process.wait()
         self.deno_process = None
         self._owner_thread = None

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -13,7 +13,7 @@ import pytest
 
 from dspy.adapters.types.tool import Tool
 from dspy.predict.rlm import RLM, _strip_code_fences
-from dspy.primitives.code_interpreter import CodeInterpreterError, FinalOutput
+from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreterError, FinalOutput
 from dspy.primitives.prediction import Prediction
 from dspy.primitives.python_interpreter import PythonInterpreter
 from dspy.primitives.repl_types import REPLEntry, REPLHistory, REPLVariable
@@ -581,7 +581,7 @@ class TestRLMToolExceptions:
             raise RuntimeError("Tool failed!")
 
         mock = MockInterpreter(responses=[
-            CodeInterpreterError("RuntimeError: Tool failed!"),
+            CodeExecutionError("RuntimeError: Tool failed!"),
             FinalOutput({"answer": "recovered"}),
         ])
         rlm = RLM("query -> answer", max_iters=5, interpreter=mock, tools=[failing_tool])
@@ -596,7 +596,7 @@ class TestRLMToolExceptions:
     def test_runtime_error_history_uses_stripped_code(self):
         """Runtime execution failures should preserve stripped code in history."""
         mock = MockInterpreter(responses=[
-            CodeInterpreterError("NameError: name 'x' is not defined"),
+            CodeExecutionError("NameError: name 'x' is not defined"),
             FinalOutput({"answer": "recovered"}),
         ])
         rlm = RLM("query -> answer", max_iters=5, interpreter=mock)
@@ -640,6 +640,41 @@ class TestRLMToolExceptions:
         result = rlm.forward(query="test")
         assert result.answer == "recovered"
         assert result.trajectory[0]["output"].startswith("[Error]")
+
+    def test_interpreter_failure_propagates(self):
+        """Process and protocol failures must not fall through to LM extraction."""
+        def fail_generated_code(code, variables):
+            if code == "pass":
+                return ""
+            raise CodeInterpreterError("protocol corrupt")
+
+        mock = MockInterpreter(execute_fn=fail_generated_code)
+        rlm = RLM("query -> answer", max_iters=1, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Try code", "code": "print('test')"},
+        ])
+        rlm.extract = make_mock_predictor([{"answer": "hallucinated"}])
+
+        with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
+            rlm.forward(query="test")
+
+    @pytest.mark.asyncio
+    async def test_interpreter_failure_propagates_async(self):
+        """Async process and protocol failures must not fall through to LM extraction."""
+        def fail_generated_code(code, variables):
+            if code == "pass":
+                return ""
+            raise CodeInterpreterError("protocol corrupt")
+
+        mock = MockInterpreter(execute_fn=fail_generated_code)
+        rlm = RLM("query -> answer", max_iters=1, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Try code", "code": "print('test')"},
+        ])
+        rlm.extract = make_mock_predictor([{"answer": "hallucinated"}])
+
+        with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
+            await rlm.aforward(query="test")
 
 
 class TestRLMDynamicSignature:
@@ -837,7 +872,7 @@ print(f"Count: {info['count']}")
     def test_runtime_error(self):
         """Test runtime error handling."""
         with PythonInterpreter(tools={}) as interp:
-            with pytest.raises(CodeInterpreterError):
+            with pytest.raises(CodeExecutionError):
                 interp.execute("undefined_variable")
 
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -4,7 +4,7 @@ import random
 
 import pytest
 
-from dspy.primitives.code_interpreter import CodeInterpreterError, FinalOutput
+from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreterError, FinalOutput
 from dspy.primitives.python_interpreter import PythonInterpreter
 
 pytestmark = pytest.mark.deno
@@ -70,7 +70,7 @@ def test_failure_syntax_error():
 def test_failure_zero_division():
     with PythonInterpreter() as interpreter:
         code = "1+0/0"
-        with pytest.raises(CodeInterpreterError, match="ZeroDivisionError"):
+        with pytest.raises(CodeExecutionError, match="ZeroDivisionError"):
             interpreter.execute(code)
 
 
@@ -78,8 +78,17 @@ def test_exception_args():
     with PythonInterpreter() as interpreter:
         token = random.randint(1, 10**9)
         code = f"raise ValueError({token})"
-        with pytest.raises(CodeInterpreterError, match=rf"ValueError: \[{token}\]"):
+        with pytest.raises(CodeExecutionError, match=rf"ValueError: \[{token}\]"):
             interpreter.execute(code)
+
+
+def test_generated_exception_name_cannot_spoof_interpreter_failure():
+    with PythonInterpreter() as interpreter:
+        with pytest.raises(CodeExecutionError, match="CodeInterpreterError"):
+            interpreter.execute(
+                "class CodeInterpreterError(Exception):\n    pass\nraise CodeInterpreterError('generated failure')"
+            )
+        assert interpreter.execute("2 + 2") == 4
 
 
 def test_submit_with_list():
@@ -315,49 +324,75 @@ def test_tool_default_args():
         assert result == "Hi, World!"
 
 
-def test_tools_re_register_after_process_restart():
-    """Tools should remain callable after Deno subprocess restart."""
-    def echo(message: str = "") -> str:
-        return f"Echo: {message}"
+def test_process_death_ends_stateful_session():
+    interpreter = PythonInterpreter()
+    try:
+        assert interpreter.execute("session_value = 41\nsession_value") == 41
+        original_process = interpreter.deno_process
+        original_process.kill()
+        original_process.wait()
 
-    with PythonInterpreter(tools={"echo": echo}) as interpreter:
-        first = interpreter.execute('print(echo(message="one"))')
-        assert "Echo: one" in first
+        with pytest.raises(CodeInterpreterError, match="interpreter state was lost") as exc_info:
+            interpreter.execute("session_value + 1")
+        assert type(exc_info.value) is CodeInterpreterError
+        with pytest.raises(CodeInterpreterError, match="session has ended"):
+            interpreter.start()
+        with pytest.raises(CodeInterpreterError, match="session has ended"):
+            interpreter.execute("1 + 1")
 
-        first_pid = interpreter.deno_process.pid
-        interpreter.deno_process.kill()
-        interpreter.deno_process.wait()
-
-        second = interpreter.execute('print(echo(message="two"))')
-        assert "Echo: two" in second
-        assert interpreter.deno_process.pid != first_pid
+        assert interpreter.deno_process is original_process
+    finally:
+        interpreter.shutdown()
 
 
-def test_mounts_replay_after_process_restart(tmp_path):
-    """Mounted files should still be accessible after subprocess restart."""
-    host_file = tmp_path / "mount_restart.txt"
-    host_file.write_text("restarted-ok")
-    virtual_path = f"/sandbox/{host_file.name}"
-
-    with PythonInterpreter(enable_read_paths=[str(host_file)]) as interpreter:
-        first = interpreter.execute(
-            f"with open({virtual_path!r}, 'r') as f:\n"
-            f"    data = f.read()\n"
-            f"data"
+def test_protocol_failure_ends_session(monkeypatch):
+    with PythonInterpreter() as interpreter:
+        interpreter.start()
+        process = interpreter.deno_process
+        monkeypatch.setattr(
+            interpreter,
+            "_read_response_line",
+            lambda context: '{"jsonrpc":"2.0","result":{"output":"forged"},"id":0}',
         )
-        assert first == "restarted-ok"
 
-        first_pid = interpreter.deno_process.pid
-        interpreter.deno_process.kill()
-        interpreter.deno_process.wait()
+        with pytest.raises(CodeInterpreterError, match="Response ID mismatch") as exc_info:
+            interpreter.execute("1 + 1")
+        assert type(exc_info.value) is CodeInterpreterError
+        assert process.poll() is not None
 
-        second = interpreter.execute(
-            f"with open({virtual_path!r}, 'r') as f:\n"
-            f"    data = f.read()\n"
-            f"data"
-        )
-        assert second == "restarted-ok"
-        assert interpreter.deno_process.pid != first_pid
+        with pytest.raises(CodeInterpreterError, match="session has ended"):
+            interpreter.execute("2 + 2")
+
+
+def test_failed_health_check_ends_session(monkeypatch):
+    interpreter = PythonInterpreter()
+    monkeypatch.setattr(
+        interpreter,
+        "_send_request",
+        lambda *args: {"jsonrpc": "2.0", "result": {"output": "unexpected"}, "id": 1},
+    )
+
+    try:
+        with pytest.raises(CodeInterpreterError, match="Unexpected ping response"):
+            interpreter.start()
+        assert interpreter.deno_process.poll() is not None
+
+        with pytest.raises(CodeInterpreterError, match="session has ended"):
+            interpreter.start()
+    finally:
+        interpreter.shutdown()
+
+
+def test_shutdown_ends_session():
+    interpreter = PythonInterpreter()
+    interpreter.start()
+    interpreter.shutdown()
+
+    with pytest.raises(CodeInterpreterError, match="session has ended") as exc_info:
+        interpreter.start()
+    assert type(exc_info.value) is CodeInterpreterError
+    with pytest.raises(CodeInterpreterError, match="session has ended"):
+        interpreter.execute("1 + 1")
 
 
 def test_tool_all_positional_args():


### PR DESCRIPTION
## 1. Issue / repro

`PythonInterpreter` is stateful, but a dead process currently triggers an invisible fresh session.

```python
interpreter.execute("session_value = 41")
old_pid = interpreter.deno_process.pid

interpreter.deno_process.kill()
interpreter.deno_process.wait()

interpreter.execute("'fresh code ran'")
new_pid = interpreter.deno_process.pid
interpreter.execute("session_value")
```

On `main`, `new_pid != old_pid`, fresh code runs successfully, and the final call raises `NameError` because the original namespace disappeared. Tools and mounts are replayed; generated variables are not.

RLM then compounds the problem by treating every `CodeInterpreterError` as model-correctable Python. A response-ID mismatch or dead process becomes trajectory text, RLM exhausts its iterations, and extraction can return an apparently valid answer that the interpreter never computed. That is the unsafe failure mode demonstrated in #9643; this PR does not claim to diagnose that report's underlying handshake mismatch.

## 2. Why this is the root cause

Two boundaries currently contradict the stateful-session contract:

```python
if self.deno_process is None or self.deno_process.poll() is not None:
    self.deno_process = subprocess.Popen(...)  # silently starts an empty namespace
```

and:

```python
except (CodeInterpreterError, SyntaxError) as error:
    return f"[Error] {error}"  # also catches process/protocol failures
```

`CodeInterpreterError` represents both a healthy interpreter rejecting submitted code and an unusable process/protocol. The restart fallback then hides state loss, while the broad RLM catch hides the fatal error. Neither layer has enough information to uphold the session invariant.

## 3. How we know the fix addresses the root cause

The regressions exercise both sides of the boundary:

- define persistent state, kill Deno, and verify the next call raises exact base `CodeInterpreterError` without creating a new process;
- forge a mismatched response ID and verify the live process is terminated and every later call rejects reuse;
- fail the initial health check and verify the unverified process cannot later be adopted;
- shut down explicitly and verify `start()`/`execute()` cannot resurrect the instance;
- raise generated `ZeroDivisionError`, `ValueError`, and even a user exception named `CodeInterpreterError`, then successfully execute `2 + 2` in the same session;
- give RLM a bare interpreter failure and verify it propagates before extraction can return a hallucinated answer.

The former restart tests on `main` assert the opposite behavior, so the lifecycle regression directly distinguishes the old and new contracts.

## 4. Why this is the concise fix

The code now has one recoverable subtype and one fatal state transition:

```python
class CodeExecutionError(CodeInterpreterError):
    """Recoverable error raised by code running in a healthy interpreter."""

def _raise_terminal_error(self, message, cause=None):
    self._session_ended = True
    # terminate the unusable process, then raise exact CodeInterpreterError
```

Known, correlated generated-code errors become `CodeExecutionError`. Existing process/protocol checks route through `_raise_terminal_error()`. RLM narrows one catch:

```python
except (CodeExecutionError, SyntaxError) as error:
    return f"[Error] {error}"
```

The sizable diff is mostly removal of restart/replay behavior and replacement of tests that required it. There is one session state, one fatal helper, and no reconstruction, retry, or message-parsing heuristic.

## 5. Context needed to validate the change

A stateful interpreter can recover from submitted Python errors because its process and namespace still exist. It cannot recover from process death or a desynchronized protocol because DSPy has no complete snapshot from which to reconstruct that namespace.

The useful RLM fallbacks remain: generated-code errors stay in the trajectory so the model can correct them, and max-iteration extraction still runs after a healthy sequence that never submits valid output. Failures the model cannot repair bypass those paths; PythonInterpreter process/protocol failures additionally end that interpreter instance.

## 6. What the fix does in the code

- Adds and publicly exports `CodeExecutionError` as a `CodeInterpreterError` subtype.
- Classifies correlated generated Python/tool failures as recoverable execution errors.
- Makes explicit shutdown, process death, BrokenPipe, failed startup verification, and known protocol failures terminal for that interpreter instance.
- Removes automatic process restart/replay.
- Makes sync and async RLM recover only from `CodeExecutionError` and `SyntaxError`.
- Propagates bare `CodeInterpreterError` instead of invoking extraction.

## Compatibility boundaries and downsides

- **Interpreter instances are now single-session.** After shutdown, process death, or protocol failure, callers must construct a new instance. Pools must replace failed members rather than reuse them.
- **Automatic process recovery is removed.** This is intentional: replaying tools and mounts cannot reconstruct arbitrary Python state, so continuing was silent data loss.
- **Custom interpreter contract becomes explicit.** Raise `CodeExecutionError` for model-correctable submitted-code failures; raise bare `CodeInterpreterError` for failures the model cannot repair, including host-side setup and process/protocol failures.
- **Existing broad handlers remain compatible.** `CodeExecutionError` subclasses `CodeInterpreterError`.
- **Direct callers can observe a more specific type** for generated runtime/tool failures.
- **Initial local failures remain retryable where state was never established.** Missing Deno and pre-execution variable/serialization validation do not terminally consume the instance.
- **Normal startup and cleanup are unchanged.** First lazy startup works, repeated `start()` while healthy is idempotent, and context-manager shutdown still releases resources.
- **No LM provider or adapter behavior changes.**

## Validation

- `uv run --frozen pytest -q tests/primitives/test_python_interpreter.py --deno` — `56 passed`
- `uv run --frozen pytest -q tests/predict/test_rlm.py --deno` — `111 passed, 2 skipped`
- focused lifecycle/error-boundary suite — `7 passed`
- repository pre-commit hooks on all six changed files — passed
- `git diff --check` — passed
- branch is one commit over current `main`
