### PR TITLE
feat(teleprompt): emit typed RandomSearch events

### DIFF
--- a/dspy/teleprompt/events.py
+++ b/dspy/teleprompt/events.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Literal
+
+from dspy.utils.callback import OptimizerEvent
+
+__all__ = [
+    "CandidateProposed",
+    "CandidateSelected",
+    "OptimizerEvent",
+    "RandomSearchCandidateProposed",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateProposed(OptimizerEvent):
+    """A logical optimizer candidate that is about to be constructed.
+
+    The index is proposal order within one optimizer callback call ID. It is
+    not an index into a score-sorted result.
+    """
+
+    candidate_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class RandomSearchCandidateProposed(CandidateProposed):
+    """RandomSearch-native details for a proposed candidate."""
+
+    seed: int
+    kind: Literal["zero_shot", "labeled_few_shot", "unshuffled_bootstrap", "shuffled_bootstrap"]
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateSelected(OptimizerEvent):
+    """The candidate returned by an optimizer run.
+
+    ``score`` uses DSPy Evaluate's aggregate percentage scale from 0 to 100.
+    """
+
+    candidate_index: int
+    score: float

--- a/dspy/teleprompt/random_search.py
+++ b/dspy/teleprompt/random_search.py
@@ -2,7 +2,12 @@ import random
 
 import dspy
 from dspy.evaluate.evaluate import Evaluate
+from dspy.teleprompt.events import (
+    CandidateSelected,
+    RandomSearchCandidateProposed,
+)
 from dspy.teleprompt.teleprompt import Teleprompter
+from dspy.utils.callback import _emit_optimizer_event
 
 from .bootstrap import BootstrapFewShot
 from .vanilla import LabeledFewShot
@@ -76,6 +81,27 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
             if (restrict is not None) and (seed not in restrict):
                 continue
 
+            candidate_index = len(scores)
+            if seed == -3:
+                candidate_kind = "zero_shot"
+            elif seed == -2:
+                candidate_kind = "labeled_few_shot"
+            elif seed == -1:
+                candidate_kind = "unshuffled_bootstrap"
+            else:
+                assert seed >= 0, seed
+                candidate_kind = "shuffled_bootstrap"
+                size = random.Random(seed).randint(self.min_num_samples, self.max_num_samples)
+
+            _emit_optimizer_event(
+                self,
+                RandomSearchCandidateProposed(
+                    candidate_index=candidate_index,
+                    seed=seed,
+                    kind=candidate_kind,
+                ),
+            )
+
             trainset_copy = list(self.trainset)
 
             if seed == -3:
@@ -104,7 +130,6 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
                 assert seed >= 0, seed
 
                 random.Random(seed).shuffle(trainset_copy)
-                size = random.Random(seed).randint(self.min_num_samples, self.max_num_samples)
 
                 optimizer = BootstrapFewShot(
                     metric=self.metric,
@@ -127,15 +152,23 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
                 display_progress=True,
             )
 
-            result = evaluate(program)
+            result = evaluate(
+                program,
+                callback_metadata={
+                    "metric_key": "eval_full",
+                    "candidate_index": candidate_index,
+                },
+            )
 
             score, subscores = result.score, [output[2] for output in result.results]
 
             all_subscores.append(subscores)
 
-            if len(scores) == 0 or score > max(scores):
+            became_best = len(scores) == 0 or score > max(scores)
+            if became_best:
                 print("New best score:", score, "for seed", seed)
                 best_program = program
+                best_candidate_index = candidate_index
 
             scores.append(score)
             print(f"Scores so far: {scores}")
@@ -154,6 +187,14 @@ class BootstrapFewShotWithRandomSearch(Teleprompter):
         )
 
         print(f"{len(best_program.candidate_programs)} candidate programs found.")
+
+        _emit_optimizer_event(
+            self,
+            CandidateSelected(
+                candidate_index=best_candidate_index,
+                score=max(scores),
+            ),
+        )
 
         return best_program
 

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -6,9 +6,19 @@ from typing import Any, Callable
 
 import dspy
 from dspy.utils.callback_context import ACTIVE_CALL_ID as ACTIVE_CALL_ID
-from dspy.utils.callback_context import _active_call_context, _normalize_active_call_context
+from dspy.utils.callback_context import (
+    _active_call_context,
+    _is_active_optimizer_call,
+    _normalize_active_call_context,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class OptimizerEvent:
+    """Base class for typed events emitted by an optimizer."""
+
+    __slots__ = ()
 
 
 class BaseCallback:
@@ -283,6 +293,48 @@ class BaseCallback:
         """
         pass
 
+    def on_optimizer_event(
+        self,
+        call_id: str,
+        instance: Any,
+        event: OptimizerEvent,
+    ):
+        """A handler triggered for a typed event during optimizer compilation.
+
+        Args:
+            call_id: The identifier of the optimizer call emitting the event.
+            instance: The Teleprompter instance.
+            event: The optimizer event.
+        """
+        pass
+
+
+def _get_active_callbacks(instance: Any) -> list[Any]:
+    """Get combined global and instance-level callbacks."""
+    return dspy.settings.get("callbacks", []) + getattr(instance, "callbacks", [])
+
+
+def _emit_optimizer_event(instance: Any, event: OptimizerEvent) -> None:
+    """Emit an event from optimizer coordinator code."""
+    handlers = []
+    for callback in _get_active_callbacks(instance):
+        handler = getattr(callback, "on_optimizer_event", None)
+        if handler is not None and getattr(handler, "__func__", None) is not BaseCallback.on_optimizer_event:
+            handlers.append((callback, handler))
+
+    if not handlers:
+        return
+
+    call_id = ACTIVE_CALL_ID.get()
+    if call_id is None or not _is_active_optimizer_call():
+        raise RuntimeError("Optimizer events must be emitted directly from an active optimizer compile callback.")
+
+    for callback, handler in handlers:
+        try:
+            handler(call_id=call_id, instance=instance, event=event)
+        except Exception as e:
+            logger.warning(f"Error when calling callback {callback}: {e}")
+
 
 def with_callbacks(fn, *, _callback_kind: str | None = None):
     """Decorator to add callback functionality to instance methods."""
@@ -317,10 +369,6 @@ def with_callbacks(fn, *, _callback_kind: str | None = None):
             except Exception as e:
                 logger.warning(f"Error when applying callback {callback}'s end handler on function {fn.__name__}: {e}.")
 
-    def _get_active_callbacks(instance):
-        """Get combined global and instance-level callbacks."""
-        return dspy.settings.get("callbacks", []) + getattr(instance, "callbacks", [])
-
     if inspect.iscoroutinefunction(fn):
 
         @functools.wraps(fn)
@@ -338,7 +386,7 @@ def with_callbacks(fn, *, _callback_kind: str | None = None):
             exception = None
             try:
                 # Active ID must be set right before the function is called, not before calling the callbacks.
-                with _active_call_context(call_id):
+                with _active_call_context(call_id, is_optimizer=is_optimizer_callback):
                     results = await fn(instance, *args, **kwargs)
                 return results
             except BaseException as e:
@@ -367,7 +415,7 @@ def with_callbacks(fn, *, _callback_kind: str | None = None):
             exception = None
             try:
                 # Active ID must be set right before the function is called, not before calling the callbacks.
-                with _active_call_context(call_id):
+                with _active_call_context(call_id, is_optimizer=is_optimizer_callback):
                     results = fn(instance, *args, **kwargs)
                 return results
             except BaseException as e:

--- a/dspy/utils/callback_context.py
+++ b/dspy/utils/callback_context.py
@@ -8,12 +8,20 @@ _ACTIVE_CALL = ContextVar("active_call", default=None)
 
 
 class _ActiveCall:
-    __slots__ = ("call_id", "is_active", "parent", "parent_call_id")
+    __slots__ = ("call_id", "is_active", "is_optimizer", "parent", "parent_call_id")
 
-    def __init__(self, call_id: str, parent_call_id: str | None, parent: "_ActiveCall | None"):
+    def __init__(
+        self,
+        call_id: str,
+        parent_call_id: str | None,
+        parent: "_ActiveCall | None",
+        *,
+        is_optimizer: bool,
+    ):
         self.call_id = call_id
         self.parent_call_id = parent_call_id
         self.parent = parent
+        self.is_optimizer = is_optimizer
         self.is_active = True
 
 
@@ -45,11 +53,22 @@ def _normalize_active_call_context() -> str | None:
     return live_call_id
 
 
+def _is_active_optimizer_call() -> bool:
+    call_id = ACTIVE_CALL_ID.get()
+    active_call = _ACTIVE_CALL.get()
+    return (
+        active_call is not None
+        and active_call.call_id == call_id
+        and active_call.is_active
+        and active_call.is_optimizer
+    )
+
+
 @contextmanager
-def _active_call_context(call_id: str):
+def _active_call_context(call_id: str, *, is_optimizer: bool = False):
     parent_call_id = _normalize_active_call_context()
     parent = _ACTIVE_CALL.get()
-    active_call = _ActiveCall(call_id, parent_call_id, parent)
+    active_call = _ActiveCall(call_id, parent_call_id, parent, is_optimizer=is_optimizer)
     call_id_token = ACTIVE_CALL_ID.set(call_id)
     active_call_token = _ACTIVE_CALL.set(active_call)
 

--- a/tests/teleprompt/test_random_search.py
+++ b/tests/teleprompt/test_random_search.py
@@ -1,9 +1,17 @@
+import asyncio
+
 import pytest
 
 import dspy
 from dspy import Example
 from dspy.predict import Predict
 from dspy.teleprompt import BootstrapFewShotWithRandomSearch
+from dspy.teleprompt.events import (
+    CandidateProposed,
+    CandidateSelected,
+    RandomSearchCandidateProposed,
+)
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback, _emit_optimizer_event
 from dspy.utils.dummies import DummyLM
 
 
@@ -18,6 +26,57 @@ class SimpleModule(dspy.Module):
 
 def simple_metric(example, prediction, trace=None):
     return example.output == prediction.output
+
+
+class IdentityModule(dspy.Module):
+    def forward(self, input):
+        return dspy.Prediction(output=input)
+
+
+def identity_metric(example, prediction, trace=None):
+    return float(example.output == prediction.output)
+
+
+class RandomSearchCallback(BaseCallback):
+    def __init__(self, optimizer):
+        self.optimizer = optimizer
+        self.optimizer_start = None
+        self.optimizer_end = None
+        self.events = []
+        self.evaluations = {}
+        self.evaluation_order = []
+
+    def on_optimizer_start(self, call_id, instance, inputs):
+        if instance is self.optimizer:
+            self.optimizer_start = {"call_id": call_id, "parent_call_id": ACTIVE_CALL_ID.get(), "inputs": inputs}
+
+    def on_optimizer_event(self, call_id, instance, event):
+        if instance is self.optimizer:
+            self.events.append((call_id, event))
+
+    def on_optimizer_end(self, call_id, outputs, exception):
+        if self.optimizer_start is not None and call_id == self.optimizer_start["call_id"]:
+            self.optimizer_end = {"call_id": call_id, "outputs": outputs, "exception": exception}
+
+    def on_evaluate_start(self, call_id, instance, inputs):
+        self.evaluation_order.append(call_id)
+        self.evaluations[call_id] = {
+            "parent_call_id": ACTIVE_CALL_ID.get(),
+            "inputs": inputs,
+            "outputs": None,
+            "exception": None,
+        }
+
+    def on_evaluate_end(self, call_id, outputs, exception):
+        self.evaluations[call_id]["outputs"] = outputs
+        self.evaluations[call_id]["exception"] = exception
+
+
+def make_identity_trainset():
+    return [
+        Example(input="correct", output="correct").with_inputs("input"),
+        Example(input="incorrect", output="different").with_inputs("input"),
+    ]
 
 
 def test_basic_workflow():
@@ -74,3 +133,106 @@ def test_restrict_as_single_use_iterator_still_matches_a_valid_seed():
     # -3 (zero-shot) is a valid seed; a plain iterator is single-use.
     result = optimizer.compile(student, teacher=teacher, trainset=trainset, restrict=iter([-3]))
     assert result is not None
+
+
+def test_random_search_correlates_candidates_with_evaluations_and_selection():
+    optimizer = BootstrapFewShotWithRandomSearch(metric=identity_metric, num_threads=2)
+    callback = RandomSearchCallback(optimizer)
+
+    with dspy.context(callbacks=[callback]):
+        result = optimizer.compile(IdentityModule(), trainset=make_identity_trainset(), restrict=[-3, -1])
+
+    run_id = callback.optimizer_start["call_id"]
+    assert callback.optimizer_start["parent_call_id"] is None
+    assert callback.optimizer_end == {"call_id": run_id, "outputs": result, "exception": None}
+    assert all(call_id == run_id for call_id, _ in callback.events)
+
+    events = [event for _, event in callback.events]
+    assert events == [
+        RandomSearchCandidateProposed(candidate_index=0, seed=-3, kind="zero_shot"),
+        RandomSearchCandidateProposed(candidate_index=1, seed=-1, kind="unshuffled_bootstrap"),
+        CandidateSelected(candidate_index=0, score=50.0),
+    ]
+    proposed = events[:2]
+    assert all(isinstance(event, CandidateProposed) for event in proposed)
+    assert all(not hasattr(event, "program") for event in events)
+
+    assert len(callback.evaluations) == 2
+    for candidate_index, call_id in enumerate(callback.evaluation_order):
+        evaluation = callback.evaluations[call_id]
+        assert evaluation["parent_call_id"] == run_id
+        assert evaluation["inputs"]["callback_metadata"] == {
+            "metric_key": "eval_full",
+            "candidate_index": candidate_index,
+        }
+        assert evaluation["outputs"].score == 50.0
+        assert evaluation["exception"] is None
+
+    selected = events[-1]
+    selected_evaluation = callback.evaluations[callback.evaluation_order[selected.candidate_index]]
+    assert selected.score == selected_evaluation["outputs"].score
+
+    assert [candidate["seed"] for candidate in result.candidate_programs] == [-3, -1]
+    assert all(set(candidate) == {"score", "subscores", "seed", "program"} for candidate in result.candidate_programs)
+
+
+def test_random_search_selection_event_matches_early_stop_winner():
+    metric_scores = iter([0.0, 1.0])
+
+    def improving_metric(example, prediction, trace=None):
+        return next(metric_scores)
+
+    optimizer = BootstrapFewShotWithRandomSearch(metric=improving_metric, num_threads=1, stop_at_score=100.0)
+    callback = RandomSearchCallback(optimizer)
+    trainset = [Example(input="value", output="value").with_inputs("input")]
+
+    with dspy.context(callbacks=[callback]):
+        result = optimizer.compile(IdentityModule(), trainset=trainset, restrict=[-3, -2, -1])
+
+    events = [event for _, event in callback.events]
+    assert events == [
+        RandomSearchCandidateProposed(candidate_index=0, seed=-3, kind="zero_shot"),
+        RandomSearchCandidateProposed(candidate_index=1, seed=-2, kind="labeled_few_shot"),
+        CandidateSelected(candidate_index=1, score=100.0),
+    ]
+    assert len(callback.evaluations) == 2
+    assert [candidate["seed"] for candidate in result.candidate_programs] == [-2, -3]
+
+
+def test_random_search_event_callback_failure_does_not_change_result():
+    class FailingCallback(BaseCallback):
+        def on_optimizer_event(self, call_id, instance, event):
+            raise ValueError("tracker failed")
+
+    optimizer = BootstrapFewShotWithRandomSearch(metric=identity_metric)
+
+    with dspy.context(callbacks=[FailingCallback()]):
+        result = optimizer.compile(IdentityModule(), trainset=make_identity_trainset(), restrict=[-3])
+
+    assert result.candidate_programs[0]["seed"] == -3
+
+
+@pytest.mark.asyncio
+async def test_optimizer_event_rejects_completed_detached_context():
+    class EventCallback(BaseCallback):
+        def on_optimizer_event(self, call_id, instance, event):
+            pytest.fail("A completed optimizer call must not emit an event")
+
+    class AsyncOptimizer(dspy.Teleprompter):
+        async def compile(self, student, *, trainset):
+            async def emit_after_compile():
+                await self.release.wait()
+                _emit_optimizer_event(self, CandidateSelected(candidate_index=0, score=100.0))
+
+            self.release = asyncio.Event()
+            self.detached_task = asyncio.create_task(emit_after_compile())
+            return student
+
+    optimizer = AsyncOptimizer()
+
+    with dspy.context(callbacks=[EventCallback()]):
+        student = object()
+        assert await optimizer.compile(student, trainset=[]) is student
+        optimizer.release.set()
+        with pytest.raises(RuntimeError, match="active optimizer compile"):
+            await optimizer.detached_task


### PR DESCRIPTION
> **Optimizer tracking stack (2/2):** #10044 optimizer lifecycle hooks → **#10045 (this PR)**. Base: #10044.

## Issue / reproduction

`BootstrapFewShotWithRandomSearch` exposes its search through console output and a final score-sorted `candidate_programs` list.

An `Evaluate` callback receives each score, but it cannot determine:

```text
Which seed and strategy produced this evaluation?
What was the candidate's proposal-order identity?
Which candidate did RandomSearch actually return?
```

Parsing logs or treating the score-sorted result position as proposal order reconstructs behavior RandomSearch already knows authoritatively.

## Why this is the root cause

Only the RandomSearch seed loop knows the mapping between proposal order, native seed, construction strategy, the corresponding `Evaluate` call, and the strict-`>` winner.

The existing `Evaluate` callback already carries aggregate and per-example scores. What is missing is candidate identity at the optimizer's semantic control-flow points.

## What the fix does

The optimizer now exposes this sequence:

| Stage | Surface | Payload |
|---|---|---|
| Proposal | `RandomSearchCandidateProposed` | run-local candidate index, seed, and strategy kind |
| Evaluation | existing `on_evaluate_start/end` | `callback_metadata.candidate_index`, `metric_key`, aggregate score, and per-example results |
| Selection | `CandidateSelected` | winning candidate index and DSPy's 0–100 aggregate score |

Callbacks consume typed events through:

```python
class Tracker(BaseCallback):
    def on_optimizer_event(self, call_id, instance, event):
        ...
```

Candidate identity is `(optimizer call_id, candidate_index)`. Indices are contiguous proposal order after `restrict` filtering. The RandomSearch seed remains an optimizer-native field rather than being overloaded as the shared identity.

## Why this fixes the root cause

RandomSearch emits proposal and selection at the exact branches that own those facts, and passes the same candidate index into the `Evaluate` call. A tracker joins semantic events to the existing evaluation callback without inspecting programs or parsing text.

Tests cover sparse seeds, a later candidate becoming the winner, early stopping before the next seed, first-wins ties, callback failure isolation, and the unchanged result schema.

## Why this is concise

This PR intentionally does **not** add a duplicate `CandidateEvaluated` event. `on_evaluate_end` remains the single source for scores and per-example results.

It also avoids:

- string candidate and evaluation IDs;
- score/unit envelope objects;
- task ownership or an event registry;
- a public custom-producer API;
- a separate event-transport PR; and
- a canonical `OptimizationRun` before another optimizer validates the model.

## Context needed to review

- `candidate_index` is proposal order, not a position in score-sorted `best_program.candidate_programs`.
- `CandidateSelected.score` is the same percentage-valued score returned by DSPy `Evaluate`.
- Strict `>` selection is unchanged, so the first candidate wins ties.
- Proposal happens before construction, so a failed candidate may have a proposal without an evaluation. The optimizer end hook reports the failure.

## Compatibility and downsides

- `Evaluate` callbacks inside RandomSearch now receive non-`None` metadata: `metric_key` and `candidate_index`.
- Existing `candidate_programs` entries remain exactly `{score, subscores, seed, program}`.
- Only RandomSearch emits these events. MIPRO and SIMBA should validate the shared model before DSPy adds canonical run storage.
- Event handlers run synchronously. Ordinary handler exceptions are logged and isolated, but slow handlers add latency.
- Event listeners are resolved from current callback configuration at emission time rather than a lifecycle-start snapshot.
- The producer helper is private and requires the exact current callback scope to be an active optimizer compile. A late detached event raises `RuntimeError` instead of being reassigned to a live ancestor. Custom optimizer emission is intentionally not yet a public contract.
- `CandidateSelected` repeats the winning aggregate score for convenience; detailed evaluation data remains on `on_evaluate_end`.
- Selection is emitted only after successful completion.

## Verification

Focused stack tests:

```bash
uv run --frozen --no-sync pytest --deno -q \
  tests/callback/test_callback.py \
  tests/callback/test_optimizer_lifecycle.py \
  tests/teleprompt/test_random_search.py
```

Direct result: `24 passed`.

The cumulative callback/evaluate/teleprompt integration sweep reports `129 passed, 25 skipped`. The sandboxed full suite reports `1152 passed, 251 skipped`; its five failures and five setup errors were all network lookups. Rerunning that exact network-dependent subset with network access reports `21 passed, 2 xfailed`.

Copy-paste demonstration using the actual RandomSearch implementation:

```bash
DSPY_CACHEDIR=/tmp/dspy-pr-demo-cache uv run --frozen --no-sync python - <<'PY'
import contextlib
import io
import logging
import warnings

warnings.filterwarnings("ignore", message="Core Pydantic V1 functionality")
logging.getLogger("dspy.evaluate.evaluate").setLevel(logging.WARNING)

import dspy
from dspy.teleprompt import BootstrapFewShotWithRandomSearch
from dspy.utils.callback import BaseCallback


class Identity(dspy.Module):
    def forward(self, text):
        return dspy.Prediction(answer=text)


def exact_match(example, prediction, trace=None):
    return example.answer == prediction.answer


class Recorder(BaseCallback):
    def __init__(self):
        self.events = []
        self.evaluate_metadata = []

    def on_optimizer_event(self, call_id, instance, event):
        self.events.append(event)

    def on_evaluate_start(self, call_id, instance, inputs):
        self.evaluate_metadata.append(inputs["callback_metadata"])


trainset = [dspy.Example(text="works", answer="works").with_inputs("text")]
recorder = Recorder()
with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()), dspy.context(callbacks=[recorder]):
    optimizer = BootstrapFewShotWithRandomSearch(metric=exact_match, num_threads=1)
    compiled = optimizer.compile(Identity(), trainset=trainset, restrict=[-3])

print("event_types", [type(event).__name__ for event in recorder.events])
print("events", recorder.events)
print("evaluate_metadata", recorder.evaluate_metadata)
print("candidate_seeds", [candidate["seed"] for candidate in compiled.candidate_programs])
PY
```

Direct output, unedited:

```text
event_types ['RandomSearchCandidateProposed', 'CandidateSelected']
events [RandomSearchCandidateProposed(candidate_index=0, seed=-3, kind='zero_shot'), CandidateSelected(candidate_index=0, score=100.0)]
evaluate_metadata [{'metric_key': 'eval_full', 'candidate_index': 0}]
candidate_seeds [-3]
```
