### PR TITLE
fix(rlm): validate generated actions before execution

### DIFF
--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -593,7 +593,7 @@ class RLM(Module):
 
     def _process_execution_result(
         self,
-        pred: Prediction,
+        reasoning: str,
         code: str,
         result: Any,
         history: REPLHistory,
@@ -604,7 +604,7 @@ class RLM(Module):
         This shared helper reduces duplication between sync and async execution paths.
 
         Args:
-            pred: The prediction containing reasoning and code attributes
+            reasoning: Validated reasoning for the executed action
             code: Code to record in history (already stripped when possible)
             result: Result from interpreter.execute() - FinalOutput, list, str, or error string
             history: Current REPL history
@@ -616,22 +616,22 @@ class RLM(Module):
         # Handle error strings from caught exceptions
         if isinstance(result, str) and result.startswith("[Error]"):
             output = self._format_output(result)
-            return history.append(reasoning=pred.reasoning, code=code, output=output)
+            return history.append(reasoning=reasoning, code=code, output=output)
 
         # Handle FINAL output
         if isinstance(result, FinalOutput):
             parsed_outputs, error = self._process_final_output(result, output_field_names)
 
             if error:
-                return history.append(reasoning=pred.reasoning, code=code, output=error)
+                return history.append(reasoning=reasoning, code=code, output=error)
 
             final_history = history.append(
-                reasoning=pred.reasoning, code=code, output=f"FINAL: {parsed_outputs}"
+                reasoning=reasoning, code=code, output=f"FINAL: {parsed_outputs}"
             )
             return Prediction(
                 **parsed_outputs,
                 trajectory=[e.model_dump() for e in final_history],
-                final_reasoning=pred.reasoning,
+                final_reasoning=reasoning,
             )
 
         # Format non-final result as output
@@ -643,7 +643,7 @@ class RLM(Module):
         output = self._format_output(output)
         if self.verbose:
             logger.info(REPLEntry.format_output(output, self.max_output_chars))
-        return history.append(reasoning=pred.reasoning, code=code, output=output)
+        return history.append(reasoning=reasoning, code=code, output=output)
 
     def _execute_code(
         self,
@@ -655,6 +655,63 @@ class RLM(Module):
             return repl.execute(code)
         except (CodeExecutionError, SyntaxError) as e:
             return f"[Error] {e}"
+
+    def _execute_action(
+        self,
+        repl: CodeInterpreter,
+        action: Prediction,
+        history: REPLHistory,
+        iteration: int,
+        output_field_names: list[str],
+    ) -> Prediction | REPLHistory:
+        """Validate and execute one generated action."""
+        reasoning = action.get("reasoning")
+        raw_code = action.get("code")
+
+        for name, value in (("reasoning", reasoning), ("code", raw_code)):
+            if value is not None and not isinstance(value, str):
+                raise TypeError(f"RLM action field `{name}` must be str, got {type(value).__name__}")
+
+        if self.verbose:
+            logger.info(
+                f"RLM iteration {iteration + 1}/{self.max_iters}\n"
+                f"Reasoning: {reasoning}\nCode:\n{raw_code}"
+            )
+
+        errors = []
+        if reasoning is None or not reasoning.strip():
+            errors.append("`reasoning` must be a non-empty string.")
+
+        code = raw_code or ""
+        parse_error = None
+        if raw_code is None or not raw_code.strip():
+            code = ""
+            errors.append("`code` must contain non-empty Python code.")
+        else:
+            try:
+                code = _strip_code_fences(raw_code)
+            except SyntaxError as error:
+                parse_error = str(error)
+            else:
+                if not code:
+                    errors.append("`code` must contain non-empty Python code.")
+
+        if errors or parse_error:
+            if errors:
+                if parse_error:
+                    errors.append(parse_error)
+                error_output = f"[Error] Malformed RLM action: {' '.join(errors)}"
+            else:
+                error_output = f"[Error] {parse_error}"
+            output = self._format_output(error_output)
+            return history.append(
+                reasoning=reasoning if reasoning and reasoning.strip() else "",
+                code=code,
+                output=output,
+            )
+
+        result = self._execute_code(repl, code)
+        return self._process_execution_result(reasoning, code, result, history, output_field_names)
 
     def _execute_iteration(
         self,
@@ -671,20 +728,7 @@ class RLM(Module):
             repl_history=history,
             iteration=f"{iteration + 1}/{self.max_iters}",
         )
-        if self.verbose:
-            logger.info(
-                f"RLM iteration {iteration + 1}/{self.max_iters}\n"
-                f"Reasoning: {action.reasoning}\nCode:\n{action.code}"
-            )
-
-        try:
-            code = _strip_code_fences(action.code)
-        except SyntaxError as e:
-            code = action.code
-            result = f"[Error] {e}"
-            return self._process_execution_result(action, code, result, history, output_field_names)
-        result = self._execute_code(repl, code)
-        return self._process_execution_result(action, code, result, history, output_field_names)
+        return self._execute_action(repl, action, history, iteration, output_field_names)
 
     # =========================================================================
     # Public Interface
@@ -763,20 +807,7 @@ class RLM(Module):
             repl_history=history,
             iteration=f"{iteration + 1}/{self.max_iters}",
         )
-        if self.verbose:
-            logger.info(
-                f"RLM iteration {iteration + 1}/{self.max_iters}\n"
-                f"Reasoning: {pred.reasoning}\nCode:\n{pred.code}"
-            )
-
-        try:
-            code = _strip_code_fences(pred.code)
-        except SyntaxError as e:
-            code = pred.code
-            result = f"[Error] {e}"
-            return self._process_execution_result(pred, code, result, history, output_field_names)
-        result = self._execute_code(repl, code)
-        return self._process_execution_result(pred, code, result, history, output_field_names)
+        return self._execute_action(repl, pred, history, iteration, output_field_names)
 
     async def aforward(self, interpreter: CodeInterpreter | None = None, /, **input_args) -> Prediction:
         """Async version of forward(). Execute RLM to produce outputs.

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -36,6 +36,7 @@ def make_mock_predictor(responses: list[dict], async_mode: bool = False):
     class MockPredictor:
         def __init__(self):
             self.idx = 0
+            self.calls = []
 
         def _next_response(self):
             result = responses[self.idx % len(responses)]
@@ -43,9 +44,11 @@ def make_mock_predictor(responses: list[dict], async_mode: bool = False):
             return Prediction(**result)
 
         def __call__(self, **kwargs):
+            self.calls.append(kwargs)
             return self._next_response()
 
         async def acall(self, **kwargs):
+            self.calls.append(kwargs)
             return self._next_response()
 
     return MockPredictor()
@@ -967,6 +970,110 @@ class TestRLMToolExceptions:
 
         with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
             await rlm.aforward(mock, query="test")
+
+
+class TestRLMMalformedActions:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("run_async", [False, True], ids=["sync", "async"])
+    @pytest.mark.parametrize(
+        ("malformed_action", "expected_entry"),
+        [
+            pytest.param(
+                {"reasoning": None, "code": None},
+                {
+                    "reasoning": "",
+                    "code": "",
+                    "output": (
+                        "[Error] Malformed RLM action: `reasoning` must be a non-empty string. "
+                        "`code` must contain non-empty Python code."
+                    ),
+                },
+                id="null-fields",
+            ),
+            pytest.param(
+                {"code": 'SUBMIT("must-not-run")'},
+                {
+                    "reasoning": "",
+                    "code": 'SUBMIT("must-not-run")',
+                    "output": "[Error] Malformed RLM action: `reasoning` must be a non-empty string.",
+                },
+                id="missing-reasoning",
+            ),
+            pytest.param(
+                {"reasoning": " \t", "code": 'SUBMIT("must-not-run")'},
+                {
+                    "reasoning": "",
+                    "code": 'SUBMIT("must-not-run")',
+                    "output": "[Error] Malformed RLM action: `reasoning` must be a non-empty string.",
+                },
+                id="blank-reasoning",
+            ),
+            pytest.param(
+                {"reasoning": "Inspect the data", "code": " \n\t"},
+                {
+                    "reasoning": "Inspect the data",
+                    "code": "",
+                    "output": "[Error] Malformed RLM action: `code` must contain non-empty Python code.",
+                },
+                id="blank-code",
+            ),
+            pytest.param(
+                {"reasoning": "Inspect the data", "code": "```python\n \n```"},
+                {
+                    "reasoning": "Inspect the data",
+                    "code": "",
+                    "output": "[Error] Malformed RLM action: `code` must contain non-empty Python code.",
+                },
+                id="empty-fenced-code",
+            ),
+        ],
+    )
+    async def test_malformed_action_is_visible_and_recoverable(self, run_async, malformed_action, expected_entry):
+        recovery_reasoning = "Retry with a complete action"
+        mock = MockInterpreter(responses=["", FinalOutput({"answer": "recovered"})])
+        rlm = RLM("query -> answer", max_iters=2, verbose=True)
+        predictor = make_mock_predictor([
+            malformed_action,
+            {"reasoning": recovery_reasoning, "code": 'SUBMIT("recovered")'},
+        ])
+        rlm.generate_action = predictor
+
+        result = await rlm.aforward(mock, query="test") if run_async else rlm.forward(mock, query="test")
+
+        assert result.answer == "recovered"
+        assert result.final_reasoning == recovery_reasoning
+        assert len(result.trajectory) == 2
+        assert result.trajectory[0] == expected_entry
+        assert result.trajectory[1]["reasoning"] == recovery_reasoning
+        assert result.trajectory[1]["code"] == 'SUBMIT("recovered")'
+        assert mock.call_history == [
+            ("pass", {"query": "test"}),
+            ('SUBMIT("recovered")', {}),
+        ]
+        assert [call["iteration"] for call in predictor.calls] == ["1/2", "2/2"]
+        assert [entry.model_dump() for entry in predictor.calls[1]["repl_history"]] == [expected_entry]
+
+    @pytest.mark.parametrize(
+        ("action", "expected_error"),
+        [
+            ({"reasoning": 42, "code": "pass"}, "RLM action field `reasoning` must be str, got int"),
+            ({"reasoning": "Inspect the data", "code": []}, "RLM action field `code` must be str, got list"),
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("run_async", [False, True], ids=["sync", "async"])
+    async def test_unexpected_action_field_types_fail_fast(self, run_async, action, expected_error):
+        mock = MockInterpreter(responses=[""])
+        rlm = RLM("query -> answer", max_iters=1)
+        rlm.generate_action = make_mock_predictor([action])
+
+        with pytest.raises(TypeError, match=expected_error):
+            if run_async:
+                await rlm.aforward(mock, query="test")
+            else:
+                rlm.forward(mock, query="test")
+
+        assert mock.call_history == [("pass", {"query": "test"})]
 
 
 class TestRLMDynamicSignature:


### PR DESCRIPTION
> **Stack:** one commit on top of #10017. GitHub should show one focused two-file diff.
>
> **Relationship to #9639:** this is a narrower alternative to the recovery proposed by @tryingET in #9639. It keeps malformed actions recoverable without making RLM's required `reasoning` output optional.

## 1. Issue / repro

RLM asks its action model for two required string fields on every iteration:

```python
reasoning: str
code: str
```

Neither field is validated before execution. That creates two surprising paths:

```python
{"reasoning": "", "code": 'SUBMIT("must-not-run")'}
# The code executes even though the required reasoning is blank.

{"reasoning": "Inspect", "code": "   "}
# The interpreter receives an empty Python no-op.
```

Legacy or custom predictor paths can also return `None`, which currently fails later through incidental string or trajectory validation rather than producing actionable model feedback.

Related to #9632. Current standard adapters already reject an entirely empty/null LM response after #9389; this PR deliberately does not change that adapter boundary.

## 2. Why this is the root cause

RLM currently treats a generated `Prediction` as executable before checking the action contract. `_strip_code_fences()` transforms a string but does not establish that both required fields exist or contain anything. `_process_execution_result()` only encounters reasoning after code has already run.

The missing boundary is therefore immediately after sync or async action generation and before logging, fence parsing, or interpreter execution.

## 3. How we know the fix targets the root cause

The regression matrix supplies malformed actions through the public sync and async RLM paths and proves that:

- missing, `None`, whitespace-only, and fenced-empty fields become one visible trajectory error;
- `SUBMIT("must-not-run")` paired with missing or blank reasoning never reaches the interpreter;
- the next action receives the exact error through `repl_history`;
- the malformed action consumes iteration `1/2`, and recovery occurs on `2/2`;
- successful recovery preserves real reasoning in `final_reasoning`;
- unexpected non-string values remain explicit `TypeError`s.

## 4. Why this is the concise fix

Both generation paths now cross one shared `_execute_action()` boundary:

```python
errors = []
if reasoning is None or not reasoning.strip():
    errors.append("`reasoning` must be a non-empty string.")
if raw_code is None or not raw_code.strip():
    errors.append("`code` must contain non-empty Python code.")

if errors:
    return history.append(...)

result = self._execute_code(repl, code)
```

There is no retry policy, cache override, provider branch, fallback interpreter, new dependency, or second sync/async implementation.

## 5. Context needed to validate the change

RLM's `reasoning` field is ordinary surfaced `str` output describing the next action; it is not a provider-private reasoning channel. The action signature and RLM documentation already require it.

`REPLEntry` still needs strings to represent a rejected action. A missing value is therefore stored as `""` only inside that explicitly invalid trajectory entry. Successful actions never normalize missing reasoning into a valid-looking `final_reasoning`.

## 6. What the fix does in the code

- Centralizes post-generation handling for sync and async actions.
- Validates field types before verbose logging.
- Requires nonblank reasoning and nonempty parsed Python code.
- Detects code blocks that become empty after fence removal.
- Records malformed actions as visible feedback without executing partial code.
- Passes validated reasoning into result processing and final output construction.

## Compatibility boundaries and downsides

- **Blank reasoning plus valid code no longer executes.** It consumes one RLM iteration and asks the next action to satisfy the declared contract.
- **Blank code is no longer an interpreter no-op.** It becomes visible trajectory feedback.
- **A malformed final iteration can force the existing extraction fallback.** No hidden iteration is added.
- **Completely empty/null LM responses still follow #9389.** Standard adapters raise `AdapterParseError` before RLM receives an action; this PR does not add a second adapter retry path.
- **Unexpected non-string action values still fail fast.** Normal adapters coerce declared string fields; other shapes indicate a custom predictor or integration contract violation.
- **No LM provider, adapter, cache, tool, interpreter lifecycle, output parsing, or serialization behavior changes.**

## Live demo / repro

This runs through public `RLM.__call__` with a real, persistent `PythonInterpreter`. The action generator is scripted only to force the exact malformed model output deterministically. The first action's executable code sets a sentinel; the second action checks whether that sentinel entered interpreter state:

```python
import dspy


class ScriptedActions:
    def __call__(self, *, repl_history, **kwargs):
        if not repl_history:
            return dspy.Prediction(reasoning="   ", code="malformed_action_ran = True")
        return dspy.Prediction(
            reasoning="Recover after the visible validation error",
            code=(
                'SUBMIT(answer="BUG: malformed code ran" '
                'if "malformed_action_ran" in globals() '
                'else "malformed code was skipped")'
            ),
        )


rlm = dspy.RLM("query -> answer", max_iters=2)
rlm.generate_action = ScriptedActions()
with dspy.PythonInterpreter() as interpreter:
    result = rlm(interpreter, query="Prove malformed RLM code is not executed.")
print(result)
```

Command:

```console
$ uv run --frozen --no-sync python rlm_action_repro.py
```

Exact unfiltered output:

```text
/private/tmp/dspy-rlm-malformed-action/.venv/lib/python3.14/site-packages/openai/_compat.py:48: UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater.
  from pydantic.v1.typing import (
Prediction(
    answer='malformed code was skipped',
    trajectory=[{'reasoning': '', 'code': 'malformed_action_ran = True', 'output': '[Error] Malformed RLM action: `reasoning` must be a non-empty string.'}, {'reasoning': 'Recover after the visible validation error', 'code': 'SUBMIT(answer="BUG: malformed code ran" if "malformed_action_ran" in globals() else "malformed code was skipped")', 'output': "FINAL: {'answer': 'malformed code was skipped'}"}],
    final_reasoning='Recover after the visible validation error'
)
```

Without this fix, the whitespace-reasoning action executes `malformed_action_ran = True`, and the second action returns `BUG: malformed code ran`. The exact output instead contains the visible validation error and `answer='malformed code was skipped'`, proving the rejected action never mutated persistent interpreter state.

## Validation

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — `160 passed, 2 skipped`
- focused malformed-action matrix — `15 passed`
- repository pre-commit hooks on both changed files — passed
- `git diff --check` — passed
- one commit and two files over #10017
