### PR TITLE
fix: flatten Chat-format tools/tool_choice in Responses API converter

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -654,7 +654,46 @@ def _convert_chat_request_to_responses_request(request: dict[str, Any]):
         text = request.pop("text", {})
         request["text"] = {**text, "format": response_format}
 
+    # Convert `tools` from Chat Completions format to Responses API flattened shape.
+    if "tools" in request:
+        request["tools"] = [
+            _chat_tool_to_responses_tool(t) for t in request["tools"]
+        ]
+
+    # Convert `tool_choice` object form from Chat to Responses shape.
+    # String values ("auto", "required", "none") pass through unchanged.
+    if isinstance(request.get("tool_choice"), dict):
+        request["tool_choice"] = _chat_tool_choice_to_responses(request["tool_choice"])
+
     return request
+
+
+def _chat_tool_to_responses_tool(t: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Chat Completions tool definition to Responses API format.
+
+    Chat format (produced by the native-FC adapter):
+        {"type": "function", "function": {name, description, parameters, strict}}
+
+    Responses format:
+        {"type": "function", name, description, parameters, strict}
+
+    Passes already-flat / hosted tools through unchanged.
+    """
+    if t.get("type") == "function" and "function" in t:
+        fn = t.pop("function")
+        t.update(fn)  # hoist name/description/parameters/strict to top level
+    return t
+
+
+def _chat_tool_choice_to_responses(tc: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Chat Completions tool_choice object to Responses API format.
+
+    Chat object form:    {"type": "function", "function": {"name": "X"}}
+    Responses form:      {"type": "function", "name": "X"}
+    """
+    if tc.get("type") == "function" and "function" in tc:
+        tc = {"type": "function", "name": tc["function"]["name"]}
+    return tc
 
 
 def _convert_content_item_to_responses_format(item: dict[str, Any]) -> dict[str, Any]:

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -680,6 +680,7 @@ def _chat_tool_to_responses_tool(t: dict[str, Any]) -> dict[str, Any]:
     Passes already-flat / hosted tools through unchanged.
     """
     if t.get("type") == "function" and "function" in t:
+        t = dict(t)  # copy to avoid mutating the caller's tool dict
         fn = t.pop("function")
         t.update(fn)  # hoist name/description/parameters/strict to top level
     return t

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1531,6 +1531,83 @@ def test_responses_api_preserves_multi_message_structure():
     assert result["input"][3]["content"] == [{"type": "input_text", "text": "And 3+3?"}]
 
 
+def test_responses_api_flattens_chat_tools() -> None:
+    """Chat-format tools are flattened to Responses-API shape."""
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "Search a knowledge base.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                    },
+                },
+            },
+        ],
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert "tools" in result
+    assert len(result["tools"]) == 1
+    tool = result["tools"][0]
+    assert tool["type"] == "function"
+    assert tool["name"] == "search"
+    assert tool["description"] == "Search a knowledge base."
+    assert "function" not in tool
+
+
+def test_responses_api_flattens_tool_choice_object() -> None:
+    """Chat-format tool_choice object is flattened to Responses-API shape."""
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}],
+        "tool_choice": {"type": "function", "function": {"name": "search"}},
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert result["tool_choice"] == {"type": "function", "name": "search"}
+
+
+def test_responses_api_preserves_string_tool_choice() -> None:
+    """String tool_choice values pass through unchanged."""
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    for choice in ("auto", "required", "none"):
+        request = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}],
+            "tool_choice": choice,
+        }
+        result = _convert_chat_request_to_responses_request(request)
+        assert result["tool_choice"] == choice, f"failed for tool_choice={choice!r}"
+
+
+def test_responses_api_no_tools_passes_through() -> None:
+    """Request without tools is unaffected by the tools conversion."""
+    from dspy.clients.lm import _convert_chat_request_to_responses_request
+
+    request = {
+        "messages": [{"role": "user", "content": "What is 2+2?"}],
+        "reasoning_effort": "low",
+    }
+
+    result = _convert_chat_request_to_responses_request(request)
+
+    assert "tools" not in result
+    assert "tool_choice" not in result
+    assert result["input"][0]["content"][0]["text"] == "What is 2+2?"
+
+
 def test_responses_api_with_image_input():
     api_response = make_response(
         output_blocks=[


### PR DESCRIPTION
## Summary

Fixes #9943

**Problem:** When `model_type="responses"` is used with native function calling, the adapter emits Chat Completions-format tools (`{"type":"function","function":{name, description, parameters}}`), but the Responses API requires the flattened shape (`{"type":"function", name, description, parameters}` — top-level keys, no nested `"function"` object). The same nesting issue affects `tool_choice` objects.

Since LiteLLM does not reshape tools on the native Responses path, the converter must handle this — which it now does.

**Changes in `dspy/clients/lm.py`:**
- `_chat_tool_to_responses_tool()` — hoists `t["function"]` keys to top level for `{"type":"function",…}` tools, passing hosted/other tool types through unchanged
- `_chat_tool_choice_to_responses()` — flattens the object form; string values (`"auto"`/`"required"`/`"none"`) pass through unchanged
- Both wired into `_convert_chat_request_to_responses_request` alongside existing `messages`/`reasoning_effort`/`response_format` translations

**Tests added (4) to `tests/clients/test_lm.py`:**
- `test_responses_api_flattens_chat_tools` — verifies `{"function":{name,description,parameters}}` → top-level keys
- `test_responses_api_flattens_tool_choice_object` — verifies `{"function":{"name":"X"}}` → `{"name":"X"}`
- `test_responses_api_preserves_string_tool_choice` — string values pass through unchanged
- `test_responses_api_no_tools_passes_through` — no-tools requests unaffected

**All 12 existing + 4 new `responses_api` tests pass (the single async failure is a pre-existing `pytest-asyncio` dependency issue).**