### PR TITLE
fix(cache): mark cache hits on strict provider response models

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -151,7 +151,10 @@ class Cache:
         if hasattr(response, "usage"):
             # Clear the usage data when cache is hit, because no LM call is made
             response.usage = {}
-            response.cache_hit = True
+            # Strict provider models (e.g. litellm's ResponsesAPIResponse) reject
+            # undeclared attributes in pydantic __setattr__, so stamp the marker
+            # directly on the instance dict.
+            object.__setattr__(response, "cache_hit", True)
         return response
 
     def put(

--- a/tests/clients/test_cache.py
+++ b/tests/clients/test_cache.py
@@ -533,3 +533,24 @@ def test_safe_types_rejects_non_types(tmp_path):
             restrict_pickle=True,
             safe_types=["not_a_type"],
         )
+
+
+class _StrictProviderResponse(pydantic.BaseModel):
+    """Mimics strict provider SDK models (e.g. litellm's ResponsesAPIResponse)."""
+
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    output: list[dict]
+    usage: dict
+
+
+def test_prepare_cached_response_marks_strict_models_as_cache_hit(cache):
+    response = _StrictProviderResponse(output=[{"type": "message"}], usage={"total_tokens": 3})
+
+    prepared = cache._prepare_cached_response(response)
+
+    assert prepared.cache_hit is True
+    assert prepared.usage == {}
+    # The original response is not mutated.
+    assert getattr(response, "cache_hit", False) is False
+    assert response.usage == {"total_tokens": 3}

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1256,6 +1256,45 @@ def test_responses_api_tool_calls(litellm_test_server, provider_fields, expected
         assert dspy_responses.call_args.kwargs["model"] == "openai/dspy-test-model"
 
 
+def test_responses_api_cache_hit_preserves_outputs_and_skips_usage(tmp_path):
+    api_response = make_response(
+        output_blocks=[
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "cached answer", "annotations": []}],
+            ),
+            ResponseReasoningItem(
+                id="reasoning_1",
+                type="reasoning",
+                summary=[Summary(type="summary_text", text="cached reasoning")],
+            ),
+        ],
+    )
+
+    original_cache = dspy.cache
+    dspy.configure_cache(enable_disk_cache=True, enable_memory_cache=True, disk_cache_dir=tmp_path / ".dspy_cache")
+    try:
+        with mock.patch("litellm.responses", autospec=True, return_value=api_response) as responses:
+            lm = dspy.LM("openai/dspy-test-model", model_type="responses")
+            with track_usage() as first_usage:
+                first = lm("cache me")
+            with track_usage() as second_usage:
+                second = lm("cache me")
+
+        assert first == [{"text": "cached answer", "reasoning_content": "cached reasoning"}]
+        assert second == first
+        assert responses.call_count == 1
+        # The fresh call records usage; the cache hit must not.
+        assert len(first_usage.usage_data) == 1
+        assert len(second_usage.usage_data) == 0
+        assert lm.history[-1]["usage"] == {}
+    finally:
+        dspy.cache = original_cache
+
+
 def test_reasoning_effort_responses_api():
     """Test that reasoning_effort gets normalized to reasoning format for Responses API."""
     with mock.patch("litellm.responses") as mock_responses:


### PR DESCRIPTION
## Summary

litellm's `ResponsesAPIResponse` forbids undeclared attributes, so `response.cache_hit = True` in `Cache._prepare_cached_response` raised `ValueError` on every Responses-path cache hit, breaking cached reads for `model_type="responses"`.

Stamp the marker with `object.__setattr__` instead of pydantic's `__setattr__`, so cache hits stay observable: `cache_hit` is accurate on cached responses and the usage tracker records nothing for cached calls.

#9842 papered over this with `try/except pass`, which made cache reads work but silently reported every Responses cache hit as a miss (and pushed empty usage entries into the tracker). This keeps the flag.

Stack: 2/3, on top of #10026.

## Verification

- New unit test: `_prepare_cached_response` on a strict (`extra="forbid"`) pydantic model sets `cache_hit`, clears usage, and does not mutate the original.
- New end-to-end test: Responses-path cache hit returns identical outputs, calls litellm once, records usage only for the fresh call.
- `tests/clients` green (142 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)