### PR TITLE
fix(teleprompt): validate restrict up front in BootstrapFewShotWithRandomSearch

### DIFF
--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -58,11 +58,13 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
         self.trainset = trainset
         self.valset = valset or trainset  # TODO: FIXME: Note this choice.
 
-        if restrict is not None and not any(seed in restrict for seed in range(-3, self.num_candidate_sets)):
-            raise ValueError(
-                f"`restrict` {restrict!r} does not match any candidate seed in "
-                f"range(-3, {self.num_candidate_sets}); no candidate programs would be evaluated."
-            )
+        if restrict is not None:
+            restrict = set(restrict)
+            if not restrict.intersection(range(-3, self.num_candidate_sets)):
+                raise ValueError(
+                    f"`restrict` {restrict!r} does not match any candidate seed in "
+                    f"range(-3, {self.num_candidate_sets}); no candidate programs would be evaluated."
+                )
 
         effective_max_errors = self.max_errors if self.max_errors is not None else dspy.settings.max_errors
 

--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -58,6 +58,12 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
         self.trainset = trainset
         self.valset = valset or trainset  # TODO: FIXME: Note this choice.
 
+        if restrict is not None and not any(seed in restrict for seed in range(-3, self.num_candidate_sets)):
+            raise ValueError(
+                f"`restrict` {restrict!r} does not match any candidate seed in "
+                f"range(-3, {self.num_candidate_sets}); no candidate programs would be evaluated."
+            )
+
         effective_max_errors = self.max_errors if self.max_errors is not None else dspy.settings.max_errors
 
         scores = []

--- a/tests/teleprompt/test_random_search.py
+++ b/tests/teleprompt/test_random_search.py
@@ -56,3 +56,21 @@ def test_restrict_matching_no_candidate_seed_raises_clear_error():
 
     with pytest.raises(ValueError, match="restrict"):
         optimizer.compile(student, teacher=teacher, trainset=trainset, restrict=[999])
+
+
+def test_restrict_as_single_use_iterator_still_matches_a_valid_seed():
+    """A single-use iterable `restrict` must not be exhausted by the upfront validation check."""
+    student = SimpleModule("input -> output")
+    teacher = SimpleModule("input -> output")
+
+    lm = DummyLM(["Initial thoughts", "Finish[blue]"])
+    dspy.configure(lm=lm)
+
+    optimizer = BootstrapFewShotWithRandomSearch(metric=simple_metric, max_bootstrapped_demos=1, max_labeled_demos=1)
+    trainset = [
+        Example(input="What is the color of the sky?", output="blue").with_inputs("input"),
+    ]
+
+    # -3 (zero-shot) is a valid seed; a plain iterator is single-use.
+    result = optimizer.compile(student, teacher=teacher, trainset=trainset, restrict=iter([-3]))
+    assert result is not None

--- a/tests/teleprompt/test_random_search.py
+++ b/tests/teleprompt/test_random_search.py
@@ -1,3 +1,5 @@
+import pytest
+
 import dspy
 from dspy import Example
 from dspy.predict import Predict
@@ -37,3 +39,20 @@ def test_basic_workflow():
         Example(input="What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!").with_inputs("input"),
     ]
     optimizer.compile(student, teacher=teacher, trainset=trainset)
+
+
+def test_restrict_matching_no_candidate_seed_raises_clear_error():
+    """restrict that matches no candidate seed should raise ValueError, not UnboundLocalError."""
+    student = SimpleModule("input -> output")
+    teacher = SimpleModule("input -> output")
+
+    lm = DummyLM(["Initial thoughts", "Finish[blue]"])
+    dspy.configure(lm=lm)
+
+    optimizer = BootstrapFewShotWithRandomSearch(metric=simple_metric, max_bootstrapped_demos=1, max_labeled_demos=1)
+    trainset = [
+        Example(input="What is the color of the sky?", output="blue").with_inputs("input"),
+    ]
+
+    with pytest.raises(ValueError, match="restrict"):
+        optimizer.compile(student, teacher=teacher, trainset=trainset, restrict=[999])


### PR DESCRIPTION
## What

If `restrict` doesn't intersect any candidate seed in `range(-3, num_candidate_sets)`, every iteration of the seed loop hits `continue` at the restrict check, so the loop body — including the `best_program = program` assignment — never runs. The code after the loop unconditionally references `best_program`, raising a confusing `UnboundLocalError` instead of a clear validation error about the invalid `restrict` argument.

## Fix

Validate `restrict` up front and raise `ValueError` with a message naming the actual problem, before any candidate evaluation work starts.

## How I verified this

- Added `test_restrict_matching_no_candidate_seed_raises_clear_error`, confirmed it fails with `UnboundLocalError` before the fix and passes (raises the intended `ValueError`) after.
- Ran the full `tests/teleprompt/test_random_search.py` (2 passed) and the broader `tests/teleprompt/` suite (74 passed).
- pre-commit (ruff lint) clean.

## Disclosure

I used AI assistance (Claude) to help investigate and draft this fix, but I personally reviewed the root cause, wrote/ran the regression test, and reviewed the final diff before submitting.