### PR TITLE
fix(tool): make dspy.Tool pickle-safe when func is a local closure

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import pickle
 from typing import TYPE_CHECKING, Any, Callable, get_origin, get_type_hints
 
 import json_repair
@@ -16,6 +17,28 @@ if TYPE_CHECKING:
     from langchain.tools import BaseTool
 
 _TYPE_MAPPING = {"string": str, "integer": int, "number": float, "boolean": bool, "array": list, "object": dict}
+
+
+class _UnpicklableToolFunc:
+    """Stand-in for a ``Tool.func`` that could not be pickled.
+
+    Local closures and lambdas cannot be pickled, so a ``Tool`` wrapping one is replaced
+    with this sentinel when the tool is pickled (see ``Tool.__getstate__``). It preserves
+    the original function's qualname for debugging and raises a clear error if the restored
+    tool is ever called, instead of silently doing nothing.
+    """
+
+    __slots__ = ("qualname",)
+
+    def __init__(self, qualname: str):
+        self.qualname = qualname
+
+    def __call__(self, *args, **kwargs):
+        raise RuntimeError(
+            f"This dspy.Tool was restored from a pickle that could not include its function "
+            f"({self.qualname!r}); the tool's metadata survived but it is no longer callable. "
+            f"Re-create the Tool from the live function to call it."
+        )
 
 
 class Tool(Type):
@@ -250,6 +273,31 @@ class Tool(Type):
         from dspy.utils.langchain_tool import convert_langchain_tool
 
         return convert_langchain_tool(tool)
+
+    def __getstate__(self):
+        """Make ``Tool`` safe to pickle even when ``func`` is a local closure or lambda.
+
+        dspy pickles and hashes demos in several places — ``BootstrapFewShot`` seeds its
+        demo shuffle by hashing the trace, ``program.save()`` pickles the program, and the
+        LM cache and multiprocessing paths pickle too. A tool backed by a local closure
+        (e.g. one capturing a client or session) would otherwise crash all of these with
+        ``AttributeError: Can't get local object '...'``.
+
+        When ``func`` can't be pickled it is replaced with a metadata-preserving sentinel,
+        so the tool round-trips everywhere. A module-level ``func`` is left untouched and
+        stays fully callable after unpickling; only a genuinely-unpicklable closure
+        degrades, and calling the restored tool then raises a clear error rather than
+        silently returning nothing.
+        """
+        state = super().__getstate__()
+        store = state.get("__dict__") or {}
+        func = store.get("func")
+        try:
+            pickle.dumps(func)
+        except Exception:
+            qualname = getattr(func, "__qualname__", getattr(func, "__name__", repr(func)))
+            state = {**state, "__dict__": {**store, "func": _UnpicklableToolFunc(qualname)}}
+        return state
 
     def __repr__(self):
         return f"Tool(name={self.name}, desc={self.desc}, args={self.args})"

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import pickle
 from typing import Any
 
 import pytest
@@ -8,6 +9,8 @@ import dspy
 from dspy.adapters.types.tool import Tool, ToolCallResults, ToolCalls, convert_input_schema_to_tool_args
 from dspy.clients.openai_format import to_openai_chat_request
 from dspy.core.types import LMMessage, LMRequest, LMToolResultPart
+from dspy.utils.dummies import DummyLM
+from dspy.utils.hasher import Hasher
 
 
 # Test fixtures
@@ -753,3 +756,97 @@ def test_tool_call_execute_with_local_functions():
             globals().pop("local_add", None)
 
     main()
+
+
+# ---------------------------------------------------------------------------
+# Pickling a Tool whose func is a local closure (regression for #9998)
+# ---------------------------------------------------------------------------
+
+def _make_closure_tool():
+    """A Tool wrapping a local closure that captures state — the pattern that
+    is not picklable by default (``AttributeError: Can't get local object``)."""
+    class Client:
+        def lookup(self, city):
+            return {"paris": "France"}[city.lower()]
+
+    def make_tool(client):
+        def country_of(city: str) -> str:
+            """Return the country a city is in."""
+            return client.lookup(city)
+
+        return country_of
+
+    return dspy.Tool(make_tool(Client()))
+
+
+def module_level_double(x: int) -> int:
+    """Double a number."""
+    return x * 2
+
+
+def test_tool_with_closure_is_picklable():
+    tool = _make_closure_tool()
+    assert tool(city="Paris") == "France"  # live tool works
+
+    restored = pickle.loads(pickle.dumps(tool))
+    # Metadata survives the round-trip.
+    assert restored.name == "country_of"
+    assert restored.desc == "Return the country a city is in."
+    assert list((restored.args or {}).keys()) == ["city"]
+
+
+def test_restored_closure_tool_raises_when_called():
+    restored = pickle.loads(pickle.dumps(_make_closure_tool()))
+    with pytest.raises(RuntimeError, match="no longer callable"):
+        restored(city="Paris")
+
+
+def test_tool_hash_is_stable_across_closure_instances():
+    # Two tools built from distinct closure instances with identical metadata
+    # must hash identically, so hashing is deterministic across processes.
+    h1 = Hasher.hash((_make_closure_tool(),))
+    h2 = Hasher.hash((_make_closure_tool(),))
+    assert h1 == h2
+
+
+def test_module_level_tool_is_unaffected():
+    # A tool backed by a module-level function keeps its real func and stays
+    # fully callable after a pickle round-trip.
+    restored = pickle.loads(pickle.dumps(dspy.Tool(module_level_double)))
+    assert restored(x=21) == 42
+
+
+class _RepeatedCallModule(dspy.Module):
+    def __init__(self, signature):
+        super().__init__()
+        self.predictor = dspy.Predict(signature)
+
+    def forward(self, **kwargs):
+        self.predictor(**kwargs)
+        return self.predictor(**kwargs)
+
+
+def test_bootstrap_with_unpicklable_tool_demo():
+    # End-to-end: BootstrapFewShot seeds its demo shuffle by hashing the trace.
+    # With >1 trace carrying a closure-backed tool, the hash previously crashed
+    # (#9998). The Tool-level fix makes the whole compile succeed.
+    class ToolSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        tools: list[dspy.Tool] = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    tool = _make_closure_tool()
+    example = dspy.Example(
+        question="Where is Paris?", tools=[tool], answer="France"
+    ).with_inputs("question", "tools")
+    dspy.configure(lm=DummyLM([{"answer": "France"}, {"answer": "France"}]))
+
+    compiled = dspy.BootstrapFewShot(
+        metric=lambda ex, pred, trace=None: pred.answer == ex.answer,
+        max_bootstrapped_demos=1,
+        max_labeled_demos=0,
+    ).compile(_RepeatedCallModule(ToolSignature), trainset=[example])
+
+    assert len(compiled.predictor.demos) == 1
+    # The live demo's tool is untouched and still callable.
+    assert compiled.predictor.demos[0].tools[0](city="Paris") == "France"


### PR DESCRIPTION
`dspy.Tool` stores the wrapped callable in a pickled field. When that callable is a local closure or a lambda (a common pattern — a tool that captures a client or session), any operation that pickles the tool crashes with `AttributeError: Can't get local object '...'`. This surfaces in `BootstrapFewShot` (which seeds its demo shuffle by hashing the trace, #9998), but it also hits `program.save()`, multiprocessing, and the LM cache — anywhere a demo carrying such a tool gets pickled.

This fixes the root cause in `Tool` rather than one call site: `__getstate__` swaps an unpicklable `func` for a metadata-preserving sentinel, so the tool round-trips everywhere. A module-level function is left untouched and stays fully callable after unpickling; only a genuinely-unpicklable closure degrades — its metadata survives and *calling* the restored tool raises a clear, actionable error instead of crashing the pickle.

## Tests

Added to `tests/adapters/test_tool.py` (4 of the 5 fail on `main`, pass with the fix):

- a closure-backed `Tool` now pickles and its metadata (name/desc/args) survives the round-trip
- calling a restored closure tool raises a clear `RuntimeError` instead of failing silently
- hashing is stable across distinct closure instances with identical metadata (deterministic seeds)
- a module-level `Tool` stays fully callable after a pickle round-trip
- end-to-end `BootstrapFewShot` compile with an unpicklable-tool demo succeeds

Fixes #9998.
