### PR TITLE
fix(callbacks): preserve lineage across parallel execution

### DIFF
--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -2,12 +2,10 @@ import functools
 import inspect
 import logging
 import uuid
-from contextvars import ContextVar
 from typing import Any, Callable
 
 import dspy
-
-ACTIVE_CALL_ID = ContextVar("active_call_id", default=None)
+from dspy.utils.callback_context import ACTIVE_CALL_ID
 
 logger = logging.getLogger(__name__)
 

--- a/dspy/utils/callback_context.py
+++ b/dspy/utils/callback_context.py
@@ -1,0 +1,20 @@
+import functools
+from contextvars import ContextVar
+from typing import Callable
+
+ACTIVE_CALL_ID = ContextVar("active_call_id", default=None)
+
+
+def _bind_active_call_id(fn: Callable) -> Callable:
+    """Bind the current callback call ID to each synchronous invocation of ``fn``."""
+    parent_call_id = ACTIVE_CALL_ID.get()
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        token = ACTIVE_CALL_ID.set(parent_call_id)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            ACTIVE_CALL_ID.reset(token)
+
+    return wrapper

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -10,6 +10,9 @@ from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 
 import tqdm
 
+from dspy.dsp.utils.settings import settings, thread_local_overrides
+from dspy.utils.callback_context import _bind_active_call_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,11 +28,9 @@ class ParallelExecutor:
         straggler_limit=3,
     ):
         """
-        Offers isolation between the tasks (dspy.settings) irrespective of whether num_threads == 1 or > 1.
-        Handles also straggler timeouts.
+        Propagates DSPy settings and callback ancestry into each task while isolating task-local changes,
+        irrespective of whether num_threads == 1 or > 1. Handles also straggler timeouts.
         """
-        from dspy.dsp.utils.settings import settings
-
         self.num_threads = num_threads or settings.num_threads
         self.max_errors = settings.max_errors if max_errors is None else max_errors
         self.disable_progress_bar = disable_progress_bar
@@ -46,7 +47,7 @@ class ParallelExecutor:
 
     def execute(self, function, data):
         tqdm.tqdm._instances.clear()
-        wrapped = self._wrap_function(function)
+        wrapped = self._wrap_function(_bind_active_call_id(function))
         if self.num_threads == 1:
             return self._execute_sequential(wrapped, data)
         return self._execute_parallel(wrapped, data)
@@ -120,8 +121,6 @@ class ParallelExecutor:
                 start_time_map[submission_id] = time.time()
 
             # Apply parent's thread-local overrides
-            from dspy.dsp.utils.settings import thread_local_overrides
-
             original = thread_local_overrides.get()
             new_overrides = {**original, **parent_overrides.copy()}
             if new_overrides.get("usage_tracker"):
@@ -156,8 +155,6 @@ class ParallelExecutor:
         executor = ThreadPoolExecutor(max_workers=self.num_threads)
         try:
             with interrupt_manager():
-                from dspy.dsp.utils.settings import thread_local_overrides
-
                 parent_overrides = thread_local_overrides.get().copy()
 
                 futures_map = {}

--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -4,6 +4,7 @@ import pytest
 
 import dspy
 from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback, with_callbacks
+from dspy.utils.callback_context import _bind_active_call_id
 from dspy.utils.dummies import DummyLM
 
 
@@ -52,6 +53,26 @@ class MyCallback(BaseCallback):
 
     def on_tool_end(self, call_id, outputs, exception):
         self.calls.append({"handler": "on_tool_end", "outputs": outputs, "exception": exception})
+
+
+def test_bind_active_call_id_restores_context_after_exception():
+    observed_call_ids = []
+
+    def fail():
+        observed_call_ids.append(ACTIVE_CALL_ID.get())
+        raise ValueError("boom")
+
+    token = ACTIVE_CALL_ID.set("parent-call")
+    try:
+        bound = _bind_active_call_id(fail)
+    finally:
+        ACTIVE_CALL_ID.reset(token)
+
+    with pytest.raises(ValueError, match="boom"):
+        bound()
+
+    assert observed_call_ids == ["parent-call"]
+    assert ACTIVE_CALL_ID.get() is None
 
 
 @pytest.mark.parametrize(

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -10,7 +10,7 @@ import dspy
 from dspy.evaluate.evaluate import Evaluate, EvaluationResult
 from dspy.evaluate.metrics import answer_exact_match
 from dspy.predict import Predict
-from dspy.utils.callback import BaseCallback
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
 from dspy.utils.dummies import DummyLM
 
 
@@ -286,6 +286,44 @@ def test_evaluate_callback():
     assert callback.start_call_count == 1
     assert callback.end_call_outputs.score == 100.0
     assert callback.end_call_count == 1
+
+
+def test_parallel_program_callbacks_are_children_of_evaluate_callback():
+    class LineageCallback(BaseCallback):
+        def __init__(self):
+            self.evaluate_call_id = None
+            self.module_parent_call_ids = []
+            self.lock = threading.Lock()
+
+        def on_evaluate_start(self, call_id, instance, inputs):
+            self.evaluate_call_id = call_id
+
+        def on_module_start(self, call_id, instance, inputs):
+            with self.lock:
+                self.module_parent_call_ids.append(ACTIVE_CALL_ID.get())
+
+    callback = LineageCallback()
+    dspy.configure(
+        lm=DummyLM(
+            {
+                "What is 1+1?": {"answer": "2"},
+                "What is 2+2?": {"answer": "4"},
+            }
+        ),
+        callbacks=[callback],
+    )
+    evaluator = Evaluate(
+        devset=[new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")],
+        metric=answer_exact_match,
+        num_threads=2,
+        display_progress=False,
+    )
+
+    evaluator(Predict("question -> answer"))
+
+    assert callback.evaluate_call_id is not None
+    assert callback.module_parent_call_ids == [callback.evaluate_call_id, callback.evaluate_call_id]
+
 
 def test_evaluation_result_repr():
     result = EvaluationResult(score=100.0, results=[(new_example("What is 1+1?", "2"), {"answer": "2"}, 100.0)])

--- a/tests/predict/test_parallel.py
+++ b/tests/predict/test_parallel.py
@@ -1,4 +1,7 @@
+import threading
+
 import dspy
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
 from dspy.utils.dummies import DummyLM
 
 
@@ -37,6 +40,41 @@ def test_parallel_module():
 
     expected_outputs = {f"test output {i}" for i in range(1, 6)}
     assert {r.output for r in output} == expected_outputs
+
+
+def test_parallel_children_inherit_parent_callback_call_id():
+    class Child(dspy.Module):
+        def forward(self, value):
+            return value
+
+    class Parent(dspy.Module):
+        def __init__(self, children):
+            self.children = children
+            self.parallel = dspy.Parallel(num_threads=2, disable_progress_bar=True)
+
+        def forward(self):
+            return self.parallel([(child, {"value": index}) for index, child in enumerate(self.children)])
+
+    class LineageCallback(BaseCallback):
+        def __init__(self):
+            self.calls = []
+            self.lock = threading.Lock()
+
+        def on_module_start(self, call_id, instance, inputs):
+            with self.lock:
+                self.calls.append((instance, call_id, ACTIVE_CALL_ID.get()))
+
+    children = [Child(), Child()]
+    parent = Parent(children)
+    callback = LineageCallback()
+    dspy.configure(callbacks=[callback])
+
+    assert parent() == [0, 1]
+
+    parent_call = next(call for call in callback.calls if call[0] is parent)
+    child_calls = [call for call in callback.calls if any(call[0] is child for child in children)]
+    assert len(child_calls) == 2
+    assert all(call[2] == parent_call[1] for call in child_calls)
 
 
 def test_batch_module():

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+from dspy.utils.callback import ACTIVE_CALL_ID
 from dspy.utils.parallelizer import ParallelExecutor
 
 
@@ -16,6 +17,21 @@ def test_worker_threads_independence():
     results = executor.execute(task, data)
 
     assert results == [2, 4, 6, 8, 10]
+
+
+@pytest.mark.parametrize("num_threads", [1, 3])
+def test_workers_inherit_active_callback_call_id(num_threads):
+    executor = ParallelExecutor(num_threads=num_threads)
+
+    for parent_call_id in ["first-parent", "second-parent"]:
+        token = ACTIVE_CALL_ID.set(parent_call_id)
+        try:
+            observed_call_ids = executor.execute(lambda _: ACTIVE_CALL_ID.get(), range(5))
+
+            assert observed_call_ids == [parent_call_id] * 5
+            assert ACTIVE_CALL_ID.get() == parent_call_id
+        finally:
+            ACTIVE_CALL_ID.reset(token)
 
 
 def test_parallel_execution_speed():


### PR DESCRIPTION
> **Independent PR:** callback lineage across `ParallelExecutor`. #10044 and #10045 build optimizer tracking on top after this lands.

## Issue / reproduction

DSPy callback ancestry changes when the same synchronous work crosses `ParallelExecutor`'s thread boundary.

Before this change, a callback-active caller observed different semantics solely from `num_threads`:

```text
num_threads=1                 num_threads>1
Parent(call_id="parent")      Parent(call_id="parent")
└── Child(parent="parent")   └── Child(parent=None)
```

This affects `Evaluate`, `dspy.Parallel`, `Module.batch`, optimizers that fan out through those APIs, and direct executor users. It is not hypothetical downstream behavior: [W&B Weave's callback-wrapped `Evaluate` replacement](https://github.com/wandb/weave/blob/d520568079fd6c935f68521259e66d0a18b0f51a/weave/integrations/dspy/dspy_sdk.py) invokes `ParallelExecutor` directly.

## Why this is the root cause

`with_callbacks` correctly stores the active call ID in `ACTIVE_CALL_ID`, a `ContextVar`, for the duration of the parent operation. Ordinary synchronous calls retain that value. `ThreadPoolExecutor` workers do not inherit it.

`ParallelExecutor` is the exact boundary where the invariant breaks. It already transports DSPy settings across that boundary so task behavior does not depend on the thread count, but it transported configured callbacks without their causal parent ID.

Binding only inside today's `Evaluate` and `Parallel` call sites would make those paths pass while leaving direct, downstream, and future executor callers with an undocumented wrapper requirement.

## Why this fixes the root cause

`ParallelExecutor.execute()` now captures the active call ID once per execution and binds it around every invocation of the submitted synchronous callable:

```python
wrapped = self._wrap_function(_bind_active_call_id(function))
```

The binder installs the captured ID, invokes the task, and restores the worker's previous value with the `ContextVar` token in `finally`. Initial submissions and straggler retries use the same bound callable.

The executor remains selective: it transports callback ancestry, not the entire Python context. This avoids copying optimizer coordinator state or async-runtime markers such as Sniffio's backend marker into raw worker threads.

## How we know this is the root cause

The tests cover the boundary at three levels:

1. A direct `ParallelExecutor` contract test runs with one and multiple threads, then reuses the same executor under a second parent ID. Both executions see the parent captured at their own `execute()` call.
2. `Evaluate(num_threads=2)` records each program callback as a child of the evaluation callback.
3. `dspy.Parallel(num_threads=2)` records each child module callback as a child of its calling module.

A focused binder test also raises from the task and proves the worker context is restored.

## Why this is the concise fix

The runtime change is one wrapper at the shared boundary. A dependency-free `callback_context.py` leaf owns the token and synchronous binder so `ParallelExecutor` can use a normal module-level import without importing the callback dispatcher or creating a cycle.

The existing `dspy.utils.callback.ACTIVE_CALL_ID` import remains valid and refers to the same `ContextVar`. `Evaluate` and `Parallel` require no callback-specific submission code.

The same cleanup makes `ParallelExecutor`'s existing settings dependencies explicit at module scope rather than hiding them in three function bodies.

## Context needed to review

Start callbacks read `ACTIVE_CALL_ID` before installing their own call ID. The value visible there is the causal parent.

`ParallelExecutor.execute()` is synchronous and joined: submitted work is structurally caused by the active caller. A genuinely detached execution API could define different ancestry, but this executor is not detached.

The binder wraps the submitted callable, not executor error-reporting machinery. Task-local context mutations therefore cannot leak into executor control flow.

## What the fix does

```text
Parent callback active on caller thread
        │
        ▼
ParallelExecutor.execute() captures parent call ID
        │
        ├── worker task: set parent → call function → restore
        └── retry task:  set parent → call function → restore
```

Sequential and threaded execution now produce the same logical callback hierarchy.

## Compatibility and downsides

- Direct threaded `ParallelExecutor` calls now inherit the submitting callback ID, matching the executor's existing single-thread behavior. This is the intended observable change.
- There is no intentional-root option. The previous root behavior was already inconsistent across thread counts; adding an option without a concrete detached-work use case would enlarge the API prematurely.
- Only `ACTIVE_CALL_ID` is transported. Arbitrary user `ContextVar`s, optimizer invocation ownership, and async-runtime state remain excluded.
- `ACTIVE_CALL_ID` remains importable from `dspy.utils.callback` and is the identical token object after the internal move.
- Custom executors that replace rather than call `ParallelExecutor.execute()` must preserve this contract themselves.
- A retry or late worker retains causal ancestry even if it finishes after its parent's end callback; causality does not require temporal nesting.
- Moving the existing settings imports to module scope changes import timing, not values or ownership: the same settings singleton and `thread_local_overrides` token are used.

## Verification

Focused tests:

```bash
uv run --frozen --no-sync pytest --deno -q \
  tests/callback/test_callback.py \
  tests/utils/test_parallelizer.py \
  tests/evaluate/test_evaluate.py \
  tests/predict/test_parallel.py
```

Direct result: `43 passed, 25 skipped`.

Copy-paste demonstration through a callback-wrapped module that uses `ParallelExecutor` directly:

```bash
uv run --frozen --no-sync python - <<'PY'
import threading
import warnings

warnings.filterwarnings("ignore", message="Core Pydantic V1 functionality")

import dspy
from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
from dspy.utils.parallelizer import ParallelExecutor


class Child(dspy.Module):
    def forward(self, value):
        return value


class Parent(dspy.Module):
    def forward(self):
        executor = ParallelExecutor(num_threads=2, disable_progress_bar=True)
        return executor.execute(lambda value: Child()(value=value), [1, 2])


class LineageRecorder(BaseCallback):
    def __init__(self):
        self.parent_call_id = None
        self.child_parent_ids = []
        self.lock = threading.Lock()

    def on_module_start(self, call_id, instance, inputs):
        with self.lock:
            if isinstance(instance, Parent):
                self.parent_call_id = call_id
            elif isinstance(instance, Child):
                self.child_parent_ids.append(ACTIVE_CALL_ID.get())


recorder = LineageRecorder()
with dspy.context(callbacks=[recorder]):
    result = Parent()()

print("result", result)
print("parent_seen", recorder.parent_call_id is not None)
print("all_children_parented", recorder.child_parent_ids == [recorder.parent_call_id] * 2)
print("outside_call", ACTIVE_CALL_ID.get())
PY
```

Direct output, unedited:

```text
result [1, 2]
parent_seen True
all_children_parented True
outside_call None
```
