### PR TITLE
docs(gepa): explain trainset/valset roles and split guidance

### DIFF
--- a/docs/docs/getting-started/gepa-optimization.md
+++ b/docs/docs/getting-started/gepa-optimization.md
@@ -86,6 +86,24 @@ Finally, we compile our optimized program:
 optimized_haiku_bot = optimizer.compile(haiku_bot, trainset=train, valset=val)
 ```
 
+### Choosing the training and validation sets
+
+GEPA uses these two splits for different jobs. The `trainset` supplies examples
+for reflective prompt updates, while the `valset` tracks Pareto scores and
+selects the program returned by `compile`. Keep a final test set separate so you
+can evaluate the optimized program on examples that influenced neither step.
+
+There is no universal split ratio. For generalization, keep as much data as
+possible in `trainset` and make `valset` the smallest sample that still
+represents the downstream distribution. Every candidate is scored on the
+validation examples, so an unnecessarily large `valset` also reduces how many
+candidate prompts GEPA can explore within a fixed metric-call budget.
+
+If you omit `valset`, GEPA reuses `trainset` for selection. That can be useful
+for inference-time search, where the goal is to find the best output for the
+examples at hand, but it deliberately allows prompts to overfit those examples.
+Pass a separate validation set when you care about performance on unseen data.
+
 Now it’s time to grab a beverage and wait.
 
 Behind the scenes, compile runs an iterative loop.


### PR DESCRIPTION
## What

Adds a "Choosing the training and validation sets" subsection to the GEPA getting-started walkthrough (`docs/docs/getting-started/gepa-optimization.md`). The walkthrough previously passed `trainset` and `valset` into `compile()` without explaining their distinct roles or the risks of how you split the data.

The new subsection covers:

- **Roles:** `trainset` drives reflective prompt updates, while `valset` tracks Pareto scores and selects the program returned by `compile`.
- **Split guidance:** keep `trainset` as large as possible and make `valset` the smallest sample that still represents the downstream distribution — an oversized `valset` also consumes metric-call budget that would otherwise let GEPA explore more candidate prompts.
- **Omitting `valset`:** GEPA reuses `trainset` for both, which is useful as an inference-time search strategy but deliberately overfits; pass a separate validation set when you care about performance on unseen data.

Addresses #8782.

## Verification

Every claim is grounded in the current implementation, `dspy/teleprompt/gepa/gepa.py`:

- Roles of the two sets — docstring, lines 485–486.
- `valset = valset or trainset` fallback plus the overfitting / inference-time-search warning — lines 515–519.
- The "a smaller `valset` lets GEPA explore more within the same budget" tradeoff — the budget computation at lines 504–512 and the warning at line 525.

Docs-only change; no code or tests are affected.

## AI assistance disclosure

Per `CONTRIBUTING.md`: this documentation was written with AI assistance (Anthropic's Claude, via Claude Code). I used it to draft the prose and to cross-check every statement against the GEPA source cited above. I have read and verified the wording and the technical claims myself, I can explain them without the tool, and I own the correctness of this change.
