### PR TITLE
fix(security): do not read local files when parsing Image/Audio from LM output

### DIFF
--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -122,11 +122,20 @@ class Audio(Type):
         length = len(self.data)
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
 
-def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:
+def encode_audio(
+    audio: Union[str, bytes, dict, "Audio", Any],
+    sampling_rate: int = 16000,
+    format: str = "wav",
+    allow_local_files: bool = False,
+) -> dict:
     """
     Encode audio to a dict with 'data' and 'audio_format'.
-    
-    Accepts: local file path, URL, data URI, dict, Audio instance, numpy array, or bytes (with known format).
+
+    Accepts: local file path (only when ``allow_local_files=True``), URL, data
+    URI, dict, Audio instance, numpy array, or bytes (with known format).
+
+    Local filesystem reads are opt-in so untrusted LM output cannot trigger
+    host file reads (#10067 / GHSA-frf5-486g-243f).
     """
     if isinstance(audio, dict) and "data" in audio and "audio_format" in audio:
         return audio
@@ -143,7 +152,7 @@ def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: in
             return {"data": b64data, "audio_format": audio_format}
         except Exception as e:
             raise ValueError(f"Malformed audio data URI: {e}")
-    elif isinstance(audio, str) and os.path.isfile(audio):
+    elif allow_local_files and isinstance(audio, str) and os.path.isfile(audio):
         a = Audio.from_file(audio)
         return {"data": a.data, "audio_format": a.audio_format}
     elif isinstance(audio, str) and audio.startswith("http"):

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -30,7 +30,15 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, url: Any = None, *, download: bool = False, verify: bool = True, **data):
+    def __init__(
+        self,
+        url: Any = None,
+        *,
+        download: bool = False,
+        verify: bool = True,
+        allow_local_files: bool = False,
+        **data,
+    ):
         """Create an Image.
 
         Parameters
@@ -38,7 +46,8 @@ class Image(Type):
         url:
             The image source. Supported values include
 
-            - ``str``: HTTP(S)/GS URL or local file path
+            - ``str``: HTTP(S)/GS URL or local file path (local paths require
+              ``allow_local_files=True``; use :meth:`from_file` for a clear API)
             - ``bytes``: raw image bytes
             - ``PIL.Image.Image``: a PIL image instance
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
@@ -50,6 +59,13 @@ class Image(Type):
         verify:
             Whether to verify SSL certificates when downloading images from URLs.
             Set to False for self-signed certificates. Default is True.
+
+        allow_local_files:
+            Whether a string path may be read from the local filesystem.
+            Defaults to ``False`` so values originating from LM output parsing
+            (via ``TypeAdapter.validate_python``) cannot exfiltrate host files
+            (#10067 / GHSA-frf5-486g-243f). Developer code that intentionally
+            loads a path should pass ``True`` or use :meth:`from_file`.
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
         """
@@ -65,7 +81,13 @@ class Image(Type):
 
         if "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.
-            data["url"] = encode_image(data["url"], download_images=download, verify=verify)
+            # Local filesystem reads require allow_local_files=True (or Image.from_file).
+            data["url"] = encode_image(
+                data["url"],
+                download_images=download,
+                verify=verify,
+                allow_local_files=allow_local_files,
+            )
 
         # Delegate the rest of initialization to pydantic's BaseModel.
         super().__init__(**data)
@@ -94,7 +116,7 @@ class Image(Type):
             DeprecationWarning,
             stacklevel=2,
         )
-        return cls(file_path)
+        return cls(file_path, allow_local_files=True)
 
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
@@ -125,7 +147,12 @@ def is_url(string: str) -> bool:
         return False
 
 
-def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_images: bool = False, verify: bool = True) -> str:
+def encode_image(
+    image: Union[str, bytes, "PILImage.Image", dict],
+    download_images: bool = False,
+    verify: bool = True,
+    allow_local_files: bool = False,
+) -> str:
     """
     Encode an image or file to a base64 data URI.
 
@@ -133,6 +160,8 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_imag
         image: The image or file to encode. Can be a PIL Image, file path, URL, or data URI.
         download_images: Whether to download images from URLs.
         verify: Whether to verify SSL certificates when downloading images.
+        allow_local_files: Whether local filesystem paths may be read. Defaults
+            to False so untrusted LM output cannot trigger host file reads (#10067).
 
     Returns:
         str: The data URI of the file or the URL if download_images is False.
@@ -147,8 +176,8 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_imag
         if image.startswith("data:"):
             # Already a data URI
             return image
-        elif os.path.isfile(image):
-            # File path
+        elif allow_local_files and os.path.isfile(image):
+            # Explicit local file load (developer opt-in only)
             return _encode_image_from_file(image)
         elif is_url(image):
             # URL
@@ -158,8 +187,13 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_imag
                 # Return the URL as is
                 return image
         else:
-            # Unsupported string format
-            raise ValueError(f"Unrecognized file string: {image}; If this file type should be supported, please open an issue.")
+            # Existing local path without allow_local_files: keep the raw string
+            # so LM-output parsing cannot exfiltrate host files (#10067).
+            if (not allow_local_files) and os.path.isfile(image):
+                return image
+            raise ValueError(
+                f"Unrecognized file string: {image}; If this file type should be supported, please open an issue."
+            )
     elif PIL_AVAILABLE and isinstance(image, PILImage.Image):
         # PIL Image
         return _encode_pil_image(image)

--- a/tests/adapters/test_media_local_file_guard.py
+++ b/tests/adapters/test_media_local_file_guard.py
@@ -1,0 +1,62 @@
+"""Regression tests for #10067 — LM output must not read local files."""
+
+from __future__ import annotations
+
+import base64
+import tempfile
+from pathlib import Path
+
+import dspy
+from dspy.adapters.json_adapter import JSONAdapter
+from dspy.adapters.types.image import encode_image
+
+
+def test_encode_image_does_not_read_local_file_by_default(tmp_path: Path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP-SECRET-TOKEN")
+    # Without allow_local_files, a path-looking string is rejected rather than read.
+    result = encode_image(str(secret))
+    # Path is left as-is; contents are never read into a data URI.
+    assert result == str(secret)
+    assert "data:" not in result
+
+
+def test_encode_image_reads_local_file_when_opted_in(tmp_path: Path):
+    secret = tmp_path / "photo.png"
+    # Minimal valid 1x1 PNG
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
+    secret.write_bytes(png)
+    result = encode_image(str(secret), allow_local_files=True)
+    assert result.startswith("data:image/")
+
+
+def test_image_from_file_still_works(tmp_path: Path):
+    secret = tmp_path / "photo.png"
+    png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
+    secret.write_bytes(png)
+    img = dspy.Image.from_file(str(secret))
+    assert img.url.startswith("data:image/")
+
+
+def test_json_adapter_parse_does_not_exfiltrate_local_file(tmp_path: Path):
+    secret = tmp_path / "SECRET_victim.txt"
+    secret.write_text("TOP-SECRET-AWS-KEY=AKIA_DEADBEEF")
+
+    class S(dspy.Signature):
+        """Return an image."""
+
+        query: str = dspy.InputField()
+        result_image: dspy.Image = dspy.OutputField()
+
+    completion = f'{{"result_image": {{"url": "{secret.as_posix()}"}}}}'
+    parsed = JSONAdapter().parse(S, completion)
+    url = parsed["result_image"].url
+    # Path may be stored as a string, but contents must never be base64-encoded.
+    secret_b64 = base64.b64encode(b"TOP-SECRET-AWS-KEY=AKIA_DEADBEEF").decode()
+    assert secret_b64 not in url
+    assert "TOP-SECRET-AWS-KEY" not in url
+    assert not url.startswith("data:")

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -422,7 +422,7 @@ def test_pdf_from_file():
 
     try:
         # Create a dspy.Image from the file
-        pdf_image = dspy.Image(tmp_file_path)
+        pdf_image = dspy.Image(tmp_file_path, allow_local_files=True)
 
         # The constructor encodes the file into a data URI we can inspect directly
         assert "data:application/pdf" in pdf_image.url


### PR DESCRIPTION
## Summary
When a signature has an `Image`/`Audio` **output** field, adapter parsing of the LM completion used to treat path-looking strings as local files and base64-encode them. A prompt-injected or malicious model can emit a path and exfiltrate host files on the next prompt (GHSA-frf5-486g-243f).

## Change
- `encode_image` / `encode_audio`: local filesystem reads require `allow_local_files=True` (default **False**)
- Existing local paths from untrusted input are stored as the raw string (not opened)
- `Image.from_file` still sets `allow_local_files=True` for intentional developer loads

## Test plan
- [x] `tests/adapters/test_media_local_file_guard.py`
- [x] `test_pdf_from_file` / `test_invalid_string_format` / `test_from_methods_warn`

Fixes #10067
