### PR TITLE
fix(rlm): honor truncation limits

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -164,6 +164,8 @@ class RLM(Module):
         """
         super().__init__()
         _validate_interpreter_factory(interpreter_factory)
+        if max_output_chars <= 0:
+            raise ValueError("max_output_chars must be greater than 0")
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
         self.max_llm_calls = max_llm_calls

--- a/dspy/primitives/repl_types.py
+++ b/dspy/primitives/repl_types.py
@@ -51,6 +51,9 @@ class REPLVariable(pydantic.BaseModel):
             field_info: Optional pydantic FieldInfo with desc/constraints metadata
             preview_chars: Max characters for preview
         """
+        if preview_chars <= 0:
+            raise ValueError("preview_chars must be greater than 0")
+
         jsonable = serialize_for_json(value)
         if isinstance(jsonable, (dict, list)):
             value_str = json.dumps(jsonable, indent=2)
@@ -58,8 +61,9 @@ class REPLVariable(pydantic.BaseModel):
             value_str = str(jsonable)
         is_truncated = len(value_str) > preview_chars
         if is_truncated:
-            half = preview_chars // 2
-            preview = value_str[:half] + "..." + value_str[-half:]
+            head_chars = preview_chars // 2
+            tail_chars = preview_chars - head_chars
+            preview = value_str[:head_chars] + "..." + value_str[-tail_chars:]
         else:
             preview = value_str
 
@@ -111,11 +115,15 @@ class REPLEntry(pydantic.BaseModel):
     @staticmethod
     def format_output(output: str, max_output_chars: int = 10_000) -> str:
         """Format output with head+tail truncation, preserving true length in header."""
+        if max_output_chars <= 0:
+            raise ValueError("max_output_chars must be greater than 0")
+
         raw_len = len(output)
         if raw_len > max_output_chars:
-            half = max_output_chars // 2
+            head_chars = max_output_chars // 2
+            tail_chars = max_output_chars - head_chars
             omitted = raw_len - max_output_chars
-            output = output[:half] + f"\n\n... ({omitted:,} characters omitted) ...\n\n" + output[-half:]
+            output = output[:head_chars] + f"\n\n... ({omitted:,} characters omitted) ...\n\n" + output[-tail_chars:]
         return f"Output ({raw_len:,} chars):\n{output}"
 
     def format(self, index: int, max_output_chars: int = 10_000) -> str:

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -133,6 +133,11 @@ class TestRLMInitialization:
         assert "query" in rlm.signature.input_fields
         assert "answer" in rlm.signature.output_fields
 
+    @pytest.mark.parametrize("max_output_chars", [0, -1])
+    def test_rejects_non_positive_output_limit(self, max_output_chars):
+        with pytest.raises(ValueError, match="max_output_chars must be greater than 0"):
+            RLM("context -> answer", max_output_chars=max_output_chars)
+
     def test_custom_signature(self):
         """Test RLM with custom signature."""
         rlm = RLM("document, question -> summary, key_facts", max_iters=5)
@@ -547,6 +552,20 @@ class TestREPLTypes:
         # True original length shown in header
         assert "200 chars" in formatted
 
+    @pytest.mark.parametrize(
+        ("limit", "head", "tail"),
+        [(1, "", "f"), (5, "ab", "def")],
+    )
+    def test_repl_entry_truncation_preserves_exact_odd_limit(self, limit, head, tail):
+        formatted = REPLEntry.format_output("abcdef", max_output_chars=limit)
+
+        assert formatted == f"Output (6 chars):\n{head}\n\n... ({6 - limit} characters omitted) ...\n\n{tail}"
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_repl_entry_rejects_non_positive_limit(self, limit):
+        with pytest.raises(ValueError, match="max_output_chars must be greater than 0"):
+            REPLEntry.format_output("abcdef", max_output_chars=limit)
+
     def test_repl_entry_format_no_truncation(self):
         """Test REPLEntry.format() passes short output through without truncation."""
         output = "a" * 50
@@ -578,6 +597,20 @@ class TestREPLTypes:
         assert var.preview.startswith("a" * 25)
         assert var.preview.endswith("b" * 25)
         assert "..." in var.preview
+
+    @pytest.mark.parametrize(
+        ("limit", "expected"),
+        [(1, "...f"), (5, "ab...def")],
+    )
+    def test_repl_variable_truncation_preserves_exact_odd_limit(self, limit, expected):
+        var = REPLVariable.from_value("value", "abcdef", preview_chars=limit)
+
+        assert var.preview == expected
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_repl_variable_rejects_non_positive_limit(self, limit):
+        with pytest.raises(ValueError, match="preview_chars must be greater than 0"):
+            REPLVariable.from_value("value", "abcdef", preview_chars=limit)
 
     def test_repl_variable_with_field_info(self):
         """Test REPLVariable includes desc and constraints from field_info."""


### PR DESCRIPTION
> **Review guide:** one commit, three files. The behavior change is two arithmetic corrections at the existing truncation sites plus explicit guards for the previously undefined non-positive limit case.

## 1. Issue / repro

Both RLM truncation paths promise a source-character limit but violate it when the limit is odd.

```python
REPLVariable.from_value("value", "abcdef", preview_chars=1).preview
REPLEntry.format_output("abcdef", max_output_chars=1)
```

On `main`, both retain all six source characters:

```text
...abcdef

Output (6 chars):

... (5 characters omitted) ...

abcdef
```

The formatted output is internally contradictory: it says five characters were omitted while displaying all six.

Non-positive limits expose the same undefined boundary. `0` currently leaks the complete value because Python treats `-0` as `0`; negative limits duplicate overlapping slices. An RLM “maximum” that retains more source text than requested is not enforcing a limit.

## 2. Why this is the root cause

Both implementations floor-divide the limit and reuse that count for both slices:

```python
half = limit // 2
head = value[:half]
tail = value[-half:]
```

For a positive odd limit, this retains `limit - 1` source characters. At limit `1`, `half == 0`, and `value[-0:]` is the complete string. That exact slicing edge explains the full-value leak.

For `limit <= 0`, there is no coherent head/tail split. The public contract is therefore made explicit: truncation limits must be positive.

## 3. How we know the fix addresses the root cause

Regressions cover both truncation sites and both boundaries:

- limit `1`: retain exactly the final character, never the complete value;
- limit `5`: retain two head characters and three tail characters;
- limits `0` and `-1`: raise a precise `ValueError`;
- `RLM(max_output_chars=...)`: rejects the invalid configuration at construction, before an interpreter or LM call starts.

The positive-limit assertions count the retained source characters directly, so the test cannot pass by merely changing a marker or omission message.

## 4. Why this is the concise fix

The positive configured limit is divided once and its remainder goes to the tail:

```python
head_chars = limit // 2
tail_chars = limit - head_chars
```

Those counts always sum to the configured limit. The invalid boundary is one explicit guard at each callable API:

```python
if limit <= 0:
    raise ValueError("... must be greater than 0")
```

There is no helper abstraction, special-case slice, alternate marker, fallback output, or prompt rewrite.

## 5. Context needed to validate the change

The limit counts retained source characters; the existing `...` marker or omission message is additional formatting. RLM deliberately keeps both the beginning and end of long values. Assigning the odd remainder to the tail retains one extra trailing character, where final results and exception details commonly appear.

`max_output_chars` is constructor configuration, so invalid values fail there immediately. The primitive methods retain their own guards because they are public/tested formatting boundaries and can be called independently of RLM.

## 6. What the fix does in the code

- Makes the retained source-character count equal every positive odd limit.
- Rejects zero and negative preview/output limits explicitly.
- Rejects invalid `RLM(max_output_chars=...)` configuration before execution.
- Adds exact limit-`1`, limit-`5`, zero, and negative regressions for both truncation paths.

## Compatibility boundaries and downsides

- **Even positive limits are byte-for-byte unchanged**, including the defaults (`1,000` and `10,000`).
- **Positive odd limits intentionally retain one additional trailing character.** Snapshots for custom odd limits will change.
- **Limit `1` stops exposing the full value/output.** This is the security/correctness edge fixed by the PR.
- **Zero and negative limits now raise `ValueError`.** They previously returned nonsensical, over-limit output; callers using them must choose a positive bound.
- **The truncation marker is not included in the source-character budget.** That existing convention is unchanged.
- **No provider, adapter, interpreter lifecycle, tool, error-recovery, or fallback behavior changes.**
- **Adjacent open work:** #9801 edits `REPLEntry.format_output` for nested Markdown fences. The concerns are independent, but whichever lands second will need a small semantic rebase.

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — `131 passed, 2 skipped`
- repository pre-commit hooks on all three changed files — passed
- `git diff --check` — passed
- branch is one commit over current `main`
