### PR TITLE
fix(teleprompt): preserve DSPy context and callbacks in AvatarOptimizer workers

### DIFF
--- a/dspy/teleprompt/avatar_optimizer.py
+++ b/dspy/teleprompt/avatar_optimizer.py
@@ -89,18 +89,26 @@ class AvatarOptimizer(Teleprompter):
         self.comparator = dspy.TypedPredictor(Comparator)
         self.feedback_instruction = dspy.Predict(FeedbackBasedInstruction)
 
-    def process_example(self, actor, example):
-        """Run a single example through a copy of ``actor`` and score it.
+    def process_example(self, actor, example, return_outputs):
+        actor = deepcopy(actor)
 
-        This is the per-example extension point: ``thread_safe_evaluator`` calls it once per
-        example from inside a worker, so overriding it here changes how every example is
-        handled. Exceptions are intentionally left uncaught -- the caller's ParallelExecutor
-        records the failure and scores the example 0.
-        """
-        actor_clone = deepcopy(actor)
-        prediction = actor_clone(**example.inputs().toDict())
-        score = self.metric(example, prediction)
-        return example, prediction, score
+        try:
+            prediction = actor(**example.inputs().toDict())
+            score = self.metric(example, prediction)
+
+            if return_outputs:
+                return example, prediction, score
+            else:
+                return score
+
+        except Exception as e:
+            print(e)
+
+            if return_outputs:
+                return example, None, 0
+            else:
+                return 0
+
 
     def thread_safe_evaluator(self, devset, actor, return_outputs=False, num_threads=None):
         total_score = 0
@@ -110,7 +118,10 @@ class AvatarOptimizer(Teleprompter):
 
         executor = ParallelExecutor(
             num_threads=num_threads,
-            # Never abort on per-example failures; failing examples are scored 0 (issue #10053).
+            # process_example swallows per-example exceptions itself, so the executor's error
+            # path is effectively unreachable. Keep the cap out of reach anyway (e.g. a failing
+            # deepcopy) to preserve the previous behaviour: a failing example scores 0 and the
+            # run continues rather than aborting.
             max_errors=len(devset) + 1,
             compare_results=True,
             # Disable straggler resubmission to preserve Avatar's at-most-once contract:
@@ -118,7 +129,9 @@ class AvatarOptimizer(Teleprompter):
             straggler_limit=0,
         )
 
-        outcomes = executor.execute(lambda example: self.process_example(actor, example), devset)
+        # Always request outputs so every worker returns a uniform (example, prediction, score);
+        # thread_safe_evaluator's own return_outputs only controls what it hands back to callers.
+        outcomes = executor.execute(lambda example: self.process_example(actor, example, True), devset)
 
         for example, outcome in zip(devset, outcomes, strict=True):
             if outcome is None:

--- a/dspy/teleprompt/avatar_optimizer.py
+++ b/dspy/teleprompt/avatar_optimizer.py
@@ -1,14 +1,13 @@
-from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from random import sample
 from typing import Callable
 
 from pydantic import BaseModel
-from tqdm import tqdm
 
 import dspy
 from dspy.predict.avatar import ActionOutput
 from dspy.teleprompt.teleprompt import Teleprompter
+from dspy.utils.parallelizer import ParallelExecutor
 
 DEFAULT_MAX_EXAMPLES = 10
 
@@ -90,26 +89,18 @@ class AvatarOptimizer(Teleprompter):
         self.comparator = dspy.TypedPredictor(Comparator)
         self.feedback_instruction = dspy.Predict(FeedbackBasedInstruction)
 
-    def process_example(self, actor, example, return_outputs):
-        actor = deepcopy(actor)
+    def process_example(self, actor, example):
+        """Run a single example through a copy of ``actor`` and score it.
 
-        try:
-            prediction = actor(**example.inputs().toDict())
-            score = self.metric(example, prediction)
-
-            if return_outputs:
-                return example, prediction, score
-            else:
-                return score
-
-        except Exception as e:
-            print(e)
-
-            if return_outputs:
-                return example, None, 0
-            else:
-                return 0
-
+        This is the per-example extension point: ``thread_safe_evaluator`` calls it once per
+        example from inside a worker, so overriding it here changes how every example is
+        handled. Exceptions are intentionally left uncaught -- the caller's ParallelExecutor
+        records the failure and scores the example 0.
+        """
+        actor_clone = deepcopy(actor)
+        prediction = actor_clone(**example.inputs().toDict())
+        score = self.metric(example, prediction)
+        return example, prediction, score
 
     def thread_safe_evaluator(self, devset, actor, return_outputs=False, num_threads=None):
         total_score = 0
@@ -117,17 +108,26 @@ class AvatarOptimizer(Teleprompter):
         results = []
         num_threads = num_threads or dspy.settings.num_threads
 
-        with ThreadPoolExecutor(max_workers=num_threads) as executor:
-            futures = [executor.submit(self.process_example, actor, example, return_outputs) for example in devset]
+        executor = ParallelExecutor(
+            num_threads=num_threads,
+            # Never abort on per-example failures; failing examples are scored 0 (issue #10053).
+            max_errors=len(devset) + 1,
+            compare_results=True,
+            # Disable straggler resubmission to preserve Avatar's at-most-once contract:
+            # each actor/metric runs exactly once per example, with no duplicate LM calls.
+            straggler_limit=0,
+        )
 
-            for future in tqdm(futures, total=total_examples, desc="Processing examples"):
-                result = future.result()
-                if return_outputs:
-                    example, prediction, score = result
-                    total_score += score
-                    results.append((example, prediction, score))
-                else:
-                    total_score += result
+        outcomes = executor.execute(lambda example: self.process_example(actor, example), devset)
+
+        for example, outcome in zip(devset, outcomes, strict=True):
+            if outcome is None:
+                # The example failed or was cancelled; count it as a zero score.
+                results.append((example, None, 0))
+            else:
+                _, prediction, score = outcome
+                total_score += score
+                results.append((example, prediction, score))
 
         avg_metric = total_score / total_examples
 

--- a/tests/teleprompt/test_avatar_optimizer.py
+++ b/tests/teleprompt/test_avatar_optimizer.py
@@ -1,0 +1,229 @@
+"""Tests for AvatarOptimizer.thread_safe_evaluator.
+
+These tests isolate the parallel-evaluation path from AvatarOptimizer.__init__ (which
+currently constructs a dspy.TypedPredictor and is affected by the unrelated #7931). We
+build the optimizer via ``__new__`` and set ``self.metric`` directly, since
+``thread_safe_evaluator`` only depends on ``self.metric`` plus dspy settings.
+"""
+
+import threading
+
+import pytest
+
+import dspy
+from dspy.teleprompt.avatar_optimizer import AvatarOptimizer
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
+from dspy.utils.dummies import DummyLM
+
+
+def _make_optimizer(metric):
+    optimizer = AvatarOptimizer.__new__(AvatarOptimizer)
+    optimizer.metric = metric
+    return optimizer
+
+
+def _devset(n):
+    return [dspy.Example(question=f"q{i}", answer="ok").with_inputs("question") for i in range(n)]
+
+
+class ContextReadingActor(dspy.Module):
+    """Actor that requires an LM to be visible in the thread that runs it.
+
+    This mirrors the real failure in issue #10053: the actor reads ``dspy.settings.lm``,
+    which is only supplied via a ``dspy.context`` override. If that override does not reach
+    the worker thread, the actor raises and the example scores 0.
+    """
+
+    def forward(self, **kwargs):
+        if dspy.settings.lm is None:
+            raise ValueError("no LM configured in this thread")
+        return dspy.Prediction(answer="ok")
+
+
+class FailingActor(dspy.Module):
+    """Actor that raises for a specific input and succeeds otherwise."""
+
+    def forward(self, question=None, **kwargs):
+        if question == "boom":
+            raise RuntimeError("boom")
+        return dspy.Prediction(answer="ok")
+
+
+class AlwaysFailingActor(dspy.Module):
+    """Actor that raises for every input."""
+
+    def forward(self, **kwargs):
+        raise RuntimeError("boom")
+
+
+def _match_metric(example, prediction):
+    return 1.0 if getattr(prediction, "answer", None) == "ok" else 0.0
+
+
+def test_context_override_propagates_to_worker_threads():
+    """Regression for #10053: a dspy.context override must reach worker threads.
+
+    Previously thread_safe_evaluator used a bare ThreadPoolExecutor, so the
+    ``dspy.context(lm=...)`` override never reached workers, the actor raised, and the
+    average score collapsed to 0.0. Routing through ParallelExecutor re-applies the
+    override in each worker, so the score is now correct (1.0).
+    """
+    optimizer = _make_optimizer(_match_metric)
+    devset = _devset(6)
+    actor = ContextReadingActor()
+
+    # lm is provided ONLY via the context override (never globally configured), so the
+    # override must transit into the worker threads for the actor to succeed.
+    with dspy.context(lm=DummyLM([{"answer": "ok"}])):
+        avg, results = optimizer.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)
+
+    assert avg == 1.0
+    assert len(results) == len(devset)
+    assert all(score == 1.0 for _, _, score in results)
+
+
+def test_results_preserve_devset_order():
+    """Results must be returned in devset order regardless of worker completion order."""
+    optimizer = _make_optimizer(_match_metric)
+    devset = _devset(12)
+    actor = ContextReadingActor()
+
+    with dspy.context(lm=DummyLM([{"answer": "ok"}])):
+        _, results = optimizer.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)
+
+    assert [example for example, _, _ in results] == devset
+
+
+def test_failing_example_scores_zero_and_counts_toward_average():
+    """An example whose actor raises is recorded as (example, None, 0) and still counted."""
+    optimizer = _make_optimizer(_match_metric)
+    devset = [
+        dspy.Example(question="ok-1", answer="ok").with_inputs("question"),
+        dspy.Example(question="boom", answer="ok").with_inputs("question"),
+        dspy.Example(question="ok-2", answer="ok").with_inputs("question"),
+        dspy.Example(question="ok-3", answer="ok").with_inputs("question"),
+    ]
+    actor = FailingActor()
+
+    with dspy.context(lm=DummyLM([{"answer": "ok"}])):
+        avg, results = optimizer.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)
+
+    # 3 successes out of 4 examples: the failure counts toward the denominator.
+    assert avg == pytest.approx(3.0 / 4.0)
+
+    failed = [(example, prediction, score) for example, prediction, score in results if example.question == "boom"]
+    assert len(failed) == 1
+    _, prediction, score = failed[0]
+    assert prediction is None
+    assert score == 0
+
+
+def test_evaluation_tolerates_more_failures_than_default_max_errors():
+    """Every failing example scores 0 without aborting, even past dspy.settings.max_errors.
+
+    The legacy evaluator swallowed every per-example exception, so an unlimited number of
+    failures never cancelled the run. Regression guard: a devset with far more failures than
+    the default max_errors (10) must still complete with an all-zero average instead of
+    raising "Execution cancelled due to errors or interruption.".
+    """
+    optimizer = _make_optimizer(_match_metric)
+    n = dspy.settings.max_errors + 5
+    devset = _devset(n)
+    actor = AlwaysFailingActor()
+
+    with dspy.context(lm=DummyLM([{"answer": "ok"}])):
+        avg, results = optimizer.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)
+
+    assert avg == 0.0
+    assert len(results) == n
+    assert all(prediction is None and score == 0 for _, prediction, score in results)
+
+
+def test_process_example_is_the_per_example_override_point():
+    """A subclass overriding process_example must still drive every example.
+
+    process_example is public API, so the parallel-evaluation path has to route through it
+    rather than inlining the work; otherwise an override is silently ignored.
+    """
+
+    class CountingOptimizer(AvatarOptimizer):
+        def __init__(self, metric):
+            self.metric = metric
+            self.calls = []
+            self.lock = threading.Lock()
+
+        def process_example(self, actor, example):
+            with self.lock:
+                self.calls.append(example.question)
+            example, prediction, score = super().process_example(actor, example)
+            # Override the score to prove the subclass's return value is what gets used.
+            return example, prediction, score * 2
+
+    optimizer = CountingOptimizer(_match_metric)
+    devset = _devset(4)
+    actor = ContextReadingActor()
+
+    with dspy.context(lm=DummyLM([{"answer": "ok"}])):
+        avg, _ = optimizer.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)
+
+    assert sorted(optimizer.calls) == sorted(example.question for example in devset)
+    assert avg == 2.0
+
+
+def test_callback_handlers_fire_inside_worker_threads():
+    """Callback handlers registered via settings must fire in the worker threads.
+
+    This is the #10043 parity point: the ``callbacks`` setting now transits into workers via
+    ParallelExecutor's thread-local override re-application, so per-example actor calls invoke
+    the handlers. (ACTIVE_CALL_ID call-ancestry transport is covered separately below.)
+    """
+
+    class RecordingCallback(BaseCallback):
+        def __init__(self):
+            self.start_threads = []
+            self.lock = threading.Lock()
+
+        def on_module_start(self, call_id, instance, inputs):
+            with self.lock:
+                self.start_threads.append(threading.get_ident())
+
+    callback = RecordingCallback()
+    optimizer = _make_optimizer(_match_metric)
+    devset = _devset(6)
+    actor = ContextReadingActor()
+
+    with dspy.context(lm=DummyLM([{"answer": "ok"}]), callbacks=[callback]):
+        optimizer.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)
+
+    # One on_module_start per example, and at least one fired off the main thread.
+    assert len(callback.start_threads) == len(devset)
+    assert any(tid != threading.main_thread().ident for tid in callback.start_threads)
+
+
+def test_active_call_id_ancestry_propagates_to_workers():
+    """The parent ACTIVE_CALL_ID should be visible to callbacks running in worker threads."""
+
+    class ParentRecordingCallback(BaseCallback):
+        def __init__(self):
+            self.parent_call_ids = []
+            self.lock = threading.Lock()
+
+        def on_module_start(self, call_id, instance, inputs):
+            with self.lock:
+                self.parent_call_ids.append(ACTIVE_CALL_ID.get())
+
+    callback = ParentRecordingCallback()
+    optimizer = _make_optimizer(_match_metric)
+    devset = _devset(4)
+    actor = ContextReadingActor()
+
+    parent_id = "parent-call-id"
+    token = ACTIVE_CALL_ID.set(parent_id)
+    try:
+        with dspy.context(lm=DummyLM([{"answer": "ok"}]), callbacks=[callback]):
+            optimizer.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)
+    finally:
+        ACTIVE_CALL_ID.reset(token)
+
+    assert callback.parent_call_ids
+    assert all(pid == parent_id for pid in callback.parent_call_ids)

--- a/tests/teleprompt/test_avatar_optimizer.py
+++ b/tests/teleprompt/test_avatar_optimizer.py
@@ -143,7 +143,11 @@ def test_process_example_is_the_per_example_override_point():
     """A subclass overriding process_example must still drive every example.
 
     process_example is public API, so the parallel-evaluation path has to route through it
-    rather than inlining the work; otherwise an override is silently ignored.
+    rather than inlining the work; otherwise an override is silently ignored. This pins the
+    existing signature -- ``process_example(self, actor, example, return_outputs)`` -- so a
+    subclass written against the pre-change API keeps working. That matters because an arity
+    mismatch would raise inside a worker, where the error is swallowed and surfaces only as a
+    silently zeroed score.
     """
 
     class CountingOptimizer(AvatarOptimizer):
@@ -152,12 +156,15 @@ def test_process_example_is_the_per_example_override_point():
             self.calls = []
             self.lock = threading.Lock()
 
-        def process_example(self, actor, example):
+        def process_example(self, actor, example, return_outputs):
             with self.lock:
                 self.calls.append(example.question)
-            example, prediction, score = super().process_example(actor, example)
+            result = super().process_example(actor, example, return_outputs)
             # Override the score to prove the subclass's return value is what gets used.
-            return example, prediction, score * 2
+            if return_outputs:
+                example, prediction, score = result
+                return example, prediction, score * 2
+            return result * 2
 
     optimizer = CountingOptimizer(_match_metric)
     devset = _devset(4)


### PR DESCRIPTION
## What Changed

- `AvatarOptimizer.thread_safe_evaluator` now dispatches examples through `ParallelExecutor` instead of a raw `ThreadPoolExecutor`, so worker threads inherit the caller's `dspy.context` (LM and settings) and callback lineage rather than falling back to global defaults.
- The executor is tuned to keep the evaluator's prior semantics: `max_errors` is set beyond the devset size and failed or cancelled examples score `0` rather than aborting the run, `straggler_limit=0` preserves the at-most-once contract (no duplicate actor/metric LM calls), and results are zipped back against the devset so output order tracks input order. Note that `compare_results=True` changes the progress bar description from "Processing examples" to "Average Metric: X / N (pct%)".
- Added `tests/teleprompt/test_avatar_optimizer.py` covering context propagation, devset ordering, zero-scoring of failing examples, tolerance past the default `max_errors`, `process_example` as an override point, and callback firing with correct `ACTIVE_CALL_ID` ancestry.

## Risk Assessment

✅ Low: A single well-bounded function swaps a bare ThreadPoolExecutor for DSPy's standard ParallelExecutor, preserving the prior error-tolerance and at-most-once contracts via explicit `max_errors` and `straggler_limit=0`, with new regression tests covering context propagation, ordering, failure handling, and the public `process_example` override point.

## Testing

Ran the 7 new AvatarOptimizer tests plus the parallelizer, callback, and settings suites (41 passed, no regressions), then demonstrated the actual user-facing fix with a before/after repro: evaluating an actor whose LM comes only from `dspy.context(lm=...)` returned average metric 0.0 with eight "No LM is loaded" errors on the base commit, and 1.0 with all examples answering correctly on the target commit. Required `uv run --extra dev` since a bare `python` is unavailable; `uv run` rewrote `uv.lock`, which I restored, leaving the worktree clean. No UI surface is involved, so evidence is a CLI transcript rather than visual.

<details>
<summary>Evidence: Before/after repro of issue #10053 (CLI transcript)</summary>

<code>===== AFTER (target 6a04816e) =====&#10;Average Metric: 8.00 / 8 (100.0%): 100%|##########| 8/8 [00:00&lt;00:00, 35.22it/s]&#10;devset size : 8&#10;average metric score : 1.0&#10;per-example predictions:&#10;q0 -&gt; answer=&#39;ok&#39; score=1.0&#10;q1 -&gt; answer=&#39;ok&#39; score=1.0&#10;q2 -&gt; answer=&#39;ok&#39; score=1.0&#10;q3 -&gt; answer=&#39;ok&#39; score=1.0&#10;q4 -&gt; answer=&#39;ok&#39; score=1.0&#10;q5 -&gt; answer=&#39;ok&#39; score=1.0&#10;q6 -&gt; answer=&#39;ok&#39; score=1.0&#10;q7 -&gt; answer=&#39;ok&#39; score=1.0&#10;&#10;EXPECTED: every example answers &#39;ok&#39;, average 1.0&#10;RESULT : PASS -- context override reached worker threads&#10;&#10;===== BEFORE (base 96bae53d, bare ThreadPoolExecutor) =====&#10;Processing examples: 100%|##########| 8/8 [00:00&lt;00:00, 49.58it/s]&#10;No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. (x8)&#10;devset size : 8&#10;average metric score : 0.0&#10;per-example predictions:&#10;q0 -&gt; answer=None score=0&#10;q1 -&gt; answer=None score=0&#10;q2 -&gt; answer=None score=0&#10;q3 -&gt; answer=None score=0&#10;q4 -&gt; answer=None score=0&#10;q5 -&gt; answer=None score=0&#10;q6 -&gt; answer=None score=0&#10;q7 -&gt; answer=None score=0&#10;&#10;EXPECTED: every example answers &#39;ok&#39;, average 1.0&#10;RESULT : FAIL -- context override lost in workers, score collapsed to 0.0</code>

```text
===== AFTER (target 6a04816e) =====

  0%|          | 0/8 [00:00<?, ?it/s]
Average Metric: 1.00 / 1 (100.0%):   0%|          | 0/8 [00:00<?, ?it/s]
Average Metric: 1.00 / 1 (100.0%):  12%|█▎        | 1/8 [00:00<00:01,  4.49it/s]
Average Metric: 2.00 / 2 (100.0%):  12%|█▎        | 1/8 [00:00<00:01,  4.49it/s]
Average Metric: 3.00 / 3 (100.0%):  25%|██▌       | 2/8 [00:00<00:01,  4.49it/s]
Average Metric: 4.00 / 4 (100.0%):  38%|███▊      | 3/8 [00:00<00:01,  4.49it/s]
Average Metric: 5.00 / 5 (100.0%):  50%|█████     | 4/8 [00:00<00:00,  4.49it/s]
Average Metric: 6.00 / 6 (100.0%):  62%|██████▎   | 5/8 [00:00<00:00,  4.49it/s]
Average Metric: 7.00 / 7 (100.0%):  75%|███████▌  | 6/8 [00:00<00:00,  4.49it/s]
Average Metric: 8.00 / 8 (100.0%):  88%|████████▊ | 7/8 [00:00<00:00,  4.49it/s]
Average Metric: 8.00 / 8 (100.0%): 100%|██████████| 8/8 [00:00<00:00, 35.22it/s]
devset size          : 8
average metric score : 1.0
per-example predictions:
  q0   -> answer='ok'     score=1.0
  q1   -> answer='ok'     score=1.0
  q2   -> answer='ok'     score=1.0
  q3   -> answer='ok'     score=1.0
  q4   -> answer='ok'     score=1.0
  q5   -> answer='ok'     score=1.0
  q6   -> answer='ok'     score=1.0
  q7   -> answer='ok'     score=1.0

EXPECTED: every example answers 'ok', average 1.0
RESULT  : PASS -- context override reached worker threads

===== BEFORE (base 96bae53d, bare ThreadPoolExecutor) =====

Processing examples:   0%|          | 0/8 [00:00<?, ?it/s]
Processing examples:  12%|█▎        | 1/8 [00:00<00:01,  6.25it/s]
Processing examples: 100%|██████████| 8/8 [00:00<00:00, 49.58it/s]
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
No LM is loaded. Please configure the LM using `dspy.configure(lm=dspy.LM(...))`. e.g, `dspy.configure(lm=dspy.LM('openai/gpt-4o-mini'))`
devset size          : 8
average metric score : 0.0
per-example predictions:
  q0   -> answer=None     score=0
  q1   -> answer=None     score=0
  q2   -> answer=None     score=0
  q3   -> answer=None     score=0
  q4   -> answer=None     score=0
  q5   -> answer=None     score=0
  q6   -> answer=None     score=0
  q7   -> answer=None     score=0

EXPECTED: every example answers 'ok', average 1.0
RESULT  : FAIL -- context override lost in workers, score collapsed to 0.0
```
</details>
<details>
<summary>Evidence: Repro script driving AvatarOptimizer with an LM supplied only via dspy.context</summary>

```text
"""End-user repro of dspy issue #10053.

A user evaluates an Avatar-style actor with AvatarOptimizer.thread_safe_evaluator,
supplying the LM the normal way: `with dspy.context(lm=...)`. The actor is a plain
dspy.Predict, so it needs the LM that the context override provides.
"""
import dspy
from dspy.teleprompt.avatar_optimizer import AvatarOptimizer
from dspy.utils.dummies import DummyLM

class QA(dspy.Signature):
    question: str = dspy.InputField()
    answer: str = dspy.OutputField()

actor = dspy.Predict(QA)

devset = [dspy.Example(question=f"q{i}", answer="ok").with_inputs("question") for i in range(8)]
metric = lambda ex, pred: 1.0 if getattr(pred, "answer", None) == "ok" else 0.0

opt = AvatarOptimizer.__new__(AvatarOptimizer)
opt.metric = metric

# The LM exists ONLY inside this context override -- never globally configured.
with dspy.context(lm=DummyLM([{"answer": "ok"}] * 50)):
    avg, results = opt.thread_safe_evaluator(devset, actor, return_outputs=True, num_threads=4)

print(f"devset size          : {len(devset)}")
print(f"average metric score : {avg}")
print("per-example predictions:")
for ex, pred, score in results:
    ans = getattr(pred, "answer", None) if pred is not None else None
    print(f"  {ex.question:<4} -> answer={ans!r:<8} score={score}")
print()
print("EXPECTED: every example answers 'ok', average 1.0")
print("RESULT  :", "PASS -- context override reached worker threads" if avg == 1.0
      else f"FAIL -- context override lost in workers, score collapsed to {avg}")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `dspy/teleprompt/avatar_optimizer.py:138` - `results` is built unconditionally (lines 138-144) but discarded when `return_outputs=False`. The old code guarded the append behind `return_outputs`. Cost is negligible (tuple references, no copies), but the accumulation could be skipped when the caller doesn&#39;t want outputs.
- ℹ️ `dspy/teleprompt/avatar_optimizer.py:126` - Switching to `compare_results=True` changes the progress bar description from &#34;Processing examples&#34; to &#34;Average Metric: X / N (pct%)&#34;. This is a user-visible output change that comes bundled with the correct score-tracking behavior, and appears intentional per the inline comment.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run --extra dev python -m pytest tests/teleprompt/test_avatar_optimizer.py -q` — 7 new tests pass (context propagation, devset ordering, failing-example zero score, tolerance past default max_errors, process_example override point, callback firing in workers, ACTIVE_CALL_ID ancestry)</code>
- <code>`uv run --extra dev --frozen python -m pytest tests/teleprompt/test_avatar_optimizer.py tests/utils/test_parallelizer.py tests/callback/test_callback.py tests/utils/test_settings.py -q` — 41 passed, no regressions in the parallelizer/callback/settings surfaces this change depends on</code>
- <code>Manual end-user repro of issue #10053 (`repro_10053.py`): evaluated a dspy.Predict actor over an 8-example devset via `thread_safe_evaluator` with the LM supplied ONLY through `dspy.context(lm=...)`, run against the target commit and against the base commit&#39;s `avatar_optimizer.py` swapped in temporarily</code>
- <code>Cleanup verification: restored `uv.lock` (mutated by `uv run`) and the fixed `avatar_optimizer.py`; `git status --porcelain` reports a clean worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

Fixes #10053 