### PR TITLE
fix(rlm): execute tools through dspy.Tool

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 import base64
 import contextvars
+import functools
+import inspect
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -426,11 +428,23 @@ class RLM(Module):
     # CodeInterpreter Lifecycle
     # =========================================================================
 
+    def _make_interpreter_tool(self, tool: Tool) -> Callable:
+        """Preserve function metadata while routing execution through Tool."""
+        if inspect.iscoroutinefunction(tool.func) or inspect.iscoroutinefunction(getattr(tool.func, "__call__", None)):
+            async def invoke(**kwargs):
+                return await tool.acall(**kwargs)
+        else:
+            def invoke(**kwargs):
+                return tool(**kwargs)
+
+        functools.update_wrapper(invoke, tool.func)
+        invoke.__signature__ = inspect.signature(tool.func)
+        return invoke
+
     def _prepare_execution_tools(self) -> dict[str, Callable]:
         """Create fresh LLM tools and merge with user-provided tools."""
         execution_tools = self._make_llm_tools()
-        # Extract underlying functions from Tool objects for the interpreter
-        execution_tools.update({name: tool.func for name, tool in self._user_tools.items()})
+        execution_tools.update({name: self._make_interpreter_tool(tool) for name, tool in self._user_tools.items()})
         return execution_tools
 
     def _inject_execution_context(self, interpreter: CodeInterpreter, execution_tools: dict[str, Callable]) -> None:

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -1181,6 +1181,54 @@ class TestRLMWithDummyLM:
 
             assert result.color == "red"
 
+    def test_dspy_tool_execution_semantics_e2e(self):
+        import inspect
+
+        from pydantic import BaseModel
+
+        import dspy
+        from dspy.utils.callback import BaseCallback
+
+        class Payload(BaseModel):
+            value: int
+
+        received = []
+        callback_events = []
+
+        async def score(payload: Payload, factor: int = 2):
+            received.append((payload, factor))
+            return payload.value * factor
+
+        class Recorder(BaseCallback):
+            def on_tool_start(self, call_id, instance, inputs):
+                callback_events.append(("start", instance))
+
+            def on_tool_end(self, call_id, outputs, exception):
+                callback_events.append(("end", outputs, exception))
+
+        tool = Tool(score, name="score_payload")
+        rlm = RLM("query -> answer: int", max_iters=1, tools=[tool])
+        execution_tool = rlm._prepare_execution_tools()["score_payload"]
+
+        assert execution_tool.__name__ == score.__name__
+        assert inspect.signature(execution_tool) == inspect.signature(score)
+
+        with dummy_lm_context([
+            {
+                "reasoning": "Call the tool",
+                "code": 'result = score_payload({"value": 3})\nSUBMIT(result)',
+            },
+        ]):
+            with dspy.context(callbacks=[Recorder()]):
+                result = rlm.forward(query="test")
+
+        assert result.answer == 6
+        assert len(received) == 1
+        assert isinstance(received[0][0], Payload)
+        assert received[0][0].value == 3
+        assert received[0][1] == 2
+        assert callback_events == [("start", tool), ("end", 6, None)]
+
     @pytest.mark.asyncio
     async def test_aforward_simple_computation_e2e(self):
         """Test aforward() full pipeline: DummyLM -> RLM -> PythonInterpreter -> result."""


### PR DESCRIPTION
## 1. Issue / repro

RLM accepts both callables and `dspy.Tool` objects, and its prompt documents the normalized `Tool` schema. But the actual interpreter path discards that `Tool` before execution:

```python
execution_tools.update({name: tool.func for name, tool in self._user_tools.items()})
```

That makes the documented tool and the executed tool different objects. For example:

```python
class Payload(BaseModel):
    value: int

async def score(payload: Payload, factor: int = 2):
    return payload.value * factor

tool = dspy.Tool(score, name="score_payload")
```

Sandbox code passes JSON data:

```python
score_payload({"value": 3})
```

On `main`, RLM invokes `score()` directly, so `payload` is a plain `dict` and the call fails with `AttributeError`. `Tool`'s JSON-schema validation, Pydantic conversion, and callbacks never run.

## 2. Why this is the root cause

RLM already normalizes every user callable into `dspy.Tool` and uses that object to generate tool documentation. `_prepare_execution_tools()` then crosses the abstraction boundary in the opposite direction by extracting `.func`.

The interpreter is behaving as designed: it invokes the callable RLM gives it. The mismatch is at the RLM assembly point, where schema/documentation ownership stays with `Tool` but execution ownership is silently transferred to the raw function.

## 3. How we know the fix addresses the root cause

The regression test exercises the public path end to end:

```python
result = score_payload({"value": 3})
SUBMIT(result)
```

It runs through `RLM -> PythonInterpreter -> Deno/Pyodide -> host tool` and proves all of the boundary's observable contracts:

- the sandbox retains `score(payload: Payload, factor: int = 2)` for registration and positional/default binding;
- the host function receives a `Payload`, not the JSON `dict` sent by sandbox code;
- the declared default `factor=2` is preserved;
- an async tool is awaited;
- `on_tool_start` and `on_tool_end` each fire once on the original `Tool`;
- the typed RLM result is `6`.

The existing sync-tool end-to-end test also passes, so ordinary synchronous functions keep their working execution path.

## 4. Why this is the concise fix

The interpreter needs two things that live on different layers:

1. the wrapped function's Python signature for sandbox registration;
2. `Tool.__call__` / `Tool.acall` for the execution contract.

One private adapter makes that connection explicit:

```python
if inspect.iscoroutinefunction(tool.func) or inspect.iscoroutinefunction(getattr(tool.func, "__call__", None)):
    async def invoke(**kwargs):
        return await tool.acall(**kwargs)
else:
    def invoke(**kwargs):
        return tool(**kwargs)

invoke.__signature__ = inspect.signature(tool.func)
```

There is no interpreter change, `Tool` API change, alternate dispatch path, exception fallback, or reconstructed schema. The production diff is 16 lines.

## 5. Context needed to validate the change

`PythonInterpreter` registers a host tool by calling `inspect.signature()` and creates a sandbox wrapper with those parameters. When sandbox code invokes that wrapper, the bridge calls the host callable with keyword arguments. The `CodeInterpreter` protocol likewise defines host tools as keyword-argument callables.

The adapter therefore preserves the exact existing `tool.func` signature for registration while changing only which object owns host-side execution.

## 6. What the fix does in the code

- Keeps the underlying function signature visible to `PythonInterpreter`.
- Routes synchronous execution through `Tool.__call__`.
- Routes declared async callables through `Tool.acall`.
- Preserves the original `Tool` instance so validation, conversion, and callbacks execute normally.
- Leaves RLM's built-in `llm_query` tools unchanged.

## Compatibility boundaries and downsides

- **Tool validation now actually runs.** Inputs that the raw Python function accepted but the declared `Tool` JSON schema rejects will now fail with the Tool's validation error. That is the intended contract of passing a `dspy.Tool`, but it is a real behavior change.
- **Pydantic conversion now actually runs.** Functions annotated with Pydantic or other supported types receive parsed objects instead of raw JSON-shaped values.
- **Tool callbacks now fire.** Callers observing DSPy callbacks will see the previously missing start/end events.
- **The Python signature is unchanged.** Parameter names, order, annotations, and function defaults still come from `inspect.signature(tool.func)`; the adapter does not infer or reorder them.
- **Sync functions remain sync wrappers.** This avoids turning working sync-tool calls in `aforward()` into coroutine execution.
- **Sync callables that merely return an awaitable now follow `Tool.__call__`.** Unless they are declared async (or have an async `__call__`), their behavior is governed by DSPy's existing `allow_tool_async_sync_conversion` setting instead of the interpreter's raw-function auto-await.
- **Async tools work here through synchronous `forward()`.** The existing `aforward()` + async-tool event-loop limitation is unchanged and is not claimed as fixed by this PR.
- **Schema-only signatures remain out of scope.** A custom `Tool(args=...)` whose schema differs from `tool.func`—notably MCP adapters whose function is only `(*args, **kwargs)`—still exposes the function signature. Fixing that honestly requires DSPy to preserve JSON Schema's explicit required/optional set; this PR does not guess that missing information.
- **No provider-specific surface changes.** LM providers, prompts, output parsing, interpreter lifecycle, serialization, and built-in RLM tools are untouched.

## Validation

- `uv run --frozen pytest --deno tests/predict/test_rlm.py -q` — `113 passed, 2 skipped`
- focused real-Deno regression — passed
- `uv run --frozen pre-commit run --files dspy/predict/rlm.py tests/predict/test_rlm.py` — passed
- `git diff --check` — passed
- branch contains one commit over current `main` (`89696e0cc`)
