### PR TITLE
ci: pin ollama image to 0.31.2 and add warm-up health check

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -142,18 +142,32 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ollama-data
-          key: ollama-llama3.2-3b-${{ runner.os }}-v1
+          key: ollama-llama3.2-3b-${{ runner.os }}-ollama0.31.2-v2
       - name: Start Ollama service
         run: |
           mkdir -p ollama-data
           docker run -d --name ollama \
             -p 11434:11434 \
             -v "$GITHUB_WORKSPACE/ollama-data:/root/.ollama" \
-            ollama/ollama:latest
+            ollama/ollama:0.31.2
           timeout 60 bash -c 'until curl -f http://localhost:11434/api/version; do sleep 2; done'
       - name: Pull LLM
         if: steps.cache-ollama.outputs.cache-hit != 'true'
         run: docker exec ollama ollama pull llama3.2:3b
+      - name: Warm up LLM
+        run: |
+          for i in 1 2 3; do
+            if curl -fsS http://localhost:11434/api/generate \
+              -d '{"model":"llama3.2:3b","prompt":"ping","stream":false}'; then
+              echo "Ollama warm-up succeeded"
+              exit 0
+            fi
+            echo "Warm-up attempt $i failed; retrying..."
+            sleep 5
+          done
+          echo "Ollama failed to serve llama3.2:3b after 3 attempts"
+          docker logs ollama || true
+          exit 1
       - name: Set LM environment variable
         run: echo "LM_FOR_TEST=ollama/llama3.2:3b" >> "$GITHUB_ENV"
       - name: Run tests


### PR DESCRIPTION
The llm_call_test job used the floating ollama/ollama:latest tag, which rolled to 0.32.0. That build's llama-server intermittently segfaults when serving llama3.2:3b, returning HTTP 500 from /api/generate and reddening the real-LM tests. Pin the server image to 0.31.2 (the last release that was latest during the stable period), bump the model cache key so a fresh model store is pulled against the pinned image, and add a warm-up generate that retries and dumps container logs so a bad model load fails fast with diagnostics instead of mid-test.