### PR TITLE
fix(evaluate): raise clear ValueError instead of ZeroDivisionError on empty devset

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -154,6 +154,9 @@ class Evaluate:
         save_as_csv = save_as_csv if save_as_csv is not None else self.save_as_csv
         save_as_json = save_as_json if save_as_json is not None else self.save_as_json
 
+        if not devset:
+            raise ValueError("devset cannot be empty.")
+
         if callback_metadata:
             logger.debug(f"Evaluate is called with callback metadata: {callback_metadata}")
 

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -56,6 +56,19 @@ def test_evaluate_call():
     assert score.score == 100.0
 
 
+def test_evaluate_empty_devset_raises_clear_error():
+    """An empty devset should raise a clear ValueError instead of a raw ZeroDivisionError
+    when computing the percentage score."""
+    program = Predict("question -> answer")
+    ev = Evaluate(
+        devset=[],
+        metric=answer_exact_match,
+        display_progress=False,
+    )
+    with pytest.raises(ValueError, match="devset"):
+        ev(program)
+
+
 def test_evaluate_single_thread_runs_in_main_thread():
     """Evaluate with num_threads=1 should run in the main thread."""
     dspy.configure(


### PR DESCRIPTION
## What

`Evaluate.__call__` computes `ncorrect / ntotal` where `ntotal = len(devset)`, with no guard for an empty devset:

```python
ncorrect, ntotal = sum(score for *_, score in results), len(devset)
logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
```

Any caller that passes an empty devset (or one that ends up empty after an upstream filter) gets an unhandled `ZeroDivisionError` raised from inside a logging call, instead of a clear, actionable error.

**Repro:**
```python
ev = Evaluate(devset=[], metric=lambda ex, pred: 1.0, display_progress=False)
ev(program)
# => ZeroDivisionError: division by zero
```

## Fix

Raise a clear `ValueError("devset cannot be empty.")` early in `__call__`, before any evaluation work begins.

## Test plan

- Added `test_evaluate_empty_devset_raises_clear_error`, verified it fails with the raw `ZeroDivisionError` against the current code, then passes with the fix.
- Ran the full `tests/evaluate/test_evaluate.py` suite (11 tests, 25 skipped/extra) — all pass, no regressions.
- `pre-commit run` (ruff lint) — clean.

## AI-Generated Contribution disclosure

Found via an AI-assisted code review pass (Claude Code) across `dspy/evaluate/`. I personally reproduced the `ZeroDivisionError`, wrote/verified the regression test, and confirmed no existing test covered this path before opening this PR.