### PR TITLE
feat(callbacks): expose optimizer lifecycle hooks

### DIFF
--- a/dspy/teleprompt/__init__.py
+++ b/dspy/teleprompt/__init__.py
@@ -31,5 +31,6 @@ __all__ = [
     "LabeledFewShot",
     "InferRules",
     "SIMBA",
+    "Teleprompter",
     "bootstrap_trace_data",
 ]

--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -1,11 +1,19 @@
 from typing import Any
 
 from dspy.primitives import Example, Module
+from dspy.utils.callback import with_callbacks
 
 
 class Teleprompter:
     def __init__(self):
         pass
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+
+        compile_method = cls.__dict__.get("compile")
+        if compile_method is not None:
+            cls.compile = with_callbacks(compile_method, _callback_kind="optimizer")
 
     def compile(self, student: Module, *, trainset: list[Example], teacher: Module | None = None, valset: list[Example] | None = None, **kwargs) -> Module:
         """

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -5,7 +5,8 @@ import uuid
 from typing import Any, Callable
 
 import dspy
-from dspy.utils.callback_context import ACTIVE_CALL_ID
+from dspy.utils.callback_context import ACTIVE_CALL_ID as ACTIVE_CALL_ID
+from dspy.utils.callback_context import _active_call_context, _normalize_active_call_context
 
 logger = logging.getLogger(__name__)
 
@@ -252,9 +253,40 @@ class BaseCallback:
         """
         pass
 
+    def on_optimizer_start(
+        self,
+        call_id: str,
+        instance: Any,
+        inputs: dict[str, Any],
+    ):
+        """A handler triggered when an optimizer starts compiling a program.
 
-def with_callbacks(fn):
+        Args:
+            call_id: A unique identifier for the optimizer call.
+            instance: The Teleprompter instance.
+            inputs: The arguments passed to the optimizer's ``compile`` method.
+        """
+        pass
+
+    def on_optimizer_end(
+        self,
+        call_id: str,
+        outputs: Any | None,
+        exception: BaseException | None = None,
+    ):
+        """A handler triggered after an optimizer finishes compiling a program.
+
+        Args:
+            call_id: The identifier shared with the corresponding start handler.
+            outputs: The compiled program, or None if compilation failed.
+            exception: The exception raised by compilation, if any.
+        """
+        pass
+
+
+def with_callbacks(fn, *, _callback_kind: str | None = None):
     """Decorator to add callback functionality to instance methods."""
+    is_optimizer_callback = _callback_kind == "optimizer"
 
     def _execute_start_callbacks(instance, fn, call_id, callbacks, args, kwargs):
         """Execute all start callbacks for a function call."""
@@ -265,7 +297,11 @@ def with_callbacks(fn):
             inputs.pop("instance")
         for callback in callbacks:
             try:
-                _get_on_start_handler(callback, instance, fn)(call_id=call_id, instance=instance, inputs=inputs)
+                _get_on_start_handler(callback, instance, fn, is_optimizer_callback)(
+                    call_id=call_id,
+                    instance=instance,
+                    inputs=inputs,
+                )
             except Exception as e:
                 logger.warning(f"Error when calling callback {callback}: {e}")
 
@@ -273,7 +309,7 @@ def with_callbacks(fn):
         """Execute all end callbacks for a function call."""
         for callback in callbacks:
             try:
-                _get_on_end_handler(callback, instance, fn)(
+                _get_on_end_handler(callback, instance, fn, is_optimizer_callback)(
                     call_id=call_id,
                     outputs=results,
                     exception=exception,
@@ -295,22 +331,21 @@ def with_callbacks(fn):
 
             call_id = uuid.uuid4().hex
 
+            _normalize_active_call_context()
             _execute_start_callbacks(instance, fn, call_id, callbacks, args, kwargs)
-
-            # Active ID must be set right before the function is called, not before calling the callbacks.
-            parent_call_id = ACTIVE_CALL_ID.get()
-            ACTIVE_CALL_ID.set(call_id)
 
             results = None
             exception = None
             try:
-                results = await fn(instance, *args, **kwargs)
+                # Active ID must be set right before the function is called, not before calling the callbacks.
+                with _active_call_context(call_id):
+                    results = await fn(instance, *args, **kwargs)
                 return results
-            except Exception as e:
-                exception = e
-                raise exception
+            except BaseException as e:
+                if is_optimizer_callback or isinstance(e, Exception):
+                    exception = e
+                raise
             finally:
-                ACTIVE_CALL_ID.set(parent_call_id)
                 _execute_end_callbacks(instance, fn, call_id, results, exception, callbacks)
 
         return async_wrapper
@@ -325,29 +360,36 @@ def with_callbacks(fn):
 
             call_id = uuid.uuid4().hex
 
+            _normalize_active_call_context()
             _execute_start_callbacks(instance, fn, call_id, callbacks, args, kwargs)
-
-            # Active ID must be set right before the function is called, not before calling the callbacks.
-            parent_call_id = ACTIVE_CALL_ID.get()
-            ACTIVE_CALL_ID.set(call_id)
 
             results = None
             exception = None
             try:
-                results = fn(instance, *args, **kwargs)
+                # Active ID must be set right before the function is called, not before calling the callbacks.
+                with _active_call_context(call_id):
+                    results = fn(instance, *args, **kwargs)
                 return results
-            except Exception as e:
-                exception = e
-                raise exception
+            except BaseException as e:
+                if is_optimizer_callback or isinstance(e, Exception):
+                    exception = e
+                raise
             finally:
-                ACTIVE_CALL_ID.set(parent_call_id)
                 _execute_end_callbacks(instance, fn, call_id, results, exception, callbacks)
 
         return sync_wrapper
 
 
-def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -> Callable:
+def _get_on_start_handler(
+    callback: BaseCallback,
+    instance: Any,
+    fn: Callable,
+    is_optimizer_callback: bool,
+) -> Callable:
     """Selects the appropriate on_start handler of the callback based on the instance and function name."""
+    if is_optimizer_callback:
+        return callback.on_optimizer_start
+
     if isinstance(instance, dspy.BaseLM):
         return callback.on_lm_start
     elif isinstance(instance, dspy.Evaluate):
@@ -368,8 +410,16 @@ def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -
     return callback.on_module_start
 
 
-def _get_on_end_handler(callback: BaseCallback, instance: Any, fn: Callable) -> Callable:
+def _get_on_end_handler(
+    callback: BaseCallback,
+    instance: Any,
+    fn: Callable,
+    is_optimizer_callback: bool,
+) -> Callable:
     """Selects the appropriate on_end handler of the callback based on the instance and function name."""
+    if is_optimizer_callback:
+        return callback.on_optimizer_end
+
     if isinstance(instance, dspy.BaseLM):
         return callback.on_lm_end
     elif isinstance(instance, dspy.Evaluate):

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -2,12 +2,10 @@ import functools
 import inspect
 import logging
 import uuid
-from contextvars import ContextVar
 from typing import Any, Callable
 
 import dspy
-
-ACTIVE_CALL_ID = ContextVar("active_call_id", default=None)
+from dspy.utils.callback_context import ACTIVE_CALL_ID
 
 logger = logging.getLogger(__name__)
 

--- a/dspy/utils/callback_context.py
+++ b/dspy/utils/callback_context.py
@@ -1,0 +1,20 @@
+import functools
+from contextvars import ContextVar
+from typing import Callable
+
+ACTIVE_CALL_ID = ContextVar("active_call_id", default=None)
+
+
+def _bind_active_call_id(fn: Callable) -> Callable:
+    """Bind the current callback call ID to each synchronous invocation of ``fn``."""
+    parent_call_id = ACTIVE_CALL_ID.get()
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        token = ACTIVE_CALL_ID.set(parent_call_id)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            ACTIVE_CALL_ID.reset(token)
+
+    return wrapper

--- a/dspy/utils/callback_context.py
+++ b/dspy/utils/callback_context.py
@@ -1,20 +1,81 @@
 import functools
+from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Callable
 
 ACTIVE_CALL_ID = ContextVar("active_call_id", default=None)
+_ACTIVE_CALL = ContextVar("active_call", default=None)
+
+
+class _ActiveCall:
+    __slots__ = ("call_id", "is_active", "parent", "parent_call_id")
+
+    def __init__(self, call_id: str, parent_call_id: str | None, parent: "_ActiveCall | None"):
+        self.call_id = call_id
+        self.parent_call_id = parent_call_id
+        self.parent = parent
+        self.is_active = True
+
+
+def _resolve_active_call(
+    call_id: str | None, active_call: _ActiveCall | None
+) -> tuple[str | None, _ActiveCall | None]:
+    # IDs set directly through ACTIVE_CALL_ID have no lifecycle metadata to resolve.
+    if active_call is None or active_call.call_id != call_id:
+        return call_id, None
+
+    while active_call is not None and not active_call.is_active:
+        call_id = active_call.parent_call_id
+        active_call = active_call.parent
+
+    return call_id, active_call
+
+
+def _normalize_active_call_context() -> str | None:
+    """Discard completed call scopes copied into detached tasks or threads."""
+    call_id = ACTIVE_CALL_ID.get()
+    active_call = _ACTIVE_CALL.get()
+    live_call_id, live_active_call = _resolve_active_call(call_id, active_call)
+
+    if live_call_id != call_id:
+        ACTIVE_CALL_ID.set(live_call_id)
+    if live_active_call is not active_call:
+        _ACTIVE_CALL.set(live_active_call)
+
+    return live_call_id
+
+
+@contextmanager
+def _active_call_context(call_id: str):
+    parent_call_id = _normalize_active_call_context()
+    parent = _ACTIVE_CALL.get()
+    active_call = _ActiveCall(call_id, parent_call_id, parent)
+    call_id_token = ACTIVE_CALL_ID.set(call_id)
+    active_call_token = _ACTIVE_CALL.set(active_call)
+
+    try:
+        yield
+    finally:
+        active_call.is_active = False
+        ACTIVE_CALL_ID.reset(call_id_token)
+        _ACTIVE_CALL.reset(active_call_token)
+        _normalize_active_call_context()
 
 
 def _bind_active_call_id(fn: Callable) -> Callable:
     """Bind the current callback call ID to each synchronous invocation of ``fn``."""
-    parent_call_id = ACTIVE_CALL_ID.get()
+    parent_call_id = _normalize_active_call_context()
+    parent = _ACTIVE_CALL.get()
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        token = ACTIVE_CALL_ID.set(parent_call_id)
+        live_call_id, live_active_call = _resolve_active_call(parent_call_id, parent)
+        call_id_token = ACTIVE_CALL_ID.set(live_call_id)
+        active_call_token = _ACTIVE_CALL.set(live_active_call)
         try:
             return fn(*args, **kwargs)
         finally:
-            ACTIVE_CALL_ID.reset(token)
+            ACTIVE_CALL_ID.reset(call_id_token)
+            _ACTIVE_CALL.reset(active_call_token)
 
     return wrapper

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -10,6 +10,9 @@ from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 
 import tqdm
 
+from dspy.dsp.utils.settings import settings, thread_local_overrides
+from dspy.utils.callback_context import _bind_active_call_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -25,11 +28,9 @@ class ParallelExecutor:
         straggler_limit=3,
     ):
         """
-        Offers isolation between the tasks (dspy.settings) irrespective of whether num_threads == 1 or > 1.
-        Handles also straggler timeouts.
+        Propagates DSPy settings and callback ancestry into each task while isolating task-local changes,
+        irrespective of whether num_threads == 1 or > 1. Handles also straggler timeouts.
         """
-        from dspy.dsp.utils.settings import settings
-
         self.num_threads = num_threads or settings.num_threads
         self.max_errors = settings.max_errors if max_errors is None else max_errors
         self.disable_progress_bar = disable_progress_bar
@@ -46,7 +47,7 @@ class ParallelExecutor:
 
     def execute(self, function, data):
         tqdm.tqdm._instances.clear()
-        wrapped = self._wrap_function(function)
+        wrapped = self._wrap_function(_bind_active_call_id(function))
         if self.num_threads == 1:
             return self._execute_sequential(wrapped, data)
         return self._execute_parallel(wrapped, data)
@@ -120,8 +121,6 @@ class ParallelExecutor:
                 start_time_map[submission_id] = time.time()
 
             # Apply parent's thread-local overrides
-            from dspy.dsp.utils.settings import thread_local_overrides
-
             original = thread_local_overrides.get()
             new_overrides = {**original, **parent_overrides.copy()}
             if new_overrides.get("usage_tracker"):
@@ -156,8 +155,6 @@ class ParallelExecutor:
         executor = ThreadPoolExecutor(max_workers=self.num_threads)
         try:
             with interrupt_manager():
-                from dspy.dsp.utils.settings import thread_local_overrides
-
                 parent_overrides = thread_local_overrides.get().copy()
 
                 futures_map = {}

--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -4,6 +4,7 @@ import pytest
 
 import dspy
 from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback, with_callbacks
+from dspy.utils.callback_context import _bind_active_call_id
 from dspy.utils.dummies import DummyLM
 
 
@@ -52,6 +53,26 @@ class MyCallback(BaseCallback):
 
     def on_tool_end(self, call_id, outputs, exception):
         self.calls.append({"handler": "on_tool_end", "outputs": outputs, "exception": exception})
+
+
+def test_bind_active_call_id_restores_context_after_exception():
+    observed_call_ids = []
+
+    def fail():
+        observed_call_ids.append(ACTIVE_CALL_ID.get())
+        raise ValueError("boom")
+
+    token = ACTIVE_CALL_ID.set("parent-call")
+    try:
+        bound = _bind_active_call_id(fail)
+    finally:
+        ACTIVE_CALL_ID.reset(token)
+
+    with pytest.raises(ValueError, match="boom"):
+        bound()
+
+    assert observed_call_ids == ["parent-call"]
+    assert ACTIVE_CALL_ID.get() is None
 
 
 @pytest.mark.parametrize(

--- a/tests/callback/test_optimizer_lifecycle.py
+++ b/tests/callback/test_optimizer_lifecycle.py
@@ -1,0 +1,212 @@
+import asyncio
+import inspect
+
+import pytest
+
+import dspy
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
+
+
+@pytest.fixture(autouse=True)
+def reset_settings():
+    original_settings = dspy.settings.copy()
+    yield
+    dspy.configure(**original_settings)
+
+
+class LifecycleRecorder(BaseCallback):
+    def __init__(self):
+        self.calls = []
+
+    def on_optimizer_start(self, call_id, instance, inputs):
+        self.calls.append(
+            {
+                "handler": "start",
+                "call_id": call_id,
+                "parent_call_id": ACTIVE_CALL_ID.get(),
+                "instance": instance,
+                "inputs": inputs,
+            }
+        )
+
+    def on_optimizer_end(self, call_id, outputs, exception):
+        self.calls.append(
+            {
+                "handler": "end",
+                "call_id": call_id,
+                "active_call_id": ACTIVE_CALL_ID.get(),
+                "outputs": outputs,
+                "exception": exception,
+            }
+        )
+
+
+def test_optimizer_lifecycle_preserves_compile_contract():
+    global_recorder = LifecycleRecorder()
+    instance_recorder = LifecycleRecorder()
+
+    class IdentityOptimizer(dspy.Teleprompter):
+        def __init__(self):
+            self.callbacks = [instance_recorder]
+
+        def compile(self, student, *, trainset, scale=1):
+            return student
+
+    optimizer = IdentityOptimizer()
+    student = dspy.Predict("question -> answer")
+    dspy.configure(callbacks=[global_recorder])
+
+    parent_token = ACTIVE_CALL_ID.set("parent")
+    try:
+        result = optimizer.compile(student, trainset=["example"])
+        assert ACTIVE_CALL_ID.get() == "parent"
+    finally:
+        ACTIVE_CALL_ID.reset(parent_token)
+
+    assert result is student
+    assert str(inspect.signature(IdentityOptimizer.compile)) == "(self, student, *, trainset, scale=1)"
+
+    for recorder in (global_recorder, instance_recorder):
+        start, end = recorder.calls
+        assert start == {
+            "handler": "start",
+            "call_id": start["call_id"],
+            "parent_call_id": "parent",
+            "instance": optimizer,
+            "inputs": {"student": student, "trainset": ["example"], "scale": 1},
+        }
+        assert end == {
+            "handler": "end",
+            "call_id": start["call_id"],
+            "active_call_id": "parent",
+            "outputs": student,
+            "exception": None,
+        }
+
+    assert global_recorder.calls[0]["call_id"] == instance_recorder.calls[0]["call_id"]
+
+
+def test_super_compile_is_a_nested_lifecycle_and_inheritance_does_not_add_a_wrapper():
+    class ParentOptimizer(dspy.Teleprompter):
+        def compile(self, student, *, trainset):
+            return student
+
+    class ChildOptimizer(ParentOptimizer):
+        def compile(self, student, *, trainset):
+            return super().compile(student, trainset=trainset)
+
+    class InheritedOptimizer(ParentOptimizer):
+        pass
+
+    student = dspy.Predict("question -> answer")
+
+    nested_recorder = LifecycleRecorder()
+    with dspy.context(callbacks=[nested_recorder]):
+        assert ChildOptimizer().compile(student, trainset=[]) is student
+
+    outer_start, inner_start, inner_end, outer_end = nested_recorder.calls
+    assert [call["handler"] for call in nested_recorder.calls] == ["start", "start", "end", "end"]
+    assert outer_start["parent_call_id"] is None
+    assert inner_start["call_id"] != outer_start["call_id"]
+    assert inner_start["parent_call_id"] == outer_start["call_id"]
+    assert inner_end["call_id"] == inner_start["call_id"]
+    assert inner_end["active_call_id"] == outer_start["call_id"]
+    assert outer_end["call_id"] == outer_start["call_id"]
+    assert outer_end["active_call_id"] is None
+
+    inherited_recorder = LifecycleRecorder()
+    with dspy.context(callbacks=[inherited_recorder]):
+        assert InheritedOptimizer().compile(student, trainset=[]) is student
+
+    assert [call["handler"] for call in inherited_recorder.calls] == ["start", "end"]
+
+
+def test_optimizer_exception_reaches_end_callback_and_restores_parent():
+    expected_exception = ValueError("compile failed")
+
+    class FailingOptimizer(dspy.Teleprompter):
+        def compile(self, student, *, trainset):
+            raise expected_exception
+
+    recorder = LifecycleRecorder()
+    dspy.configure(callbacks=[recorder])
+
+    parent_token = ACTIVE_CALL_ID.set("parent")
+    try:
+        with pytest.raises(ValueError, match="compile failed"):
+            FailingOptimizer().compile(object(), trainset=[])
+        assert ACTIVE_CALL_ID.get() == "parent"
+    finally:
+        ACTIVE_CALL_ID.reset(parent_token)
+
+    start, end = recorder.calls
+    assert end["call_id"] == start["call_id"]
+    assert end["active_call_id"] == "parent"
+    assert end["outputs"] is None
+    assert end["exception"] is expected_exception
+
+
+@pytest.mark.asyncio
+async def test_async_compile_reports_cancellation_to_optimizer_end():
+    class AsyncOptimizer(dspy.Teleprompter):
+        async def compile(self, student, *, trainset):
+            raise asyncio.CancelledError
+
+    recorder = LifecycleRecorder()
+
+    with dspy.context(callbacks=[recorder]):
+        with pytest.raises(asyncio.CancelledError):
+            await AsyncOptimizer().compile(object(), trainset=[])
+
+    start, end = recorder.calls
+    assert start["handler"] == "start"
+    assert end["handler"] == "end"
+    assert end["call_id"] == start["call_id"]
+    assert end["outputs"] is None
+    assert isinstance(end["exception"], asyncio.CancelledError)
+
+
+@pytest.mark.asyncio
+async def test_detached_task_does_not_reuse_completed_optimizer_call_id():
+    release_detached_task = asyncio.Event()
+    detached_task = None
+
+    class Recorder(LifecycleRecorder):
+        def __init__(self):
+            super().__init__()
+            self.module_parent_call_ids = []
+
+        def on_module_start(self, call_id, instance, inputs):
+            self.module_parent_call_ids.append(ACTIVE_CALL_ID.get())
+
+    class ChildModule(dspy.Module):
+        def forward(self):
+            return "done"
+
+    child = ChildModule()
+
+    class AsyncOptimizer(dspy.Teleprompter):
+        async def compile(self, student, *, trainset):
+            nonlocal detached_task
+
+            async def run_after_compile():
+                await release_detached_task.wait()
+                return child()
+
+            detached_task = asyncio.create_task(run_after_compile())
+            return student
+
+    recorder = Recorder()
+
+    with dspy.context(callbacks=[recorder]):
+        student = object()
+        assert await AsyncOptimizer().compile(student, trainset=[]) is student
+        optimizer_call_id = recorder.calls[0]["call_id"]
+
+        release_detached_task.set()
+        assert detached_task is not None
+        assert await detached_task == "done"
+
+    assert [call["handler"] for call in recorder.calls] == ["start", "end"]
+    assert recorder.calls[1]["call_id"] == optimizer_call_id
+    assert recorder.module_parent_call_ids == [None]

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -10,7 +10,7 @@ import dspy
 from dspy.evaluate.evaluate import Evaluate, EvaluationResult
 from dspy.evaluate.metrics import answer_exact_match
 from dspy.predict import Predict
-from dspy.utils.callback import BaseCallback
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
 from dspy.utils.dummies import DummyLM
 
 
@@ -286,6 +286,44 @@ def test_evaluate_callback():
     assert callback.start_call_count == 1
     assert callback.end_call_outputs.score == 100.0
     assert callback.end_call_count == 1
+
+
+def test_parallel_program_callbacks_are_children_of_evaluate_callback():
+    class LineageCallback(BaseCallback):
+        def __init__(self):
+            self.evaluate_call_id = None
+            self.module_parent_call_ids = []
+            self.lock = threading.Lock()
+
+        def on_evaluate_start(self, call_id, instance, inputs):
+            self.evaluate_call_id = call_id
+
+        def on_module_start(self, call_id, instance, inputs):
+            with self.lock:
+                self.module_parent_call_ids.append(ACTIVE_CALL_ID.get())
+
+    callback = LineageCallback()
+    dspy.configure(
+        lm=DummyLM(
+            {
+                "What is 1+1?": {"answer": "2"},
+                "What is 2+2?": {"answer": "4"},
+            }
+        ),
+        callbacks=[callback],
+    )
+    evaluator = Evaluate(
+        devset=[new_example("What is 1+1?", "2"), new_example("What is 2+2?", "4")],
+        metric=answer_exact_match,
+        num_threads=2,
+        display_progress=False,
+    )
+
+    evaluator(Predict("question -> answer"))
+
+    assert callback.evaluate_call_id is not None
+    assert callback.module_parent_call_ids == [callback.evaluate_call_id, callback.evaluate_call_id]
+
 
 def test_evaluation_result_repr():
     result = EvaluationResult(score=100.0, results=[(new_example("What is 1+1?", "2"), {"answer": "2"}, 100.0)])

--- a/tests/predict/test_parallel.py
+++ b/tests/predict/test_parallel.py
@@ -1,4 +1,7 @@
+import threading
+
 import dspy
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
 from dspy.utils.dummies import DummyLM
 
 
@@ -37,6 +40,41 @@ def test_parallel_module():
 
     expected_outputs = {f"test output {i}" for i in range(1, 6)}
     assert {r.output for r in output} == expected_outputs
+
+
+def test_parallel_children_inherit_parent_callback_call_id():
+    class Child(dspy.Module):
+        def forward(self, value):
+            return value
+
+    class Parent(dspy.Module):
+        def __init__(self, children):
+            self.children = children
+            self.parallel = dspy.Parallel(num_threads=2, disable_progress_bar=True)
+
+        def forward(self):
+            return self.parallel([(child, {"value": index}) for index, child in enumerate(self.children)])
+
+    class LineageCallback(BaseCallback):
+        def __init__(self):
+            self.calls = []
+            self.lock = threading.Lock()
+
+        def on_module_start(self, call_id, instance, inputs):
+            with self.lock:
+                self.calls.append((instance, call_id, ACTIVE_CALL_ID.get()))
+
+    children = [Child(), Child()]
+    parent = Parent(children)
+    callback = LineageCallback()
+    dspy.configure(callbacks=[callback])
+
+    assert parent() == [0, 1]
+
+    parent_call = next(call for call in callback.calls if call[0] is parent)
+    child_calls = [call for call in callback.calls if any(call[0] is child for child in children)]
+    assert len(child_calls) == 2
+    assert all(call[2] == parent_call[1] for call in child_calls)
 
 
 def test_batch_module():

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+from dspy.utils.callback import ACTIVE_CALL_ID
 from dspy.utils.parallelizer import ParallelExecutor
 
 
@@ -16,6 +17,21 @@ def test_worker_threads_independence():
     results = executor.execute(task, data)
 
     assert results == [2, 4, 6, 8, 10]
+
+
+@pytest.mark.parametrize("num_threads", [1, 3])
+def test_workers_inherit_active_callback_call_id(num_threads):
+    executor = ParallelExecutor(num_threads=num_threads)
+
+    for parent_call_id in ["first-parent", "second-parent"]:
+        token = ACTIVE_CALL_ID.set(parent_call_id)
+        try:
+            observed_call_ids = executor.execute(lambda _: ACTIVE_CALL_ID.get(), range(5))
+
+            assert observed_call_ids == [parent_call_id] * 5
+            assert ACTIVE_CALL_ID.get() == parent_call_id
+        finally:
+            ACTIVE_CALL_ID.reset(token)
 
 
 def test_parallel_execution_speed():


### PR DESCRIPTION
> **Optimizer tracking stack (1/2):** **#10044 (this PR)** → #10045 RandomSearch events. This PR is based on independently mergeable #10043 because both touch callback call-ID plumbing.

## Issue / reproduction

DSPy callbacks can observe modules, LMs, tools, adapters, and evaluations inside an optimizer, but they cannot observe the optimizer's `compile` boundary itself.

A callback therefore cannot answer:

```text
Which compile call caused this work?
What arguments started it?
Which program did it return?
Did it fail or get cancelled?
```

## Why this is the root cause

`Teleprompter.compile` is only an interface. Every concrete optimizer overrides it, so decorating the base method would never see those calls. Existing callback dispatch also treats an otherwise unknown wrapped method as a module call.

The missing boundary is where each `Teleprompter` subclass declares its concrete `compile` method.

## What the fix does

- Adds `BaseCallback.on_optimizer_start` and `on_optimizer_end`.
- Lets the existing callback wrapper carry an internal `optimizer` kind when selecting handlers.
- Wraps a `compile` method declared directly on a `Teleprompter` subclass when that subclass is created.
- Tracks whether a callback call scope is still live, so detached work cannot reuse a completed optimizer as its parent.
- Exports `Teleprompter` from `dspy.teleprompt`'s public surface.

The callback shape matches DSPy's existing components:

```python
class Tracker(BaseCallback):
    def on_optimizer_start(self, call_id, instance, inputs): ...
    def on_optimizer_end(self, call_id, outputs, exception): ...
```

## Why this fixes the root cause

The wrapper is installed at the one point shared by direct optimizer implementations: subclass definition. It preserves the visible signature with `functools.wraps`, assigns a call ID before entering the method body, restores the parent ID before the end callback, and reports optimizer cancellation or other `BaseException` exits before re-raising them.

`super().compile()` remains an ordinary nested method call. Its inner start callback sees the outer optimizer call ID as its parent, so the relationship uses the same callback tree DSPy already exposes elsewhere.

Python copies `ContextVar` values into child tasks. Restoring the parent task's string cannot invalidate that copy, so each wrapped call also carries a private mutable scope. Scope exit marks it complete; the next callback dispatch in a copied task or bound thread walks to the nearest still-live ancestor before invoking handlers.

## Why this is concise

The production change is one callback classification branch, an eight-line subclass hook, and one private linked call scope. The scope is the full detached-work fix: contexts copy the same tiny liveness object, so there is no global lookup or owner bookkeeping. It deliberately does not add:

- an optimizer invocation registry;
- task or thread ownership;
- recursion or `super()` deduplication;
- callback-wrapper discovery or suppression;
- opaque-decorator handling; or
- result/coroutine validation.

Those mechanisms accounted for most of the previous implementation and defended behavior no built-in optimizer currently exercises.

## Review map

- `dspy/teleprompt/teleprompt.py`: wraps direct `compile` declarations.
- `dspy/utils/callback.py`: defines and dispatches lifecycle handlers.
- `dspy/utils/callback_context.py`: drops completed call scopes copied into detached tasks or bound threads.
- `tests/callback/test_optimizer_lifecycle.py`: exercises signatures, inputs/output, nesting, inheritance, failures, and async cancellation.

## Compatibility and downsides

- This is a **compile method-call lifecycle**, not an inferred logical-run lifecycle. Real `super().compile()` paths such as `InferRules` produce nested pairs on the same instance. Trackers that only want the outer call can use the parent call ID.
- A subclass that only inherits `compile` gets no additional wrapper. A `compile` supplied solely by a mixin and absent from the subclass `__dict__` is not wrapped.
- `functools.wraps` preserves the visible signature, but function identity and the class `__dict__` entry change.
- An explicitly generic-`@with_callbacks`-decorated `compile` may retain its inner module callback pair inside the optimizer pair. DSPy does not silently suppress a decorator the author requested.
- Global callbacks now observe internal child optimizers, increasing callback volume.
- Async `compile` methods use the existing async callback path. Optimizer cancellation is passed to `on_optimizer_end` and re-raised; ordinary callback handler failures remain logged and isolated.
- Callback dispatch from a copied async/thread context skips completed wrapper-created scopes and resumes at the nearest live ancestor. This prevents a detached task from reporting work under an optimizer that has already ended.
- `ACTIVE_CALL_ID` remains the same public string-valued `ContextVar`. A raw `.get()` in detached code, before that code enters another callback-wrapped boundary, therefore retains normal Python snapshot semantics. Start/end handlers are normalized before dispatch; replacing the `ContextVar` with a proxy would be a wider compatibility break.
- Replacing `compile` after class creation does not install a wrapper automatically.

## Verification

Focused lifecycle and callback tests:

```bash
uv run --frozen --no-sync pytest --deno -q \
  tests/callback/test_callback.py \
  tests/callback/test_optimizer_lifecycle.py \
  tests/teleprompt/test_teleprompt.py
```

Direct result: `18 passed`.

The cumulative callback/evaluate/teleprompt integration sweep reports `125 passed, 25 skipped`. The sandboxed full suite reports `1148 passed, 251 skipped`; its five failures and five setup errors were all network lookups. Rerunning that exact network-dependent subset with network access reports `21 passed, 2 xfailed`.

Copy-paste demonstration:

```bash
DSPY_CACHEDIR=/tmp/dspy-pr-demo-cache uv run --frozen --no-sync python - <<'PY'
import warnings
warnings.filterwarnings("ignore", message="Core Pydantic V1 functionality")

import dspy
from dspy.utils.callback import BaseCallback


class Recorder(BaseCallback):
    def on_optimizer_start(self, call_id, instance, inputs):
        self.call_id = call_id
        print("start", type(instance).__name__, "examples", len(inputs["trainset"]))

    def on_optimizer_end(self, call_id, outputs, exception):
        print("end", "same_call", call_id == self.call_id, "output", type(outputs).__name__, "error", exception)


class IdentityOptimizer(dspy.Teleprompter):
    def compile(self, student, *, trainset):
        return student


student = dspy.Predict("question -> answer")
with dspy.context(callbacks=[Recorder()]):
    compiled = IdentityOptimizer().compile(student, trainset=["example"])

print("compiled_is_student", compiled is student)
PY
```

Direct output, unedited:

```text
start IdentityOptimizer examples 1
end same_call True output Predict error None
compiled_is_student True
```

The detached-task regression runs the child module only after optimizer end. Direct output, unedited:

```text
order ['optimizer_start', 'optimizer_end', 'module_start']
detached_parent None
```
