### PR TITLE
feat(serialization): persist namespaced artifact metadata

### DIFF
--- a/docs/docs/diving-deeper/saving-and-loading.md
+++ b/docs/docs/diving-deeper/saving-and-loading.md
@@ -40,15 +40,19 @@ When you call `Module.load_state(state)`, DSPy runs the load against a deep copy
 
 Both are runtime-only: callbacks are hooks the caller registers per process, and history is a growing log of LM calls. They’re dropped in `__getstate__` so they don’t ride along with pickled programs and don’t bloat state files. After loading, re-register callbacks if you need them; history starts fresh.
 
-### 9. Metadata sits in a separate file
+### 9. Artifact metadata is opaque integration state
+
+`Module.artifact_metadata` lets integrations attach artifact provenance and similar state without making it an optimizable parameter. It maps integration-owned string namespaces to JSON objects. DSPy persists this data but does not interpret it; each integration owns its namespace, schema, and compatibility policy. Attach it to the top-level program passed to `dump_state` or `save`; state-only serialization does not independently preserve metadata attached to intermediate container modules.
+
+### 10. Dependency metadata sits in a separate file
 
 When you save a full program, the directory contains `program.pkl` and `metadata.json`. The metadata file holds dependency versions (Python, DSPy, cloudpickle) so you can read them without unpickling. State-only JSON saves embed the same metadata under a `"metadata"` key in the JSON dict.
 
-### 10. Version mismatches warn, don’t block
+### 11. Version mismatches warn, don’t block
 
 If you load a program saved under an older DSPy, you get a warning logged with the version delta — but the load proceeds. The save format aims for backward compatibility, and a hard version check would force users to keep stale virtualenvs around to load old programs.
 
-### 11. `modules_to_serialize` embeds user-defined classes by value
+### 12. `modules_to_serialize` embeds user-defined classes by value
 
 By default, cloudpickle serializes user classes by import path (`mymodule.MyClass`). If the loading side doesn’t have `mymodule` importable, the load fails. Passing `modules_to_serialize=[MyClass.__module__]` (or the module object) registers it with `cloudpickle.register_pickle_by_value`, embedding the class code in the pickle. Useful when you’re saving a program defined in a script rather than a package.
 
@@ -96,13 +100,33 @@ program = dspy.load("haiku_ensemble/", allow_pickle=True)
 You rarely call these directly — `Module.save` / `Module.load` are the user-facing pair — but knowing what they round-trip helps when debugging a state file.
 
 **`Module.dump_state(json_mode=True)` → `dict`**  
-Returns `{name: parameter.dump_state(...)}` for every named parameter in the tree. `json_mode=True` (the default) forces JSON-serializable shapes; `False` allows pickle-only objects through (used internally by the `.pkl` save path).
+Returns `{name: parameter.dump_state(...)}` for every named parameter in the tree, plus a reserved metadata envelope containing `artifact_metadata` when it is non-empty. `json_mode=True` (the default) forces JSON-serializable shapes; `False` allows pickle-only parameter objects through (used internally by the `.pkl` save path). Artifact metadata is always JSON-compatible and is omitted from the dumped state when empty.
 
 **`Module.load_state(state, *, allow_unsafe_lm_state=False)`**  
-Applies a state dict. Runs the load on a deep copy first to validate, then commits to the live module. Failure on the trial leaves the live module unchanged.
+Applies a state dict. Runs the load on a deep copy first to validate, then commits to the live module. Failure on the trial leaves the live module unchanged. Loading replaces the module’s complete `artifact_metadata` mapping with the saved mapping; loading state without artifact metadata clears any existing values.
+
+**`Module.artifact_metadata`**
+
+A mapping for integration-owned artifact data. Use a stable string namespace and store a JSON object under it:
+
+```python
+program.artifact_metadata["com.example.optimizer"] = {
+    "optimization_run_id": "run-123",
+    "compiled_from_run_id": "run-122",
+}
+program.save("program.json")
+
+loaded_program = MyProgram()
+loaded_program.load("program.json")
+assert loaded_program.artifact_metadata["com.example.optimizer"]["optimization_run_id"] == "run-123"
+```
+
+The mapping round-trips through direct `dump_state` / `load_state` calls and state-only JSON or PKL `save` / `load` calls. Whole-program saves preserve it inside `program.pkl`; the inspectable `metadata.json` sidecar continues to contain dependency versions only. DSPy does not merge, inspect, or act on namespace payloads.
+
+Programs that override `dump_state` or `load_state` must delegate to the base implementation to participate in artifact metadata persistence.
 
 **`Predict.dump_state(json_mode=True)`**  
-A single predictor’s state: `{"traces": [...], "train": [...], "demos": [...], "signature": {...}, "lm": {...}}`. Demos are serialized via a `serialize_object` helper that recursively converts Pydantic objects to plain dicts.
+A single predictor’s state: `{"traces": [...], "train": [...], "demos": [...], "signature": {...}, "lm": {...}}`, plus the same metadata envelope when artifact metadata is set. Demos are serialized via a `serialize_object` helper that recursively converts Pydantic objects to plain dicts.
 
 **`Signature.dump_state()`**  
 `{"instructions": str, "fields": [{"prefix": str, "description": str}, ...]}`. The instructions are the docstring — what optimizers like GEPA rewrite. Field metadata (prefix, description) round-trips too; field names and types are reconstructed from the live Signature class on load.

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -10,6 +10,7 @@ from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.clients.base_lm import BaseLM
 from dspy.dsp.utils.settings import settings
 from dspy.predict.parameter import Parameter
+from dspy.primitives.base_module import _METADATA_KEY, _artifact_metadata_from_state
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import Signature, ensure_signature
@@ -86,7 +87,7 @@ class Predict(Module, Parameter):
 
         state["signature"] = self.signature.dump_state()
         state["lm"] = self.lm.dump_state() if self.lm else None
-        return state
+        return self._state_with_artifact_metadata(state)
 
     def load_state(self, state: dict, *, allow_unsafe_lm_state: bool = False) -> "Predict":
         """Load the saved state of a `Predict` object.
@@ -99,7 +100,8 @@ class Predict(Module, Parameter):
         Returns:
             Self to allow method chaining.
         """
-        excluded_keys = ["signature", "extended_signature", "lm"]
+        artifact_metadata = _artifact_metadata_from_state(state)
+        excluded_keys = ["signature", "extended_signature", "lm", _METADATA_KEY]
         for name, value in state.items():
             # `excluded_keys` are fields that go through special handling.
             if name not in excluded_keys:
@@ -116,6 +118,7 @@ class Predict(Module, Parameter):
         if "extended_signature" in state:  # legacy, up to and including 2.5, for CoT.
             raise NotImplementedError("Loading extended_signature is no longer supported in DSPy 2.6+")
 
+        self._dspy_artifact_metadata = artifact_metadata
         return self
 
     def _get_positional_args_error_message(self):

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -1,8 +1,10 @@
 import copy
 import logging
+import math
 from collections import deque
 from collections.abc import Generator
 from pathlib import Path
+from typing import Any
 
 import cloudpickle
 import orjson
@@ -16,9 +18,126 @@ from dspy.utils.saving import get_dependency_versions
 logger = logging.getLogger(__name__)
 
 
+_METADATA_KEY = "metadata"
+_ARTIFACT_METADATA_KEY = "artifact_metadata"
+_MISSING = object()
+
+
+def _copy_json_value(value: Any, *, path: str, active_containers: set[int]) -> Any:
+    """Validate and copy a value composed only of JSON data types."""
+    if value is None or type(value) in (bool, int, str):
+        return value
+
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError(f"`{path}` must not contain non-finite numbers.")
+        return value
+
+    if type(value) is list:
+        container_id = id(value)
+        if container_id in active_containers:
+            raise ValueError(f"`{path}` must not contain cyclic data.")
+        active_containers.add(container_id)
+        try:
+            return [
+                _copy_json_value(item, path=f"{path}[{index}]", active_containers=active_containers)
+                for index, item in enumerate(value)
+            ]
+        finally:
+            active_containers.remove(container_id)
+
+    if type(value) is dict:
+        container_id = id(value)
+        if container_id in active_containers:
+            raise ValueError(f"`{path}` must not contain cyclic data.")
+        active_containers.add(container_id)
+        try:
+            copied = {}
+            for key, item in value.items():
+                if type(key) is not str:
+                    raise TypeError(f"`{path}` must contain only string keys, but received {type(key).__name__}.")
+                copied[key] = _copy_json_value(
+                    item,
+                    path=f"{path}.{key}",
+                    active_containers=active_containers,
+                )
+            return copied
+        finally:
+            active_containers.remove(container_id)
+
+    raise TypeError(f"`{path}` must contain only JSON-compatible values, but received {type(value).__name__}.")
+
+
+def _validate_and_copy_artifact_metadata(metadata: Any) -> dict[str, dict[str, Any]]:
+    if type(metadata) is not dict:
+        raise TypeError(f"`artifact_metadata` must be a dict, but received {type(metadata).__name__}.")
+
+    copied = {}
+    for namespace, payload in metadata.items():
+        if type(namespace) is not str:
+            raise TypeError(
+                f"`artifact_metadata` namespace keys must be strings, but received {type(namespace).__name__}."
+            )
+        if not namespace:
+            raise ValueError("`artifact_metadata` namespace keys must not be empty.")
+        if type(payload) is not dict:
+            raise TypeError(
+                f"`artifact_metadata.{namespace}` must be a JSON object, but received {type(payload).__name__}."
+            )
+        copied[namespace] = _copy_json_value(
+            payload,
+            path=f"artifact_metadata.{namespace}",
+            active_containers=set(),
+        )
+
+    # Validate constraints imposed by the JSON serializer as well, such as its integer range.
+    try:
+        orjson.dumps(copied)
+    except TypeError as error:
+        raise TypeError(f"`artifact_metadata` must be JSON serializable: {error}") from error
+
+    return copied
+
+
+def _artifact_metadata_from_state(state: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    if type(state) is not dict:
+        raise TypeError(f"`state` must be a dict, but received {type(state).__name__}.")
+
+    metadata = state.get(_METADATA_KEY, _MISSING)
+    if metadata is _MISSING:
+        return {}
+    if type(metadata) is not dict:
+        raise TypeError(f"`{_METADATA_KEY}` must be a dict, but received {type(metadata).__name__}.")
+
+    artifact_metadata = metadata.get(_ARTIFACT_METADATA_KEY, _MISSING)
+    if artifact_metadata is _MISSING:
+        return {}
+    return _validate_and_copy_artifact_metadata(artifact_metadata)
+
+
 class BaseModule:
     def __init__(self):
         pass
+
+    @property
+    def artifact_metadata(self) -> dict[str, dict[str, Any]]:
+        """Namespaced JSON metadata persisted when this module is the serialization root."""
+        if not hasattr(self, "_dspy_artifact_metadata"):
+            self._dspy_artifact_metadata = {}
+        return self._dspy_artifact_metadata
+
+    @artifact_metadata.setter
+    def artifact_metadata(self, value: dict[str, dict[str, Any]]) -> None:
+        self._dspy_artifact_metadata = _validate_and_copy_artifact_metadata(value)
+
+    def _state_with_artifact_metadata(self, state: dict[str, Any]) -> dict[str, Any]:
+        if _METADATA_KEY in state:
+            raise ValueError(f"`{_METADATA_KEY}` is reserved for DSPy serialization metadata.")
+
+        artifact_metadata = _validate_and_copy_artifact_metadata(self.artifact_metadata)
+        if artifact_metadata:
+            state[_METADATA_KEY] = {_ARTIFACT_METADATA_KEY: artifact_metadata}
+        return state
 
     def named_parameters(self):
         """
@@ -154,10 +273,13 @@ class BaseModule:
         return new_instance
 
     def dump_state(self, json_mode=True):
-        return {name: param.dump_state(json_mode=json_mode) for name, param in self.named_parameters()}
+        state = {name: param.dump_state(json_mode=json_mode) for name, param in self.named_parameters()}
+        return self._state_with_artifact_metadata(state)
 
     def load_state(self, state, *, allow_unsafe_lm_state=False):
         from dspy.predict.predict import Predict
+
+        artifact_metadata = _artifact_metadata_from_state(state)
 
         def _apply(module):
             for name, param in module.named_parameters():
@@ -168,6 +290,9 @@ class BaseModule:
 
         _apply(self.deepcopy())  # trial run raises before self is touched
         _apply(self)
+
+        self._dspy_artifact_metadata = artifact_metadata
+
     def save(self, path, save_program=False, modules_to_serialize=None):
         """Save the module.
 
@@ -207,6 +332,9 @@ class BaseModule:
             if path.exists() and not path.is_dir():
                 raise NotADirectoryError(f"The path '{path}' exists but is not a directory.")
 
+            for _, module in self.named_sub_modules():
+                _validate_and_copy_artifact_metadata(getattr(module, "_dspy_artifact_metadata", {}))
+
             if not path.exists():
                 # Create the directory (and any parent directories)
                 path.mkdir(parents=True)
@@ -231,7 +359,7 @@ class BaseModule:
 
         if path.suffix == ".json":
             state = self.dump_state()
-            state["metadata"] = metadata
+            state.setdefault(_METADATA_KEY, {}).update(metadata)
             try:
                 with open(path, "wb") as f:
                     f.write(orjson.dumps(state, option=orjson.OPT_INDENT_2 | orjson.OPT_APPEND_NEWLINE))
@@ -245,7 +373,7 @@ class BaseModule:
             logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
                           'this, prefer saving using json format using module.save("module.json").')
             state = self.dump_state(json_mode=False)
-            state["metadata"] = metadata
+            state.setdefault(_METADATA_KEY, {}).update(metadata)
             with open(path, "wb") as f:
                 cloudpickle.dump(state, f)
         else:

--- a/tests/primitives/test_artifact_metadata.py
+++ b/tests/primitives/test_artifact_metadata.py
@@ -1,0 +1,255 @@
+import copy
+
+import cloudpickle
+import orjson
+import pytest
+
+import dspy
+
+
+class ArtifactProgram(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.predict = dspy.Predict("question -> answer")
+
+
+class MetadataParameterProgram(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.metadata = dspy.Predict("question -> answer")
+
+
+def make_program(kind):
+    if kind == "module":
+        return ArtifactProgram()
+    return dspy.Predict("question -> answer")
+
+
+def artifact_payload():
+    return {
+        "optimization_run_id": "run-123",
+        "context": {
+            "attempt": 2,
+            "labels": ["candidate", None, True],
+            "score": 0.75,
+        },
+    }
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+def test_artifact_metadata_is_a_mutable_mapping(kind):
+    program = make_program(kind)
+
+    assert program.artifact_metadata == {}
+
+    metadata = program.artifact_metadata
+    metadata["cmpnd"] = artifact_payload()
+
+    assert program.artifact_metadata == {"cmpnd": artifact_payload()}
+
+
+def test_artifact_metadata_assignment_validates_copies_and_replaces():
+    program = ArtifactProgram()
+    assigned = {"cmpnd": artifact_payload()}
+
+    program.artifact_metadata = assigned
+    assigned["cmpnd"]["context"]["labels"].append("assignment mutation")
+
+    assert program.artifact_metadata == {"cmpnd": artifact_payload()}
+
+    with pytest.raises(TypeError):
+        program.artifact_metadata = {"cmpnd": "run-123"}
+
+    assert program.artifact_metadata == {"cmpnd": artifact_payload()}
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+def test_artifact_metadata_round_trips_through_raw_state(kind):
+    source = make_program(kind)
+    source.artifact_metadata["cmpnd"] = artifact_payload()
+    source.artifact_metadata["registry"] = {"model_version": "v2"}
+
+    state = source.dump_state()
+
+    assert state["metadata"]["artifact_metadata"] == {
+        "cmpnd": artifact_payload(),
+        "registry": {"model_version": "v2"},
+    }
+
+    target = make_program(kind)
+    target.artifact_metadata["existing"] = {"value": "old"}
+    target.load_state(state)
+
+    assert target.artifact_metadata == {
+        "cmpnd": artifact_payload(),
+        "registry": {"model_version": "v2"},
+    }
+    if kind == "predict":
+        assert not hasattr(target, "metadata")
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+def test_empty_artifact_metadata_is_omitted_and_missing_metadata_clears(kind):
+    source = make_program(kind)
+
+    state = source.dump_state()
+
+    assert "metadata" not in state
+
+    target = make_program(kind)
+    target.artifact_metadata["cmpnd"] = artifact_payload()
+    target.load_state(state)
+
+    assert target.artifact_metadata == {}
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+def test_dumped_and_loaded_artifact_metadata_are_detached(kind):
+    source = make_program(kind)
+    source.artifact_metadata["cmpnd"] = artifact_payload()
+
+    state = source.dump_state()
+    state["metadata"]["artifact_metadata"]["cmpnd"]["context"]["labels"].append("dump mutation")
+
+    assert source.artifact_metadata == {"cmpnd": artifact_payload()}
+
+    load_state = source.dump_state()
+    target = make_program(kind)
+    target.load_state(load_state)
+    load_state["metadata"]["artifact_metadata"]["cmpnd"]["context"]["labels"].append("load mutation")
+
+    assert target.artifact_metadata == {"cmpnd": artifact_payload()}
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+@pytest.mark.parametrize("suffix", [".json", ".pkl"])
+def test_artifact_metadata_round_trips_through_state_only_files(kind, suffix, tmp_path):
+    source = make_program(kind)
+    source.artifact_metadata["cmpnd"] = artifact_payload()
+    path = tmp_path / f"program{suffix}"
+
+    source.save(path)
+
+    if suffix == ".json":
+        saved_state = orjson.loads(path.read_bytes())
+    else:
+        with path.open("rb") as file:
+            saved_state = cloudpickle.load(file)
+    assert saved_state["metadata"]["artifact_metadata"] == {"cmpnd": artifact_payload()}
+    assert "dependency_versions" in saved_state["metadata"]
+
+    target = make_program(kind)
+    target.artifact_metadata["existing"] = {"value": "old"}
+    target.load(path, allow_pickle=suffix == ".pkl")
+
+    assert target.artifact_metadata == {"cmpnd": artifact_payload()}
+    if kind == "predict":
+        assert not hasattr(target, "metadata")
+
+
+@pytest.mark.parametrize("suffix", [".json", ".pkl"])
+def test_empty_artifact_metadata_is_omitted_from_state_only_files(suffix, tmp_path):
+    program = ArtifactProgram()
+    path = tmp_path / f"program{suffix}"
+
+    program.save(path)
+
+    if suffix == ".json":
+        saved_state = orjson.loads(path.read_bytes())
+    else:
+        with path.open("rb") as file:
+            saved_state = cloudpickle.load(file)
+    assert "artifact_metadata" not in saved_state["metadata"]
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+def test_artifact_metadata_round_trips_through_full_program_save(kind, tmp_path):
+    source = make_program(kind)
+    source.artifact_metadata["cmpnd"] = artifact_payload()
+    path = tmp_path / "program"
+
+    source.save(path, save_program=True)
+    loaded = dspy.load(path, allow_pickle=True)
+
+    assert loaded.artifact_metadata == {"cmpnd": artifact_payload()}
+
+
+def test_full_program_save_validates_artifact_metadata(tmp_path):
+    program = ArtifactProgram()
+    program.predict.artifact_metadata["cmpnd"] = {"value": object()}
+
+    with pytest.raises(TypeError):
+        program.save(tmp_path / "program", save_program=True)
+
+
+def test_metadata_is_a_reserved_root_state_key():
+    program = MetadataParameterProgram()
+
+    with pytest.raises(ValueError, match="reserved for DSPy serialization metadata"):
+        program.dump_state()
+
+
+@pytest.mark.parametrize(
+    ("namespace", "payload", "exception"),
+    [
+        (1, {}, TypeError),
+        ("", {}, ValueError),
+        ("cmpnd", "run-123", TypeError),
+        ("cmpnd", {1: "value"}, TypeError),
+        ("cmpnd", {"value": object()}, TypeError),
+        ("cmpnd", {"score": float("nan")}, ValueError),
+        ("cmpnd", {"score": float("inf")}, ValueError),
+    ],
+)
+def test_dump_state_validates_artifact_metadata_as_namespaced_json_objects(namespace, payload, exception):
+    program = ArtifactProgram()
+    program.artifact_metadata[namespace] = payload
+
+    with pytest.raises(exception):
+        program.dump_state()
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+@pytest.mark.parametrize(
+    ("artifact_metadata", "exception"),
+    [
+        (None, TypeError),
+        ({1: {}}, TypeError),
+        ({"": {}}, ValueError),
+        ({"cmpnd": "run-123"}, TypeError),
+        ({"cmpnd": {"value": object()}}, TypeError),
+        ({"cmpnd": {"score": float("-inf")}}, ValueError),
+    ],
+)
+def test_load_state_rejects_invalid_artifact_metadata_without_mutation(kind, artifact_metadata, exception):
+    source = make_program(kind)
+    state = source.dump_state()
+    state["metadata"] = {"artifact_metadata": artifact_metadata}
+
+    target = make_program(kind)
+    target.artifact_metadata["existing"] = {"value": "old"}
+
+    with pytest.raises(exception):
+        target.load_state(state)
+
+    assert target.artifact_metadata == {"existing": {"value": "old"}}
+
+
+@pytest.mark.parametrize("kind", ["module", "predict"])
+def test_failed_parameter_load_preserves_artifact_metadata(kind):
+    source = make_program(kind)
+    source.artifact_metadata["cmpnd"] = artifact_payload()
+    state = source.dump_state()
+    if kind == "module":
+        del state["predict"]
+    else:
+        del state["signature"]
+
+    target = make_program(kind)
+    target.artifact_metadata["existing"] = {"value": "old"}
+    original_metadata = copy.deepcopy(target.artifact_metadata)
+
+    with pytest.raises(KeyError):
+        target.load_state(state)
+
+    assert target.artifact_metadata == original_metadata


### PR DESCRIPTION
## Summary

- add a mutable `BaseModule.artifact_metadata` mapping for integration-owned, namespaced JSON objects
- persist the mapping through `dump_state` / `load_state`, state-only JSON and pickle saves, and whole-program saves
- merge artifact metadata with DSPy's existing dependency-version envelope instead of introducing a separate serialization API
- prevent the reserved file metadata envelope from leaking into root `Predict` instances
- document serialization-root scope and add focused coverage for validation, replacement, clearing, and failed loads

## Why

DSPy state-only serialization currently preserves named parameters but drops arbitrary Python attributes. Integrations that attach provenance such as an optimization run ID therefore lose that data across a raw state or file round-trip.

This adds a general persistence channel rather than special-casing optimization lineage. DSPy stores the data opaquely; each integration owns its namespace and schema.

## Behavior

```python
program.artifact_metadata["cmpnd"] = {
    "optimization_run_id": "run-123",
}
```

Artifact metadata must be a JSON object under a non-empty string namespace. Loading replaces the complete mapping, and loading state without artifact metadata clears stale values. Metadata is validated and copied before serialization or mutation of the loaded program.

## Validation

- `uv run --frozen pytest --deno -q tests/primitives/test_artifact_metadata.py tests/primitives/test_base_module.py tests/primitives/test_module.py tests/utils/test_saving.py tests/predict/test_predict.py` — 158 passed, 4 skipped
- `uv run --frozen ruff check dspy/primitives/base_module.py dspy/predict/predict.py tests/primitives/test_artifact_metadata.py`
- `git diff --check`
