### PR TITLE
fix(rlm): protect RLM-owned namespaces

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -14,6 +14,7 @@ import base64
 import contextvars
 import functools
 import inspect
+import keyword
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -172,7 +173,7 @@ class RLM(Module):
         self.sub_lm = sub_lm
         self._interpreter_factory = interpreter_factory
         self._user_tools = self._normalize_tools(tools)
-        self._validate_tools(self._user_tools)
+        self._validate_namespace(self._user_tools)
 
         # Build the action and extract signatures
         action_sig, extract_sig = self._build_signatures()
@@ -183,8 +184,9 @@ class RLM(Module):
     # Tool Creation and Validation
     # =========================================================================
 
-    # Reserved tool names that conflict with built-in sandbox functions
-    _RESERVED_TOOL_NAMES = frozenset({"llm_query", "llm_query_batched", "SUBMIT", "print"})
+    # Names owned by RLM rather than the user-provided signature or tools.
+    _RESERVED_SANDBOX_NAMES = frozenset({"llm_query", "llm_query_batched", "SUBMIT", "print"})
+    _RESERVED_RESULT_NAMES = frozenset({"trajectory", "final_reasoning"})
 
     def _normalize_tools(self, tools: list[Callable] | None) -> dict[str, Tool]:
         """Normalize tools list to a dict of Tool objects keyed by name."""
@@ -205,17 +207,34 @@ class RLM(Module):
                 raise TypeError(f"Tool {func!r} must be callable, got {type(func).__name__}")
             return Tool(func)
 
-        # List of callables/Tools -> normalize to Tool objects
-        tool_list = [to_tool(t) for t in tools]
-        return {tool.name: tool for tool in tool_list}
+        normalized = {}
+        for value in tools:
+            tool = to_tool(value)
+            if tool.name in normalized:
+                raise ValueError(f"Duplicate tool name '{tool.name}'")
+            normalized[tool.name] = tool
+        return normalized
 
-    def _validate_tools(self, tools: dict[str, Tool]) -> None:
-        """Validate user-provided tools have valid names."""
+    def _validate_namespace(self, tools: dict[str, Tool]) -> None:
+        """Validate names owned by the RLM result and sandbox APIs."""
         for name in tools:
-            if not name.isidentifier():
-                raise ValueError(f"Invalid tool name '{name}': must be a valid Python identifier")
-            if name in self._RESERVED_TOOL_NAMES:
+            if not name.isidentifier() or keyword.iskeyword(name):
+                raise ValueError(f"Invalid tool name '{name}': must be a valid Python identifier and not a keyword")
+            if name in self._RESERVED_SANDBOX_NAMES:
                 raise ValueError(f"Tool name '{name}' conflicts with built-in sandbox function")
+
+        input_names = set(self.signature.input_fields)
+        reserved_inputs = sorted(input_names & self._RESERVED_SANDBOX_NAMES)
+        if reserved_inputs:
+            raise ValueError(f"Input fields conflict with built-in sandbox functions: {reserved_inputs}")
+
+        tool_inputs = sorted(input_names & tools.keys())
+        if tool_inputs:
+            raise ValueError(f"Input fields conflict with user tools: {tool_inputs}")
+
+        reserved_outputs = sorted(set(self.signature.output_fields) & self._RESERVED_RESULT_NAMES)
+        if reserved_outputs:
+            raise ValueError(f"Output fields conflict with RLM result metadata: {reserved_outputs}")
 
     def _format_tool_docs(self, tools: dict[str, Tool]) -> str:
         """Format user-provided tools for inclusion in instructions."""
@@ -398,12 +417,17 @@ class RLM(Module):
         return output
 
     def _validate_inputs(self, input_args: dict[str, Any]) -> None:
-        """Raise ValueError if required input fields are missing."""
+        """Validate call-time arguments against the signature's input namespace."""
         if "interpreter" in input_args and "interpreter" not in self.signature.input_fields:
             raise TypeError(
                 "To use a caller-owned interpreter, pass it as the first positional argument when calling the module."
             )
-        missing = set(self.signature.input_fields.keys()) - set(input_args.keys())
+        input_names = set(self.signature.input_fields)
+        unexpected = set(input_args) - input_names
+        if unexpected:
+            raise ValueError(f"Unexpected inputs not declared in the signature: {sorted(unexpected)}")
+
+        missing = input_names - set(input_args)
         if missing:
             raise ValueError(f"Missing required inputs: {sorted(missing)}")
 

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -160,7 +160,15 @@ class TestRLMInitialization:
         with pytest.raises(ValueError, match="must be a valid Python identifier"):
             RLM("context -> answer", tools=[tool])
 
-    @pytest.mark.parametrize("tool_name", ["llm_query", "SUBMIT", "print"])
+    def test_tool_validation_rejects_python_keyword(self):
+        def my_tool() -> str:
+            return "result"
+
+        tool = Tool(my_tool, name="for")
+        with pytest.raises(ValueError, match="not a keyword"):
+            RLM("context -> answer", tools=[tool])
+
+    @pytest.mark.parametrize("tool_name", ["llm_query", "llm_query_batched", "SUBMIT", "print"])
     def test_tool_validation_reserved_names(self, tool_name):
         """Test RLM rejects tool names that conflict with built-in functions."""
         def my_tool() -> str:
@@ -183,6 +191,33 @@ class TestRLMInitialization:
 
         with pytest.raises(TypeError, match="tools must be a list, not a dict"):
             RLM("context -> answer", tools={"my_tool": my_tool})
+
+    def test_duplicate_tool_names_rejected(self):
+        def first() -> str:
+            return "first"
+
+        def second() -> str:
+            return "second"
+
+        with pytest.raises(ValueError, match="Duplicate tool name 'lookup'"):
+            RLM("context -> answer", tools=[Tool(first, name="lookup"), Tool(second, name="lookup")])
+
+    @pytest.mark.parametrize("input_name", ["llm_query", "llm_query_batched", "SUBMIT", "print"])
+    def test_input_names_cannot_shadow_sandbox_functions(self, input_name):
+        with pytest.raises(ValueError, match="Input fields conflict with built-in sandbox functions"):
+            RLM(f"{input_name} -> answer")
+
+    def test_input_name_cannot_shadow_user_tool(self):
+        def lookup() -> str:
+            return "result"
+
+        with pytest.raises(ValueError, match="Input fields conflict with user tools: \\['lookup'\\]"):
+            RLM("lookup -> answer", tools=[lookup])
+
+    @pytest.mark.parametrize("output_name", ["trajectory", "final_reasoning"])
+    def test_output_names_cannot_shadow_result_metadata(self, output_name):
+        with pytest.raises(ValueError, match=f"Output fields conflict with RLM result metadata: \\['{output_name}'\\]"):
+            RLM(f"context -> {output_name}")
 
     def test_optional_parameters(self):
         """Test RLM optional parameters and their defaults."""
@@ -276,6 +311,21 @@ class TestRLMInitialization:
 
         with pytest.raises(TypeError, match="Sub-LM response must contain text, got NoneType"):
             tools["llm_query"]("test prompt")
+    @pytest.mark.parametrize("unexpected_name", ["SUBMIT", "lookup", "tools"])
+    def test_forward_rejects_undeclared_inputs_before_interpreter_execution(self, unexpected_name):
+        def lookup() -> str:
+            return "tool result"
+
+        factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "done"})])
+        rlm = RLM("context -> answer", tools=[lookup], interpreter_factory=factory)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+        ])
+
+        with pytest.raises(ValueError, match=f"Unexpected inputs not declared in the signature: \\['{unexpected_name}'\\]"):
+            rlm(context="some context", **{unexpected_name: "shadowed value"})
+
+        assert factory.instances == []
 
     def test_batched_query_errors_have_clear_markers(self):
         """Test that errors in llm_query_batched are prefixed with [ERROR]."""
@@ -1065,6 +1115,19 @@ print(json.dumps(data))
 
 class TestRLMAsyncMock:
     """Unit tests for RLM aforward() using MockInterpreter (no Deno required)."""
+
+    @pytest.mark.asyncio
+    async def test_aforward_rejects_undeclared_inputs_before_interpreter_execution(self):
+        factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "done"})])
+        rlm = RLM("context -> answer", interpreter_factory=factory)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+        ])
+
+        with pytest.raises(ValueError, match="Unexpected inputs not declared in the signature: \\['SUBMIT'\\]"):
+            await rlm.acall(context="some context", SUBMIT="shadowed value")
+
+        assert factory.instances == []
 
     @pytest.mark.asyncio
     async def test_aforward_basic(self):


### PR DESCRIPTION
> **Scope:** one commit, two files. This PR owns only RLM namespace validation. Signature-default binding has been restored to a separate child PR.

## 1. Issue / repro

RLM combines signature inputs, user tools, built-in helpers, and returned metadata, but currently accepts names that it will later overwrite or silently discard.

```python
# The second tool silently replaces the first during dict construction.
RLM("context -> answer", tools=[
    Tool(first, name="lookup"),
    Tool(second, name="lookup"),
])

# Undeclared kwargs enter the sandbox and can shadow owned bindings.
rlm(context="x", lookup="not the lookup tool")
rlm(context="x", SUBMIT="not the submit helper")

# RLM later tries to add its own trajectory field to the Prediction.
RLM("context -> trajectory")
```

Call-time `tools=` has the same problem: it is currently treated as an ordinary undeclared input, not as an explicit tool-registration API.

## 2. Why this is the root cause

Names are validated independently and after information has already been lost:

```python
# Duplicate names are destroyed here before validation can observe them.
return {tool.name: tool for tool in tool_list}

# Only missing inputs are checked; extra keys flow into the interpreter.
missing = set(self.signature.input_fields) - set(input_args)
```

These are not interpreter-precedence bugs. RLM creates the combined sandbox and result namespaces, so it must reject configurations with two meanings for one name before starting an interpreter.

## 3. How we know the fix targets the root cause

Tests exercise every ownership boundary directly:

- duplicate, keyword, and reserved tool names fail during construction;
- input/helper and input/tool collisions fail during construction;
- reserved result names fail during construction;
- undeclared sync and async call inputs fail before an interpreter is created;
- valid tools and declared inputs continue through the existing execution path.

The failure timing is part of the contract: invalid constructor configuration fails in `__init__`, while invalid call inputs fail before interpreter creation.

## 4. Why this is the concise fix

Tool normalization becomes an explicit loop so duplicates remain observable. One `_validate_namespace()` compares the sets owned at construction. `_validate_inputs()` adds one unexpected-key check at the call boundary.

There is no renaming scheme, precedence table, alias system, fallback path, or sandbox-specific repair. Ambiguous programs fail where the ambiguity is introduced.

## 5. Context needed to validate the change

| Boundary | Names that must remain unique |
|---|---|
| Sandbox bindings | declared inputs, user tools, `llm_query`, `llm_query_batched`, `SUBMIT`, `print` |
| Returned `Prediction` | declared outputs, `trajectory`, `final_reasoning` |

Tool names and output names do **not** share a binding namespace, so this remains valid:

```python
result = lookup(...)
SUBMIT(lookup=result)
```

The tool is a callable sandbox binding; the same-named output is only a keyword accepted by `SUBMIT`.

## 6. What the fix does

- Preserves duplicate tool names long enough to reject them.
- Rejects Python keywords and RLM-reserved tool names.
- Rejects declared input collisions with helpers or tools.
- Rejects undeclared sync and async call inputs before interpreter startup.
- Reserves `trajectory` and `final_reasoning` for RLM result metadata.

## Compatibility boundaries and downsides

- **Undeclared kwargs now raise `ValueError`.** Callers using them as an undocumented REPL-variable injection path must declare them in the signature.
- **Call-time `tools=` is not tool registration.** It is rejected when undeclared; tools remain constructor configuration.
- **Duplicate tools no longer use last-write-wins.** Give them distinct names.
- **Conflicting signatures fail earlier.** Inputs that reuse helper/tool names and outputs named `trajectory` or `final_reasoning` must be renamed.
- **Tool/output overlap remains valid.** Outputs are `SUBMIT` keywords, not sandbox bindings.
- **No signature-default, provider, adapter, tool-execution, interpreter-lifecycle, output-coercion, or serialization behavior changes.**

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — `141 passed, 2 skipped`
- repository pre-commit hooks on both changed files — passed
- `git diff --check` — passed
- one commit over current `main`
