### PR TITLE
fix(utils): Unbatchify re-arms the full timeout on every queue.get(), violating max_wait_time

### DIFF
--- a/dspy/utils/unbatchify.py
+++ b/dspy/utils/unbatchify.py
@@ -57,8 +57,9 @@ class Unbatchify:
             futures = []
             start_time = time.time()
             while len(batch) < self.max_batch_size and (time.time() - start_time) < self.max_wait_time:
+                remaining_time = self.max_wait_time - (time.time() - start_time)
                 try:
-                    input_item, future = self.input_queue.get(timeout=self.max_wait_time)
+                    input_item, future = self.input_queue.get(timeout=max(remaining_time, 0))
                     batch.append(input_item)
                     futures.append(future)
                 except queue.Empty:

--- a/tests/utils/test_unbatchify.py
+++ b/tests/utils/test_unbatchify.py
@@ -70,3 +70,28 @@ def test_unbatchify_timeout_trigger():
     assert results == [101, 201]
 
     unbatcher.close()
+
+
+def test_unbatchify_honors_max_wait_time_under_trickling_input():
+    """A batch must flush within max_wait_time of the FIRST item arriving, even if
+    later items keep trickling in just under max_wait_time apart from each other.
+    Each queue.get() must wait only the time remaining in the window, not the full
+    max_wait_time again - otherwise the total wait can be a multiple of the budget."""
+    batch_fn_mock = MagicMock(wraps=simple_batch_processor)
+    wait_time = 0.1
+    unbatcher = Unbatchify(batch_fn=batch_fn_mock, max_batch_size=10, max_wait_time=wait_time)
+
+    start = time.time()
+    future_1 = unbatcher.submit(1)
+    time.sleep(wait_time * 0.8)  # arrives well within the window, but close to its edge
+    future_2 = unbatcher.submit(2)
+
+    results = [future_1.result(timeout=2), future_2.result(timeout=2)]
+    elapsed = time.time() - start
+
+    assert results == [2, 3]
+    # Generous slack for scheduling jitter, but must stay well under 2x the budget
+    # (which is what the unfixed code produces for this timing).
+    assert elapsed < wait_time * 1.5
+
+    unbatcher.close()


### PR DESCRIPTION
## What

The worker loop's outer `while` condition correctly checks elapsed time against `max_wait_time`, but each inner `queue.get(timeout=self.max_wait_time)` call re-arms with the *full* timeout again rather than the time remaining in the window. Under trickling input (items arriving spaced just under `max_wait_time` apart), each `get()` succeeds before its own fresh timeout expires, so the outer time check is only re-evaluated after another full wait — the batch can be flushed at a multiple of the configured `max_wait_time` instead of within it.

Measured: with `max_wait_time=0.1s` and two items arriving 0.08s apart, the batch flushed at **0.181s** — nearly double the configured bound.

```python
u = Unbatchify(batch_fn=..., max_batch_size=10, max_wait_time=0.1)
# item 1 submitted at t=0, item 2 submitted at t=0.08
# batch flushes at t≈0.18, not within t≈0.1
```

## Fix

Compute the time remaining in the window and pass that (floored at 0) to `queue.get()` instead of the full `max_wait_time`.

## Testing

Added `test_unbatchify_honors_max_wait_time_under_trickling_input` to `tests/utils/test_unbatchify.py`. Confirmed via `git stash` that it fails against the pre-fix code (measured 0.181s against a `wait_time*1.5 = 0.15s` bound) and passes after.

- `pytest tests/utils/test_unbatchify.py` — 3/3 passed.
- `ruff check`/`ruff format --check` clean on the changed lines (pre-existing unrelated formatting drift elsewhere in the file left untouched).
- pre-commit (ruff lint) passed on commit.

## AI disclosure

Developed with AI assistance (Claude Code), which located the timing bug while auditing `unbatchify.py`'s worker loop. I reviewed the diff, independently reproduced the max_wait_time violation and the fix by executing both against the actual class with real threads/timing, and ran the tests/linters myself before opening this PR.