### PR TITLE
fix(predict): ProgramOfThought._parse_code drops output-capturing echo for single-line generated code

### DIFF
--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -162,7 +162,7 @@ class ProgramOfThought(Module):
             return code, "Error: Code format is not correct."
         lines = code_block.split("\n")
         last_line_match = re.match(r"^(\w+)\s*=", lines[-1].strip())
-        if last_line_match and len(lines) > 1:
+        if last_line_match:
             code_block += "\n" + last_line_match.group(1)
         return code_block, None
 

--- a/tests/predict/test_program_of_thought.py
+++ b/tests/predict/test_program_of_thought.py
@@ -264,3 +264,27 @@ def test_pot_code_parse_error():
     ):
         pot(question="What is 1+1?")
     mock_execute_code.assert_not_called()
+
+
+def test_pot_parse_code_appends_echo_for_single_line_assignment():
+    """_parse_code appends a trailing bare-name echo of the last assigned variable so the
+    interpreter's last-expression value is captured as output. This must also apply when
+    the generated code is a single line, not just when it's the last of several lines --
+    a bare `answer = 42` is a common, simple case an LM can legitimately generate."""
+    pot = ProgramOfThought(BasicQA)
+
+    code_block, error = pot._parse_code({"generated_code": "answer = 42"})
+
+    assert error is None
+    assert code_block == "answer = 42\nanswer"
+
+
+def test_pot_parse_code_multiline_assignment_still_appends_echo():
+    """Regression guard: the multi-line case (already covered before this fix) must keep
+    working the same way."""
+    pot = ProgramOfThought(BasicQA)
+
+    code_block, error = pot._parse_code({"generated_code": "x = 1\nanswer = x + 41"})
+
+    assert error is None
+    assert code_block == "x = 1\nanswer = x + 41\nanswer"


### PR DESCRIPTION
## Problem

`_parse_code` appends a trailing bare-name echo of the last assigned variable (e.g. code ending in `answer = 42` gets `\nanswer` appended) so the interpreter's last-expression-value semantics capture that variable as the program's output. But the append was gated on `len(lines) > 1`, so single-line-only generated code — e.g. a bare `answer = 42` with no preceding lines, a simple and common case an LM can legitimately produce — never gets the echo appended, silently dropping the computed output (the interpreter's last-expression value ends up `None`/unset instead of the assigned value).

## Fix

Drop the `len(lines) > 1` guard. The `last_line_match` check already ensures this only fires when the final line is itself an assignment, so single-line code without an assignment (e.g. a bare `print(...)` call) is unaffected.

## Testing

- Added `test_pot_parse_code_appends_echo_for_single_line_assignment` (new coverage — this specific path had none) plus a regression guard for the existing multi-line case.
- Both new tests call `_parse_code` directly on a `ProgramOfThought` instance — no deno/interpreter required (only `_execute_code` needs a real interpreter, and this bug is entirely in the pure string-parsing logic before that point).
- Confirmed red→green: reverting only `program_of_thought.py` reproduces `'answer = 42' == 'answer = 42\nanswer'` failing (echo missing); reapplying passes.
- Full `tests/predict/` suite (excluding deno-marked tests): 223 passed, 6 skipped (unrelated).
- `ruff check` — clean.
- xref: no open PR touches `program_of_thought.py`.

## AI disclosure

Found via an AI-assisted code review pass (Claude Code) over `dspy/predict/`. I personally traced the guard condition against `_execute_code`'s reliance on the interpreter's last-expression value, reproduced the dropped-echo behavior with a standalone script, verified the fix against single-line, multi-line, and non-assignment cases, and ran the relevant test suite plus lint before submitting.