### PR TITLE
Fix tool result serialization for dataclasses and namedtuples in RLM

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -117,8 +117,11 @@ def _make_jsonable(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return _make_jsonable(_dump_pydantic(value))
     if dataclasses.is_dataclass(value) and not isinstance(value, type):
-        return _make_jsonable(dataclasses.asdict(value))
-    if hasattr(value, "_asdict") and callable(value._asdict):
+        try:
+            return _make_jsonable(dataclasses.asdict(value))
+        except Exception:
+            return value  # fall through to json.dumps/str fallback
+    if isinstance(value, tuple) and hasattr(value, "_fields") and hasattr(value, "_asdict"):
         return _make_jsonable(value._asdict())
     if isinstance(value, dict):
         return {k: _make_jsonable(v) for k, v in value.items()}

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -7,6 +7,7 @@ protocol defined in interpreter.py.
 """
 
 import asyncio
+import dataclasses
 import functools
 import inspect
 import json
@@ -106,16 +107,25 @@ def _dump_pydantic(value: BaseModel) -> Any:
         raise CodeInterpreterError(f"Unable to serialize {type(value).__name__} as JSON: {e}") from e
 
 
-def _coerce_pydantic(value: Any) -> Any:
-    """Recursively convert Pydantic ``BaseModel`` instances to JSON-compatible values."""
+def _make_jsonable(value: Any) -> Any:
+    """Recursively convert structured types to JSON-serializable values.
+
+    Handles Pydantic BaseModel, dataclasses, and namedtuples so that
+    ``json.dumps()`` can serialize tool results without falling back to
+    ``str()``.
+    """
     if isinstance(value, BaseModel):
-        return _coerce_pydantic(_dump_pydantic(value))
+        return _make_jsonable(_dump_pydantic(value))
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _make_jsonable(dataclasses.asdict(value))
+    if hasattr(value, "_asdict") and callable(value._asdict):
+        return _make_jsonable(value._asdict())
     if isinstance(value, dict):
-        return {k: _coerce_pydantic(v) for k, v in value.items()}
+        return {k: _make_jsonable(v) for k, v in value.items()}
     if isinstance(value, list):
-        return [_coerce_pydantic(v) for v in value]
+        return [_make_jsonable(v) for v in value]
     if isinstance(value, tuple):
-        return tuple(_coerce_pydantic(v) for v in value)
+        return tuple(_make_jsonable(v) for v in value)
     return value
 
 
@@ -383,7 +393,7 @@ class PythonInterpreter:
             result = self.tools[tool_name](**kwargs)
             if asyncio.iscoroutine(result):
                 result = _await_in_sync(result)
-            result = _coerce_pydantic(result)
+            result = _make_jsonable(result)
             if result is None or isinstance(result, str):
                 response = _jsonrpc_result({"value": str(result) if result is not None else "", "type": "string"}, request_id)
             else:

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -836,6 +836,23 @@ def test_tool_returns_collections_namedtuple():
         assert result == 7.0
 
 
+def test_tool_returns_dataclass_with_unserializable_field_falls_back():
+    """Dataclass with non-serializable fields should fall back to str() gracefully."""
+    import threading
+
+    @dataclasses.dataclass
+    class _Holder:
+        name: str
+        lock: threading.Lock
+
+    def get_holder() -> _Holder:
+        return _Holder(name="test", lock=threading.Lock())
+
+    with PythonInterpreter(tools={"get_holder": get_holder}) as sandbox:
+        result = sandbox.execute("h = get_holder()\ntype(h).__name__")
+        assert result == "str"
+
+
 # =============================================================================
 # Multi-Output SUBMIT Tests
 # =============================================================================

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -1,8 +1,10 @@
 import asyncio
+import dataclasses
 import json
 import os
 import random
 from datetime import datetime
+from typing import NamedTuple
 
 import pytest
 from pydantic import BaseModel, ConfigDict
@@ -742,6 +744,96 @@ def test_tool_returning_unserializable_pydantic_model_raises_execution_error():
             match="CodeInterpreterError.*Unable to serialize _UnserializableModel as JSON",
         ):
             sandbox.execute("get_value()")
+
+
+# -- dataclass tool returns --------------------------------------------------
+
+
+@dataclasses.dataclass
+class _BBox:
+    x0: float
+    top: float
+    x1: float
+    bottom: float
+
+
+@dataclasses.dataclass
+class _PageTable:
+    index: int
+    bbox: _BBox
+    strategy: str
+
+
+def test_tool_returns_dataclass():
+    """Dataclass instances returned from a tool should arrive as dicts."""
+
+    def get_bbox() -> _BBox:
+        return _BBox(x0=18.2, top=108.0, x1=554.4, bottom=748.8)
+
+    with PythonInterpreter(tools={"get_bbox": get_bbox}) as sandbox:
+        result = sandbox.execute("b = get_bbox()\n(b['x0'], b['bottom'])")
+        assert result == [18.2, 748.8]
+
+
+def test_tool_returns_nested_dataclass():
+    """Nested dataclass instances should be recursively converted to dicts."""
+
+    def get_table() -> _PageTable:
+        return _PageTable(index=0, bbox=_BBox(x0=1.0, top=2.0, x1=3.0, bottom=4.0), strategy="lines")
+
+    with PythonInterpreter(tools={"get_table": get_table}) as sandbox:
+        result = sandbox.execute("t = get_table()\n(t['bbox']['x0'], t['strategy'])")
+        assert result == [1.0, "lines"]
+
+
+def test_tool_returns_list_of_dataclasses():
+    """Lists of dataclass instances should round-trip as lists of dicts."""
+
+    def get_tables() -> list[_PageTable]:
+        return [
+            _PageTable(index=0, bbox=_BBox(x0=1.0, top=2.0, x1=3.0, bottom=4.0), strategy="lines"),
+            _PageTable(index=1, bbox=_BBox(x0=5.0, top=6.0, x1=7.0, bottom=8.0), strategy="text"),
+        ]
+
+    with PythonInterpreter(tools={"get_tables": get_tables}) as sandbox:
+        result = sandbox.execute("ts = get_tables()\n[t['index'] for t in ts]")
+        assert result == [0, 1]
+
+
+# -- namedtuple tool returns -------------------------------------------------
+
+
+class _TypedPoint(NamedTuple):
+    x: float
+    y: float
+    label: str
+
+
+from collections import namedtuple
+
+_Point = namedtuple("_Point", ["x", "y"])
+
+
+def test_tool_returns_typing_namedtuple():
+    """typing.NamedTuple instances should arrive as dicts."""
+
+    def get_point() -> _TypedPoint:
+        return _TypedPoint(x=10.5, y=20.3, label="origin")
+
+    with PythonInterpreter(tools={"get_point": get_point}) as sandbox:
+        result = sandbox.execute("p = get_point()\n(p['x'], p['label'])")
+        assert result == [10.5, "origin"]
+
+
+def test_tool_returns_collections_namedtuple():
+    """collections.namedtuple instances should arrive as dicts."""
+
+    def get_point() -> _Point:
+        return _Point(x=3.0, y=4.0)
+
+    with PythonInterpreter(tools={"get_point": get_point}) as sandbox:
+        result = sandbox.execute("p = get_point()\np['x'] + p['y']")
+        assert result == 7.0
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Tools returning `dataclasses`, `typing.NamedTuple`, or `collections.namedtuple` instances from RLM currently get serialized via `str()` (Python repr), because `json.dumps()` fails on these types and the code falls back to string conversion. This means the LLM receives tool results like:

```
PageTable(index=0, bbox=BBox(x0=18.2, top=108.0, x1=554.4, bottom=748.8), row_count=2, ...)
```

...instead of clean JSON dicts it can index into directly. The LLM then has to regex-parse repr strings to extract data, which is fragile and wastes tokens/iterations.

This is the same class of issue as #10015 (scalar type preservation), but for structured return types.

## Fix

Extends the existing `_coerce_pydantic()` helper (renamed to `_make_jsonable()`) to also handle:

- **`dataclasses.dataclass`** — via `dataclasses.asdict()` (recurses into nested dataclasses automatically)
- **`typing.NamedTuple`** — via `._asdict()`
- **`collections.namedtuple`** — via `._asdict()`

The function already handled `pydantic.BaseModel`, `dict`, `list`, and `tuple` — these continue to work identically.

After this fix, a tool returning `[PageTable(index=0, bbox=BBox(x0=18.2, ...))]` arrives in the sandbox as `[{"index": 0, "bbox": {"x0": 18.2, ...}}]`, which the LLM can work with as normal dicts.

## Test plan

- [x] `test_tool_returns_dataclass` — single dataclass arrives as dict, fields accessible by key
- [x] `test_tool_returns_nested_dataclass` — nested dataclass (dataclass containing dataclass) recursively converted
- [x] `test_tool_returns_list_of_dataclasses` — list of dataclasses round-trips as list of dicts
- [x] `test_tool_returns_typing_namedtuple` — `typing.NamedTuple` arrives as dict
- [x] `test_tool_returns_collections_namedtuple` — `collections.namedtuple` arrives as dict
- [x] All 64 existing tests continue to pass (including pydantic model tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
