### PR TITLE
fix(rlm): normalize sub-LM responses

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -256,14 +256,24 @@ class RLM(Module):
         def _query_lm(prompt: str) -> str:
             target_lm = lm if lm is not None else dspy.settings.lm
             if target_lm is None:
-                raise RuntimeError("No LM configured. Use dspy.configure(lm=...) or pass sub_lm to RLM.")
+                raise dspy.LMNotConfiguredError(
+                    "No LM configured. Use dspy.configure(lm=...) or pass sub_lm to RLM."
+                )
             response = target_lm(prompt)
-            if isinstance(response, list) and response:
-                item = response[0]
-                if isinstance(item, dict) and "text" in item:
-                    return item["text"]
-                return item
-            return str(response)
+            if isinstance(response, dspy.LMResponse):
+                text = response.text
+            elif isinstance(response, list) and response:
+                first_output = response[0]
+                text = first_output.get("text") if isinstance(first_output, dict) else first_output
+            else:
+                raise TypeError(
+                    "Sub-LM must return dspy.LMResponse or a non-empty list of text outputs, "
+                    f"got {type(response).__name__}."
+                )
+
+            if not isinstance(text, str):
+                raise TypeError(f"Sub-LM response must contain text, got {type(text).__name__}.")
+            return text
 
         def llm_query(prompt: str) -> str:
             """Query the LLM with a prompt string."""
@@ -273,7 +283,7 @@ class RLM(Module):
             return _query_lm(prompt)
 
         def llm_query_batched(prompts: list[str]) -> list[str]:
-            """Query the LLM with multiple prompts concurrently."""
+            """Query prompts concurrently, isolating LM failures while propagating contract errors."""
             if not prompts:
                 return []
             _check_and_increment(len(prompts))
@@ -288,7 +298,7 @@ class RLM(Module):
                     idx = future_to_idx[future]
                     try:
                         results[idx] = future.result()
-                    except Exception as e:
+                    except dspy.LMError as e:
                         results[idx] = f"[ERROR] {e}"
             return [results[i] for i in range(len(prompts))]
 

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -240,12 +240,51 @@ class TestRLMInitialization:
         with pytest.raises(TypeError, match="first positional argument"):
             rlm(query="test", interpreter=MockInterpreter())
 
+    def test_llm_query_returns_legacy_response_text(self):
+        from dspy.utils.dummies import DummyLM
+
+        tools = RLM("context -> answer", sub_lm=DummyLM([{"answer": "legacy answer"}]))._make_llm_tools()
+
+        assert tools["llm_query"]("test prompt") == "[[ ## answer ## ]]\nlegacy answer"
+
+    def test_llm_query_returns_typed_response_text(self):
+        import dspy
+        from dspy.utils.dummies import DummyLM
+
+        tools = RLM("context -> answer", sub_lm=DummyLM([{"answer": "typed answer"}]))._make_llm_tools()
+
+        with dspy.context(experimental=True):
+            result = tools["llm_query"]("test prompt")
+
+        assert result == "[[ ## answer ## ]]\ntyped answer"
+
+    def test_llm_query_rejects_unsupported_response_shape(self):
+        from unittest.mock import MagicMock
+
+        tools = RLM("context -> answer", sub_lm=MagicMock(return_value="untyped response"))._make_llm_tools()
+
+        with pytest.raises(TypeError, match="Sub-LM must return dspy.LMResponse or a non-empty list"):
+            tools["llm_query"]("test prompt")
+
+    def test_llm_query_reports_textless_response_type(self):
+        from unittest.mock import MagicMock
+
+        tools = RLM(
+            "context -> answer",
+            sub_lm=MagicMock(return_value=[{"tool_calls": []}]),
+        )._make_llm_tools()
+
+        with pytest.raises(TypeError, match="Sub-LM response must contain text, got NoneType"):
+            tools["llm_query"]("test prompt")
+
     def test_batched_query_errors_have_clear_markers(self):
         """Test that errors in llm_query_batched are prefixed with [ERROR]."""
         from unittest.mock import MagicMock
 
+        import dspy
+
         mock_lm = MagicMock()
-        mock_lm.side_effect = RuntimeError("LM failed")
+        mock_lm.side_effect = dspy.LMTransportError("LM failed")
 
         rlm = RLM("context -> answer", max_llm_calls=10, sub_lm=mock_lm)
         tools = rlm._make_llm_tools()
@@ -254,6 +293,25 @@ class TestRLMInitialization:
         assert len(results) == 1
         assert results[0].startswith("[ERROR]")
         assert "LM failed" in results[0]
+
+    def test_batched_query_marks_missing_lm_configuration(self):
+        import dspy
+
+        with dspy.context(lm=None):
+            tools = RLM("context -> answer")._make_llm_tools()
+            results = tools["llm_query_batched"](["test prompt"])
+
+        assert results == ["[ERROR] No LM configured. Use dspy.configure(lm=...) or pass sub_lm to RLM."]
+
+    def test_batched_query_propagates_programming_errors(self):
+        from unittest.mock import MagicMock
+
+        mock_lm = MagicMock()
+        mock_lm.side_effect = TypeError("invalid LM implementation")
+        tools = RLM("context -> answer", max_llm_calls=10, sub_lm=mock_lm)._make_llm_tools()
+
+        with pytest.raises(TypeError, match="invalid LM implementation"):
+            tools["llm_query_batched"](["test prompt"])
 
     def test_batched_query_inherits_request_context(self):
         import contextvars


### PR DESCRIPTION
> **Review guide:** one commit, two production decisions in the same `llm_query` boundary:
>
> 1. normalize DSPy's typed and legacy LM return contracts to text;
> 2. isolate only `dspy.LMError` failures in batched calls, so programming/contract errors stay visible.

## 1. Issue / repro

RLM's `llm_query()` tool changes meaning when DSPy's typed LM mode is active.

```python
lm = DummyLM([{"answer": "typed answer"}])
tools = RLM("context -> answer", sub_lm=lm)._make_llm_tools()

with dspy.context(experimental=True):
    print(tools["llm_query"]("test prompt"))
```

The same LM returns answer text in default mode. On `main`, typed mode instead returns the Pydantic representation of the entire response:

```text
model='dummy' outputs=[LMOutput(parts=[LMTextPart(... text='[[ ## answer ## ]]\ntyped answer')], ...)] ...
```

There is a second surprise at this boundary: `llm_query_batched()` converts every worker exception—including `TypeError` from a broken LM implementation—into an `[ERROR]` string.

## 2. Why this is the root cause

`BaseLM` has two public return shapes during the typed migration:

- default calls return a non-empty legacy list of text outputs;
- explicit/experimental typed calls return `LMResponse`.

RLM handles only the first, then stringifies everything else:

```python
response = target_lm(prompt)
if isinstance(response, list) and response:
    ...
return str(response)
```

An `LMResponse` therefore reaches `str(response)` instead of `.text`. Separately, the batch path catches `Exception`, although DSPy already defines `LMError` as the provider/configuration/transport failure boundary.

## 3. How we know the fix addresses the root cause

The regression uses the real `DummyLM`/`BaseLM` path in both modes:

```python
assert legacy_tool("test prompt") == "[[ ## answer ## ]]\nlegacy answer"

with dspy.context(experimental=True):
    assert typed_tool("test prompt") == "[[ ## answer ## ]]\ntyped answer"
```

The typed assertion fails on `main` because the result begins with `model='dummy'`; it passes here because RLM reads `LMResponse.text`.

Batch tests prove the intended classification:

```python
LMTransportError(...)  -> "[ERROR] ..."  # one failed slot
LMNotConfiguredError   -> "[ERROR] ..."  # one failed slot
TypeError(...)         -> raises          # broken implementation/contract
```

A textless legacy response also proves that the diagnostic names the received type (`NoneType`) instead of failing with a generic message.

## 4. Why this is the concise fix

The scalar tool explicitly handles the two DSPy contracts and rejects anything else:

```python
if isinstance(response, dspy.LMResponse):
    text = response.text
elif isinstance(response, list) and response:
    first_output = response[0]
    text = first_output.get("text") if isinstance(first_output, dict) else first_output
else:
    raise TypeError(...)

if not isinstance(text, str):
    raise TypeError(f"... got {type(text).__name__}.")
```

The batch change is one type substitution: `except Exception` becomes `except dspy.LMError`. There is no attribute probing, provider-specific parsing, retry, or stringification fallback.

## 5. Context needed to validate the change

`llm_query()` is a text-returning semantic helper exposed inside the interpreter. Returning response metadata changes the generated program's input even when the underlying answer is identical.

Per-slot batch errors are still strategically useful: one expected provider failure should not discard successful siblings. DSPy's exception taxonomy makes that policy precise. Programming and response-contract errors mean the helper itself is broken and should remain visible.

## 6. What the fix does in the code

- Returns `LMResponse.text` for typed DSPy calls.
- Preserves text extraction from the established legacy list shape.
- Requires either shape to contain a string.
- Reports the received type for a textless response.
- Classifies missing LM setup as `LMNotConfiguredError`.
- Keeps per-slot batch markers for `LMError` failures.
- Lets unexpected implementation errors escape the batch.

## Compatibility boundaries and downsides

- **Raw callable return values are no longer stringified.** `sub_lm` is declared as a DSPy LM; custom implementations must return `LMResponse` or the documented legacy list shape.
- **Empty legacy lists and responses without string text now raise `TypeError`.** Actual empty-string text remains valid. Tool-call-only responses cannot satisfy a text-returning helper.
- **Unexpected batch exceptions now fail the batch.** This is intentionally less tolerant so programming and contract errors cannot masquerade as provider failures.
- **Expected LM failures remain isolated.** Configuration, transport, provider, rate-limit, and other `LMError` subclasses still become one `[ERROR]` entry.
- **Missing LM setup now raises `LMNotConfiguredError` instead of plain `RuntimeError`.** Scalar callers catching only that exact error type must update; batch behavior remains an `[ERROR]` result.
- **No provider-specific response parsing is added.** Both accepted branches are DSPy-level contracts.
- **Call limits, ordering, copied request context, threading, and valid scalar behavior are unchanged.**

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — `127 passed, 2 skipped`
- focused legacy, typed, unsupported-shape, textless-shape, missing-configuration, LM-error, unexpected-error, and request-context tests — passed
- repository pre-commit hooks on both changed files — passed
- `git diff --check` — passed
- branch contains one commit over current `main`
