### PR TITLE
fix(teleprompt): hash unpicklable tool demos safely

### DIFF
--- a/dspy/teleprompt/bootstrap.py
+++ b/dspy/teleprompt/bootstrap.py
@@ -1,4 +1,5 @@
 import logging
+import pickle
 import random
 import threading
 
@@ -250,7 +251,11 @@ class BootstrapFewShot(Teleprompter):
                 if len(demos) > 1:
                     from dspy.utils.hasher import Hasher
 
-                    rng = random.Random(Hasher.hash(tuple(demos)))
+                    try:
+                        seed = Hasher.hash(tuple(demos))
+                    except (AttributeError, TypeError, pickle.PickleError):
+                        seed = Hasher.hash(tuple(demo.toDict() for demo in demos))
+                    rng = random.Random(seed)
                     demos = [rng.choice(demos[:-1]) if rng.random() < 0.5 else demos[-1]]
                 self.name2traces[name].extend(demos)
 

--- a/tests/teleprompt/test_bootstrap.py
+++ b/tests/teleprompt/test_bootstrap.py
@@ -36,6 +36,16 @@ class SimpleModule(dspy.Module):
         return self.predictor(**kwargs)
 
 
+class RepeatedCallModule(dspy.Module):
+    def __init__(self, signature):
+        super().__init__()
+        self.predictor = Predict(signature)
+
+    def forward(self, **kwargs):
+        self.predictor(**kwargs)
+        return self.predictor(**kwargs)
+
+
 def test_compile_with_predict_instances():
     # Create Predict instances for student and teacher
     # Note that dspy.Predict is not itself a module, so we can't use it directly here
@@ -132,3 +142,51 @@ def test_validation_set_usage():
 
     # Check that validation examples are part of student's demos after compilation
     assert len(compiled_student.predictor.demos) >= len(valset), "Validation set not used in compiled student demos"
+
+
+def test_compile_multiple_traces_with_unpicklable_tool():
+    class Client:
+        def lookup(self, city):
+            return {"paris": "France"}[city.lower()]
+
+    def make_tool(client):
+        def country_of(city: str) -> str:
+            """Return the country a city is in."""
+            return client.lookup(city)
+
+        return country_of
+
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    tool = dspy.Tool(make_tool(Client()))
+    example = Example(question="Where is Paris?", tools=[tool], answer="France").with_inputs("question", "tools")
+    dspy.configure(lm=DummyLM([{"answer": "France"}, {"answer": "France"}]))
+
+    compiled = BootstrapFewShot(
+        metric=lambda example, prediction, trace=None: prediction.answer == example.answer,
+        max_bootstrapped_demos=1,
+        max_labeled_demos=0,
+    ).compile(RepeatedCallModule(ToolSignature), trainset=[example])
+
+    assert len(compiled.predictor.demos) == 1
+    assert compiled.predictor.demos[0].tools[0](city="Paris") == "France"
+
+
+def test_unexpected_demo_hash_error_propagates(monkeypatch):
+    dspy.configure(lm=DummyLM([{"output": "blue"}, {"output": "blue"}]))
+    bootstrap = BootstrapFewShot(
+        metric=simple_metric,
+        max_bootstrapped_demos=1,
+        max_labeled_demos=0,
+    )
+
+    def raise_unexpected_error(value):
+        raise RuntimeError("Unexpected hashing failure")
+
+    monkeypatch.setattr("dspy.utils.hasher.Hasher.hash", raise_unexpected_error)
+
+    with pytest.raises(RuntimeError, match="Unexpected hashing failure"):
+        bootstrap.compile(RepeatedCallModule("input -> output"), trainset=trainset)


### PR DESCRIPTION
## What changed

`BootstrapFewShot` currently crashes while hashing successful demo traces when a demo contains a `dspy.Tool` backed by a local closure or client object that standard pickle cannot serialize.

This change:

- preserves the existing raw-demo hash whenever it works;
- falls back to hashing `demo.toDict()` only for known pickle/serialization errors;
- leaves the live demo and its Tool untouched and callable;
- allows unexpected errors such as `RuntimeError` to continue propagating.

Fixes #9998.

## Verification

Tested on Python 3.12.6:

- `python -m pytest tests/teleprompt/test_bootstrap.py -q` — 7 passed
- `python -m pytest tests/teleprompt -q` — 75 passed
- `python -m pytest tests/adapters/test_tool.py tests/primitives/test_example.py -q` — 55 passed
- `ruff check dspy/teleprompt/bootstrap.py tests/teleprompt/test_bootstrap.py` — passed
- `ruff format --check dspy/teleprompt/bootstrap.py tests/teleprompt/test_bootstrap.py` — passed

The regression test verifies that a closure-backed Tool compiles and remains callable. A negative test verifies that unrelated hashing failures are not swallowed.

## Before

On pristine `main`, compilation crashes while hashing the demos:

![Before — BootstrapFewShot fails on a closure-backed Tool](https://raw.githubusercontent.com/Dkm0315/dspy/b70537e6e25dd6441052b6875965c5ae6708473b/evidence/dspy-9998/before.png)

## After

The same scenario compiles successfully, with the focused and adjacent test suites passing:

![After — regression and safety-boundary tests pass](https://raw.githubusercontent.com/Dkm0315/dspy/b70537e6e25dd6441052b6875965c5ae6708473b/evidence/dspy-9998/after.png)


Before 

<img width="1280" height="721" alt="image" src="https://github.com/user-attachments/assets/ad6c7d94-e090-49dc-b848-5b04994ac863" />

After

<img width="1280" height="850" alt="image" src="https://github.com/user-attachments/assets/9da9220a-b79b-425a-8e4d-d262b22ea1a1" />
