### PR TITLE
feat(retrievers): add ChromaDB retriever

### DIFF
--- a/dspy/retrievers/chromadb_rm.py
+++ b/dspy/retrievers/chromadb_rm.py
@@ -1,6 +1,5 @@
 import dspy
 from dspy.dsp.utils import dotdict
-from dspy.primitives.prediction import Prediction
 
 try:
     import chromadb
@@ -51,7 +50,7 @@ class ChromadbRM(dspy.Retrieve):
         self._chromadb_collection = self._chromadb_client.get_collection(name=collection_name)
         super().__init__(k=k)
 
-    def forward(self, query_or_queries: str | list[str], k: int | None = None, **kwargs) -> Prediction:
+    def forward(self, query_or_queries: str | list[str], k: int | None = None, **kwargs) -> list[dotdict]:
         """Search with ChromaDB for the top k passages for the given query or queries.
 
         Args:
@@ -59,7 +58,7 @@ class ChromadbRM(dspy.Retrieve):
             k (Optional[int]): The number of top passages to retrieve. Defaults to self.k.
 
         Returns:
-            dspy.Prediction: An object containing the retrieved passages.
+            list[dotdict]: One dotdict per retrieved passage, each with a `long_text` field.
         """
         k = k if k is not None else self.k
         queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries

--- a/dspy/retrievers/chromadb_rm.py
+++ b/dspy/retrievers/chromadb_rm.py
@@ -1,0 +1,72 @@
+import dspy
+from dspy.dsp.utils import dotdict
+from dspy.primitives.prediction import Prediction
+
+try:
+    import chromadb
+except ImportError as err:
+    raise ImportError(
+        "The 'chromadb' extra is required to use ChromadbRM. Install it with `pip install dspy-ai[chromadb]`",
+    ) from err
+
+
+class ChromadbRM(dspy.Retrieve):
+    """A retrieval module that uses ChromaDB to return the top passages for a given query.
+
+    Assumes that a ChromaDB collection has been created and populated with documents, where
+    each document's text is stored as the collection's document content.
+
+    Args:
+        collection_name (str): The name of the ChromaDB collection to search.
+        chromadb_client (chromadb.Client): An instance of the ChromaDB client.
+        k (int, optional): The default number of top passages to retrieve. Defaults to 3.
+
+    Examples:
+        Below is a code snippet that shows how to use ChromaDB as the default retriever:
+        ```python
+        import chromadb
+
+        chromadb_client = chromadb.Client()
+        retriever_model = ChromadbRM("my_collection_name", chromadb_client=chromadb_client)
+        dspy.configure(lm=llm, rm=retriever_model)
+
+        retrieve = dspy.Retrieve(k=1)
+        topK_passages = retrieve("what are the stages in planning, sanctioning and execution of public works").passages
+        ```
+
+        Below is a code snippet that shows how to use ChromaDB in the forward() function of a module
+        ```python
+        self.retrieve = ChromadbRM("my_collection_name", chromadb_client=chromadb_client, k=num_passages)
+        ```
+    """
+
+    def __init__(
+        self,
+        collection_name: str,
+        chromadb_client: chromadb.Client,
+        k: int = 3,
+    ):
+        self._collection_name = collection_name
+        self._chromadb_client = chromadb_client
+        self._chromadb_collection = self._chromadb_client.get_collection(name=collection_name)
+        super().__init__(k=k)
+
+    def forward(self, query_or_queries: str | list[str], k: int | None = None, **kwargs) -> Prediction:
+        """Search with ChromaDB for the top k passages for the given query or queries.
+
+        Args:
+            query_or_queries (Union[str, list[str]]): The query or queries to search for.
+            k (Optional[int]): The number of top passages to retrieve. Defaults to self.k.
+
+        Returns:
+            dspy.Prediction: An object containing the retrieved passages.
+        """
+        k = k if k is not None else self.k
+        queries = [query_or_queries] if isinstance(query_or_queries, str) else query_or_queries
+        queries = [q for q in queries if q]
+        passages = []
+        for query in queries:
+            results = self._chromadb_collection.query(query_texts=[query], n_results=k)
+            parsed_results = results["documents"][0]
+            passages.extend(dotdict({"long_text": d}) for d in parsed_results)
+        return passages

--- a/dspy/retrievers/chromadb_rm.py
+++ b/dspy/retrievers/chromadb_rm.py
@@ -6,7 +6,7 @@ try:
     import chromadb
 except ImportError as err:
     raise ImportError(
-        "The 'chromadb' extra is required to use ChromadbRM. Install it with `pip install dspy-ai[chromadb]`",
+        "The 'chromadb' extra is required to use ChromadbRM. Install it with `pip install dspy[chromadb]`",
     ) from err
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client>=4.5.4,<4.22.0"]
+chromadb = ["chromadb>=0.4.0"]
 mcp = ["mcp; python_version >= '3.10'"]
 langchain = ["langchain_core>=0.3.0"]
 optuna = ["optuna>=3.4.0"]

--- a/tests/retrievers/test_chromadb_rm.py
+++ b/tests/retrievers/test_chromadb_rm.py
@@ -1,0 +1,46 @@
+import sys
+import types
+from unittest.mock import MagicMock
+
+fake_chromadb = types.ModuleType("chromadb")
+fake_chromadb.Client = MagicMock
+sys.modules.setdefault("chromadb", fake_chromadb)
+
+from dspy.retrievers.chromadb_rm import ChromadbRM  # noqa: E402
+
+
+def test_forward_wraps_documents_as_long_text():
+    fake_collection = MagicMock()
+    fake_collection.query.return_value = {"documents": [["doc1", "doc2"]]}
+    fake_client = MagicMock()
+    fake_client.get_collection.return_value = fake_collection
+
+    rm = ChromadbRM("my_collection", fake_client, k=2)
+    result = rm.forward("some query")
+
+    assert [dd["long_text"] for dd in result] == ["doc1", "doc2"]
+
+
+def test_forward_passes_k_to_query():
+    fake_collection = MagicMock()
+    fake_collection.query.return_value = {"documents": [["doc1", "doc2"]]}
+    fake_client = MagicMock()
+    fake_client.get_collection.return_value = fake_collection
+
+    rm = ChromadbRM("my_collection", fake_client, k=2)
+    rm.forward("some query")
+
+    fake_collection.query.assert_called_with(query_texts=["some query"], n_results=2)
+
+
+def test_forward_filters_empty_queries():
+    fake_collection = MagicMock()
+    fake_collection.query.return_value = {"documents": [["doc1", "doc2"]]}
+    fake_client = MagicMock()
+    fake_client.get_collection.return_value = fake_collection
+
+    rm = ChromadbRM("my_collection", fake_client, k=2)
+    rm.forward(["", "real question"])
+
+    assert fake_collection.query.call_count == 1
+    fake_collection.query.assert_called_with(query_texts=["real question"], n_results=2)


### PR DESCRIPTION
## What
Adds `ChromadbRM`, a `Retrieve` module that returns the top-k passages from a ChromaDB collection, mirroring `dspy/retrievers/weaviate_rm.py`.

## Details
`forward()` accepts a query or list of queries (empty strings are filtered out), runs `collection.query(query_texts=[query], n_results=k)` for each, and wraps every returned document as a `dotdict({"long_text": ...})` so results stay interchangeable with other DSPy retrievers. `chromadb` is an optional dependency, guarded by an import check with an install hint.

## Tests
`tests/retrievers/test_chromadb_rm.py` — mocked tests that run `forward()` against a fake ChromaDB client (no live instance): documents are wrapped as `long_text`, `k` is passed through as `n_results`, and empty queries are skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
