### PR TITLE
refactor(lm): normalize Responses output parsing, unify legacy tool-call shape

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -862,35 +862,12 @@ class BaseLM:
 
         Returns:
             List of processed outputs, which is always of size 1 because the Response API only supports one output.
+            Each output is a dictionary in the same shape the chat path produces: `text` is always present, and
+            `reasoning_content`, `tool_calls`, and `citations` appear when present.
         """
-        text_outputs = []
-        tool_calls = []
-        reasoning_contents = []
-
-        for output_item in response.output:
-            output_item_type = output_item.type
-            if output_item_type == "message":
-                for content_item in output_item.content:
-                    text_outputs.append(content_item.text)
-            elif output_item_type == "function_call":
-                tool_calls.append(output_item.model_dump(exclude_none=True))
-            elif output_item_type == "reasoning":
-                if getattr(output_item, "content", None) and len(output_item.content) > 0:
-                    for content_item in output_item.content:
-                        reasoning_contents.append(content_item.text)
-                elif getattr(output_item, "summary", None) and len(output_item.summary) > 0:
-                    for summary_item in output_item.summary:
-                        reasoning_contents.append(summary_item.text)
-
-        result = {}
-        if len(text_outputs) > 0:
-            result["text"] = "".join(text_outputs)
-        if len(tool_calls) > 0:
-            result["tool_calls"] = tool_calls
-        if len(reasoning_contents) > 0:
-            result["reasoning_content"] = "".join(reasoning_contents)
-        # All `response.output` items map to one answer, so we return a list of size 1.
-        return [result]
+        request = LMRequest(model=self.model, messages=[])
+        lm_response = responses_to_lm_response(response, request)
+        return [output.to_output_dict() for output in lm_response.outputs]
 
 
 def inspect_history(n: int = 1, file: "TextIO | None" = None) -> None:

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -910,10 +910,6 @@ class LMResponse(BaseModel):
         for output in self.outputs:
             if _requires_output_dict(output):
                 outputs.append(output.to_output_dict())
-            elif output.text is not None:
-                # Join text parts so legacy outputs stay `str`, never a list,
-                # when an output carries multiple text (or text + media) parts.
-                outputs.append(output.text)
             else:
                 outputs.append(output.to_value())
         return outputs

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -910,6 +910,10 @@ class LMResponse(BaseModel):
         for output in self.outputs:
             if _requires_output_dict(output):
                 outputs.append(output.to_output_dict())
+            elif output.text is not None:
+                # Join text parts so legacy outputs stay `str`, never a list,
+                # when an output carries multiple text (or text + media) parts.
+                outputs.append(output.text)
             else:
                 outputs.append(output.to_value())
         return outputs

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1215,18 +1215,15 @@ def test_lm_replaces_system_with_developer_role():
 
 
 @pytest.mark.parametrize(
-    ("provider_fields", "expected_provider_fields"),
+    "provider_fields",
     [
-        ({}, {}),
-        ({"caller": None, "namespace": None}, {}),
-        (
-            {"caller": {"type": "direct"}, "namespace": "collaboration"},
-            {"caller": {"type": "direct"}, "namespace": "collaboration"},
-        ),
+        {},
+        {"caller": None, "namespace": None},
+        {"caller": {"type": "direct"}, "namespace": "collaboration"},
     ],
     ids=["legacy", "empty-provider-fields", "populated-provider-fields"],
 )
-def test_responses_api_tool_calls(litellm_test_server, provider_fields, expected_provider_fields):
+def test_responses_api_tool_calls(litellm_test_server, provider_fields):
     api_base, _ = litellm_test_server
     base_tool_call = {
         "type": "function_call",
@@ -1234,9 +1231,23 @@ def test_responses_api_tool_calls(litellm_test_server, provider_fields, expected
         "arguments": json.dumps({"city": "Paris"}),
         "call_id": "call_1",
         "status": "completed",
-        "id": "call_1",
+        "id": "fc_1",
     }
-    expected_response = [{"tool_calls": [{**base_tool_call, **expected_provider_fields}]}]
+    # Legacy outputs use the chat-unified tool-call shape regardless of which
+    # provider fields the Responses item carries; the full provider item stays
+    # available on the typed path via LMToolCallPart.provider_data.
+    expected_response = [
+        {
+            "text": None,
+            "tool_calls": [
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})},
+                    "id": "call_1",
+                }
+            ],
+        }
+    ]
 
     api_response = make_response(
         output_blocks=[{**base_tool_call, **provider_fields}],
@@ -1295,10 +1306,37 @@ def test_responses_api_cache_hit_preserves_outputs_and_skips_usage(tmp_path):
         dspy.cache = original_cache
 
 
+def test_responses_api_joins_multiple_text_outputs():
+    """Multiple message items must join into one text string, never leak a list."""
+    api_response = make_response(
+        output_blocks=[
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "part one. ", "annotations": []}],
+            ),
+            ResponseOutputMessage(
+                id="msg_2",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "part two.", "annotations": []}],
+            ),
+        ],
+    )
+
+    with mock.patch("litellm.responses", autospec=True, return_value=api_response):
+        lm = dspy.LM("openai/dspy-test-model", model_type="responses", cache=False)
+        outputs = lm("multi part query")
+
+    assert outputs == [{"text": "part one. part two."}]
+
+
 def test_reasoning_effort_responses_api():
     """Test that reasoning_effort gets normalized to reasoning format for Responses API."""
-    with mock.patch("litellm.responses") as mock_responses:
-        # OpenAI model with Responses API - should normalize
+    with mock.patch("litellm.responses", return_value=make_response([])) as mock_responses:
         lm = dspy.LM(
             model="openai/gpt-5", model_type="responses", reasoning_effort="low", max_tokens=16000, temperature=1.0
         )
@@ -2078,3 +2116,44 @@ def test_lm_responses_does_not_validate_reasoning_temperature_client_side():
     sent = responses.call_args.kwargs
     assert sent["temperature"] == 0.7
     assert sent["reasoning"] == {"effort": "low", "summary": "auto"}
+def test_responses_to_lm_response_normalizes_mixed_text_reasoning_and_tool_calls():
+    from dspy.clients.openai_format import responses_to_lm_response
+    from dspy.core.types import LMRequest, LMThinkingPart
+
+    response = make_response(
+        [
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "I should use weather.", "annotations": []}],
+            ),
+            {
+                "type": "function_call",
+                "name": "get_weather",
+                "arguments": '{"city": "Paris",}',
+                "call_id": "call_1",
+                "id": "fc_1",
+                "status": "completed",
+            },
+            ResponseReasoningItem(
+                id="reasoning_1",
+                type="reasoning",
+                summary=[Summary(type="summary_text", text="Need live weather.")],
+            ),
+        ]
+    )
+
+    lm_response = responses_to_lm_response(response, LMRequest(model="openai/dspy-test-model", messages=[]))
+    output = lm_response.outputs[0]
+
+    assert output.text == "I should use weather."
+    assert output.reasoning_content == "Need live weather."
+    assert isinstance(output.parts[2], LMThinkingPart)
+    assert output.tool_calls[0].id == "call_1"
+    assert output.tool_calls[0].name == "get_weather"
+    assert output.tool_calls[0].args == {}
+    assert output.tool_calls[0].provider_data["raw_arguments"] == '{"city": "Paris",}'
+    assert "arguments_parse_error" in output.tool_calls[0].provider_data
+    assert lm_response.usage.total_tokens == 2

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -9,6 +9,7 @@ from dspy.core.types import (
     LMConfig,
     LMDocumentPart,
     LMHistoryEntry,
+    LMImagePart,
     LMMessage,
     LMOutput,
     LMOutputBuilder,
@@ -19,6 +20,7 @@ from dspy.core.types import (
     LMResponse,
     LMStreamDeltaEvent,
     LMTextDelta,
+    LMTextPart,
     LMThinkingDelta,
     LMThinkingPart,
     LMToolCallDelta,
@@ -427,6 +429,18 @@ def test_history_entry_exposes_existing_dict_style_properties():
 def test_response_rejects_empty_outputs():
     with pytest.raises(pydantic.ValidationError):
         LMResponse(model="model", outputs=[])
+
+
+def test_response_to_outputs_preserves_multipart_values():
+    image = LMImagePart(url="https://example.com/image.png")
+    response = LMResponse(
+        outputs=[
+            LMOutput(parts=[LMTextPart(text="part one"), LMTextPart(text="part two")]),
+            LMOutput(parts=[LMTextPart(text="caption"), image]),
+        ]
+    )
+
+    assert response.to_outputs() == [["part one", "part two"], ["caption", image]]
 
 
 def test_output_to_value_preserves_redacted_thinking_part():


### PR DESCRIPTION
## Before / after

Before, `model_type="responses"` hand-parsed provider output and returned provider-native tool-call dumps; after, Responses output is normalized through `LMResponse` and legacy tool calls use the same public shape as chat completions.

## Behavior changes

- **[REFACTOR]** `BaseLM._process_response()` now delegates Responses parsing to `responses_to_lm_response()` and serializes the normalized `LMOutput` instead of maintaining a second hand-written parser.
- **[BREAKING / DELIBERATE]** Legacy Responses tool calls now use the same shape as chat completions: `{"type": "function", "function": {"name": ..., "arguments": ...}, "id": call_id}`. Tool-only outputs include `"text": null`.
- **[FIX]** Multiple Responses message items still produce one joined `text` string through the Responses-specific legacy dictionary boundary.
- **[FIX]** Invalid JSON tool arguments normalize to `{}` while the raw arguments and parse error remain available in `LMToolCallPart.provider_data`.

## Unchanged / boundaries

- **[AUDIT BOUNDARY]** `LMResponse.to_outputs()` is unchanged. Multipart typed outputs—including multiple text parts and mixed text/media parts—continue to preserve their part boundaries as lists.
- Text-only Responses calls keep the existing legacy result shape: one output dictionary with a `text` field.
- A Responses API result still maps to one DSPy output; this PR does not add multi-candidate support.
- Raw provider function-call fields, including provider item IDs and status, remain available on the typed path through `LMToolCallPart.provider_data`.
- The legacy output dictionary remains limited to text, reasoning, tool calls, citations, and logprobs where supported. This PR does not add new legacy keys for media, files, or refusals.
- Request conversion, hosted-tool passthrough, tool-choice conversion, and replay behavior were fixed in #10026 and are intentionally not changed here.
- No fallback parser is retained; Responses output has one normalization path.

## Review guide

1. `dspy/clients/base_lm.py`: the parser delegation and public legacy output boundary.
2. `tests/clients/test_lm.py`: Responses integration contracts, unified tool calls, multi-message text joining, and mixed normalized parts.
3. `tests/core/test_types.py`: regression locking the unchanged multipart `LMResponse.to_outputs()` behavior.

## Verification

- Live #9943 reproduction with `openai/gpt-5-nano`:
  - Forced Chat-shaped tool and object-form `tool_choice` through the OpenAI Responses API: **passed**.
  - `ReActV2` with `ChatAdapter(use_native_function_calling=True)`: **passed**; `search` executed once and its result was submitted.
- `uv run --frozen pytest --deno -q tests/clients/test_lm.py tests/core/test_types.py tests/adapters/test_chat_adapter.py tests/clients/test_cache.py tests/clients/test_lm_direct_live.py tests/clients/test_disk_serialization.py`
  - **221 passed, 27 skipped**
- `uv run --frozen ruff check dspy/clients/base_lm.py dspy/core/types.py tests/clients/test_lm.py tests/core/test_types.py`
  - **passed**
- `git diff --check origin/main...HEAD`
  - **passed**

Response side of #9842 by @MaximeRivest, rebased directly onto current `main` after #10026 merged.
