### PR TITLE
fix(rlm): honor declared input defaults

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Iterator
 
 import pydantic
+from pydantic_core import PydanticUndefined
 
 import dspy
 from dspy.adapters.types.tool import Tool
@@ -394,11 +395,15 @@ class RLM(Module):
         return output
 
     def _validate_inputs(self, input_args: dict[str, Any]) -> None:
-        """Validate call-time arguments against the signature's input namespace."""
+        """Apply declared defaults and validate inputs against the signature."""
         input_names = set(self.signature.input_fields)
         unexpected = set(input_args) - input_names
         if unexpected:
             raise ValueError(f"Unexpected inputs not declared in the signature: {sorted(unexpected)}")
+
+        for name, field in self.signature.input_fields.items():
+            if name not in input_args and field.default is not PydanticUndefined:
+                input_args[name] = field.default
 
         missing = input_names - set(input_args)
         if missing:

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -253,6 +253,52 @@ class TestRLMInitialization:
         assert "b" in str(exc_info.value)
         assert "c" in str(exc_info.value)
 
+    @pytest.mark.parametrize(
+        ("call_args", "expected_context"),
+        [
+            ({"query": "What is DSPy?"}, "default context"),
+            ({"query": "What is DSPy?", "context": "caller context"}, "caller context"),
+        ],
+    )
+    def test_forward_applies_declared_input_defaults(self, call_args, expected_context):
+        import dspy
+
+        class QA(dspy.Signature):
+            context: str = dspy.InputField(default="default context")
+            qualifier: str | None = dspy.InputField(default=None)
+            query: str = dspy.InputField()
+            answer: str = dspy.OutputField()
+
+        mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
+        rlm = RLM(QA, interpreter=mock)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+        ])
+
+        result = rlm.forward(**call_args)
+
+        assert result.answer == "done"
+        assert mock.call_history[0][1] == {
+            **call_args,
+            "context": expected_context,
+            "qualifier": None,
+        }
+
+    def test_optional_input_without_default_remains_required(self):
+        import dspy
+
+        class QA(dspy.Signature):
+            context: str | None = dspy.InputField()
+            answer: str = dspy.OutputField()
+
+        mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
+        rlm = RLM(QA, interpreter=mock)
+
+        with pytest.raises(ValueError, match="Missing required inputs: \\['context'\\]"):
+            rlm.forward()
+
+        assert mock.call_history == []
+
     @pytest.mark.parametrize("unexpected_name", ["SUBMIT", "lookup"])
     def test_forward_rejects_undeclared_inputs_before_interpreter_execution(self, unexpected_name):
         def lookup() -> str:


### PR DESCRIPTION
## 1. Issue / repro

RLM rejects a signature input even when the signature declares an explicit default:

```python
class QA(dspy.Signature):
    context: str = dspy.InputField(default="default context")
    query: str = dspy.InputField()
    answer: str = dspy.OutputField()

dspy.RLM(QA)(query="What is DSPy?")
# ValueError: Missing required inputs: ['context']
```

That makes the same DSPy signature mean something different at the `RLM` boundary than it does at the established `Predict` boundary, which already honors literal `InputField(default=...)` values.

## 2. Why this is the root cause

The strict input validation added by #10020 currently computes missing inputs from every declared input name:

```python
missing = input_names - set(input_args)
```

It never distinguishes Pydantic's `PydanticUndefined` sentinel from an explicitly declared default. The interpreter is downstream of this check, so no interpreter, prompt, or provider change can make a defaulted call reach execution.

## 3. How we know the fix addresses the root cause

The fix checks the signature field at the exact point where RLM decides whether an input is missing. Focused tests exercise the public `forward()` path and assert what the interpreter actually receives:

```python
result = rlm.forward(query="What is DSPy?")

assert result.answer == "done"
assert interpreter_variables == {
    "query": "What is DSPy?",
    "context": "default context",
    "qualifier": None,
}
```

The same test supplies an explicit `context` and proves that the caller's value wins. A separate boundary test proves that `str | None` without `default=None` remains required.

## 4. Why this is the concise fix

The runtime change is one sentinel import and four lines in the existing input-validation method:

```python
for name, field in self.signature.input_fields.items():
    if name not in input_args and field.default is not PydanticUndefined:
        input_args[name] = field.default
```

There is no new binder, alternate execution path, fallback, coercion layer, or change to interpreter state. The existing missing-input check then handles only fields that truly have no supplied or declared value.

## 5. Context needed to validate the change

This PR is deliberately stacked on #10020 because that PR establishes the strict RLM call boundary. The intended order is:

1. reject names that are not declared by the signature;
2. populate explicitly declared literal defaults;
3. reject any inputs that are still missing.

`forward()` receives a fresh `**input_args` dictionary for each call. Updating that call-local dictionary makes the resolved values flow through the existing variable metadata, serialization, interpreter injection, and extraction paths without adding another representation of bound inputs.

## 6. What the fix does in the code

- Applies literal `InputField(default=...)` values before checking for missing inputs.
- Preserves every caller-supplied value, including explicit `None`.
- Passes the completed input dictionary through the existing RLM execution path.
- Keeps undeclared-input rejection and genuinely required inputs unchanged.

## Compatibility boundaries and downsides

- **This changes one previously failing call into a valid call.** Omitting a field with an explicit literal default now executes RLM instead of raising `ValueError`.
- **Explicit caller values still win.** The default is applied only when the key is absent.
- **Nullable does not mean optional.** `value: str | None = InputField()` remains required; users must declare `default=None` to make omission valid.
- **`default_factory` is out of scope.** This matches `Predict`'s current literal-default check and avoids introducing a second, broader binding policy in RLM.
- **No new type coercion or default validation.** RLM passes the declared value through exactly as `Predict` does today.
- **No provider or interpreter compatibility surface changes.** Tool calls, Deno/Pyodide behavior, custom interpreters, LM providers, async execution, output parsing, and serialization protocols are untouched.
- **This PR depends on #10020.** It should be reviewed and merged after that parent because both intentionally touch `_validate_inputs()`.

## Validation

- `uv run --frozen pytest --deno tests/predict/test_rlm.py -q` — `126 passed, 2 skipped`
- `uv run --frozen pre-commit run --files dspy/predict/rlm.py tests/predict/test_rlm.py` — passed
- `git diff --check` — passed
- branch contains one commit over #10020
