### PR TITLE
fix(interpreter): report file synchronization failures

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -266,9 +266,11 @@ class PythonInterpreter:
         for path in self.enable_write_paths:
             virtual_path = f"/sandbox/{os.path.basename(str(path))}"
             host_path = _canonicalize_path(path)
-            sync_msg = _jsonrpc_notification("sync_file", {"virtual_path": virtual_path, "host_path": host_path})
-            self.deno_process.stdin.write(sync_msg + "\n")
-            self.deno_process.stdin.flush()
+            self._send_request(
+                "sync_file",
+                {"virtual_path": virtual_path, "host_path": host_path},
+                f"syncing {path}",
+            )
 
     def _extract_parameters(self, fn: Callable) -> list[dict]:
         """Extract parameter info from a callable for sandbox registration."""

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -244,16 +244,19 @@ while (true) {
   const requestId = input.id; // May be undefined for notifications
 
   // Handle notifications (no response expected)
+  if (method === "shutdown") break;
+
   if (method === "sync_file") {
+    const virtualPath = params.virtual_path;
+    const hostPath = params.host_path || virtualPath;
     try {
-      const virtualPath = params.virtual_path;
-      const hostPath = params.host_path || virtualPath;
       await Deno.writeFile(hostPath, pyodide.FS.readFile(virtualPath));
-    } catch (e) { /* ignore sync errors */ }
+      console.log(jsonrpcResult({ synced: virtualPath }, requestId));
+    } catch (e) {
+      console.log(jsonrpcError(JSONRPC_APP_ERRORS.RuntimeError, `Failed to sync file: ${e.message}`, requestId));
+    }
     continue;
   }
-
-  if (method === "shutdown") break;
 
   // Handle requests (expect response)
   if (method === "mount_file") {

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -181,6 +181,18 @@ def test_enable_write_flag(tmp_path):
         assert f.read() == "original_content", "File should not be changed when sync_files is False"
 
 
+def test_sync_failure_is_reported(tmp_path):
+    testfile_path = tmp_path / "sync_failure.txt"
+    testfile_path.write_text("original_content")
+    virtual_path = f"/sandbox/{testfile_path.name}"
+
+    with PythonInterpreter(enable_write_paths=[testfile_path]) as interpreter:
+        with pytest.raises(CodeInterpreterError, match="Failed to sync file"):
+            interpreter.execute(f"import os\nos.remove({virtual_path!r})")
+
+    assert testfile_path.read_text() == "original_content"
+
+
 def test_enable_net_flag():
     test_url = "https://example.com"
 


### PR DESCRIPTION
> **Stack:** this PR is based on [#10018](https://github.com/stanfordnlp/dspy/pull/10018) (`fix(rlm): fail closed on interpreter failures`). Its own diff is one commit and three files.

## 1. Issue / repro

PythonInterpreter can report successful execution even when it fails to copy a sandbox file back to the host.

```python
path.write_text("original_content")

with PythonInterpreter(enable_write_paths=[path]) as interpreter:
    result = interpreter.execute(
        "import os\nos.remove('/sandbox/sync_failure.txt')"
    )
```

On `main`, this returns an empty successful result while the host file still contains `original_content`. The sandbox mutation could not be synchronized, but the caller has no way to know.

## 2. Why this is the root cause

Execution results are acknowledged JSON-RPC requests, but file synchronization is a fire-and-forget notification:

```python
sync_msg = _jsonrpc_notification("sync_file", ...)
stdin.write(sync_msg)
```

The runner then explicitly discards failures:

```javascript
try {
  await Deno.writeFile(...);
} catch (error) { /* ignore sync errors */ }
```

Python returns the execution result before learning whether the requested persistent side effect succeeded.

## 3. How we know the fix addresses the root cause

The regression mounts a real temporary file, deletes its virtual sandbox copy, and then lets normal post-execution synchronization run.

Untouched `main` at `24ec85de4` prints:

```text
''
original_content
```

This branch raises `CodeInterpreterError` containing `Failed to sync file`, and the assertion confirms that the original host file remains unchanged.

The full PythonInterpreter suite passes through the real Deno/Pyodide runner after the protocol change.

## 4. Why this is the concise fix

The existing request helper already writes a JSON-RPC request, waits for the matching response, validates its ID, and raises on an error response. File sync now uses that boundary:

```python
self._send_request("sync_file", params, f"syncing {path}")
```

The runner returns one matching success or error response. There is no retry, polling loop, filesystem fallback, or second synchronization protocol.

## 5. Context needed to validate the change

For each configured write path, PythonInterpreter:

1. mounts the host file into Pyodide;
2. executes submitted Python;
3. copies the virtual file back to the host when `sync_files=True`.

Step 3 is part of the observable result of `execute()`. A successful Python expression is not a successful interpreter operation when its requested host-side file changes were lost.

The parent PR matters to RLM specifically: once sync failure becomes a bare `CodeInterpreterError`, #10018 ensures RLM propagates it rather than treating it as model-correctable Python.

## 6. What the fix does in the code

- Sends each `sync_file` operation as an acknowledged JSON-RPC request.
- Returns `{synced: virtualPath}` after a successful write.
- Returns a structured JSON-RPC error when the virtual file cannot be read or the host file cannot be written.
- Adds a real-runner regression for a missing virtual file.

## Compatibility boundaries and downsides

- **Intentional behavior change:** a failed sync now raises instead of returning false success.
- **One round trip per write path:** `execute()` now waits for each file's acknowledgment. This adds small synchronization latency in exchange for knowing whether persistence succeeded.
- **Custom runners:** a custom `deno_command` implementing DSPy's runner protocol must respond to `sync_file` requests. The bundled runner is updated in the same commit.
- **`sync_files=False` is unchanged:** no synchronization request is sent.
- **Successful file writes are unchanged:** content and mount paths are the same.
- **Multiple-file sync remains sequential, not atomic:** if a later file fails, earlier files may already have synchronized. Transactional file updates are outside this PR.
- **No provider, tool, RLM prompt, or fallback change.**

## Validation

- `uv run --frozen pytest -q tests/primitives/test_python_interpreter.py --deno` on the stacked branch — `55 passed`
- focused missing-virtual-file regression — passed
- repository pre-commit hooks on all three changed files — passed
- direct repro against untouched `main` — returns `''` and leaves `original_content`; this branch raises
