### PR TITLE
fix(react): ReAct.truncate_trajectory silently empties trajectory on single tool call

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -172,7 +172,7 @@ class ReAct(Module):
         Users can override this method to implement their own truncation logic.
         """
         keys = list(trajectory.keys())
-        if len(keys) < 4:
+        if len(keys) <= 4:
             # Every tool call has 4 keys: thought, tool_name, tool_args, and observation.
             raise ValueError(
                 "The trajectory is too long so your prompt exceeded the context window, but the trajectory cannot be "

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -252,6 +252,23 @@ def test_trajectory_truncation():
     assert result.output_text == "Final output"
 
 
+def test_truncate_trajectory_raises_on_single_tool_call():
+    # A trajectory with exactly one tool call has 4 keys (thought, tool_name, tool_args,
+    # observation). Per truncate_trajectory's own docstring/error message, this is the
+    # smallest trajectory that cannot be truncated further, so it must raise instead of
+    # silently popping every key and returning an empty trajectory.
+    react = dspy.ReAct("input_text -> output_text", tools=[])
+    trajectory = {
+        "thought_0": "Thought 0",
+        "tool_name_0": "finish",
+        "tool_args_0": {},
+        "observation_0": "Completed.",
+    }
+
+    with pytest.raises(ValueError):
+        react.truncate_trajectory(trajectory)
+
+
 @pytest.mark.asyncio
 async def test_context_window_exceeded_after_retries():
     def echo(text: str) -> str:


### PR DESCRIPTION
## Symptom

`ReAct.truncate_trajectory` documents (in its own comment and error message) that a trajectory holding exactly one tool call — 4 keys: `thought_i`, `tool_name_i`, `tool_args_i`, `observation_i` — cannot be truncated further and should raise `ValueError`. The guard is:

```python
keys = list(trajectory.keys())
if len(keys) < 4:
    # Every tool call has 4 keys: thought, tool_name, tool_args, and observation.
    raise ValueError(
        "The trajectory is too long so your prompt exceeded the context window, but the trajectory cannot be "
        "truncated because it only has one tool call."
    )

for key in keys[:4]:
    trajectory.pop(key)
```

`len(keys) < 4` is `False` when `len(keys) == 4` (the single-tool-call case), so instead of raising, the code falls through and pops all 4 keys, silently returning an **empty trajectory**.

This is reached from `_call_with_potential_trajectory_truncation`'s retry loop: after exactly one tool call has been recorded, if the LM keeps exceeding the context window on retries, the trajectory is silently wiped rather than the loop raising as documented, and the extraction step then runs against an empty trajectory instead of surfacing a clear error.

## Fix

Change the guard to `len(keys) <= 4`, matching the documented invariant.

## Verification

- Added `test_truncate_trajectory_raises_on_single_tool_call` in `tests/predict/test_react.py`, constructing a 4-key trajectory directly and asserting `truncate_trajectory` raises `ValueError`.
- Confirmed **red** against the unfixed guard (test failed with "DID NOT RAISE ValueError" — trajectory became `{}`).
- Confirmed **green** after the one-line fix.
- Full `tests/predict/` suite: 236 passed, 62 skipped (pre-existing, unrelated — no LM API key in this environment).
- `ruff check` clean on changed files.

## AI-Generated Contributions

Per CONTRIBUTING.md's AI-disclosure guidance: I used Claude (AI-assisted, human-in-the-loop) to help find and fix this bug. Claude located the off-by-one by reading `truncate_trajectory` against its own docstring/comment, wrote the failing test first, confirmed it red against the unfixed code, applied the minimal fix, and confirmed it green plus the full `tests/predict/` suite. I reviewed and verified the diagnosis and fix before submitting — this was not an unsupervised autonomous agent opening the PR.