### PR TITLE
fix(adapters): coerce numeric Literal members when parsing plain-text LM output

### DIFF
--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -170,6 +170,19 @@ def parse_value(value, annotation):
             if v in allowed:
                 return v
 
+            # The value may be a non-string literal member (e.g. an int or float) that the LM
+            # rendered as plain text, e.g. "3" for `Literal[1, 2, 3]`. ChatAdapter/XMLAdapter always
+            # hand raw strings to this function, so without this coercion such literals could never
+            # match `allowed` even when the LM's response is otherwise correct.
+            for allowed_value in allowed:
+                if isinstance(allowed_value, bool) or not isinstance(allowed_value, (int, float)):
+                    continue
+                try:
+                    if type(allowed_value)(v) == allowed_value:
+                        return allowed_value
+                except (ValueError, TypeError):
+                    continue
+
         raise ValueError(f"{value!r} is not one of {allowed!r}")
 
     if not isinstance(value, str):

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -77,6 +77,25 @@ def test_parse_value_literal():
         parse_value("invalid", Literal["option1", "option2"])
 
 
+def test_parse_value_literal_numeric():
+    # ChatAdapter/XMLAdapter always hand raw strings to parse_value, so numeric literal
+    # members (e.g. from `Literal[1, 2, 3]`) must be coercible from their plain-text form.
+    assert parse_value("1", Literal[1, 2, 3]) == 1
+    assert parse_value("3", Literal[1, 2, 3]) == 3
+    assert parse_value(2, Literal[1, 2, 3]) == 2
+
+    # Float literals
+    assert parse_value("1.5", Literal[1.5, 2.5]) == 1.5
+
+    # Mixed-type literals: string members should still be matched as strings
+    assert parse_value("yes", Literal["yes", "no", 1]) == "yes"
+    assert parse_value("1", Literal["yes", "no", 1]) == 1
+
+    # Out-of-range values must still raise
+    with pytest.raises(ValueError):
+        parse_value("4", Literal[1, 2, 3])
+
+
 def test_parse_value_union():
     # Test Union with None (Optional)
     assert parse_value("test", Optional[str]) == "test"


### PR DESCRIPTION
## Problem

Signatures with an integer or float `Literal` output field (e.g. `Literal[1, 2, 3, 4, 5]`, a common pattern for rating/classification tasks) fail to parse whenever the response goes through `ChatAdapter` or `XMLAdapter`, even when the LM answers correctly.

```python
class RateSignature(dspy.Signature):
    text: str = dspy.InputField()
    rating: Literal[1, 2, 3, 4, 5] = dspy.OutputField()

adapter = dspy.ChatAdapter()
completion = "[[ ## rating ## ]]\n3\n\n[[ ## completed ## ]]\n"
adapter.parse(RateSignature, completion)
# AdapterParseError: Failed to parse field rating with value 3 from the LM response.
# Error message: '3' is not one of (1, 2, 3, 4, 5)
```

## Root cause

`ChatAdapter.parse()` and `XMLAdapter.parse()` always hand the raw text segment they extract from the completion to `dspy.adapters.utils.parse_value()` as a plain Python `str`. In the `Literal` branch of `parse_value`, the code only checks `value in allowed` plus a few quote/prefix-stripping cases meant for *string* literal members. It never attempts to coerce the string into the type of a non-string literal member, so `"3" in (1, 2, 3, 4, 5)` is always `False` even though `3` is a valid option.

`JSONAdapter` doesn't hit this because `json_repair.loads()` already returns native Python types (e.g. `int 3`), which pass the initial `value in allowed` check directly.

## Fix

In the `Literal` branch of `parse_value` (`dspy/adapters/utils.py`), after the existing string-matching attempts fail, try coercing the (already quote-stripped) string against the type of each non-bool int/float literal member, returning that member if the coercion matches. Out-of-range or otherwise invalid values still raise `ValueError` as before.

## Testing

- Reproduced the bug directly against `ChatAdapter.parse()` with a `Literal[1,2,3,4,5]` output field, confirmed it raises `AdapterParseError` on unmodified code, and confirmed the fix resolves it.
- Used `git stash`/`git stash pop` to confirm the failure reproduces on unmodified code and disappears only with the patch applied.
- Added `test_parse_value_literal_numeric` to `tests/adapters/test_adapter_utils.py`, covering int literals, float literals, mixed string/int literals, and the still-invalid out-of-range case.
- Ran `tests/adapters/test_adapter_utils.py` (7 passed), `tests/adapters/test_chat_adapter.py` (68/69 passed - the one failure, `test_chat_adapter_parses_float_with_underscores`, is a pre-existing `json_repair`-version-dependent failure that reproduces identically on unmodified code and is unrelated to this change), `tests/adapters/test_json_adapter.py` (38 passed), and `tests/adapters/test_xml_adapter.py` (19 passed).
