### PR TITLE
feat(utils): native OpenTelemetry tracing via dspy.enable_otel_tracing()

### DIFF
--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -46,6 +46,7 @@ from dspy.utils.syncify import syncify
 from dspy.utils.saving import load
 from dspy.streaming.streamify import streamify
 from dspy.utils.usage_tracker import track_usage
+from dspy.utils.otel import OtelCallback, enable_otel_tracing
 
 from dspy.dsp.utils.settings import settings
 from dspy.dsp.colbertv2 import ColBERTv2

--- a/dspy/utils/otel.py
+++ b/dspy/utils/otel.py
@@ -1,0 +1,342 @@
+"""OpenTelemetry tracing for DSPy programs, built on the callback system.
+
+LM and tool spans follow the OpenTelemetry GenAI semantic conventions
+(https://opentelemetry.io/docs/specs/semconv/gen-ai/). Spans for DSPy-specific
+components without a GenAI equivalent (modules, adapters, evaluation) carry
+``dspy.*``-namespaced attributes.
+
+Requires the ``opentelemetry-api`` package (``pip install dspy[otel]``). Spans
+are emitted through whichever tracer provider is passed in (or the globally
+registered one), so traces can be exported to any OTLP-compatible backend.
+"""
+
+import json
+import os
+from typing import Any
+
+from pydantic import BaseModel
+
+from dspy.core.types import LMMessage, LMRequest, LMResponse
+from dspy.dsp.utils.settings import settings
+from dspy.utils.callback import BaseCallback
+
+_CAPTURE_CONTENT_ENV_VAR = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+_SUPPORTED_SEMCONV_VERSIONS = (1,)
+
+
+def _json_default(value: Any) -> Any:
+    from dspy.primitives.example import Example
+
+    if isinstance(value, Example):
+        return value.toDict()
+    if isinstance(value, BaseModel):
+        return value.model_dump()
+    return repr(value)
+
+
+def _serialize(value: Any) -> str:
+    return json.dumps(value, default=_json_default, ensure_ascii=False)
+
+
+def _to_genai_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert OpenAI-shaped chat messages to the GenAI semconv message structure."""
+    normalized = []
+    for message in messages:
+        content = message.get("content")
+        if isinstance(content, str):
+            parts = [{"type": "text", "content": content}]
+        elif isinstance(content, list):
+            parts = content
+        else:
+            parts = []
+        normalized.append({"role": message.get("role", "user"), "parts": parts})
+    return normalized
+
+
+def _lm_input_messages(inputs: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract OpenAI-shaped chat messages from `BaseLM.__call__` inputs."""
+    if inputs.get("messages") is not None:
+        return inputs["messages"]
+    if inputs.get("prompt") is not None:
+        return [{"role": "user", "content": inputs["prompt"]}]
+
+    items = inputs.get("items") or ()
+    request = inputs.get("request")
+    if request is None and items and isinstance(items[0], LMRequest):
+        request = items[0]
+        items = items[1:]
+    if request is not None:
+        return [message.model_dump(exclude_none=True) for message in request.messages]
+
+    messages = []
+    for item in items:
+        if isinstance(item, LMMessage):
+            messages.append(item.model_dump(exclude_none=True))
+        elif isinstance(item, str):
+            messages.append({"role": "user", "content": item})
+        else:
+            messages.append({"role": "user", "content": _serialize(item)})
+    return messages
+
+
+def _lm_output_messages(outputs: LMResponse | list[dict[str, Any] | str]) -> list[dict[str, Any]]:
+    """Convert LM outputs (typed or legacy) to the GenAI semconv message structure."""
+    if isinstance(outputs, LMResponse):
+        parts = [{"type": "text", "content": outputs.text}] if outputs.text else []
+        return [{"role": "assistant", "parts": parts}]
+
+    messages = []
+    for output in outputs:
+        if isinstance(output, str):
+            parts = [{"type": "text", "content": output}]
+        elif output.get("text"):
+            parts = [{"type": "text", "content": output["text"]}]
+        else:
+            parts = []
+        messages.append({"role": "assistant", "parts": parts})
+    return messages
+
+
+def _usage_attributes(outputs: Any) -> dict[str, int]:
+    """Extract gen_ai.usage.* attributes; only typed `LMResponse` outputs carry usage."""
+    if not isinstance(outputs, LMResponse):
+        return {}
+    usage = outputs.usage_as_dict()
+    attributes = {}
+    input_tokens = usage.get("input_tokens", usage.get("prompt_tokens"))
+    output_tokens = usage.get("output_tokens", usage.get("completion_tokens"))
+    if input_tokens is not None:
+        attributes["gen_ai.usage.input_tokens"] = input_tokens
+    if output_tokens is not None:
+        attributes["gen_ai.usage.output_tokens"] = output_tokens
+    return attributes
+
+
+class OtelCallback(BaseCallback):
+    """A callback that emits OpenTelemetry spans for DSPy component calls.
+
+    Spans nest through the OpenTelemetry context, so DSPy spans parent
+    correctly under any surrounding application spans and vice versa.
+
+    Args:
+        tracer_provider: The tracer provider to emit spans through. Defaults
+            to the globally registered provider, which is a no-op unless an
+            OpenTelemetry SDK has been configured.
+        capture_content: Whether to record prompts, completions, tool
+            arguments/results, and module/adapter inputs/outputs on spans.
+            Defaults to True unless the standard
+            ``OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`` environment
+            variable is set to a false value (``false`` or ``0``).
+        semconv_version: The DSPy GenAI attribute-layout version. Only version
+            1 exists today; the parameter lets attribute layouts evolve with
+            the (still-in-development) GenAI semantic conventions without
+            breaking existing dashboards.
+
+    Example:
+
+    ```
+    import dspy
+
+    dspy.configure(callbacks=[dspy.OtelCallback()])
+    ```
+    """
+
+    def __init__(
+        self,
+        tracer_provider: Any | None = None,
+        capture_content: bool | None = None,
+        semconv_version: int = 1,
+    ):
+        try:
+            from opentelemetry import context as otel_context
+            from opentelemetry import trace as otel_trace
+        except ImportError as e:
+            raise ImportError(
+                "OtelCallback requires the `opentelemetry-api` package. "
+                "Install it with `pip install dspy[otel]`."
+            ) from e
+
+        if semconv_version not in _SUPPORTED_SEMCONV_VERSIONS:
+            raise ValueError(
+                f"Unsupported semconv_version {semconv_version!r}; supported versions: {_SUPPORTED_SEMCONV_VERSIONS}."
+            )
+
+        from dspy.__metadata__ import __version__
+
+        self._otel_trace = otel_trace
+        self._otel_context = otel_context
+        provider = tracer_provider if tracer_provider is not None else otel_trace.get_tracer_provider()
+        self._tracer = provider.get_tracer("dspy", __version__)
+
+        if capture_content is None:
+            env_value = os.environ.get(_CAPTURE_CONTENT_ENV_VAR)
+            capture_content = env_value is None or env_value.strip().lower() not in ("false", "0")
+        self.capture_content = capture_content
+        self.semconv_version = semconv_version
+
+        # call_id -> (span, context attach token); starts and ends are paired
+        # by with_callbacks, and both run in the same thread/task context.
+        self._active_spans: dict[str, tuple[Any, Any]] = {}
+
+    def _start_span(self, call_id: str, name: str, kind: Any, attributes: dict[str, Any]):
+        attributes = {key: value for key, value in attributes.items() if value is not None}
+        span = self._tracer.start_span(name, kind=kind, attributes=attributes)
+        token = self._otel_context.attach(self._otel_trace.set_span_in_context(span))
+        self._active_spans[call_id] = (span, token)
+
+    def _end_span(self, call_id: str, exception: Exception | None, attributes: dict[str, Any] | None = None):
+        span, token = self._active_spans.pop(call_id)
+        self._otel_context.detach(token)
+        if attributes:
+            span.set_attributes({key: value for key, value in attributes.items() if value is not None})
+        if exception is not None:
+            span.record_exception(exception)
+            span.set_status(self._otel_trace.Status(self._otel_trace.StatusCode.ERROR, str(exception)))
+        span.end()
+
+    def on_module_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        from dspy.predict.predict import Predict
+
+        attributes = {"dspy.module.type": type(instance).__name__}
+        if isinstance(instance, Predict):
+            attributes["dspy.module.signature"] = instance.signature.signature
+        if self.capture_content:
+            attributes["dspy.module.input"] = _serialize(inputs)
+        self._start_span(call_id, type(instance).__name__, self._otel_trace.SpanKind.INTERNAL, attributes)
+
+    def on_module_end(self, call_id: str, outputs: Any | None, exception: Exception | None = None):
+        attributes = {}
+        if self.capture_content and outputs is not None:
+            attributes["dspy.module.output"] = _serialize(outputs)
+        self._end_span(call_id, exception, attributes)
+
+    def on_lm_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        model = instance.model
+        if "/" in model:
+            provider, model_name = model.split("/", 1)
+        else:
+            provider, model_name = None, model
+
+        attributes = {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.provider.name": provider,
+            "gen_ai.request.model": model_name,
+            "gen_ai.request.temperature": instance.kwargs.get("temperature"),
+            "gen_ai.request.max_tokens": instance.kwargs.get("max_tokens"),
+        }
+        if self.capture_content:
+            attributes["gen_ai.input.messages"] = _serialize(_to_genai_messages(_lm_input_messages(inputs)))
+        self._start_span(call_id, f"chat {model_name}", self._otel_trace.SpanKind.CLIENT, attributes)
+
+    def on_lm_end(self, call_id: str, outputs: dict[str, Any] | None, exception: Exception | None = None):
+        attributes = {}
+        if outputs is not None:
+            attributes.update(_usage_attributes(outputs))
+            if isinstance(outputs, LMResponse) and outputs.model is not None:
+                attributes["gen_ai.response.model"] = outputs.model
+            if self.capture_content:
+                attributes["gen_ai.output.messages"] = _serialize(_lm_output_messages(outputs))
+        self._end_span(call_id, exception, attributes)
+
+    def on_adapter_format_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        self._start_adapter_span(call_id, instance, inputs, method="format")
+
+    def on_adapter_format_end(self, call_id: str, outputs: dict[str, Any] | None, exception: Exception | None = None):
+        self._end_adapter_span(call_id, outputs, exception)
+
+    def on_adapter_parse_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        self._start_adapter_span(call_id, instance, inputs, method="parse")
+
+    def on_adapter_parse_end(self, call_id: str, outputs: dict[str, Any] | None, exception: Exception | None = None):
+        self._end_adapter_span(call_id, outputs, exception)
+
+    def _start_adapter_span(self, call_id: str, instance: Any, inputs: dict[str, Any], method: str):
+        attributes = {"dspy.adapter.type": type(instance).__name__, "dspy.adapter.method": method}
+        if self.capture_content:
+            attributes["dspy.adapter.input"] = _serialize(inputs)
+        self._start_span(
+            call_id, f"{type(instance).__name__}.{method}", self._otel_trace.SpanKind.INTERNAL, attributes
+        )
+
+    def _end_adapter_span(self, call_id: str, outputs: Any | None, exception: Exception | None):
+        attributes = {}
+        if self.capture_content and outputs is not None:
+            attributes["dspy.adapter.output"] = _serialize(outputs)
+        self._end_span(call_id, exception, attributes)
+
+    def on_tool_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        attributes = {
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": instance.name,
+            "gen_ai.tool.description": instance.desc,
+            "gen_ai.tool.type": "function",
+        }
+        if self.capture_content:
+            attributes["gen_ai.tool.call.arguments"] = _serialize(inputs["kwargs"])
+        self._start_span(
+            call_id, f"execute_tool {instance.name}", self._otel_trace.SpanKind.INTERNAL, attributes
+        )
+
+    def on_tool_end(self, call_id: str, outputs: dict[str, Any] | None, exception: Exception | None = None):
+        attributes = {}
+        if self.capture_content and outputs is not None:
+            attributes["gen_ai.tool.call.result"] = _serialize(outputs)
+        self._end_span(call_id, exception, attributes)
+
+    def on_evaluate_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        attributes = {"dspy.evaluate.num_examples": len(instance.devset)}
+        self._start_span(call_id, "Evaluate", self._otel_trace.SpanKind.INTERNAL, attributes)
+
+    def on_evaluate_end(self, call_id: str, outputs: Any | None, exception: Exception | None = None):
+        from dspy.evaluate.evaluate import EvaluationResult
+
+        attributes = {}
+        if isinstance(outputs, EvaluationResult):
+            attributes["dspy.evaluate.score"] = float(outputs.score)
+        self._end_span(call_id, exception, attributes)
+
+
+def enable_otel_tracing(
+    tracer_provider: Any | None = None,
+    capture_content: bool | None = None,
+    semconv_version: int = 1,
+) -> OtelCallback:
+    """Enable OpenTelemetry tracing for all DSPy component calls.
+
+    Registers an `OtelCallback` as a global DSPy callback. Calling this more
+    than once returns the already-registered callback instead of adding a
+    duplicate.
+
+    Args:
+        tracer_provider: The tracer provider to emit spans through. Defaults
+            to the globally registered provider.
+        capture_content: Whether to record prompts, completions, tool
+            arguments/results, and module/adapter inputs/outputs on spans. See
+            `OtelCallback` for the default behavior.
+        semconv_version: The DSPy GenAI attribute-layout version.
+
+    Returns:
+        The registered `OtelCallback`.
+
+    Example:
+
+    ```
+    import dspy
+
+    dspy.enable_otel_tracing()
+    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+    dspy.Predict("question -> answer")(question="What is DSPy?")
+    ```
+    """
+    existing_callbacks = settings.get("callbacks", [])
+    for callback in existing_callbacks:
+        if isinstance(callback, OtelCallback):
+            return callback
+
+    callback = OtelCallback(
+        tracer_provider=tracer_provider,
+        capture_content=capture_content,
+        semconv_version=semconv_version,
+    )
+    settings.configure(callbacks=[*existing_callbacks, callback])
+    return callback

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -1,4 +1,5 @@
 import contextlib
+import contextvars
 import copy
 import logging
 import signal
@@ -165,7 +166,12 @@ class ParallelExecutor:
                 submission_counter = 0
 
                 for idx, item in enumerate(data):
-                    f = executor.submit(worker, parent_overrides, submission_counter, idx, item)
+                    # Run each worker inside a copy of the submitting thread's context so
+                    # contextvars (e.g. OpenTelemetry context, ACTIVE_CALL_ID) propagate
+                    # into the pool threads. Each submission needs its own copy because a
+                    # Context cannot be entered concurrently.
+                    ctx = contextvars.copy_context()
+                    f = executor.submit(ctx.run, worker, parent_overrides, submission_counter, idx, item)
                     futures_map[f] = (submission_counter, idx, item)
                     futures_set.add(f)
                     submission_counter += 1
@@ -210,6 +216,7 @@ class ParallelExecutor:
                                 if st and (now - st) >= self.timeout:
                                     resubmitted.add(f)
                                     nf = executor.submit(
+                                        contextvars.copy_context().run,
                                         worker,
                                         parent_overrides,
                                         submission_counter,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ langchain = ["langchain_core>=0.3.0"]
 optuna = ["optuna>=3.4.0"]
 numpy = ["numpy>=1.26.0"]
 litellm = ["litellm>=1.65.8"]
+otel = ["opentelemetry-api>=1.25.0"]
 dev = [
     "pytest>=6.2.5",
     "pytest-mock>=3.12.0",
@@ -65,6 +66,7 @@ test_extras = [
     "optuna>=3.4.0",
     "langchain_core>=0.3.0",
     "numpy>=1.26.0",
+    "opentelemetry-sdk>=1.25.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/utils/test_otel.py
+++ b/tests/utils/test_otel.py
@@ -1,0 +1,237 @@
+import json
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind, StatusCode
+
+import dspy
+from dspy.utils.dummies import DummyLM
+from dspy.utils.otel import OtelCallback
+
+
+@pytest.fixture(autouse=True)
+def reset_settings():
+    original_settings = dspy.settings.copy()
+
+    yield
+
+    dspy.configure(**original_settings)
+
+
+@pytest.fixture()
+def tracing():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return exporter, provider
+
+
+def get_span(spans, name):
+    matches = [span for span in spans if span.name == name]
+    assert len(matches) == 1, f"Expected exactly one span named {name!r}, got {[s.name for s in spans]}"
+    return matches[0]
+
+
+def test_chain_of_thought_emits_nested_spans(tracing):
+    exporter, provider = tracing
+    lm = DummyLM([{"reasoning": "France has a capital.", "answer": "Paris"}])
+    dspy.configure(lm=lm, callbacks=[OtelCallback(tracer_provider=provider)])
+
+    dspy.ChainOfThought("question -> answer")(question="What is the capital of France?")
+
+    spans = exporter.get_finished_spans()
+    cot_span = get_span(spans, "ChainOfThought")
+    predict_span = get_span(spans, "Predict")
+    format_span = get_span(spans, "ChatAdapter.format")
+    chat_span = get_span(spans, "chat dummy")
+    parse_span = get_span(spans, "ChatAdapter.parse")
+
+    # All spans belong to one trace, rooted at the ChainOfThought span.
+    assert {span.context.trace_id for span in spans} == {cot_span.context.trace_id}
+    assert cot_span.parent is None
+    assert predict_span.parent.span_id == cot_span.context.span_id
+    for span in (format_span, chat_span, parse_span):
+        assert span.parent.span_id == predict_span.context.span_id
+
+    assert cot_span.attributes["dspy.module.type"] == "ChainOfThought"
+    module_input = json.loads(cot_span.attributes["dspy.module.input"])
+    assert module_input["kwargs"]["question"] == "What is the capital of France?"
+    assert "Paris" in cot_span.attributes["dspy.module.output"]
+
+    assert predict_span.attributes["dspy.module.signature"] == "question -> reasoning, answer"
+
+    assert chat_span.kind == SpanKind.CLIENT
+    assert chat_span.attributes["gen_ai.operation.name"] == "chat"
+    assert chat_span.attributes["gen_ai.request.model"] == "dummy"
+    input_messages = json.loads(chat_span.attributes["gen_ai.input.messages"])
+    assert [message["role"] for message in input_messages] == ["system", "user"]
+    output_messages = json.loads(chat_span.attributes["gen_ai.output.messages"])
+    assert output_messages[0]["role"] == "assistant"
+    assert "Paris" in output_messages[0]["parts"][0]["content"]
+
+    assert format_span.attributes["dspy.adapter.method"] == "format"
+    assert parse_span.attributes["dspy.adapter.method"] == "parse"
+
+
+def test_capture_content_disabled_omits_payloads(tracing):
+    exporter, provider = tracing
+    lm = DummyLM([{"answer": "Paris"}])
+    dspy.configure(lm=lm, callbacks=[OtelCallback(tracer_provider=provider, capture_content=False)])
+
+    dspy.Predict("question -> answer")(question="What is the capital of France?")
+
+    spans = exporter.get_finished_spans()
+    content_attributes = {
+        "dspy.module.input",
+        "dspy.module.output",
+        "dspy.adapter.input",
+        "dspy.adapter.output",
+        "gen_ai.input.messages",
+        "gen_ai.output.messages",
+    }
+    for span in spans:
+        assert not content_attributes & set(span.attributes)
+
+    # Non-content attributes are still present.
+    chat_span = get_span(spans, "chat dummy")
+    assert chat_span.attributes["gen_ai.request.model"] == "dummy"
+    assert get_span(spans, "Predict").attributes["dspy.module.signature"] == "question -> answer"
+
+
+def test_capture_content_env_var(tracing, monkeypatch):
+    _, provider = tracing
+    monkeypatch.setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "false")
+    assert OtelCallback(tracer_provider=provider).capture_content is False
+
+    monkeypatch.setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "true")
+    assert OtelCallback(tracer_provider=provider).capture_content is True
+
+    monkeypatch.delenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")
+    assert OtelCallback(tracer_provider=provider).capture_content is True
+
+    # An explicit argument wins over the environment variable.
+    monkeypatch.setenv("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "false")
+    assert OtelCallback(tracer_provider=provider, capture_content=True).capture_content is True
+
+
+def test_typed_lm_span_carries_usage(tracing):
+    exporter, provider = tracing
+
+    class TypedLM(dspy.BaseLM):
+        forward_contract = "typed_lm"
+
+        def forward(self, request):
+            return dspy.LMResponse.from_text(
+                "hello",
+                model=request.model,
+                usage={"prompt_tokens": 3, "completion_tokens": 5},
+            )
+
+    dspy.configure(callbacks=[OtelCallback(tracer_provider=provider)])
+    lm = TypedLM(model="test/typed")
+
+    with dspy.context(experimental=True):
+        lm(prompt="hi")
+
+    chat_span = get_span(exporter.get_finished_spans(), "chat typed")
+    assert chat_span.attributes["gen_ai.provider.name"] == "test"
+    assert chat_span.attributes["gen_ai.request.model"] == "typed"
+    assert chat_span.attributes["gen_ai.usage.input_tokens"] == 3
+    assert chat_span.attributes["gen_ai.usage.output_tokens"] == 5
+    output_messages = json.loads(chat_span.attributes["gen_ai.output.messages"])
+    assert output_messages == [{"role": "assistant", "parts": [{"type": "text", "content": "hello"}]}]
+
+
+def test_tool_span_records_exception(tracing):
+    exporter, provider = tracing
+    dspy.configure(callbacks=[OtelCallback(tracer_provider=provider)])
+
+    def divide(numerator: int, denominator: int) -> float:
+        """Divide two numbers."""
+        return numerator / denominator
+
+    tool = dspy.Tool(divide)
+    with pytest.raises(ZeroDivisionError):
+        tool(numerator=1, denominator=0)
+
+    tool_span = get_span(exporter.get_finished_spans(), "execute_tool divide")
+    assert tool_span.attributes["gen_ai.operation.name"] == "execute_tool"
+    assert tool_span.attributes["gen_ai.tool.name"] == "divide"
+    assert json.loads(tool_span.attributes["gen_ai.tool.call.arguments"]) == {"numerator": 1, "denominator": 0}
+    assert tool_span.status.status_code == StatusCode.ERROR
+    assert tool_span.events[0].name == "exception"
+
+
+def test_tool_span_records_result(tracing):
+    exporter, provider = tracing
+    dspy.configure(callbacks=[OtelCallback(tracer_provider=provider)])
+
+    def add(a: int, b: int) -> int:
+        """Add two numbers."""
+        return a + b
+
+    dspy.Tool(add)(a=1, b=2)
+
+    tool_span = get_span(exporter.get_finished_spans(), "execute_tool add")
+    assert json.loads(tool_span.attributes["gen_ai.tool.call.result"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_async_calls_emit_nested_spans(tracing):
+    exporter, provider = tracing
+    lm = DummyLM([{"answer": "Paris"}])
+    dspy.configure(lm=lm, callbacks=[OtelCallback(tracer_provider=provider)])
+
+    await dspy.Predict("question -> answer").acall(question="What is the capital of France?")
+
+    spans = exporter.get_finished_spans()
+    predict_span = get_span(spans, "Predict")
+    chat_span = get_span(spans, "chat dummy")
+    assert predict_span.parent is None
+    assert chat_span.parent.span_id == predict_span.context.span_id
+
+
+def test_evaluate_spans_nest_across_threads(tracing):
+    exporter, provider = tracing
+    lm = DummyLM([{"answer": "Paris"}, {"answer": "Rome"}, {"answer": "Berlin"}])
+    dspy.configure(lm=lm, callbacks=[OtelCallback(tracer_provider=provider)])
+
+    devset = [
+        dspy.Example(question="capital of France?", answer="Paris").with_inputs("question"),
+        dspy.Example(question="capital of Italy?", answer="Rome").with_inputs("question"),
+        dspy.Example(question="capital of Germany?", answer="Berlin").with_inputs("question"),
+    ]
+    evaluate = dspy.Evaluate(
+        devset=devset,
+        metric=lambda example, prediction, trace=None: 1.0,
+        num_threads=2,
+    )
+    result = evaluate(dspy.Predict("question -> answer"))
+
+    spans = exporter.get_finished_spans()
+    evaluate_span = get_span(spans, "Evaluate")
+    assert evaluate_span.attributes["dspy.evaluate.num_examples"] == 3
+    assert evaluate_span.attributes["dspy.evaluate.score"] == float(result.score)
+
+    # Spans created inside worker threads stay in the Evaluate trace.
+    predict_spans = [span for span in spans if span.name == "Predict"]
+    assert len(predict_spans) == 3
+    for span in predict_spans:
+        assert span.context.trace_id == evaluate_span.context.trace_id
+        assert span.parent.span_id == evaluate_span.context.span_id
+
+
+def test_enable_otel_tracing_is_idempotent(tracing):
+    _, provider = tracing
+
+    callback = dspy.enable_otel_tracing(tracer_provider=provider)
+    assert dspy.enable_otel_tracing(tracer_provider=provider) is callback
+    assert [cb for cb in dspy.settings.callbacks if isinstance(cb, OtelCallback)] == [callback]
+
+
+def test_unsupported_semconv_version(tracing):
+    _, provider = tracing
+    with pytest.raises(ValueError, match="Unsupported semconv_version"):
+        OtelCallback(tracer_provider=provider, semconv_version=2)

--- a/uv.lock
+++ b/uv.lock
@@ -761,7 +761,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "3.2.1"
+version = "3.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -818,6 +818,9 @@ numpy = [
 optuna = [
     { name = "optuna" },
 ]
+otel = [
+    { name = "opentelemetry-api" },
+]
 test-extras = [
     { name = "datasets" },
     { name = "langchain-core" },
@@ -825,6 +828,7 @@ test-extras = [
     { name = "mcp", version = "1.9.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "opentelemetry-sdk" },
     { name = "optuna" },
     { name = "pandas" },
 ]
@@ -856,6 +860,8 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'numpy'", specifier = ">=1.26.0" },
     { name = "numpy", marker = "extra == 'test-extras'", specifier = ">=1.26.0" },
     { name = "openai", specifier = ">=1.66.2" },
+    { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.25.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'test-extras'", specifier = ">=1.25.0" },
     { name = "optuna", marker = "extra == 'optuna'", specifier = ">=3.4.0" },
     { name = "optuna", marker = "extra == 'test-extras'", specifier = ">=3.4.0" },
     { name = "orjson", specifier = ">=3.9.0" },
@@ -873,7 +879,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.1" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = ">=4.5.4,<4.22.0" },
 ]
-provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "numpy", "litellm", "dev", "test-extras"]
+provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "numpy", "litellm", "otel", "dev", "test-extras"]
 
 [[package]]
 name = "email-validator"
@@ -2081,6 +2087,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/ea/bbeef604d1fe0f7e9111745bb8a81362973a95713b28855beb9a9832ab12/openai-1.88.0.tar.gz", hash = "sha256:122d35e42998255cf1fc84560f6ee49a844e65c054cd05d3e42fda506b832bb1", size = 470963, upload-time = "2025-06-17T05:04:45.856Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/03/ef68d77a38dd383cbed7fc898857d394d5a8b0520a35f054e7fe05dc3ac1/openai-1.88.0-py3-none-any.whl", hash = "sha256:7edd7826b3b83f5846562a6f310f040c79576278bf8e3687b30ba05bb5dff978", size = 734293, upload-time = "2025-06-17T05:04:43.858Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912, upload-time = "2026-06-24T15:19:35.434Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852, upload-time = "2026-06-24T15:19:52.169Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713, upload-time = "2026-06-24T15:19:53.339Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

DSPy has no first-party, vendor-neutral tracing story. The two existing paths are:

- **MLflow** (`mlflow.dspy.autolog()`): built cleanly on DSPy's `BaseCallback` system, but exports only to MLflow.
- **OpenInference** (`openinference-instrumentation-dspy`): vendor-neutral OTLP, but bypasses the callback system entirely and monkey-patches DSPy internals with `wrapt` (`LM.__call__`, `Predict.forward`, `Module.__call__`, `Adapter`, `Tool`, `Retrieve`, plus custom copyable wrappers so `deepcopy` doesn't break). It reaches into `signature.output_fields`, `Prediction._store`, and `__qualname__` dispatch, and has broken across DSPy releases (e.g. #7627).

This PR adds native OpenTelemetry emission built on the public callback surface, so any OTLP backend (Jaeger, Grafana, Langfuse, Phoenix via its convention-translation processor, Datadog, ...) works without third-party patching of DSPy internals:

```python
import dspy

dspy.enable_otel_tracing()  # or dspy.configure(callbacks=[dspy.OtelCallback()])
```

## What this looks like

A `dspy.ReAct` agent with one tool, exported to a local Jaeger via OTLP:

![Jaeger waterfall of a ReAct trace](https://raw.githubusercontent.com/stanfordnlp/dspy/assets/otel-screenshots/jaeger_react_trace.png)

LM spans carry GenAI-semconv attributes, including full structured messages (content capture is on by default, with an opt-out):

![Jaeger span detail showing gen_ai.input.messages](https://raw.githubusercontent.com/stanfordnlp/dspy/assets/otel-screenshots/jaeger_chat_span.png)

## Design

- **Callback bridge, not per-call-site instrumentation.** `OtelCallback` maps `BaseCallback` events to spans; parenting rides the OTel context, so DSPy spans nest correctly under surrounding application spans and vice versa.
- **OTel GenAI semantic conventions** (`gen_ai.*`) for LM spans (`chat {model}`, CLIENT kind, provider/model/temperature/max_tokens, `gen_ai.input.messages` / `gen_ai.output.messages`, `gen_ai.usage.*`) and tool spans (`execute_tool {name}`, `gen_ai.tool.*`). Since the GenAI conventions are still in Development status, `semconv_version=1` is an explicit knob so attribute layouts can evolve without breaking dashboards.
- **`dspy.*` attributes** for spans with no GenAI equivalent: modules (`dspy.module.type`, `dspy.module.signature`, content-gated `dspy.module.input/output`), adapters (`ChatAdapter.format` / `.parse` spans), and `Evaluate` (`dspy.evaluate.num_examples`, `dspy.evaluate.score`).
- **Content capture defaults on** (enabling tracing is already an explicit opt-in); disable per callback (`capture_content=False`) or via the standard `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` env var.
- **Optional dependency.** Only `opentelemetry-api` (new `dspy[otel]` extra), imported lazily inside `OtelCallback.__init__`; `import dspy` is unaffected when it isn't installed. Without a configured SDK the API is a no-op.
- **Token usage** is emitted when LM outputs are a typed `LMResponse` (explicit `LMRequest` calls or `dspy.context(experimental=True)`). The legacy list-output path has no race-free per-call usage source; that needs a callback-payload enrichment and is deliberately left to a follow-up.

## ParallelExecutor contextvars fix

`ParallelExecutor` previously copied only `thread_local_overrides` into worker threads, so contextvars — the OTel context and the callback system's `ACTIVE_CALL_ID` — did not propagate, and spans created inside `Evaluate`/`Parallel` workers became orphan traces. Workers now run inside `contextvars.copy_context()` captured at submit time. This also fixes span parenting for other callback-based integrations (e.g. MLflow) across `Evaluate`/`Parallel`.

## Tests

- `tests/utils/test_otel.py` (10 tests): span nesting/parenting for `ChainOfThought`, content gating (param + env var), typed-path `gen_ai.usage.*`, tool success/error spans with ERROR status + exception events, async calls, `Evaluate` spans parenting across worker threads, idempotent `enable_otel_tracing()`, unsupported `semconv_version` rejection.
- Neighboring suites pass: `tests/callback`, `tests/utils/test_parallelizer.py`, `tests/evaluate`, `tests/streaming` (72 passed, 30 skipped).
- Verified end-to-end with a real `openai/gpt-5-nano` ReAct program exported to Jaeger via OTLP (screenshots above).

## Not in this PR (planned follow-ups)

- Streaming span coverage (callbacks do not fire around streamed responses).
- Compile/optimizer tracing and gating (pairs with the upcoming optimizer lifecycle hooks).
- Legacy-path token usage via callback payload enrichment.
- Docs page under the observability tutorial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
