### PR TITLE
fix(adapters): unwrap markdown code fence in parse_value so None survives (#8181)

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -2,6 +2,7 @@ import ast
 import enum
 import inspect
 import json
+import re
 import types
 from collections.abc import Mapping
 from typing import Any, Literal, Union, get_args, get_origin
@@ -146,6 +147,19 @@ def find_enum_member(enum, identifier):
     raise ValueError(f"{identifier} is not a valid name or value for the enum {enum.__name__}")
 
 
+_MARKDOWN_CODE_FENCE = re.compile(r"\s*```[^\n]*\n(?P<body>.*?)\n?```\s*\Z", re.DOTALL)
+
+
+def _strip_markdown_code_fence(text):
+    """Return the inner body of a single ```lang ... ``` markdown code fence, or None.
+
+    An LM sometimes wraps a dict/list value in a fenced code block. Returns None when
+    `text` is not a single fenced block, so callers can leave non-fenced input untouched.
+    """
+    match = _MARKDOWN_CODE_FENCE.fullmatch(text)
+    return match.group("body") if match else None
+
+
 def parse_value(value, annotation):
     if annotation is str:
         return str(value)
@@ -179,12 +193,23 @@ def parse_value(value, annotation):
         # Handle union annotations, e.g., `str | None`, `Optional[str]`, `Union[str, int, None]`, etc.
         return TypeAdapter(annotation).validate_python(value)
 
-    candidate = json_repair.loads(value)  # json_repair.loads returns "" on failure.
-    if candidate == "" and value != "":
+    # An LM may wrap a dict/list value in a markdown code fence (```python ... ```).
+    # json_repair coerces the Python literal None into the string "None" (it only
+    # understands lowercase JSON null), so when the value is a single fenced block,
+    # strip the fence and ast.literal_eval it first so None/True/False survive (#8181).
+    unfenced = _strip_markdown_code_fence(value)
+    if unfenced is not None:
         try:
-            candidate = ast.literal_eval(value)
+            candidate = ast.literal_eval(unfenced)
         except (ValueError, SyntaxError):
-            candidate = value
+            unfenced = None
+    if unfenced is None:
+        candidate = json_repair.loads(value)  # json_repair.loads returns "" on failure.
+        if candidate == "" and value != "":
+            try:
+                candidate = ast.literal_eval(value)
+            except (ValueError, SyntaxError):
+                candidate = value
 
     try:
         return TypeAdapter(annotation).validate_python(candidate)

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -105,3 +105,20 @@ def test_parse_value_json_repair():
     malformed = "not json or literal"
     with pytest.raises(Exception):
         parse_value(malformed, dict)
+
+
+def test_parse_value_preserves_none_in_markdown_fenced_dict():
+    """#8181: an LM may wrap a dict/list output value in a markdown code fence
+    (```python ... ```). ast.literal_eval can't parse the fence, so parse_value
+    used to fall through to json_repair, which coerces the Python literal ``None``
+    to the string ``"None"``. The fence must be stripped so ``None`` survives."""
+    fenced = '```python\n{"memory_text": "x", "memory_url_info": None}\n```'
+    result = parse_value(fenced, dict)
+    assert result == {"memory_text": "x", "memory_url_info": None}
+    assert result["memory_url_info"] is None  # not the string "None"
+
+
+def test_parse_value_plain_fence_without_language():
+    """A code fence without a language tag must also be unwrapped."""
+    fenced = "```\n[1, None, 3]\n```"
+    assert parse_value(fenced, list) == [1, None, 3]


### PR DESCRIPTION
Fixes #8181.

When an LM wraps a dict/list output value in a markdown code fence (```python ... ```), `json_repair.loads` coerces the Python literal `None` into the string `"None"` — json_repair only understands lowercase JSON `null`. Because `parse_value` tries json_repair first and only falls back to `ast.literal_eval` when json_repair returns `""`, the fenced value never reaches `ast.literal_eval` and the `None` is silently turned into the string `"None"`.

## What changed

`dspy/adapters/utils.py`:

- New `_strip_markdown_code_fence(text)` helper: returns the inner body of a single ```` ```lang ... ``` ```` block, or `None` when `text` is not a single fenced block (non-fenced input is left untouched).
- In `parse_value`, when the value is a single fenced block, strip the fence and `ast.literal_eval` the unwrapped body **before** the json_repair fallback, so `None`/`True`/`False` literals survive. Non-fenced input keeps the existing json_repair-then-ast path unchanged.

## Reproduction

On stock `main`:

```python
from dspy.adapters.utils import parse_value

fenced = "```\n[1, None, 3]\n```"
parse_value(fenced, list)
# -> [1, 'None', 3]   # the None became the string "None"
```

With this patch it returns `[1, None, 3]`.

## Tests

Two offline unit regressions added to `tests/adapters/test_adapter_utils.py` (fenced dict with `None`, and a plain fence without a language tag). Full `tests/adapters/test_adapter_utils.py` is green (8/8). Verified A/B: the two new tests **fail on stock `main`** and **pass with the patch**. `ruff check` clean on the touched files.

## Disclosure

AI-assisted (Claude Code): the change and tests were drafted with AI assistance, then reviewed, adversarially re-checked, and verified (stock-vs-patched A/B) by me before submission. This contribution is my own and offered under the project's MIT license.
