### PR TITLE
fix(utils): pretty_print_history(n=0) prints entire history instead of nothing

### DIFF
--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -47,7 +47,7 @@ def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO
             with suppress(json.JSONDecodeError):
                 arguments = json.loads(arguments) if isinstance(arguments, str) else arguments
             print(_green(f"{function.get('name') or tool_call.get('name', '<unknown>')}: {json.dumps(arguments, ensure_ascii=False) if isinstance(arguments, (dict, list)) else str(arguments)}", use_colors=use_colors), file=out)
-    for item in history[-n:]:
+    for item in (history[-n:] if n > 0 else []):
         messages = item["messages"] or [{"role": "user", "content": item["prompt"]}]
         outputs = item["outputs"]
         timestamp = item.get("timestamp", "Unknown time")

--- a/tests/clients/test_inspect_global_history.py
+++ b/tests/clients/test_inspect_global_history.py
@@ -125,6 +125,23 @@ def test_inspect_empty_history(capsys):
     assert isinstance(history, list)
 
 
+def test_inspect_history_n_zero_prints_no_entries():
+    """n=0 should print no entries. `history[-n:]` treats `-0` as `0`, which previously
+    returned the *entire* list instead of an empty slice, leaking every entry's content."""
+    out = StringIO()
+    history = [
+        {"messages": [{"role": "user", "content": f"query {i}"}], "outputs": ["a"], "timestamp": f"t{i}"}
+        for i in range(3)
+    ]
+
+    pretty_print_history(history, n=0, file=out)
+
+    text = out.getvalue()
+    for i in range(3):
+        assert f"query {i}" not in text
+        assert f"t{i}" not in text
+
+
 def test_inspect_history_n_larger_than_history(capsys):
     lm = DummyLM([{"response": "First"}, {"response": "Second"}])
     dspy.configure(lm=lm)


### PR DESCRIPTION
## What

`pretty_print_history(history, n=0)` prints the **entire** history instead of nothing.

`history[-n:]` with `n=0` slices `history[0:]`, i.e. the whole list — Python slicing doesn't treat `-0` specially (`-0 == 0`), so the intent of "print the last `n` entries" silently breaks at `n=0`.

## Fix

`history[-n:] if n > 0 else []`

## How I verified this

- Added a test asserting `pretty_print_history(history, n=0)` produces no entry content, confirmed it fails (prints the whole history) before the fix, passes after.
- Ran the full `tests/clients/test_inspect_global_history.py` suite: 7 passed.
- Ran the broader `tests/clients/` + `tests/utils/` suites: 225 passed (8 pre-existing errors in `test_lm.py`, confirmed unrelated — missing `litellm` CLI binary in this environment, reproduces identically with my fix stashed out).
- pre-commit (ruff) clean.

Note: the function also has an unconditional trailing `print("\n\n\n")` footer that still runs even when the loop body never executes (empty history or `n=0`) — that's pre-existing, orthogonal cosmetic behavior I did not touch; my test is scoped to assert no entry *content* leaks through, not fully-empty output.

## Disclosure

I used AI assistance (Claude) to help investigate and draft this fix, but I personally reviewed the root cause, wrote/ran the regression test, and reviewed the final diff before submitting.