### PR TITLE
fix(adapters): ChatAdapter.parse corrupts values on indented field headers

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -219,11 +219,12 @@ class ChatAdapter(Adapter):
         sections = [(None, [])]
 
         for line in completion.splitlines():
-            match = field_header_pattern.match(line.strip())
+            stripped_line = line.strip()
+            match = field_header_pattern.match(stripped_line)
             if match:
                 # If the header pattern is found, split the rest of the line as content
                 header = match.group(1)
-                remaining_content = line[match.end() :].strip()
+                remaining_content = stripped_line[match.end() :].strip()
                 sections.append((header, [remaining_content] if remaining_content else []))
             else:
                 sections[-1][1].append(line)

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2797,3 +2797,23 @@ def test_provider_tool_calls_preserve_id_and_repair_arguments():
             dspy.ToolCalls.ToolCall(id="call_from_responses", name="search", args={"query": "cats"})
         ]
     )
+
+
+def test_parse_handles_indented_field_headers():
+    """A field header line with leading whitespace should not corrupt the parsed value.
+
+    `parse()` matches the header pattern against `line.strip()`, but previously sliced the
+    remaining content out of the *unstripped* `line` using the match offset from the *stripped*
+    string -- when the line had leading whitespace, the offsets no longer lined up, so the parsed
+    value retained trailing characters of the header marker itself.
+    """
+
+    class MySignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    completion = "  [[ ## answer ## ]] Paris is the capital of France\n\n[[ ## completed ## ]]\n"
+
+    result = dspy.ChatAdapter().parse(MySignature, completion)
+
+    assert result == {"answer": "Paris is the capital of France"}


### PR DESCRIPTION
## What

`ChatAdapter.parse()` matches the field-header regex against `line.strip()`, but then slices the remaining content out of the *unstripped* `line` using the match offset computed from the *stripped* string:

```python
match = field_header_pattern.match(line.strip())
if match:
    header = match.group(1)
    remaining_content = line[match.end() :].strip()  # offset from stripped, sliced from unstripped
```

When a header line has leading whitespace, the offsets no longer line up, so the parsed value retains trailing characters of the header marker itself.

**Repro:**
```python
completion = "  [[ ## answer ## ]] Paris is the capital of France\n\n[[ ## completed ## ]]\n"
ChatAdapter().parse(MySignature, completion)
# => {'answer': ']] Paris is the capital of France'}   (should be {'answer': 'Paris is the capital of France'})
```

## Fix

Compute both the match and the slice against the same (stripped) string:

```python
stripped_line = line.strip()
match = field_header_pattern.match(stripped_line)
if match:
    header = match.group(1)
    remaining_content = stripped_line[match.end() :].strip()
```

## Test plan

- Added `test_parse_handles_indented_field_headers`, verified it fails against the current code with the exact corrupted output shown above, then passes with the fix.
- Ran the full `tests/adapters/` suite (231 tests) — all pass, no regressions.
- `pre-commit run` (ruff lint) — clean.

## AI-Generated Contribution disclosure

Found via an AI-assisted code review pass (Claude Code) across `dspy/adapters/`. I traced the root cause myself (confirmed the offset-mismatch mechanism by reading the surrounding parse logic), personally reproduced the bug with the exact snippet above, and wrote/verified the regression test before opening this PR.