### PR TITLE
Make Audio URL download opt-in; add SSRF guard + timeout to Audio & Image (fixes #9993)

### DIFF
--- a/dspy/adapters/types/_url_safety.py
+++ b/dspy/adapters/types/_url_safety.py
@@ -1,42 +1,76 @@
 """Shared URL-safety helpers for media types that download from URLs.
 
-`Image` and `Audio` can fetch media from a URL. Two things must be true for that
-to be safe against SSRF and hanging-host DoS:
+`Image` and `Audio` can fetch media from a URL. Three things must be true for
+that to be safe against SSRF and hanging-host DoS:
 
 1. The fetch must be gated behind an explicit opt-in, so untrusted content
    (tool output, a retrieved document, a model output being cast to a media
    type) can never *trigger* an outbound request on its own. That gating lives
    in the media types themselves.
 
-2. Even an opted-in fetch must validate its destination, because the URL itself
-   may have come from untrusted input. `assert_public_url` rejects URLs that
-   resolve to loopback, private, link-local, or otherwise non-public addresses
-   (e.g. the cloud metadata endpoint ``169.254.169.254``).
+2. Every request the fetch actually makes must go to a public destination, at
+   every hop. `safe_get` validates the initial URL *and every redirect target*
+   with `assert_public_url` before connecting, so a public URL that redirects
+   to an internal address (e.g. the cloud metadata endpoint) is refused.
 
-These are complementary: (1) controls the trigger, (2) validates the target.
+3. Neither the DNS lookup nor the HTTP request may hang indefinitely. The HTTP
+   request is bounded by `timeout`; name resolution is bounded separately (see
+   `_resolve`), since `socket.getaddrinfo` does not honor the socket timeout on
+   most platforms.
+
+Known limitation: `assert_public_url` validates at resolution time and does not
+defend against DNS rebinding (a host that resolves public here and private when
+the socket actually connects). Closing that requires resolving once and
+connecting to the pinned IP with the original host in the SNI/Host header, which
+is a deeper change than a media loader should own.
 """
 from __future__ import annotations
 
 import ipaddress
 import socket
-from urllib.parse import urlparse
+import threading
+from urllib.parse import urljoin, urlparse
+
+import requests
 
 DEFAULT_DOWNLOAD_TIMEOUT = 30.0
+MAX_REDIRECTS = 5
 
 
-def assert_public_url(url: str) -> None:
+def _resolve(host: str, port: int, timeout: float):
+    """`socket.getaddrinfo` with a hard wall-clock timeout.
+
+    `getaddrinfo` ignores `socket.setdefaulttimeout` on most platforms, so a
+    host pointed at a dead DNS server can hang the caller indefinitely. Run it
+    on a daemon thread and give up after `timeout` seconds; the caller never
+    blocks longer than that even if the lookup thread is still stuck.
+    """
+    box: dict = {}
+
+    def work():
+        try:
+            box["ok"] = socket.getaddrinfo(host, port)
+        except Exception as e:  # noqa: BLE001 - surfaced below as ValueError
+            box["err"] = e
+
+    th = threading.Thread(target=work, daemon=True)
+    th.start()
+    th.join(timeout)
+    if th.is_alive():
+        raise ValueError(f"DNS resolution for {host!r} timed out after {timeout}s (SSRF check).")
+    if "err" in box:
+        raise ValueError(f"Could not resolve host {host!r}: {box['err']}")
+    return box["ok"]
+
+
+def assert_public_url(url: str, *, dns_timeout: float = DEFAULT_DOWNLOAD_TIMEOUT) -> None:
     """Raise ``ValueError`` unless every address ``url``'s host resolves to is
     a public, routable IP address.
 
     Guards against the common SSRF targets: loopback (``127.0.0.1``,
     ``localhost``), private ranges (``10/8``, ``192.168/16``, ...), link-local
     (``169.254/16``, including the cloud metadata endpoint), and other reserved
-    or non-global ranges.
-
-    Note: this validates at resolution time and does not defend against DNS
-    rebinding (a host that resolves to a public IP here but a private one when
-    the request is actually made). That is a deeper mitigation than a media
-    loader should own; this closes the direct SSRF surface.
+    or non-global ranges. Name resolution is bounded by ``dns_timeout``.
     """
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https"):
@@ -48,11 +82,7 @@ def assert_public_url(url: str) -> None:
     if not host:
         raise ValueError(f"Could not parse a host from URL: {url!r}")
 
-    try:
-        addrinfos = socket.getaddrinfo(host, parsed.port or (443 if parsed.scheme == "https" else 80))
-    except socket.gaierror as e:
-        raise ValueError(f"Could not resolve host {host!r}: {e}") from e
-
+    addrinfos = _resolve(host, parsed.port or (443 if parsed.scheme == "https" else 80), dns_timeout)
     for info in addrinfos:
         ip = ipaddress.ip_address(info[4][0])
         if not ip.is_global or ip.is_multicast or ip.is_reserved:
@@ -62,3 +92,32 @@ def assert_public_url(url: str) -> None:
                 "(e.g. a trusted internal host), fetch the bytes yourself and "
                 "pass them directly."
             )
+
+
+def safe_get(
+    url: str,
+    *,
+    verify: bool = True,
+    timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
+    max_redirects: int = MAX_REDIRECTS,
+) -> requests.Response:
+    """GET ``url``, validating the destination at every hop.
+
+    Redirects are followed manually so that each ``Location`` is checked with
+    ``assert_public_url`` before it is fetched. This closes the redirect-based
+    SSRF bypass: a public URL that 3xx-redirects to an internal address is
+    refused instead of followed. Returns the final (non-redirect) response;
+    the caller is responsible for ``raise_for_status()``.
+    """
+    current = url
+    for _ in range(max_redirects + 1):
+        assert_public_url(current, dns_timeout=timeout)
+        resp = requests.get(current, verify=verify, timeout=timeout, allow_redirects=False)
+        if resp.is_redirect or resp.is_permanent_redirect:
+            location = resp.headers.get("Location")
+            if not location:
+                return resp
+            current = urljoin(resp.url, location)
+            continue
+        return resp
+    raise ValueError(f"Too many redirects (> {max_redirects}) while downloading {url!r}.")

--- a/dspy/adapters/types/_url_safety.py
+++ b/dspy/adapters/types/_url_safety.py
@@ -1,0 +1,64 @@
+"""Shared URL-safety helpers for media types that download from URLs.
+
+`Image` and `Audio` can fetch media from a URL. Two things must be true for that
+to be safe against SSRF and hanging-host DoS:
+
+1. The fetch must be gated behind an explicit opt-in, so untrusted content
+   (tool output, a retrieved document, a model output being cast to a media
+   type) can never *trigger* an outbound request on its own. That gating lives
+   in the media types themselves.
+
+2. Even an opted-in fetch must validate its destination, because the URL itself
+   may have come from untrusted input. `assert_public_url` rejects URLs that
+   resolve to loopback, private, link-local, or otherwise non-public addresses
+   (e.g. the cloud metadata endpoint ``169.254.169.254``).
+
+These are complementary: (1) controls the trigger, (2) validates the target.
+"""
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+DEFAULT_DOWNLOAD_TIMEOUT = 30.0
+
+
+def assert_public_url(url: str) -> None:
+    """Raise ``ValueError`` unless every address ``url``'s host resolves to is
+    a public, routable IP address.
+
+    Guards against the common SSRF targets: loopback (``127.0.0.1``,
+    ``localhost``), private ranges (``10/8``, ``192.168/16``, ...), link-local
+    (``169.254/16``, including the cloud metadata endpoint), and other reserved
+    or non-global ranges.
+
+    Note: this validates at resolution time and does not defend against DNS
+    rebinding (a host that resolves to a public IP here but a private one when
+    the request is actually made). That is a deeper mitigation than a media
+    loader should own; this closes the direct SSRF surface.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Refusing to download from URL with scheme {parsed.scheme!r}; "
+            "only http and https are allowed."
+        )
+    host = parsed.hostname
+    if not host:
+        raise ValueError(f"Could not parse a host from URL: {url!r}")
+
+    try:
+        addrinfos = socket.getaddrinfo(host, parsed.port or (443 if parsed.scheme == "https" else 80))
+    except socket.gaierror as e:
+        raise ValueError(f"Could not resolve host {host!r}: {e}") from e
+
+    for info in addrinfos:
+        ip = ipaddress.ip_address(info[4][0])
+        if not ip.is_global or ip.is_multicast or ip.is_reserved:
+            raise ValueError(
+                f"Refusing to download from {url!r}: host {host!r} resolves to "
+                f"non-public address {ip} (SSRF guard). If this is intentional "
+                "(e.g. a trusted internal host), fetch the bytes yourself and "
+                "pass them directly."
+            )

--- a/dspy/adapters/types/_url_safety.py
+++ b/dspy/adapters/types/_url_safety.py
@@ -22,7 +22,9 @@ Known limitation: `assert_public_url` validates at resolution time and does not
 defend against DNS rebinding (a host that resolves public here and private when
 the socket actually connects). Closing that requires resolving once and
 connecting to the pinned IP with the original host in the SNI/Host header, which
-is a deeper change than a media loader should own.
+is a deeper change than a media loader should own. (The CGNAT / RFC 6598 range
+that older Pythons mislabel as global is handled explicitly; see
+`_EXTRA_BLOCKED_NETS`.)
 """
 from __future__ import annotations
 
@@ -35,6 +37,13 @@ import requests
 
 DEFAULT_DOWNLOAD_TIMEOUT = 30.0
 MAX_REDIRECTS = 5
+
+# Ranges some Python versions mislabel as globally routable, checked explicitly
+# so the guard is correct regardless of interpreter version. Python < 3.11
+# reports 100.64.0.0/10 (CGNAT / RFC 6598 shared address space) as
+# ``is_global`` = True (CPython bpo-38655); DSPy supports 3.10, so we reject it
+# here rather than rely on ``is_global`` alone.
+_EXTRA_BLOCKED_NETS = [ipaddress.ip_network("100.64.0.0/10")]
 
 
 def _resolve(host: str, port: int, timeout: float):
@@ -85,7 +94,8 @@ def assert_public_url(url: str, *, dns_timeout: float = DEFAULT_DOWNLOAD_TIMEOUT
     addrinfos = _resolve(host, parsed.port or (443 if parsed.scheme == "https" else 80), dns_timeout)
     for info in addrinfos:
         ip = ipaddress.ip_address(info[4][0])
-        if not ip.is_global or ip.is_multicast or ip.is_reserved:
+        extra_blocked = any(ip.version == net.version and ip in net for net in _EXTRA_BLOCKED_NETS)
+        if not ip.is_global or ip.is_multicast or ip.is_reserved or extra_blocked:
             raise ValueError(
                 f"Refusing to download from {url!r}: host {host!r} resolves to "
                 f"non-public address {ip} (SSRF guard). If this is intentional "

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -7,6 +7,7 @@ from typing import Any, Union
 import pydantic
 import requests
 
+from dspy.adapters.types._url_safety import DEFAULT_DOWNLOAD_TIMEOUT, assert_public_url
 from dspy.adapters.types.base_type import Type
 
 try:
@@ -30,6 +31,29 @@ class Audio(Type):
         frozen=True,
         extra="forbid",
     )
+
+    def __init__(
+        self,
+        source: Any = None,
+        *,
+        download: bool = False,
+        verify: bool = True,
+        timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
+        **data: Any,
+    ):
+        """Construct an Audio from a file path, data URI, bytes, numpy array,
+        dict, or (with ``download=True``) a URL.
+
+        Downloading from a URL is opt-in for security. A bare ``Audio(url)`` or
+        a string coerced into an ``Audio``-typed field will NOT fetch; it raises
+        and points you at ``Audio.from_url(url)``. Pass ``download=True`` to opt
+        in. ``verify`` toggles SSL verification and ``timeout`` bounds the
+        request; both flow through to the download.
+        """
+        if source is not None and "data" not in data:
+            encoded = encode_audio(source, download=download, verify=verify, timeout=timeout)
+            data = {**data, **encoded}
+        super().__init__(**data)
 
     def format(self) -> list[dict[str, Any]]:
         try:
@@ -56,11 +80,16 @@ class Audio(Type):
         return encode_audio(values)
 
     @classmethod
-    def from_url(cls, url: str) -> "Audio":
+    def from_url(cls, url: str, *, verify: bool = True, timeout: float = DEFAULT_DOWNLOAD_TIMEOUT) -> "Audio":
         """
         Download an audio file from URL and encode it as base64.
+
+        The destination is validated against the SSRF guard (rejects loopback,
+        private, and link-local addresses), the request is bounded by ``timeout``
+        seconds, and ``verify`` toggles SSL certificate verification.
         """
-        response = requests.get(url)
+        assert_public_url(url)
+        response = requests.get(url, verify=verify, timeout=timeout)
         response.raise_for_status()
         mime_type = response.headers.get("Content-Type", "audio/wav")
         if not mime_type.startswith("audio/"):
@@ -122,11 +151,25 @@ class Audio(Type):
         length = len(self.data)
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
 
-def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:
+def encode_audio(
+    audio: Union[str, bytes, dict, "Audio", Any],
+    sampling_rate: int = 16000,
+    format: str = "wav",
+    *,
+    download: bool = False,
+    verify: bool = True,
+    timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
+) -> dict:
     """
     Encode audio to a dict with 'data' and 'audio_format'.
-    
+
     Accepts: local file path, URL, data URI, dict, Audio instance, numpy array, or bytes (with known format).
+
+    Downloading from a URL is opt-in (``download=True``) for security: this
+    function runs from ``Audio``'s ``before`` validator, so any string coerced
+    into an ``Audio`` field would otherwise trigger an implicit outbound request
+    (an SSRF and hanging-host DoS surface). With ``download=False`` (the default)
+    an ``http(s)`` string raises and points at ``Audio.from_url(url)``.
     """
     if isinstance(audio, dict) and "data" in audio and "audio_format" in audio:
         return audio
@@ -147,7 +190,15 @@ def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: in
         a = Audio.from_file(audio)
         return {"data": a.data, "audio_format": a.audio_format}
     elif isinstance(audio, str) and audio.startswith("http"):
-        a = Audio.from_url(audio)
+        if not download:
+            raise ValueError(
+                "Audio will not download from a URL by default, because this "
+                "runs from a validator and any string coerced into an Audio "
+                "field would trigger an implicit outbound request (SSRF / "
+                "hanging-host DoS). To download intentionally, call "
+                "Audio.from_url(url), or opt in with Audio(url, download=True)."
+            )
+        a = Audio.from_url(audio, verify=verify, timeout=timeout)
         return {"data": a.data, "audio_format": a.audio_format}
     elif SF_AVAILABLE and hasattr(audio, "shape"):
         a = Audio.from_array(audio, sampling_rate=sampling_rate, format=format)

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -5,9 +5,8 @@ import os
 from typing import Any, Union
 
 import pydantic
-import requests
 
-from dspy.adapters.types._url_safety import DEFAULT_DOWNLOAD_TIMEOUT, assert_public_url
+from dspy.adapters.types._url_safety import DEFAULT_DOWNLOAD_TIMEOUT, safe_get
 from dspy.adapters.types.base_type import Type
 
 try:
@@ -85,11 +84,11 @@ class Audio(Type):
         Download an audio file from URL and encode it as base64.
 
         The destination is validated against the SSRF guard (rejects loopback,
-        private, and link-local addresses), the request is bounded by ``timeout``
-        seconds, and ``verify`` toggles SSL certificate verification.
+        private, and link-local addresses) at every redirect hop, the request is
+        bounded by ``timeout`` seconds, and ``verify`` toggles SSL certificate
+        verification.
         """
-        assert_public_url(url)
-        response = requests.get(url, verify=verify, timeout=timeout)
+        response = safe_get(url, verify=verify, timeout=timeout)
         response.raise_for_status()
         mime_type = response.headers.get("Content-Type", "audio/wav")
         if not mime_type.startswith("audio/"):

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -8,9 +8,8 @@ from typing import Any, Union
 from urllib.parse import urlparse
 
 import pydantic
-import requests
 
-from dspy.adapters.types._url_safety import DEFAULT_DOWNLOAD_TIMEOUT, assert_public_url
+from dspy.adapters.types._url_safety import DEFAULT_DOWNLOAD_TIMEOUT, safe_get
 from dspy.adapters.types.base_type import Type
 
 try:
@@ -205,12 +204,12 @@ def _encode_image_from_url(image_url: str, verify: bool = True, timeout: float =
         timeout: Seconds to wait for the request before giving up.
 
     The destination is validated against the SSRF guard (rejects loopback,
-    private, and link-local addresses) before the request is made. Even though
-    downloading is already opt-in, an explicit ``download=True`` can still point
-    at an internal address if the URL came from untrusted input.
+    private, and link-local addresses) at every redirect hop before the request
+    is made. Even though downloading is already opt-in, an explicit
+    ``download=True`` can still point at an internal address if the URL came from
+    untrusted input.
     """
-    assert_public_url(image_url)
-    response = requests.get(image_url, verify=verify, timeout=timeout)
+    response = safe_get(image_url, verify=verify, timeout=timeout)
     response.raise_for_status()
     content_type = response.headers.get("Content-Type", "")
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 import pydantic
 import requests
 
+from dspy.adapters.types._url_safety import DEFAULT_DOWNLOAD_TIMEOUT, assert_public_url
 from dspy.adapters.types.base_type import Type
 
 try:
@@ -30,7 +31,7 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, url: Any = None, *, download: bool = False, verify: bool = True, **data):
+    def __init__(self, url: Any = None, *, download: bool = False, verify: bool = True, timeout: float = DEFAULT_DOWNLOAD_TIMEOUT, **data):
         """Create an Image.
 
         Parameters
@@ -51,6 +52,10 @@ class Image(Type):
             Whether to verify SSL certificates when downloading images from URLs.
             Set to False for self-signed certificates. Default is True.
 
+        timeout:
+            Seconds to wait for a URL download before giving up. Only applies
+            when ``download=True``.
+
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
         """
 
@@ -65,7 +70,7 @@ class Image(Type):
 
         if "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.
-            data["url"] = encode_image(data["url"], download_images=download, verify=verify)
+            data["url"] = encode_image(data["url"], download_images=download, verify=verify, timeout=timeout)
 
         # Delegate the rest of initialization to pydantic's BaseModel.
         super().__init__(**data)
@@ -125,7 +130,7 @@ def is_url(string: str) -> bool:
         return False
 
 
-def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_images: bool = False, verify: bool = True) -> str:
+def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_images: bool = False, verify: bool = True, timeout: float = DEFAULT_DOWNLOAD_TIMEOUT) -> str:
     """
     Encode an image or file to a base64 data URI.
 
@@ -133,6 +138,7 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_imag
         image: The image or file to encode. Can be a PIL Image, file path, URL, or data URI.
         download_images: Whether to download images from URLs.
         verify: Whether to verify SSL certificates when downloading images.
+        timeout: Seconds to wait for a URL download before giving up.
 
     Returns:
         str: The data URI of the file or the URL if download_images is False.
@@ -153,7 +159,7 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_imag
         elif is_url(image):
             # URL
             if download_images:
-                return _encode_image_from_url(image, verify=verify)
+                return _encode_image_from_url(image, verify=verify, timeout=timeout)
             else:
                 # Return the URL as is
                 return image
@@ -190,14 +196,21 @@ def _encode_image_from_file(file_path: str) -> str:
     return f"data:{mime_type};base64,{encoded_data}"
 
 
-def _encode_image_from_url(image_url: str, verify: bool = True) -> str:
+def _encode_image_from_url(image_url: str, verify: bool = True, timeout: float = DEFAULT_DOWNLOAD_TIMEOUT) -> str:
     """Encode a file from a URL to a base64 data URI.
-    
+
     Args:
         image_url: The URL of the image to download.
         verify: Whether to verify SSL certificates. Set to False for self-signed certs.
+        timeout: Seconds to wait for the request before giving up.
+
+    The destination is validated against the SSRF guard (rejects loopback,
+    private, and link-local addresses) before the request is made. Even though
+    downloading is already opt-in, an explicit ``download=True`` can still point
+    at an internal address if the URL came from untrusted input.
     """
-    response = requests.get(image_url, verify=verify)
+    assert_public_url(image_url)
+    response = requests.get(image_url, verify=verify, timeout=timeout)
     response.raise_for_status()
     content_type = response.headers.get("Content-Type", "")
 

--- a/tests/adapters/test_url_safety.py
+++ b/tests/adapters/test_url_safety.py
@@ -3,9 +3,12 @@
 All tests are offline: the SSRF guard and the opt-in gate both raise before any
 network request is made, so no real download happens.
 """
-import pytest
+from unittest import mock
 
-from dspy.adapters.types._url_safety import assert_public_url
+import pytest
+import requests
+
+from dspy.adapters.types._url_safety import assert_public_url, safe_get
 from dspy.adapters.types.audio import Audio, encode_audio
 from dspy.adapters.types.image import _encode_image_from_url
 
@@ -85,3 +88,56 @@ def test_audio_non_url_paths_still_work():
 def test_image_from_url_applies_ssrf_guard():
     with pytest.raises(ValueError):
         _encode_image_from_url("http://169.254.169.254/latest/meta-data/")
+
+
+# ---------------------------------------------------------------------------
+# Redirect bypass: a public URL that redirects to a private one must be refused
+# ---------------------------------------------------------------------------
+
+def _redirect_resp(location, url="http://8.8.8.8/start"):
+    r = requests.Response()
+    r.status_code = 302
+    r.url = url
+    r.headers["Location"] = location
+    return r
+
+
+def _ok_resp(url="http://8.8.8.8/x"):
+    r = requests.Response()
+    r.status_code = 200
+    r.url = url
+    r._content = b"ok"
+    return r
+
+
+@mock.patch("dspy.adapters.types._url_safety.requests.get")
+def test_safe_get_blocks_redirect_to_private(mock_get):
+    # First hop is a public literal IP (passes the guard); it 302-redirects to
+    # the metadata endpoint, which must be caught before it is followed.
+    mock_get.return_value = _redirect_resp("http://169.254.169.254/latest/meta-data/")
+    with pytest.raises(ValueError):
+        safe_get("http://8.8.8.8/start")
+
+
+@mock.patch("dspy.adapters.types._url_safety.requests.get")
+def test_safe_get_follows_public_redirect(mock_get):
+    # A redirect to another public address is allowed.
+    mock_get.side_effect = [_redirect_resp("http://1.1.1.1/next"), _ok_resp("http://1.1.1.1/next")]
+    resp = safe_get("http://8.8.8.8/start")
+    assert resp.status_code == 200
+
+
+@mock.patch("dspy.adapters.types._url_safety.requests.get")
+def test_safe_get_caps_redirects(mock_get):
+    # An endless public redirect loop terminates instead of hanging.
+    mock_get.return_value = _redirect_resp("http://8.8.8.8/loop")
+    with pytest.raises(ValueError, match="Too many redirects"):
+        safe_get("http://8.8.8.8/start", max_redirects=3)
+
+
+def test_dns_resolution_is_bounded():
+    # assert_public_url must not hang on a dead resolver; a tiny timeout raises.
+    with mock.patch("dspy.adapters.types._url_safety.socket.getaddrinfo",
+                    side_effect=lambda *a, **k: __import__("time").sleep(5)):
+        with pytest.raises(ValueError, match="timed out"):
+            assert_public_url("http://example.com/x", dns_timeout=0.2)

--- a/tests/adapters/test_url_safety.py
+++ b/tests/adapters/test_url_safety.py
@@ -26,6 +26,7 @@ from dspy.adapters.types.image import _encode_image_from_url
     "http://172.16.0.1/x",                         # private
     "http://[::1]/x",                              # ipv6 loopback
     "http://0.0.0.0/x",                            # unspecified
+    "http://100.64.0.1/x",                         # CGNAT / RFC 6598 (mislabeled global on <3.11)
 ])
 def test_guard_rejects_non_public_addresses(url):
     with pytest.raises(ValueError):

--- a/tests/adapters/test_url_safety.py
+++ b/tests/adapters/test_url_safety.py
@@ -1,0 +1,87 @@
+"""Tests for the URL-download safety controls on Audio and Image.
+
+All tests are offline: the SSRF guard and the opt-in gate both raise before any
+network request is made, so no real download happens.
+"""
+import pytest
+
+from dspy.adapters.types._url_safety import assert_public_url
+from dspy.adapters.types.audio import Audio, encode_audio
+from dspy.adapters.types.image import _encode_image_from_url
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("url", [
+    "http://127.0.0.1/x",                          # loopback
+    "http://localhost/x",                          # loopback name
+    "http://169.254.169.254/latest/meta-data/",    # cloud metadata endpoint
+    "http://10.0.0.5/x",                           # private
+    "http://192.168.1.1/x",                        # private
+    "http://172.16.0.1/x",                         # private
+    "http://[::1]/x",                              # ipv6 loopback
+    "http://0.0.0.0/x",                            # unspecified
+])
+def test_guard_rejects_non_public_addresses(url):
+    with pytest.raises(ValueError):
+        assert_public_url(url)
+
+
+@pytest.mark.parametrize("url", [
+    "http://8.8.8.8/x",       # public IP (validated, not fetched)
+    "https://1.1.1.1/x",
+])
+def test_guard_allows_public_addresses(url):
+    assert_public_url(url) is None  # does not raise
+
+
+@pytest.mark.parametrize("url", ["ftp://example.com/x", "file:///etc/passwd", "gopher://x"])
+def test_guard_rejects_non_http_schemes(url):
+    with pytest.raises(ValueError, match="scheme"):
+        assert_public_url(url)
+
+
+# ---------------------------------------------------------------------------
+# Audio: download is opt-in (secure by default)
+# ---------------------------------------------------------------------------
+
+def test_encode_audio_url_requires_optin():
+    with pytest.raises(ValueError, match="will not download"):
+        encode_audio("http://example.com/a.wav")  # download defaults to False
+
+
+def test_bare_audio_url_does_not_download():
+    # A string coerced/constructed into Audio must not trigger a fetch.
+    with pytest.raises(ValueError, match="will not download"):
+        Audio("http://example.com/a.wav")
+
+
+def test_audio_field_coercion_does_not_download():
+    # The model_validator path (untrusted coercion) must also refuse.
+    with pytest.raises(ValueError, match="will not download"):
+        Audio.model_validate("http://example.com/a.wav")
+
+
+def test_audio_from_url_applies_ssrf_guard():
+    # Even the explicit download path validates the destination.
+    with pytest.raises(ValueError):
+        Audio.from_url("http://127.0.0.1/a.wav")
+
+
+def test_audio_non_url_paths_still_work():
+    # Data URI and explicit data/format construction never touch the network.
+    a = Audio("data:audio/wav;base64,QUJD")
+    assert a.data == "QUJD" and a.audio_format == "wav"
+    b = Audio(data="QUJD", audio_format="mp3")
+    assert b.data == "QUJD" and b.audio_format == "mp3"
+
+
+# ---------------------------------------------------------------------------
+# Image: opt-in already existed; guard is the new part
+# ---------------------------------------------------------------------------
+
+def test_image_from_url_applies_ssrf_guard():
+    with pytest.raises(ValueError):
+        _encode_image_from_url("http://169.254.169.254/latest/meta-data/")


### PR DESCRIPTION
Fixes #9993. Implements option 1 from the issue thread (opt in via constructor, mirroring `Image`), plus the destination validation @ErenAta16 asked for on both types.

## The problem

`Audio` downloaded from any `http(s)` string unconditionally, and `encode_audio` runs from `Audio`'s `model_validator(mode="before")`. So any string coerced into an `Audio`-typed field (a tool return, text parsed from a retrieved document, a model output an adapter is casting) triggered a live outbound `requests.get` with no timeout and no SSL control. That is an SSRF surface and a hanging-host DoS, and it fired without any explicit `Audio(...)` call.

## The fix

**Trigger gating (Audio).** Downloading from a URL is now opt-in, mirroring `Image`. A bare `Audio(url)` or a string coerced into an `Audio` field raises a clear error pointing at `Audio.from_url(url)`; `Audio(url, download=True)` opts in.

**Destination validation (Audio + Image).** A shared `assert_public_url` guard (`dspy/adapters/types/_url_safety.py`) rejects loopback / private / link-local / reserved addresses (including the `169.254.169.254` cloud metadata endpoint) and non-`http(s)` schemes. Applied in `Audio.from_url` **and** `Image._encode_image_from_url`, so an explicit `download=True` still cannot be pointed at an internal address when the URL itself came from untrusted input. Gating the trigger and validating the destination are complementary, per @ErenAta16's note.

**Timeout + verify.** Added a request timeout to both download paths (`Audio` had neither a timeout nor SSL-verify control; `Image` lacked a timeout).

## Breaking change

`Audio("http://...")` no longer auto fetches. The raised error gives the one line migration (`Audio.from_url(url)`, or `download=True`). This is the intended tradeoff for a real SSRF/DoS fix, as discussed in the issue.

## Scope note

The guard validates at DNS resolution time and does not defend against DNS rebinding (a host that resolves public here but private at request time). That is a deeper mitigation than a media loader should own; it is called out in the code. This PR closes the direct SSRF surface and the unconditional-download/no-timeout surface.

## Tests

`tests/adapters/test_url_safety.py` (new, fully offline: the guard and the opt in gate both raise before any network call). Covers: guard rejects loopback/private/link-local/metadata/ipv6-loopback/non-http schemes and allows public IPs; `Audio` refuses to download by default via both the constructor and the coercion path; `Audio.from_url` and `Image._encode_image_from_url` apply the guard; non-URL Audio paths still work. Existing `tests/adapters/test_audio.py` and `tests/signatures/test_adapter_image.py` pass.
