### PR TITLE
fix(react): feed AdapterParseError back into the trajectory instead of crashing (#8377)

### DIFF
--- a/docs/docs/diving-deeper/tools-react-and-mcp.md
+++ b/docs/docs/diving-deeper/tools-react-and-mcp.md
@@ -40,6 +40,8 @@ ReAct registers an extra `finish` tool — a no-arg callable — and the loop ex
 
 A raised exception from a tool is caught inside `forward` and recorded as `observation_i = "Execution error in <tool>: <traceback>"`. The LM sees the error text on the next iteration and can react to it. Surfacing failures into the LM’s reasoning loop, rather than terminating the program, is the default an agent expects — the model is supposed to recover.
 
+The same principle covers malformed LM responses: when the reasoning step cannot be parsed (an `AdapterParseError`, e.g. the model emits a `tool_args` header instead of `next_tool_args`), ReAct records the step with the fields that did parse (placeholders for the rest) plus an `observation_i` describing the expected vs. found fields, and continues — so a parse-failure step still contributes the usual four trajectory keys. If the final extraction step itself fails to parse, it is retried once with that feedback appended to the prompt before the error is surfaced.
+
 ### 9. A separate extractor module produces the declared outputs
 
 After the loop ends, ReAct hands the trajectory to a `dspy.ChainOfThought` over a fallback signature that includes the original output fields plus a `trajectory` input. The extractor’s job is to read the trajectory and produce the signature’s declared outputs in their correct types. Decoupling navigation (the loop) from extraction (the typed answer) makes both halves easier to optimize and easier to debug.

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -165,7 +165,13 @@ class CodeAct(ReAct, ProgramOfThought):
                 "The trajectory is empty, so it cannot be truncated to fit the context window."
             )
 
-        iteration_indices = {int(key.rsplit("_", 1)[-1]) for key in keys}
+        # Non-indexed entries (e.g. the prompt-only "parse_feedback" key added by the extractor
+        # parse retry) are not iteration steps: skip them when computing indices and never pop them.
+        iteration_indices = {
+            int(key.rsplit("_", 1)[-1])
+            for key in keys
+            if key.rsplit("_", 1)[-1].isdigit()
+        }
         if len(iteration_indices) < 2:
             # Only one iteration is present; dropping it would leave no context (same spirit as
             # ReAct's single-tool-call guard).
@@ -176,7 +182,8 @@ class CodeAct(ReAct, ProgramOfThought):
 
         oldest = min(iteration_indices)
         for key in keys:
-            if int(key.rsplit("_", 1)[-1]) == oldest:
+            suffix = key.rsplit("_", 1)[-1]
+            if suffix.isdigit() and int(suffix) == oldest:
                 trajectory.pop(key)
 
         return trajectory

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -147,3 +147,36 @@ class CodeAct(ReAct, ProgramOfThought):
 
             extract = self._call_extract_with_parse_retry(self.extractor, trajectory, **kwargs)
             return dspy.Prediction(trajectory=trajectory, **extract)
+
+    def truncate_trajectory(self, trajectory):
+        """Truncate the oldest CodeAct iteration so the trajectory fits the context window.
+
+        CodeAct steps have a variable number of keys (1 on a parse/execution failure:
+        ``observation_i``; 2 on success: ``generated_code_i`` + ``code_output_i``), unlike
+        ReAct's fixed 4 keys per step. Popping a fixed ``keys[:4]`` slice (ReAct's behavior)
+        would cut across iteration boundaries and desynchronize the trajectory, so instead we
+        drop every key belonging to the earliest iteration index.
+
+        Users can override this method to implement their own truncation logic.
+        """
+        keys = list(trajectory.keys())
+        if not keys:
+            raise ValueError(
+                "The trajectory is empty, so it cannot be truncated to fit the context window."
+            )
+
+        iteration_indices = {int(key.rsplit("_", 1)[-1]) for key in keys}
+        if len(iteration_indices) < 2:
+            # Only one iteration is present; dropping it would leave no context (same spirit as
+            # ReAct's single-tool-call guard).
+            raise ValueError(
+                "The trajectory is too long so your prompt exceeded the context window, but it "
+                "cannot be truncated because it only contains a single iteration."
+            )
+
+        oldest = min(iteration_indices)
+        for key in keys:
+            if int(key.rsplit("_", 1)[-1]) == oldest:
+                trajectory.pop(key)
+
+        return trajectory

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -9,6 +9,7 @@ from dspy.predict.react import ReAct
 from dspy.primitives.code_interpreter import CodeInterpreter, _validate_interpreter_factory
 from dspy.primitives.python_interpreter import PythonInterpreter
 from dspy.signatures.signature import Signature, ensure_signature
+from dspy.utils.exceptions import AdapterParseError
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +118,15 @@ class CodeAct(ReAct, ProgramOfThought):
             trajectory = {}
             max_iters = kwargs.pop("max_iters", self.max_iters)
             for idx in range(max_iters):
-                code_data = self.codeact(trajectory=trajectory, **kwargs)
+                try:
+                    code_data = self.codeact(trajectory=trajectory, **kwargs)
+                except AdapterParseError as err:
+                    # Same failure class as dspy.ReAct (#8377): record the parse
+                    # failure as an observation and let the model self-correct.
+                    logger.warning(f"Failed to parse the LM response for the next step: {err}")
+                    trajectory[f"observation_{idx}"] = self._format_parse_failure_observation(err)
+                    continue
+
                 output = None
                 code, error = self._parse_code(code_data)
 
@@ -136,5 +145,5 @@ class CodeAct(ReAct, ProgramOfThought):
                 if code_data.finished:
                     break
 
-            extract = self._call_with_potential_trajectory_truncation(self.extractor, trajectory, **kwargs)
+            extract = self._call_extract_with_parse_retry(self.extractor, trajectory, **kwargs)
             return dspy.Prediction(trajectory=trajectory, **extract)

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -161,3 +161,36 @@ class CodeAct(ReAct, ProgramOfThought):
 
             extract = self._call_extract_with_parse_retry(self.extractor, trajectory, **kwargs)
             return dspy.Prediction(trajectory=trajectory, **extract)
+
+    def truncate_trajectory(self, trajectory):
+        """Truncate the oldest CodeAct iteration so the trajectory fits the context window.
+
+        CodeAct steps have a variable number of keys (1 on a parse/execution failure:
+        ``observation_i``; 2 on success: ``generated_code_i`` + ``code_output_i``), unlike
+        ReAct's fixed 4 keys per step. Popping a fixed ``keys[:4]`` slice (ReAct's behavior)
+        would cut across iteration boundaries and desynchronize the trajectory, so instead we
+        drop every key belonging to the earliest iteration index.
+
+        Users can override this method to implement their own truncation logic.
+        """
+        keys = list(trajectory.keys())
+        if not keys:
+            raise ValueError(
+                "The trajectory is empty, so it cannot be truncated to fit the context window."
+            )
+
+        iteration_indices = {int(key.rsplit("_", 1)[-1]) for key in keys}
+        if len(iteration_indices) < 2:
+            # Only one iteration is present; dropping it would leave no context (same spirit as
+            # ReAct's single-tool-call guard).
+            raise ValueError(
+                "The trajectory is too long so your prompt exceeded the context window, but it "
+                "cannot be truncated because it only contains a single iteration."
+            )
+
+        oldest = min(iteration_indices)
+        for key in keys:
+            if int(key.rsplit("_", 1)[-1]) == oldest:
+                trajectory.pop(key)
+
+        return trajectory

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -179,7 +179,13 @@ class CodeAct(ReAct, ProgramOfThought):
                 "The trajectory is empty, so it cannot be truncated to fit the context window."
             )
 
-        iteration_indices = {int(key.rsplit("_", 1)[-1]) for key in keys}
+        # Non-indexed entries (e.g. the prompt-only "parse_feedback" key added by the extractor
+        # parse retry) are not iteration steps: skip them when computing indices and never pop them.
+        iteration_indices = {
+            int(key.rsplit("_", 1)[-1])
+            for key in keys
+            if key.rsplit("_", 1)[-1].isdigit()
+        }
         if len(iteration_indices) < 2:
             # Only one iteration is present; dropping it would leave no context (same spirit as
             # ReAct's single-tool-call guard).
@@ -190,7 +196,8 @@ class CodeAct(ReAct, ProgramOfThought):
 
         oldest = min(iteration_indices)
         for key in keys:
-            if int(key.rsplit("_", 1)[-1]) == oldest:
+            suffix = key.rsplit("_", 1)[-1]
+            if suffix.isdigit() and int(suffix) == oldest:
                 trajectory.pop(key)
 
         return trajectory

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -10,6 +10,7 @@ from dspy.predict.react import ReAct
 from dspy.primitives.code_interpreter import CodeInterpreter, _validate_interpreter_factory
 from dspy.primitives.python_interpreter import PythonInterpreter
 from dspy.signatures.signature import Signature, ensure_signature
+from dspy.utils.exceptions import AdapterParseError
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +132,15 @@ class CodeAct(ReAct, ProgramOfThought):
             trajectory = {}
             max_iters = kwargs.pop("max_iters", self.max_iters)
             for idx in range(max_iters):
-                code_data = self.codeact(trajectory=trajectory, **kwargs)
+                try:
+                    code_data = self.codeact(trajectory=trajectory, **kwargs)
+                except AdapterParseError as err:
+                    # Same failure class as dspy.ReAct (#8377): record the parse
+                    # failure as an observation and let the model self-correct.
+                    logger.warning(f"Failed to parse the LM response for the next step: {err}")
+                    trajectory[f"observation_{idx}"] = self._format_parse_failure_observation(err)
+                    continue
+
                 output = None
                 code, error = self._parse_code(code_data)
 
@@ -150,5 +159,5 @@ class CodeAct(ReAct, ProgramOfThought):
                 if code_data.finished:
                     break
 
-            extract = self._call_with_potential_trajectory_truncation(self.extractor, trajectory, **kwargs)
+            extract = self._call_extract_with_parse_retry(self.extractor, trajectory, **kwargs)
             return dspy.Prediction(trajectory=trajectory, **extract)

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -5,7 +5,7 @@ import dspy
 from dspy.adapters.types.tool import Tool
 from dspy.primitives.module import Module
 from dspy.signatures.signature import ensure_signature
-from dspy.utils.exceptions import ContextWindowExceededError
+from dspy.utils.exceptions import AdapterParseError, ContextWindowExceededError
 
 logger = logging.getLogger(__name__)
 
@@ -92,12 +92,44 @@ class ReAct(Module):
         trajectory_signature = dspy.Signature(f"{', '.join(trajectory.keys())} -> x")
         return adapter.format_user_message_content(trajectory_signature, trajectory)
 
+    def _format_parse_failure_observation(self, err: AdapterParseError) -> str:
+        """Build the trajectory observation fed back to the model after a parse failure.
+
+        Mirrors how tool execution errors are surfaced: the model sees what went
+        wrong and can self-correct on the next iteration (see issue #8377, where
+        models aperiodically emit e.g. `tool_args` instead of `next_tool_args`).
+        """
+        expected = ", ".join(err.signature.output_fields.keys())
+        message = f"Your previous response could not be parsed. Expected fields: [{expected}]"
+        if err.parsed_result is not None:
+            # Only the missing-fields parse failure reports what was found; a
+            # value-parse failure (e.g. invalid JSON in one field) does not.
+            message += f"; fields found: [{', '.join(err.parsed_result.keys()) or 'none'}]"
+        return f"{message}. Redo this step, producing every expected field exactly once with its exact field header."
+
+    def _record_parse_failure(self, trajectory: dict[str, Any], idx: int, err: AdapterParseError) -> None:
+        """Record an unparseable reasoning step as a full trajectory entry.
+
+        Writes all four keys of a normal step (preserving the four-keys-per-step
+        trajectory shape that `truncate_trajectory` relies on), reusing whatever
+        fields were successfully parsed and marking the rest.
+        """
+        parsed = err.parsed_result or {}
+        trajectory[f"thought_{idx}"] = parsed.get("next_thought", "[response could not be parsed]")
+        trajectory[f"tool_name_{idx}"] = parsed.get("next_tool_name", "[response could not be parsed]")
+        trajectory[f"tool_args_{idx}"] = parsed.get("next_tool_args", {})
+        trajectory[f"observation_{idx}"] = self._format_parse_failure_observation(err)
+
     def forward(self, **input_args):
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
         for idx in range(max_iters):
             try:
                 pred = self._call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
+            except AdapterParseError as err:
+                logger.warning(f"Failed to parse the LM response for the next step: {_fmt_exc(err)}")
+                self._record_parse_failure(trajectory, idx, err)
+                continue
             except ValueError as err:
                 logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {_fmt_exc(err)}")
                 break
@@ -114,7 +146,7 @@ class ReAct(Module):
             if pred.next_tool_name == "finish":
                 break
 
-        extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
+        extract = self._call_extract_with_parse_retry(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)
 
     async def aforward(self, **input_args):
@@ -123,6 +155,10 @@ class ReAct(Module):
         for idx in range(max_iters):
             try:
                 pred = await self._async_call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
+            except AdapterParseError as err:
+                logger.warning(f"Failed to parse the LM response for the next step: {_fmt_exc(err)}")
+                self._record_parse_failure(trajectory, idx, err)
+                continue
             except ValueError as err:
                 logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {_fmt_exc(err)}")
                 break
@@ -139,8 +175,34 @@ class ReAct(Module):
             if pred.next_tool_name == "finish":
                 break
 
-        extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
+        extract = await self._async_call_extract_with_parse_retry(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)
+
+    def _extract_retry_trajectory(self, trajectory, err: AdapterParseError):
+        """Return a prompt-only copy of the trajectory with parse-failure feedback appended.
+
+        The copy is used for a single retry of the extraction step; the stored
+        trajectory is left untouched so its shape stays consistent.
+        """
+        return {**trajectory, "parse_feedback": self._format_parse_failure_observation(err)}
+
+    def _call_extract_with_parse_retry(self, module, trajectory, **input_args):
+        try:
+            return self._call_with_potential_trajectory_truncation(module, trajectory, **input_args)
+        except AdapterParseError as err:
+            logger.warning(f"Failed to parse the LM response for the extraction step, retrying once: {_fmt_exc(err)}")
+            return self._call_with_potential_trajectory_truncation(
+                module, self._extract_retry_trajectory(trajectory, err), **input_args
+            )
+
+    async def _async_call_extract_with_parse_retry(self, module, trajectory, **input_args):
+        try:
+            return await self._async_call_with_potential_trajectory_truncation(module, trajectory, **input_args)
+        except AdapterParseError as err:
+            logger.warning(f"Failed to parse the LM response for the extraction step, retrying once: {_fmt_exc(err)}")
+            return await self._async_call_with_potential_trajectory_truncation(
+                module, self._extract_retry_trajectory(trajectory, err), **input_args
+            )
 
     def _call_with_potential_trajectory_truncation(self, module, trajectory, **input_args):
         for _ in range(3):

--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -5,7 +5,7 @@ import dspy
 from dspy.adapters.types.tool import Tool
 from dspy.primitives.module import Module
 from dspy.signatures.signature import ensure_signature
-from dspy.utils.exceptions import ContextWindowExceededError, format_error_for_lm
+from dspy.utils.exceptions import AdapterParseError, ContextWindowExceededError, format_error_for_lm
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +92,34 @@ class ReAct(Module):
         trajectory_signature = dspy.Signature(f"{', '.join(trajectory.keys())} -> x")
         return adapter.format_user_message_content(trajectory_signature, trajectory)
 
+    def _format_parse_failure_observation(self, err: AdapterParseError) -> str:
+        """Build the trajectory observation fed back to the model after a parse failure.
+
+        Mirrors how tool execution errors are surfaced: the model sees what went
+        wrong and can self-correct on the next iteration (see issue #8377, where
+        models aperiodically emit e.g. `tool_args` instead of `next_tool_args`).
+        """
+        expected = ", ".join(err.signature.output_fields.keys())
+        message = f"Your previous response could not be parsed. Expected fields: [{expected}]"
+        if err.parsed_result is not None:
+            # Only the missing-fields parse failure reports what was found; a
+            # value-parse failure (e.g. invalid JSON in one field) does not.
+            message += f"; fields found: [{', '.join(err.parsed_result.keys()) or 'none'}]"
+        return f"{message}. Redo this step, producing every expected field exactly once with its exact field header."
+
+    def _record_parse_failure(self, trajectory: dict[str, Any], idx: int, err: AdapterParseError) -> None:
+        """Record an unparseable reasoning step as a full trajectory entry.
+
+        Writes all four keys of a normal step (preserving the four-keys-per-step
+        trajectory shape that `truncate_trajectory` relies on), reusing whatever
+        fields were successfully parsed and marking the rest.
+        """
+        parsed = err.parsed_result or {}
+        trajectory[f"thought_{idx}"] = parsed.get("next_thought", "[response could not be parsed]")
+        trajectory[f"tool_name_{idx}"] = parsed.get("next_tool_name", "[response could not be parsed]")
+        trajectory[f"tool_args_{idx}"] = parsed.get("next_tool_args", {})
+        trajectory[f"observation_{idx}"] = self._format_parse_failure_observation(err)
+
     def forward(self, **input_args):
         trajectory = {}
         max_iters = input_args.pop("max_iters", self.max_iters)
@@ -101,6 +129,10 @@ class ReAct(Module):
             except ContextWindowExceededError as err:
                 logger.warning(f"Ending the trajectory: {format_error_for_lm(err, traceback_frames=5)}")
                 break
+            except AdapterParseError as err:
+                logger.warning(f"Failed to parse the LM response for the next step: {format_error_for_lm(err, traceback_frames=5)}")
+                self._record_parse_failure(trajectory, idx, err)
+                continue
             except ValueError as err:
                 logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {format_error_for_lm(err, traceback_frames=5)}")
                 break
@@ -117,7 +149,7 @@ class ReAct(Module):
             if pred.next_tool_name == "finish":
                 break
 
-        extract = self._call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
+        extract = self._call_extract_with_parse_retry(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)
 
     async def aforward(self, **input_args):
@@ -129,6 +161,10 @@ class ReAct(Module):
             except ContextWindowExceededError as err:
                 logger.warning(f"Ending the trajectory: {format_error_for_lm(err, traceback_frames=5)}")
                 break
+            except AdapterParseError as err:
+                logger.warning(f"Failed to parse the LM response for the next step: {format_error_for_lm(err, traceback_frames=5)}")
+                self._record_parse_failure(trajectory, idx, err)
+                continue
             except ValueError as err:
                 logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {format_error_for_lm(err, traceback_frames=5)}")
                 break
@@ -145,8 +181,34 @@ class ReAct(Module):
             if pred.next_tool_name == "finish":
                 break
 
-        extract = await self._async_call_with_potential_trajectory_truncation(self.extract, trajectory, **input_args)
+        extract = await self._async_call_extract_with_parse_retry(self.extract, trajectory, **input_args)
         return dspy.Prediction(trajectory=trajectory, **extract)
+
+    def _extract_retry_trajectory(self, trajectory, err: AdapterParseError):
+        """Return a prompt-only copy of the trajectory with parse-failure feedback appended.
+
+        The copy is used for a single retry of the extraction step; the stored
+        trajectory is left untouched so its shape stays consistent.
+        """
+        return {**trajectory, "parse_feedback": self._format_parse_failure_observation(err)}
+
+    def _call_extract_with_parse_retry(self, module, trajectory, **input_args):
+        try:
+            return self._call_with_potential_trajectory_truncation(module, trajectory, **input_args)
+        except AdapterParseError as err:
+            logger.warning(f"Failed to parse the LM response for the extraction step, retrying once: {format_error_for_lm(err, traceback_frames=5)}")
+            return self._call_with_potential_trajectory_truncation(
+                module, self._extract_retry_trajectory(trajectory, err), **input_args
+            )
+
+    async def _async_call_extract_with_parse_retry(self, module, trajectory, **input_args):
+        try:
+            return await self._async_call_with_potential_trajectory_truncation(module, trajectory, **input_args)
+        except AdapterParseError as err:
+            logger.warning(f"Failed to parse the LM response for the extraction step, retrying once: {format_error_for_lm(err, traceback_frames=5)}")
+            return await self._async_call_with_potential_trajectory_truncation(
+                module, self._extract_retry_trajectory(trajectory, err), **input_args
+            )
 
     def _call_with_potential_trajectory_truncation(self, module, trajectory, **input_args):
         last_error = None

--- a/dspy/utils/exceptions.py
+++ b/dspy/utils/exceptions.py
@@ -240,7 +240,7 @@ class AdapterParseError(DSPyError):
         signature: Signature,
         lm_response: str,
         message: str | None = None,
-        parsed_result: str | None = None,
+        parsed_result: dict[str, Any] | None = None,
     ):
         self.adapter_name = adapter_name
         self.signature = signature

--- a/dspy/utils/exceptions.py
+++ b/dspy/utils/exceptions.py
@@ -262,7 +262,7 @@ class AdapterParseError(DSPyError):
         signature: Signature,
         lm_response: str,
         message: str | None = None,
-        parsed_result: str | None = None,
+        parsed_result: dict[str, Any] | None = None,
     ):
         self.adapter_name = adapter_name
         self.signature = signature

--- a/tests/predict/test_code_act.py
+++ b/tests/predict/test_code_act.py
@@ -275,3 +275,51 @@ class CustomTool:
 def test_codeact_tool_validation():
     with pytest.raises(ValueError, match=r"CodeAct only accepts functions and not callable objects."):
         CodeAct(BasicQA, tools=[CustomTool()])
+
+
+def _simple_tool(x: int) -> int:
+    return x
+
+
+def test_codeact_truncate_trajectory_drops_oldest_iteration_boundary_aware():
+    """CodeAct steps have a variable key count (1 on failure: observation_i; 2 on success:
+    generated_code_i + code_output_i|observation_i), unlike ReAct's fixed 4 keys/step. Popping
+    ReAct's fixed keys[:4] slice cuts across iteration boundaries and desynchronizes the
+    trajectory. CodeAct must drop exactly the earliest iteration's keys."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    trajectory = {
+        "generated_code_0": "print(1)",   # iter 0: success -> 2 keys
+        "code_output_0": "1",
+        "observation_1": "parse failure",  # iter 1: failure -> 1 key
+        "generated_code_2": "print(2)",    # iter 2: execution error -> 2 keys
+        "observation_2": "exec error",
+    }
+    out = program.truncate_trajectory(trajectory)
+
+    # Oldest iteration (0) fully removed; every later iteration is preserved intact.
+    assert "generated_code_0" not in out
+    assert "code_output_0" not in out
+    assert out["observation_1"] == "parse failure"
+    assert out["generated_code_2"] == "print(2)"
+    assert out["observation_2"] == "exec error"
+    assert out is trajectory
+
+
+def test_codeact_truncate_trajectory_parse_failure_only_steps():
+    """Consecutive AdapterParseError iterations leave observation-only entries (one key each).
+    The inherited ReAct truncation (fixed keys[:4] slice, <4 keys -> ValueError) could not trim
+    such a trajectory; CodeAct's iteration-boundary truncation must drop the oldest step."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    trajectory = {"observation_0": "parse failure", "observation_1": "parse failure"}
+    out = program.truncate_trajectory(trajectory)
+
+    assert "observation_0" not in out
+    assert out["observation_1"] == "parse failure"
+
+
+def test_codeact_truncate_trajectory_single_iteration_raises():
+    """A trajectory with only one iteration cannot be truncated (dropping it leaves no context),
+    mirroring ReAct's single-tool-call guard."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    with pytest.raises(ValueError):
+        program.truncate_trajectory({"generated_code_0": "print(1)", "code_output_0": "1"})

--- a/tests/predict/test_code_act.py
+++ b/tests/predict/test_code_act.py
@@ -323,3 +323,28 @@ def test_codeact_truncate_trajectory_single_iteration_raises():
     program = CodeAct("question -> answer", tools=[_simple_tool])
     with pytest.raises(ValueError):
         program.truncate_trajectory({"generated_code_0": "print(1)", "code_output_0": "1"})
+
+
+def test_codeact_truncate_trajectory_skips_non_indexed_keys():
+    """The extractor parse retry adds a prompt-only ``parse_feedback`` key (no iteration index).
+    Truncation must skip non-indexed keys when computing iteration indices (``int("feedback")``
+    used to raise ValueError) and must never pop them: the feedback survives the trim."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    trajectory = {
+        "observation_0": "parse failure",
+        "observation_1": "parse failure",
+        "parse_feedback": "fix your output",
+    }
+    out = program.truncate_trajectory(trajectory)
+
+    assert "observation_0" not in out
+    assert out["observation_1"] == "parse failure"
+    assert out["parse_feedback"] == "fix your output"
+
+
+def test_codeact_truncate_trajectory_only_feedback_and_single_iteration_raises():
+    """A non-indexed key alone does not make a trajectory truncatable: with one real iteration
+    plus ``parse_feedback``, the single-iteration guard must still raise."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    with pytest.raises(ValueError):
+        program.truncate_trajectory({"observation_0": "parse failure", "parse_feedback": "fix"})

--- a/tests/predict/test_code_act.py
+++ b/tests/predict/test_code_act.py
@@ -285,3 +285,51 @@ class CustomTool:
 def test_codeact_tool_validation():
     with pytest.raises(ValueError, match=r"CodeAct only accepts functions and not callable objects."):
         CodeAct(BasicQA, tools=[CustomTool()])
+
+
+def _simple_tool(x: int) -> int:
+    return x
+
+
+def test_codeact_truncate_trajectory_drops_oldest_iteration_boundary_aware():
+    """CodeAct steps have a variable key count (1 on failure: observation_i; 2 on success:
+    generated_code_i + code_output_i|observation_i), unlike ReAct's fixed 4 keys/step. Popping
+    ReAct's fixed keys[:4] slice cuts across iteration boundaries and desynchronizes the
+    trajectory. CodeAct must drop exactly the earliest iteration's keys."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    trajectory = {
+        "generated_code_0": "print(1)",   # iter 0: success -> 2 keys
+        "code_output_0": "1",
+        "observation_1": "parse failure",  # iter 1: failure -> 1 key
+        "generated_code_2": "print(2)",    # iter 2: execution error -> 2 keys
+        "observation_2": "exec error",
+    }
+    out = program.truncate_trajectory(trajectory)
+
+    # Oldest iteration (0) fully removed; every later iteration is preserved intact.
+    assert "generated_code_0" not in out
+    assert "code_output_0" not in out
+    assert out["observation_1"] == "parse failure"
+    assert out["generated_code_2"] == "print(2)"
+    assert out["observation_2"] == "exec error"
+    assert out is trajectory
+
+
+def test_codeact_truncate_trajectory_parse_failure_only_steps():
+    """Consecutive AdapterParseError iterations leave observation-only entries (one key each).
+    The inherited ReAct truncation (fixed keys[:4] slice, <4 keys -> ValueError) could not trim
+    such a trajectory; CodeAct's iteration-boundary truncation must drop the oldest step."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    trajectory = {"observation_0": "parse failure", "observation_1": "parse failure"}
+    out = program.truncate_trajectory(trajectory)
+
+    assert "observation_0" not in out
+    assert out["observation_1"] == "parse failure"
+
+
+def test_codeact_truncate_trajectory_single_iteration_raises():
+    """A trajectory with only one iteration cannot be truncated (dropping it leaves no context),
+    mirroring ReAct's single-tool-call guard."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    with pytest.raises(ValueError):
+        program.truncate_trajectory({"generated_code_0": "print(1)", "code_output_0": "1"})

--- a/tests/predict/test_code_act.py
+++ b/tests/predict/test_code_act.py
@@ -333,3 +333,28 @@ def test_codeact_truncate_trajectory_single_iteration_raises():
     program = CodeAct("question -> answer", tools=[_simple_tool])
     with pytest.raises(ValueError):
         program.truncate_trajectory({"generated_code_0": "print(1)", "code_output_0": "1"})
+
+
+def test_codeact_truncate_trajectory_skips_non_indexed_keys():
+    """The extractor parse retry adds a prompt-only ``parse_feedback`` key (no iteration index).
+    Truncation must skip non-indexed keys when computing iteration indices (``int("feedback")``
+    used to raise ValueError) and must never pop them: the feedback survives the trim."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    trajectory = {
+        "observation_0": "parse failure",
+        "observation_1": "parse failure",
+        "parse_feedback": "fix your output",
+    }
+    out = program.truncate_trajectory(trajectory)
+
+    assert "observation_0" not in out
+    assert out["observation_1"] == "parse failure"
+    assert out["parse_feedback"] == "fix your output"
+
+
+def test_codeact_truncate_trajectory_only_feedback_and_single_iteration_raises():
+    """A non-indexed key alone does not make a trajectory truncatable: with one real iteration
+    plus ``parse_feedback``, the single-iteration guard must still raise."""
+    program = CodeAct("question -> answer", tools=[_simple_tool])
+    with pytest.raises(ValueError):
+        program.truncate_trajectory({"observation_0": "parse failure", "parse_feedback": "fix"})

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -471,3 +471,235 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_react_recovers_from_adapter_parse_error():
+    # Regression test for https://github.com/stanfordnlp/dspy/issues/8377:
+    # the LM aperiodically emits a wrong section header (e.g. `tool_args`
+    # instead of `next_tool_args`); ReAct should feed the parse failure back
+    # into the trajectory and let the model self-correct, mirroring how tool
+    # execution errors are handled, instead of crashing the whole call.
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            # Wrong field name, exactly as reported in #8377 -> AdapterParseError.
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+            # The model self-corrects on the next iteration.
+            {
+                "next_thought": "Retrying with the correct fields.",
+                "next_tool_name": "add",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "I have the sum, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            {"reasoning": "Added the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = react(a=1, b=2)
+    traj = outputs.trajectory
+
+    assert outputs.c == 3
+    # The parse failure was recorded as a full 4-key step (preserving the
+    # trajectory shape truncate_trajectory relies on), reusing the fields that
+    # did parse and pointing out what was missing.
+    assert "could not be parsed" in traj["observation_0"]
+    assert "next_tool_args" in traj["observation_0"]
+    assert traj["thought_0"] == "I need to add two numbers."
+    assert traj["tool_name_0"] == "add"
+    assert traj["tool_args_0"] == {}
+    # ...and the loop continued: the next iteration executed the tool normally.
+    assert traj["tool_name_1"] == "add"
+    assert traj["observation_1"] == 3
+    assert traj["tool_name_2"] == "finish"
+
+
+def test_react_parse_error_every_iteration_falls_back_to_extract():
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    max_iters = 3
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            # Every iteration produces an unparseable step.
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+        ]
+        * max_iters
+        + [{"reasoning": "Could not run any tool.", "c": "3"}]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = react(a=1, b=2, max_iters=max_iters)
+    traj = outputs.trajectory
+
+    # No crash: the parse failure of every iteration is in the trajectory and
+    # the extract fallback still produced the outputs.
+    assert outputs.c == 3
+    for idx in range(max_iters):
+        assert "could not be parsed" in traj[f"observation_{idx}"]
+
+
+@pytest.mark.asyncio
+async def test_async_react_recovers_from_adapter_parse_error():
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "Retrying with the correct fields.",
+                "next_tool_name": "add",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "I have the sum, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            {"reasoning": "Added the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = await react.acall(a=1, b=2)
+    traj = outputs.trajectory
+
+    assert outputs.c == 3
+    assert "could not be parsed" in traj["observation_0"]
+    assert traj["tool_name_1"] == "add"
+    assert traj["observation_1"] == 3
+
+
+def test_react_parse_failure_preserves_trajectory_truncation_alignment():
+    # A parse-failure step must contribute the same four keys as a normal step,
+    # so truncate_trajectory (which pops keys in groups of four) stays aligned.
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "Retrying with the correct fields.",
+                "next_tool_name": "add",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "I have the sum, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            {"reasoning": "Added the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    traj = react(a=1, b=2).trajectory
+    assert len(traj) % 4 == 0
+
+    # Truncating drops the oldest step (the parse failure) as one whole unit,
+    # leaving the first real tool call intact and aligned.
+    truncated = react.truncate_trajectory(dict(traj))
+    assert truncated["thought_1"] == "Retrying with the correct fields."
+    assert truncated["tool_name_1"] == "add"
+    assert truncated["observation_1"] == 3
+
+
+def test_react_extract_parse_error_is_retried_with_feedback():
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I have the answer, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            # The extraction step emits a wrong field name -> AdapterParseError.
+            {"reasoning": "Adding the numbers.", "d": "3"},
+            # The retry (with parse feedback in the prompt) self-corrects.
+            {"reasoning": "Adding the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = react(a=1, b=2)
+    assert outputs.c == 3
+    # The prompt-only feedback is not stored in the returned trajectory.
+    assert "parse_feedback" not in outputs.trajectory
+
+
+def test_react_extract_parse_error_propagates_after_retry():
+    from dspy.utils.exceptions import AdapterParseError
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I have the answer, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            # The extraction step fails to parse twice: the error is real, surface it.
+            {"reasoning": "Adding the numbers.", "d": "3"},
+            {"reasoning": "Adding the numbers.", "d": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    with pytest.raises(AdapterParseError):
+        react(a=1, b=2)
+
+
+def test_codeact_recovers_from_adapter_parse_error():
+    from dspy.predict import CodeAct
+
+    # No tools: keeps the test free of the Deno interpreter (tool registration
+    # is the only pre-loop interpreter use), while still exercising the loop.
+    program = CodeAct("question -> answer", tools=[], max_iters=2)
+    lm = DummyLM(
+        [
+            # Both iterations emit an unparseable step (wrong field name).
+            {"reasoning": "Thinking.", "code": "print(42)"},
+            {"reasoning": "Thinking.", "code": "print(42)"},
+            {"reasoning": "Done.", "answer": "42"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = program(question="What is 6*7?")
+    assert outputs.answer == "42"
+    assert "could not be parsed" in outputs.trajectory["observation_0"]
+    assert "could not be parsed" in outputs.trajectory["observation_1"]

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -534,3 +534,235 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_react_recovers_from_adapter_parse_error():
+    # Regression test for https://github.com/stanfordnlp/dspy/issues/8377:
+    # the LM aperiodically emits a wrong section header (e.g. `tool_args`
+    # instead of `next_tool_args`); ReAct should feed the parse failure back
+    # into the trajectory and let the model self-correct, mirroring how tool
+    # execution errors are handled, instead of crashing the whole call.
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            # Wrong field name, exactly as reported in #8377 -> AdapterParseError.
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+            # The model self-corrects on the next iteration.
+            {
+                "next_thought": "Retrying with the correct fields.",
+                "next_tool_name": "add",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "I have the sum, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            {"reasoning": "Added the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = react(a=1, b=2)
+    traj = outputs.trajectory
+
+    assert outputs.c == 3
+    # The parse failure was recorded as a full 4-key step (preserving the
+    # trajectory shape truncate_trajectory relies on), reusing the fields that
+    # did parse and pointing out what was missing.
+    assert "could not be parsed" in traj["observation_0"]
+    assert "next_tool_args" in traj["observation_0"]
+    assert traj["thought_0"] == "I need to add two numbers."
+    assert traj["tool_name_0"] == "add"
+    assert traj["tool_args_0"] == {}
+    # ...and the loop continued: the next iteration executed the tool normally.
+    assert traj["tool_name_1"] == "add"
+    assert traj["observation_1"] == 3
+    assert traj["tool_name_2"] == "finish"
+
+
+def test_react_parse_error_every_iteration_falls_back_to_extract():
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    max_iters = 3
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            # Every iteration produces an unparseable step.
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+        ]
+        * max_iters
+        + [{"reasoning": "Could not run any tool.", "c": "3"}]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = react(a=1, b=2, max_iters=max_iters)
+    traj = outputs.trajectory
+
+    # No crash: the parse failure of every iteration is in the trajectory and
+    # the extract fallback still produced the outputs.
+    assert outputs.c == 3
+    for idx in range(max_iters):
+        assert "could not be parsed" in traj[f"observation_{idx}"]
+
+
+@pytest.mark.asyncio
+async def test_async_react_recovers_from_adapter_parse_error():
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "Retrying with the correct fields.",
+                "next_tool_name": "add",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "I have the sum, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            {"reasoning": "Added the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = await react.acall(a=1, b=2)
+    traj = outputs.trajectory
+
+    assert outputs.c == 3
+    assert "could not be parsed" in traj["observation_0"]
+    assert traj["tool_name_1"] == "add"
+    assert traj["observation_1"] == 3
+
+
+def test_react_parse_failure_preserves_trajectory_truncation_alignment():
+    # A parse-failure step must contribute the same four keys as a normal step,
+    # so truncate_trajectory (which pops keys in groups of four) stays aligned.
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I need to add two numbers.",
+                "next_tool_name": "add",
+                "tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "Retrying with the correct fields.",
+                "next_tool_name": "add",
+                "next_tool_args": {"a": 1, "b": 2},
+            },
+            {
+                "next_thought": "I have the sum, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            {"reasoning": "Added the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    traj = react(a=1, b=2).trajectory
+    assert len(traj) % 4 == 0
+
+    # Truncating drops the oldest step (the parse failure) as one whole unit,
+    # leaving the first real tool call intact and aligned.
+    truncated = react.truncate_trajectory(dict(traj))
+    assert truncated["thought_1"] == "Retrying with the correct fields."
+    assert truncated["tool_name_1"] == "add"
+    assert truncated["observation_1"] == 3
+
+
+def test_react_extract_parse_error_is_retried_with_feedback():
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I have the answer, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            # The extraction step emits a wrong field name -> AdapterParseError.
+            {"reasoning": "Adding the numbers.", "d": "3"},
+            # The retry (with parse feedback in the prompt) self-corrects.
+            {"reasoning": "Adding the numbers.", "c": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = react(a=1, b=2)
+    assert outputs.c == 3
+    # The prompt-only feedback is not stored in the returned trajectory.
+    assert "parse_feedback" not in outputs.trajectory
+
+
+def test_react_extract_parse_error_propagates_after_retry():
+    from dspy.utils.exceptions import AdapterParseError
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I have the answer, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            # The extraction step fails to parse twice: the error is real, surface it.
+            {"reasoning": "Adding the numbers.", "d": "3"},
+            {"reasoning": "Adding the numbers.", "d": "3"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    with pytest.raises(AdapterParseError):
+        react(a=1, b=2)
+
+
+def test_codeact_recovers_from_adapter_parse_error():
+    from dspy.predict import CodeAct
+
+    # No tools: keeps the test free of the Deno interpreter (tool registration
+    # is the only pre-loop interpreter use), while still exercising the loop.
+    program = CodeAct("question -> answer", tools=[], max_iters=2)
+    lm = DummyLM(
+        [
+            # Both iterations emit an unparseable step (wrong field name).
+            {"reasoning": "Thinking.", "code": "print(42)"},
+            {"reasoning": "Thinking.", "code": "print(42)"},
+            {"reasoning": "Done.", "answer": "42"},
+        ]
+    )
+    dspy.configure(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False))
+
+    outputs = program(question="What is 6*7?")
+    assert outputs.answer == "42"
+    assert "could not be parsed" in outputs.trajectory["observation_0"]
+    assert "could not be parsed" in outputs.trajectory["observation_1"]

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -746,6 +746,58 @@ def test_react_extract_parse_error_propagates_after_retry():
         react(a=1, b=2)
 
 
+@pytest.mark.asyncio
+async def test_async_react_extract_parse_error_is_retried_with_feedback():
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I have the answer, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            # The extraction step emits a wrong field name -> AdapterParseError.
+            {"reasoning": "Adding the numbers.", "d": "3"},
+            # The retry (with parse feedback in the prompt) self-corrects.
+            {"reasoning": "Adding the numbers.", "c": "3"},
+        ]
+    )
+    # dspy.configure may only be called from the first async task; use dspy.context here.
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False)):
+        outputs = await react.acall(a=1, b=2)
+    assert outputs.c == 3
+    # The prompt-only feedback is not stored in the returned trajectory.
+    assert "parse_feedback" not in outputs.trajectory
+
+
+@pytest.mark.asyncio
+async def test_async_react_extract_parse_error_propagates_after_retry():
+    from dspy.utils.exceptions import AdapterParseError
+
+    async def add(a: int, b: int) -> int:
+        return a + b
+
+    react = dspy.ReAct("a, b -> c:int", tools=[add])
+    lm = DummyLM(
+        [
+            {
+                "next_thought": "I have the answer, finishing.",
+                "next_tool_name": "finish",
+                "next_tool_args": {},
+            },
+            # The extraction step fails to parse twice: the error is real, surface it.
+            {"reasoning": "Adding the numbers.", "d": "3"},
+            {"reasoning": "Adding the numbers.", "d": "3"},
+        ]
+    )
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter(use_json_adapter_fallback=False)):
+        with pytest.raises(AdapterParseError):
+            await react.acall(a=1, b=2)
+
+
 def test_codeact_recovers_from_adapter_parse_error():
     from dspy.predict import CodeAct
 


### PR DESCRIPTION
Fixes #8377.

ReAct's loop only caught `ValueError` around the reasoning step, so an `AdapterParseError` (a `DSPyError`) propagated and crashed the whole call whenever the LM aperiodically emitted a malformed step — e.g. a `tool_args` section header instead of `next_tool_args`, or an omitted field, as reported with Claude Sonnet and qwen models.

## What changed

- `dspy/predict/react.py`: catch `AdapterParseError` in `forward`/`aforward` and record the failed step as a full four-key trajectory entry (the fields that did parse, placeholders for the rest, and a corrective observation listing expected vs found fields), then continue the loop so the model can self-correct. Writing all four keys preserves the four-keys-per-step trajectory shape `truncate_trajectory` relies on. This mirrors how ReAct already surfaces tool execution errors and is bounded by `max_iters`. Helpers `_format_parse_failure_observation` / `_call_extract_with_parse_retry` (+ async twin) handle the extractor step's parse retry.
- `dspy/predict/code_act.py`: `CodeAct` subclasses `ReAct`, so its `forward` gets the same AdapterParseError -> observation -> continue treatment and the extract-with-parse-retry call. Scoped to the parse-error handling only, on top of the current `interpreter_factory` structure from #10022.
- `dspy/utils/exceptions.py`: minor `AdapterParseError.parsed_result` annotation correction.

## Reproduction

Inject a malformed LM response (a `tool_args` header instead of `next_tool_args`) into a ReAct step. On stock `main` the call raises `AdapterParseError` and crashes; with this patch ReAct records the parse failure as an observation and continues, letting the model self-correct within `max_iters`.

## Tests

`tests/predict/test_react.py` adds sync and async parse-error-recovery tests; the full file is green (15 passed, 1 skipped). `ruff check` clean on the touched files.

## Disclosure

AI-assisted (Claude Code): the change and tests were drafted with AI assistance, then reviewed and verified by me (test suite + a check of the CodeAct reconciliation against the interpreter_factory structure) before submission. This contribution is my own and offered under the project's MIT license.
