### PR TITLE
fix(predict): honor signature input defaults

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -4,7 +4,6 @@ import types
 from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
-from pydantic_core import PydanticUndefined
 
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.clients.base_lm import BaseLM
@@ -183,9 +182,9 @@ class Predict(Module, Parameter):
                 config["prediction"] = kwargs.pop("prediction")
 
         # Populate default values for missing input fields.
-        for k, v in signature.input_fields.items():
-            if k not in kwargs and v.default is not PydanticUndefined:
-                kwargs[k] = v.default
+        for name, field in signature.input_fields.items():
+            if name not in kwargs and not field.is_required():
+                kwargs[name] = field.default_factory() if field.default_factory is not None else field.default
 
         # Check and warn for extra fields not in signature
         extra_fields = [k for k in kwargs if k not in signature.input_fields]

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -417,7 +417,7 @@ class RLM(Module):
         return output
 
     def _validate_inputs(self, input_args: dict[str, Any]) -> None:
-        """Validate call-time arguments against the signature's input namespace."""
+        """Apply declared defaults and validate inputs against the signature."""
         if "interpreter" in input_args and "interpreter" not in self.signature.input_fields:
             raise TypeError(
                 "To use a caller-owned interpreter, pass it as the first positional argument when calling the module."
@@ -426,6 +426,10 @@ class RLM(Module):
         unexpected = set(input_args) - input_names
         if unexpected:
             raise ValueError(f"Unexpected inputs not declared in the signature: {sorted(unexpected)}")
+
+        for name, field in self.signature.input_fields.items():
+            if name not in input_args and not field.is_required():
+                input_args[name] = field.default_factory() if field.default_factory is not None else field.default
 
         missing = input_names - set(input_args)
         if missing:

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1061,6 +1061,7 @@ def test_per_module_history_disabled():
         program(question="What is the capital of France?")
     assert len(program.history) == 0
 
+
 def test_input_field_default_value():
     class SpyLM(dspy.LM):
         def __init__(self):
@@ -1084,11 +1085,50 @@ def test_input_field_default_value():
     user_message = lm.calls[0]["messages"][-1]["content"]
     assert "DEFAULT_CONTEXT" in user_message
 
+
+def test_input_field_default_factory_runs_once_per_omitted_call():
+    class SpyLM(dspy.LM):
+        def __init__(self):
+            super().__init__("dummy")
+            self.calls = []
+
+        def __call__(self, prompt=None, messages=None, **kwargs):
+            self.calls.append({"messages": messages})
+            return ["[[ ## answer ## ]]\ntest"]
+
+    generated_contexts = []
+
+    def make_context():
+        context = f"FACTORY_CONTEXT_{len(generated_contexts) + 1}"
+        generated_contexts.append(context)
+        return context
+
+    class SignatureWithFactory(dspy.Signature):
+        context: str = dspy.InputField(default_factory=make_context)
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    lm = SpyLM()
+    dspy.configure(lm=lm)
+    predictor = Predict(SignatureWithFactory)
+
+    predictor(question="first")
+    predictor(question="second")
+    predictor(context="EXPLICIT_CONTEXT", question="third")
+
+    user_messages = [call["messages"][-1]["content"] for call in lm.calls]
+    assert generated_contexts == ["FACTORY_CONTEXT_1", "FACTORY_CONTEXT_2"]
+    assert "FACTORY_CONTEXT_1" in user_messages[0]
+    assert "FACTORY_CONTEXT_2" in user_messages[1]
+    assert "EXPLICIT_CONTEXT" in user_messages[2]
+
+
 def log_test_helper():
     lm = DummyLM([{"answer": "test output"}])
     dspy.configure(lm=lm)
     dspy_logger = logging.getLogger("dspy")
     dspy_logger.propagate = True
+
 
 def test_extra_fields_warning(caplog):
     """Test that extra fields not in signature generate a warning."""

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -311,6 +311,81 @@ class TestRLMInitialization:
 
         with pytest.raises(TypeError, match="Sub-LM response must contain text, got NoneType"):
             tools["llm_query"]("test prompt")
+    @pytest.mark.parametrize(
+        ("call_args", "expected_context"),
+        [
+            ({"query": "What is DSPy?"}, "default context"),
+            ({"query": "What is DSPy?", "context": "caller context"}, "caller context"),
+        ],
+    )
+    def test_forward_applies_declared_input_defaults(self, call_args, expected_context):
+        import dspy
+
+        class QA(dspy.Signature):
+            context: str = dspy.InputField(default="default context")
+            qualifier: str | None = dspy.InputField(default=None)
+            query: str = dspy.InputField()
+            answer: str = dspy.OutputField()
+
+        mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
+        rlm = RLM(QA)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+        ])
+
+        result = rlm.forward(mock, **call_args)
+
+        assert result.answer == "done"
+        assert mock.call_history[0][1] == {
+            **call_args,
+            "context": expected_context,
+            "qualifier": None,
+        }
+
+    def test_forward_calls_declared_default_factory_only_when_input_is_omitted(self):
+        import dspy
+
+        generated_contexts = []
+
+        def make_context():
+            context = [f"factory context {len(generated_contexts) + 1}"]
+            generated_contexts.append(context)
+            return context
+
+        class QA(dspy.Signature):
+            context: list[str] = dspy.InputField(default_factory=make_context)
+            query: str = dspy.InputField()
+            answer: str = dspy.OutputField()
+
+        rlm = RLM(QA)
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+        ])
+        default_mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
+        explicit_mock = MockInterpreter(responses=[FinalOutput({"answer": "done"})])
+
+        rlm.forward(default_mock, query="uses default")
+        rlm.forward(explicit_mock, context=["caller context"], query="uses caller value")
+
+        assert generated_contexts == [["factory context 1"]]
+        assert default_mock.call_history[0][1]["context"] == ["factory context 1"]
+        assert explicit_mock.call_history[0][1]["context"] == ["caller context"]
+
+    def test_optional_input_without_default_remains_required(self):
+        import dspy
+
+        class QA(dspy.Signature):
+            context: str | None = dspy.InputField()
+            answer: str = dspy.OutputField()
+
+        factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "done"})])
+        rlm = RLM(QA, interpreter_factory=factory)
+
+        with pytest.raises(ValueError, match="Missing required inputs: \\['context'\\]"):
+            rlm()
+
+        assert factory.instances == []
+
     @pytest.mark.parametrize("unexpected_name", ["SUBMIT", "lookup", "tools"])
     def test_forward_rejects_undeclared_inputs_before_interpreter_execution(self, unexpected_name):
         def lookup() -> str:


### PR DESCRIPTION
> **Stack:** one commit on top of #10020. This restores the independent landing path intended by #10024, which was accidentally merged into its parent branch. It also includes the zero-argument `default_factory` follow-up found while reviewing that change.

## 1. Issue / repro

RLM rejects omitted inputs even when the signature declares their values, while `Predict` handles literal defaults but skips factory-backed defaults:

```python
class QA(dspy.Signature):
    context: str = dspy.InputField(default="default context")
    tags: list[str] = dspy.InputField(default_factory=list)
    query: str = dspy.InputField()
    answer: str = dspy.OutputField()

dspy.RLM(QA)(query="What is DSPy?")
# Before: ValueError: Missing required inputs: ['context', 'tags']
```

The same signature should not have different omission semantics at the `Predict` and `RLM` boundaries.

## 2. Why this is the root cause

RLM currently classifies every absent input name as missing without consulting its field declaration. `Predict` consults `field.default`, which handles literal values but leaves `default_factory` fields unresolved.

Both decisions happen before LM or interpreter execution. No provider, prompt, or interpreter change can repair a declared default that never reaches those layers.

## 3. How we know the fix targets the root cause

The public-path tests prove that:

- omitted literal defaults reach RLM;
- explicit caller values override those defaults;
- `default=None` is distinct from a nullable field without a default;
- zero-argument factories run exactly once for each omitted call;
- factories do not run when the caller supplies a value;
- `Predict` and RLM use the same required/default distinction.

## 4. Why this is the concise fix

Both module boundaries use Pydantic's stable `is_required()` predicate and then resolve the one declared value source:

```python
if name not in inputs and not field.is_required():
    inputs[name] = field.default_factory() if field.default_factory is not None else field.default
```

There is no new binder, fallback chain, coercion layer, alternate execution path, or Signature-model construction.

## 5. Context needed to validate the change

DSPy uses Pydantic fields to describe signatures, but module calls do not instantiate or validate a Signature model. Defaults are therefore resolved and passed through; caller inputs are not newly coerced or validated by this PR.

The supported factory contract is deliberately the synchronous zero-argument form available across DSPy's full `pydantic>=2.0` range.

## 6. What the fix does

- Applies declared literal and zero-argument factory defaults before missing-input validation.
- Preserves every explicit caller value, including explicit `None`.
- Adds factory support to the existing `Predict` default path.
- Keeps nullable-but-defaultless inputs required.

## Compatibility boundaries and downsides

- **Previously failing calls now execute.** Omitting a field with a declared default reaches LM/interpreter work instead of raising.
- **A zero-argument factory runs once per omitted module call.** Its exception propagates before LM or interpreter execution.
- **Factories are synchronous in both call paths.** `Predict.acall()` and `RLM.aforward()` do not await async factories.
- **Nullable does not mean optional.** `value: str | None = InputField()` remains required unless it declares `default=None`.
- **Literal mutable defaults retain their existing shared-object semantics.** Use `default_factory` for a fresh mutable value per call.
- **Defaults are resolved, not Pydantic-validated.** Existing DSPy calls continue to pass declared and caller values through without constructing a Signature model.
- **Data-aware Pydantic 2.10+ factories are not supported.** DSPy has no honest `validated_data` mapping because it does not validate/coerce Signature inputs.

  Passing raw DSPy kwargs as `validated_data` would silently implement different semantics:

  ```python
  from pydantic import BaseModel, Field

  def make_doubled(data):
      return data["count"] * 2

  class Inputs(BaseModel):
      count: int
      doubled: int = Field(default_factory=make_doubled)

  Inputs(count="3").doubled      # 6: Pydantic validates count to int first
  make_doubled({"count": "3"})   # "33": raw DSPy input
  ```

  Pydantic 2.0–2.9 also has no `validated_data` factory API; it was added in 2.10. Honest support would require a separate input-validation and field-ordering design.
- **No namespace, provider, adapter, tool, interpreter-lifecycle, output, or serialization behavior changes.**

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_predict.py tests/predict/test_rlm.py` — `227 passed, 2 skipped`
- zero-argument factory contract probed on Pydantic `2.0`, `2.10.0`, and locked `2.12.4` — passed
- repository pre-commit hooks on all four changed files — passed
- `git diff --check` — passed
- one commit over #10020
