### PR TITLE
fix(adapters): make resource loading explicit

### DIFF
--- a/docs/docs/api/primitives/Audio.md
+++ b/docs/docs/api/primitives/Audio.md
@@ -10,7 +10,7 @@
             - extract_custom_type_from_annotation
             - format
             - from_array
-            - from_file
+            - from_path
             - from_url
             - is_streamable
             - parse_lm_response

--- a/docs/docs/api/primitives/File.md
+++ b/docs/docs/api/primitives/File.md
@@ -1,7 +1,7 @@
-# dspy.Audio
+# dspy.File
 
 <!-- START_API_REF -->
-::: dspy.Audio
+::: dspy.File
     handler: python
     options:
         members:
@@ -9,15 +9,13 @@
             - description
             - extract_custom_type_from_annotation
             - format
-            - from_array
             - from_bytes
+            - from_file_id
             - from_path
-            - from_url
             - is_streamable
             - parse_lm_response
             - parse_stream_chunk
             - serialize_model
-            - validate_input
         show_source: true
         show_root_heading: true
         heading_level: 2

--- a/docs/docs/api/primitives/Image.md
+++ b/docs/docs/api/primitives/Image.md
@@ -9,8 +9,10 @@
             - description
             - extract_custom_type_from_annotation
             - format
+            - from_bytes
             - from_PIL
             - from_path
+            - from_pil
             - from_url
             - is_streamable
             - parse_lm_response

--- a/docs/docs/api/primitives/Image.md
+++ b/docs/docs/api/primitives/Image.md
@@ -10,7 +10,7 @@
             - extract_custom_type_from_annotation
             - format
             - from_PIL
-            - from_file
+            - from_path
             - from_url
             - is_streamable
             - parse_lm_response

--- a/docs/docs/api/primitives/index.md
+++ b/docs/docs/api/primitives/index.md
@@ -6,6 +6,7 @@ API reference for DSPy primitives. Select a page below.
 - [Audio](Audio.md)
 - [Code](Code.md)
 - [Example](Example.md)
+- [File](File.md)
 - [History](History.md)
 - [Image](Image.md)
 - [Prediction](Prediction.md)

--- a/docs/docs/community/normalized-lm-api-migration.md
+++ b/docs/docs/community/normalized-lm-api-migration.md
@@ -114,7 +114,7 @@ from dspy.core.types import LMImagePart
 with dspy.context(experimental=True):
     response = lm(
         dspy.System("Be concise."),
-        dspy.User("Describe this image.", dspy.Image("https://example.com/dog.png")), #Coming soon!
+        dspy.User("Describe this image.", dspy.Image(url="https://example.com/dog.png")), #Coming soon!
         temperature=0.2,
     )
 ```

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -127,9 +127,9 @@ The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `forma
 
 URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 
-**`dspy.Audio(data, audio_format)`**
+**`dspy.Audio(source)`**
 
-Base64 audio data plus format string (`"wav"`, `"mp3"`), or in-memory bytes/array data. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
+A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
 
 **`dspy.File(file_data=None, file_id=None, filename=None)`**
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -123,14 +123,17 @@ Types adapters know how to render and parse beyond Python’s standard ones. Eac
 **`dspy.adapters.types.Type`**  
 The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `format()` to plug in a new type. Adapters wrap the output of `format()` with `<<CUSTOM-TYPE-START-IDENTIFIER>>...<<END-IDENTIFIER>>` so multi-modal content can be inserted into a single message stream and later split out.
 
-**`dspy.Image(url, download=False, verify=True)`**  
-URL, local path, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). `download=True` fetches the image and base64-encodes it, useful when the LM provider can’t reach the URL.
+**`dspy.Image(url)`**
 
-**`dspy.Audio(data, audio_format)`**  
-Base64 audio data plus format string (`"wav"`, `"mp3"`). Renders as the provider’s audio content block.
+URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 
-**`dspy.File(file_data=None, file_id=None, filename=None)`**  
-Either a data URI or a file ID (some providers preupload files and reference them by ID).
+**`dspy.Audio(data, audio_format)`**
+
+Base64 audio data plus format string (`"wav"`, `"mp3"`), or in-memory bytes/array data. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
+
+**`dspy.File(file_data=None, file_id=None, filename=None)`**
+
+Either in-memory bytes, a data URI, or a file ID (some providers preupload files and reference them by ID). Use `File.from_path(path)` to read a local file.
 
 **`dspy.Code(code, language="python")`**  
 Code with a class-level `language` parameter. `dspy.Code["java"]` produces a Code subclass typed for Java. `format()` returns the raw string — no wrapper, no fencing.

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -123,7 +123,7 @@ Types adapters know how to render and parse beyond Python’s standard ones. Eac
 **`dspy.adapters.types.Type`**  
 The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `format()` to plug in a new type. Adapters wrap the output of `format()` with `<<CUSTOM-TYPE-START-IDENTIFIER>>...<<END-IDENTIFIER>>` so multi-modal content can be inserted into a single message stream and later split out.
 
-**`dspy.Image(url)`**
+**`dspy.Image(source)`**
 
 URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -129,7 +129,7 @@ URL reference or data URI. `format()` returns the provider’s image content blo
 
 **`dspy.Audio(data=..., audio_format=...)`**
 
-Raw base64 audio data and its format. Renders as the provider’s audio content block. Use `Audio.from_path(path)` or the synchronous `Audio.from_url(url)` for resource loading, `Audio.from_bytes(data, audio_format=...)` for raw bytes, or `Audio.from_array(array, sampling_rate, audio_format=...)` for array data.
+Raw base64 audio data and its format. Audio data URIs are also accepted; their format is inferred and their payload is normalized to raw base64. Renders as the provider’s audio content block. Use `Audio.from_path(path)` or the synchronous `Audio.from_url(url)` for resource loading, `Audio.from_bytes(data, audio_format=...)` for raw bytes, or `Audio.from_array(array, sampling_rate, audio_format=...)` for array data.
 
 **`dspy.File(file_data=None, file_id=None, filename=None)`**
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -125,11 +125,11 @@ The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `forma
 
 **`dspy.Image(source)`**
 
-URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
+URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_path(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 
 **`dspy.Audio(source)`**
 
-A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
+A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_path(path)` or `Audio.from_url(url)` for resource loading.
 
 **`dspy.File(file_data=None, file_id=None, filename=None)`**
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -123,17 +123,17 @@ Types adapters know how to render and parse beyond Python’s standard ones. Eac
 **`dspy.adapters.types.Type`**  
 The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `format()` to plug in a new type. Adapters wrap the output of `format()` with `<<CUSTOM-TYPE-START-IDENTIFIER>>...<<END-IDENTIFIER>>` so multi-modal content can be inserted into a single message stream and later split out.
 
-**`dspy.Image(source)`**
+**`dspy.Image(url=...)`**
 
-URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_path(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
+URL reference or data URI. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_path(path)` to read a local file, `Image.from_url(url)` to synchronously download a remote resource, `Image.from_bytes(data)` for encoded image bytes, or `Image.from_pil(image)` for a PIL image.
 
-**`dspy.Audio(source)`**
+**`dspy.Audio(data=..., audio_format=...)`**
 
-A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_path(path)` or `Audio.from_url(url)` for resource loading.
+Raw base64 audio data and its format. Renders as the provider’s audio content block. Use `Audio.from_path(path)` or the synchronous `Audio.from_url(url)` for resource loading, `Audio.from_bytes(data, audio_format=...)` for raw bytes, or `Audio.from_array(array, sampling_rate, audio_format=...)` for array data.
 
 **`dspy.File(file_data=None, file_id=None, filename=None)`**
 
-Either in-memory bytes, a data URI, or a file ID (some providers preupload files and reference them by ID). Use `File.from_path(path)` to read a local file.
+Either a data URI or a file ID (some providers preupload files and reference them by ID). Use `File.from_path(path)` to read a local file, `File.from_bytes(data)` for raw bytes, or `File.from_file_id(id)` for a preuploaded file.
 
 **`dspy.Code(code, language="python")`**  
 Code with a class-level `language` parameter. `dspy.Code["java"]` produces a Code subclass typed for Java. `format()` returns the raw string — no wrapper, no fencing.

--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -164,7 +164,7 @@ class DogPictureSignature(dspy.Signature):
 
 image_url = "https://picsum.photos/id/237/200/300"
 classify = dspy.Predict(DogPictureSignature)
-classify(image_1=dspy.Image.from_url(image_url))
+classify(image_1=dspy.Image(image_url))
 ```
 
 **Possible Output:**

--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -164,7 +164,7 @@ class DogPictureSignature(dspy.Signature):
 
 image_url = "https://picsum.photos/id/237/200/300"
 classify = dspy.Predict(DogPictureSignature)
-classify(image_1=dspy.Image(image_url))
+classify(image_1=dspy.Image(url=image_url))
 ```
 
 **Possible Output:**

--- a/docs/docs/tutorials/audio/index.ipynb
+++ b/docs/docs/tutorials/audio/index.ipynb
@@ -301,7 +301,7 @@
     "            f.write(response.content)\n",
     "    with open(wav_path, \"rb\") as f:\n",
     "        encoded = base64.b64encode(f.read()).decode(\"utf-8\")\n",
-    "    return dspy.Audio(data=encoded, format=\"wav\")"
+    "    return dspy.Audio(data=encoded, audio_format=\"wav\")"
    ]
   },
   {

--- a/docs/docs/tutorials/audio/index.ipynb
+++ b/docs/docs/tutorials/audio/index.ipynb
@@ -514,7 +514,7 @@
     "\n",
     "audio_bytes = base64.b64decode(pred.audio.data)\n",
     "array, rate = sf.read(io.BytesIO(audio_bytes), dtype=\"float32\")\n",
-    "Audio(array, rate=rate)"
+    "Audio.from_array(array, sampling_rate=rate)"
    ]
   },
   {
@@ -687,7 +687,7 @@
     "\n",
     "audio_bytes = base64.b64decode(pred.audio.data)\n",
     "array, rate = sf.read(io.BytesIO(audio_bytes), dtype=\"float32\")\n",
-    "Audio(array, rate=rate)"
+    "Audio.from_array(array, sampling_rate=rate)"
    ]
   },
   {

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
             - Audio: api/primitives/Audio.md
             - Code: api/primitives/Code.md
             - Example: api/primitives/Example.md
+            - File: api/primitives/File.md
             - History: api/primitives/History.md
             - Image: api/primitives/Image.md
             - Prediction: api/primitives/Prediction.md

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -39,16 +39,15 @@ class Audio(Type):
             if "data" in data:
                 raise TypeError("Audio received data as both a positional and keyword argument")
             value = args[0]
-            sampling_rate = data.pop("sampling_rate", 16000)
+            sampling_rate = data.pop("sampling_rate", None)
             audio_format = data.pop("audio_format", None)
-            if audio_format is not None and isinstance(value, str) and not value.startswith("data:audio/"):
-                normalized = {"data": value, "audio_format": audio_format}
-            else:
-                normalized = encode_audio(
-                    value,
-                    sampling_rate=sampling_rate,
-                    format=audio_format or data.pop("format", "wav"),
+            if audio_format is not None and _carries_own_format(value):
+                raise TypeError(
+                    "Audio received audio_format alongside an input that already carries its format; provide only one"
                 )
+            if sampling_rate is not None and not hasattr(value, "shape"):
+                raise TypeError("Audio received sampling_rate for a non-array input; it only applies to array data")
+            normalized = encode_audio(value, sampling_rate=sampling_rate or 16000, format=audio_format or "wav")
             normalized.update(data)
             data = normalized
         super().__init__(**data)
@@ -71,14 +70,18 @@ class Audio(Type):
         return encode_audio(values)
 
     @classmethod
-    def from_url(cls, url: str) -> "Audio":
+    def from_url(cls, url: str, verify: bool = True) -> "Audio":
         """
         Download an audio file from URL and encode it as base64.
+
+        Args:
+            url: The URL of the audio to download.
+            verify: Whether to verify SSL certificates. Set to False for self-signed certs.
         """
         parsed_url = urlparse(url)
         if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
             raise ValueError(f"Audio.from_url requires an HTTP(S) URL, received: {url}")
-        response = requests.get(url)
+        response = requests.get(url, verify=verify)
         response.raise_for_status()
         mime_type = response.headers.get("Content-Type", "audio/wav")
         if not mime_type.startswith("audio/"):
@@ -137,6 +140,15 @@ class Audio(Type):
     def __repr__(self) -> str:
         length = len(self.data)
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
+
+
+def _carries_own_format(value: Any) -> bool:
+    """Whether an audio input already carries its own format (making audio_format redundant)."""
+    if isinstance(value, Audio):
+        return True
+    if isinstance(value, dict) and "audio_format" in value:
+        return True
+    return isinstance(value, str) and value.startswith("data:audio/")
 
 
 def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -3,6 +3,7 @@ import io
 import mimetypes
 import os
 from typing import Any, Union
+from urllib.parse import urlparse
 
 import pydantic
 import requests
@@ -31,19 +32,33 @@ class Audio(Type):
         extra="forbid",
     )
 
+    def __init__(self, *args, **data):
+        if len(args) > 1:
+            raise TypeError(f"Audio expected at most 1 positional argument, received {len(args)}")
+        if args:
+            if "data" in data:
+                raise TypeError("Audio received data as both a positional and keyword argument")
+            value = args[0]
+            sampling_rate = data.pop("sampling_rate", 16000)
+            audio_format = data.pop("audio_format", None)
+            if audio_format is not None and isinstance(value, str) and not value.startswith("data:audio/"):
+                normalized = {"data": value, "audio_format": audio_format}
+            else:
+                normalized = encode_audio(
+                    value,
+                    sampling_rate=sampling_rate,
+                    format=audio_format or data.pop("format", "wav"),
+                )
+            normalized.update(data)
+            data = normalized
+        super().__init__(**data)
+
     def format(self) -> list[dict[str, Any]]:
         try:
             data = self.data
         except Exception as e:
             raise ValueError(f"Failed to format audio for DSPy: {e}")
-        return [{
-            "type": "input_audio",
-            "input_audio": {
-                "data": data,
-                "format": self.audio_format
-            }
-        }]
-
+        return [{"type": "input_audio", "input_audio": {"data": data, "format": self.audio_format}}]
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -60,6 +75,9 @@ class Audio(Type):
         """
         Download an audio file from URL and encode it as base64.
         """
+        parsed_url = urlparse(url)
+        if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
+            raise ValueError(f"Audio.from_url requires an HTTP(S) URL, received: {url}")
         response = requests.get(url)
         response.raise_for_status()
         mime_type = response.headers.get("Content-Type", "audio/wav")
@@ -95,9 +113,7 @@ class Audio(Type):
         return cls(data=encoded_data, audio_format=audio_format)
 
     @classmethod
-    def from_array(
-        cls, array: Any, sampling_rate: int, format: str = "wav"
-    ) -> "Audio":
+    def from_array(cls, array: Any, sampling_rate: int, format: str = "wav") -> "Audio":
         """
         Process numpy-like array and encode it as base64. Uses sampling rate and audio format for encoding.
         """
@@ -122,33 +138,29 @@ class Audio(Type):
         length = len(self.data)
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
 
+
 def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:
     """
     Encode audio to a dict with 'data' and 'audio_format'.
-    
-    Accepts: local file path, URL, data URI, dict, Audio instance, numpy array, or bytes (with known format).
+
+    Accepts in-memory data: data URI, dict, Audio instance, numpy array, or bytes.
     """
     if isinstance(audio, dict) and "data" in audio and "audio_format" in audio:
         return audio
     elif isinstance(audio, Audio):
         return {"data": audio.data, "audio_format": audio.audio_format}
     elif isinstance(audio, str) and audio.startswith("data:audio/"):
-        try:
-            header, b64data = audio.split(",", 1)
-            mime = header.split(";")[0].split(":")[1]
-            audio_format = mime.split("/")[1]
-
-            audio_format = _normalize_audio_format(audio_format)
-
-            return {"data": b64data, "audio_format": audio_format}
-        except Exception as e:
-            raise ValueError(f"Malformed audio data URI: {e}")
-    elif isinstance(audio, str) and os.path.isfile(audio):
-        a = Audio.from_file(audio)
-        return {"data": a.data, "audio_format": a.audio_format}
-    elif isinstance(audio, str) and audio.startswith("http"):
-        a = Audio.from_url(audio)
-        return {"data": a.data, "audio_format": a.audio_format}
+        header, separator, b64data = audio.partition(",")
+        mime = header.removeprefix("data:").split(";", 1)[0]
+        _, format_separator, audio_format = mime.partition("/")
+        if not separator or not format_separator or not audio_format:
+            raise ValueError("Malformed audio data URI")
+        return {"data": b64data, "audio_format": _normalize_audio_format(audio_format)}
+    elif isinstance(audio, str):
+        raise ValueError(
+            "String audio inputs must be data URIs. "
+            "Load local files with Audio.from_file() and remote resources with Audio.from_url()."
+        )
     elif SF_AVAILABLE and hasattr(audio, "shape"):
         a = Audio.from_array(audio, sampling_rate=sampling_rate, format=format)
         return {"data": a.data, "audio_format": a.audio_format}

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -135,7 +135,7 @@ class Audio(Type):
     def from_file(cls, file_path: str) -> "Audio":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Audio.from_file is deprecated and will be removed in 3.5; use Audio.from_path instead.",
+            "Audio.from_file is deprecated and will be removed in 3.4; use Audio.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -74,6 +74,12 @@ class Audio(Type):
         """
         Download an audio file from URL and encode it as base64.
 
+        Security: this performs an explicit, caller-initiated fetch and applies no
+        SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
+        will reach private, loopback, or cloud-metadata hosts and follow redirects to
+        them. When ``url`` is derived from untrusted input, the caller is responsible
+        for validating the host against an allowlist before calling this method.
+
         Args:
             url: The URL of the audio to download.
             verify: Whether to verify SSL certificates. Set to False for self-signed certs.

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -25,6 +25,15 @@ def _normalize_audio_format(audio_format: str) -> str:
 
 
 class Audio(Type):
+    """An audio input type for DSPy.
+
+    Construct from in-memory values only: a data URI string, raw ``bytes`` (with
+    ``audio_format=``), a numpy-like array, a ``{"data", "audio_format"}`` dict, or another
+    ``Audio``. Raw base64 is passed as ``Audio(data=..., audio_format=...)``. Construction and
+    adapter parsing never access the filesystem or network; use :meth:`from_path` to read a local
+    file, :meth:`from_url` to download a remote resource, or :meth:`from_array` for array data.
+    """
+
     data: str
     audio_format: str
 
@@ -126,7 +135,7 @@ class Audio(Type):
     def from_file(cls, file_path: str) -> "Audio":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Audio.from_file is deprecated; use Audio.from_path instead.",
+            "Audio.from_file is deprecated and will be removed in 3.5; use Audio.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -27,11 +27,10 @@ def _normalize_audio_format(audio_format: str) -> str:
 class Audio(Type):
     """An audio input type for DSPy.
 
-    Construct from in-memory values only: a data URI string, raw ``bytes`` (with
-    ``audio_format=``), a numpy-like array, a ``{"data", "audio_format"}`` dict, or another
-    ``Audio``. Raw base64 is passed as ``Audio(data=..., audio_format=...)``. Construction and
-    adapter parsing never access the filesystem or network; use :meth:`from_path` to read a local
-    file, :meth:`from_url` to download a remote resource, or :meth:`from_array` for array data.
+    Raw base64 is passed as ``Audio(data=..., audio_format=...)``. Construction and adapter
+    parsing never access the filesystem or network; use :meth:`from_path` to read a local file,
+    :meth:`from_url` to download a remote resource, :meth:`from_bytes` for audio bytes, or
+    :meth:`from_array` for array data.
     """
 
     data: str
@@ -42,25 +41,12 @@ class Audio(Type):
         extra="forbid",
     )
 
-    def __init__(self, *args, **data):
-        if len(args) > 1:
-            raise TypeError(f"Audio expected at most 1 positional argument, received {len(args)}")
-        if args:
-            if "data" in data:
-                raise TypeError("Audio received data as both a positional and keyword argument")
-            value = args[0]
-            sampling_rate = data.pop("sampling_rate", None)
-            audio_format = data.pop("audio_format", None)
-            if audio_format is not None and _carries_own_format(value):
-                raise TypeError(
-                    "Audio received audio_format alongside an input that already carries its format; provide only one"
-                )
-            if sampling_rate is not None and not hasattr(value, "shape"):
-                raise TypeError("Audio received sampling_rate for a non-array input; it only applies to array data")
-            normalized = encode_audio(value, sampling_rate=sampling_rate or 16000, format=audio_format or "wav")
-            normalized.update(data)
-            data = normalized
-        super().__init__(**data)
+    @pydantic.field_validator("audio_format")
+    @classmethod
+    def validate_audio_format(cls, value: str) -> str:
+        if not value:
+            raise ValueError("audio_format must be a non-empty string")
+        return _normalize_audio_format(value)
 
     def format(self) -> list[dict[str, Any]]:
         try:
@@ -77,12 +63,22 @@ class Audio(Type):
         """
         if isinstance(values, cls):
             return {"data": values.data, "audio_format": values.audio_format}
-        return encode_audio(values)
+        if isinstance(values, dict):
+            return dict(values)
+        raise ValueError("Audio must be constructed from data and audio_format fields or an explicit from_* factory")
 
     @classmethod
-    def from_url(cls, url: str, verify: bool = True) -> "Audio":
+    def from_url(
+        cls,
+        url: str,
+        *,
+        timeout: float | tuple[float, float] = 30.0,
+        verify: bool | str = True,
+    ) -> "Audio":
         """
         Download an audio file from URL and encode it as base64.
+
+        This is a synchronous, blocking network operation.
 
         Security: this performs an explicit, caller-initiated fetch and applies no
         SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
@@ -92,57 +88,56 @@ class Audio(Type):
 
         Args:
             url: The URL of the audio to download.
+            timeout: Connection and read timeout in seconds, either as one value or a tuple.
             verify: Whether to verify SSL certificates. Set to False for self-signed certs.
         """
         parsed_url = urlparse(url)
         if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
             raise ValueError(f"Audio.from_url requires an HTTP(S) URL, received: {url}")
-        response = requests.get(url, verify=verify)
+        response = requests.get(url, timeout=timeout, verify=verify)
         response.raise_for_status()
-        mime_type = response.headers.get("Content-Type", "audio/wav")
+        mime_type = response.headers.get("Content-Type", "audio/wav").split(";", 1)[0].strip().lower()
         if not mime_type.startswith("audio/"):
             raise ValueError(f"Unsupported MIME type for audio: {mime_type}")
-        audio_format = mime_type.split("/")[1]
-
-        audio_format = _normalize_audio_format(audio_format)
-
-        encoded_data = base64.b64encode(response.content).decode("utf-8")
-        return cls(data=encoded_data, audio_format=audio_format)
+        audio_format = _normalize_audio_format(mime_type.split("/", 1)[1])
+        return cls.from_bytes(response.content, audio_format=audio_format)
 
     @classmethod
-    def from_path(cls, file_path: str) -> "Audio":
+    def from_path(cls, path: str | os.PathLike[str]) -> "Audio":
         """
         Read local audio file and encode it as base64.
         """
-        if not os.path.isfile(file_path):
-            raise ValueError(f"File not found: {file_path}")
+        with open(path, "rb") as file:
+            file_data = file.read()
 
-        mime_type, _ = mimetypes.guess_type(file_path)
+        path_string = os.fspath(path)
+        mime_type, _ = mimetypes.guess_type(path_string)
         if not mime_type or not mime_type.startswith("audio/"):
             raise ValueError(f"Unsupported MIME type for audio: {mime_type}")
 
-        with open(file_path, "rb") as file:
-            file_data = file.read()
-
-        audio_format = mime_type.split("/")[1]
-
-        audio_format = _normalize_audio_format(audio_format)
-
-        encoded_data = base64.b64encode(file_data).decode("utf-8")
-        return cls(data=encoded_data, audio_format=audio_format)
+        audio_format = _normalize_audio_format(mime_type.split("/", 1)[1])
+        return cls.from_bytes(file_data, audio_format=audio_format)
 
     @classmethod
-    def from_file(cls, file_path: str) -> "Audio":
+    def from_bytes(cls, audio_bytes: bytes, *, audio_format: str) -> "Audio":
+        """Create Audio from raw bytes with an explicit format."""
+        if not audio_format:
+            raise ValueError("audio_format must be a non-empty string")
+        encoded_data = base64.b64encode(audio_bytes).decode("utf-8")
+        return cls(data=encoded_data, audio_format=_normalize_audio_format(audio_format))
+
+    @classmethod
+    def from_file(cls, path: str | os.PathLike[str]) -> "Audio":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
             "Audio.from_file is deprecated and will be removed in 3.4; use Audio.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return cls.from_path(file_path)
+        return cls.from_path(path)
 
     @classmethod
-    def from_array(cls, array: Any, sampling_rate: int, format: str = "wav") -> "Audio":
+    def from_array(cls, array: Any, sampling_rate: int, *, audio_format: str = "wav") -> "Audio":
         """
         Process numpy-like array and encode it as base64. Uses sampling rate and audio format for encoding.
         """
@@ -154,11 +149,10 @@ class Audio(Type):
             byte_buffer,
             array,
             sampling_rate,
-            format=format.upper(),
+            format=audio_format.upper(),
             subtype="PCM_16",
         )
-        encoded_data = base64.b64encode(byte_buffer.getvalue()).decode("utf-8")
-        return cls(data=encoded_data, audio_format=format)
+        return cls.from_bytes(byte_buffer.getvalue(), audio_format=audio_format)
 
     def __str__(self) -> str:
         return self.serialize_model()
@@ -168,23 +162,19 @@ class Audio(Type):
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
 
 
-def _carries_own_format(value: Any) -> bool:
-    """Whether an audio input already carries its own format (making audio_format redundant)."""
-    if isinstance(value, Audio):
-        return True
-    if isinstance(value, dict) and "audio_format" in value:
-        return True
-    return isinstance(value, str) and value.startswith("data:audio/")
-
-
-def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:
+def encode_audio(
+    audio: Union[str, bytes, dict, "Audio", Any],
+    *,
+    sampling_rate: int | None = None,
+    audio_format: str | None = None,
+) -> dict:
     """
     Encode audio to a dict with 'data' and 'audio_format'.
 
     Accepts in-memory data: data URI, dict, Audio instance, numpy array, or bytes.
     """
     if isinstance(audio, dict) and "data" in audio and "audio_format" in audio:
-        return audio
+        return dict(audio)
     elif isinstance(audio, Audio):
         return {"data": audio.data, "audio_format": audio.audio_format}
     elif isinstance(audio, str) and audio.startswith("data:audio/"):
@@ -200,10 +190,15 @@ def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: in
             "Load local files with Audio.from_path() and remote resources with Audio.from_url()."
         )
     elif SF_AVAILABLE and hasattr(audio, "shape"):
-        a = Audio.from_array(audio, sampling_rate=sampling_rate, format=format)
+        if sampling_rate is None:
+            raise ValueError("sampling_rate is required for array audio inputs")
+        array_format = "wav" if audio_format is None else audio_format
+        a = Audio.from_array(audio, sampling_rate=sampling_rate, audio_format=array_format)
         return {"data": a.data, "audio_format": a.audio_format}
     elif isinstance(audio, bytes):
-        encoded = base64.b64encode(audio).decode("utf-8")
-        return {"data": encoded, "audio_format": format}
+        if audio_format is None:
+            raise ValueError("audio_format is required for byte audio inputs")
+        a = Audio.from_bytes(audio, audio_format=audio_format)
+        return {"data": a.data, "audio_format": a.audio_format}
     else:
         raise ValueError(f"Unsupported type for encode_audio: {type(audio)}")

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import io
 import mimetypes
 import os
@@ -24,13 +25,39 @@ def _normalize_audio_format(audio_format: str) -> str:
     return audio_format.removeprefix("x-")
 
 
+def _validate_base64_audio_data(data: str) -> str:
+    if not data:
+        raise ValueError("Audio data must be non-empty base64 or an audio data URI")
+    try:
+        base64.b64decode(data, validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise ValueError("Audio data must be valid base64 or an audio data URI") from error
+    return data
+
+
+def _parse_audio_data_uri(data_uri: str) -> tuple[str, str]:
+    header, separator, data = data_uri.partition(",")
+    media_type, *parameters = header.removeprefix("data:").split(";")
+    media_category, format_separator, audio_format = media_type.partition("/")
+    if (
+        not separator
+        or media_category.lower() != "audio"
+        or not format_separator
+        or not audio_format
+        or "base64" not in {parameter.lower() for parameter in parameters}
+    ):
+        raise ValueError("Audio data URI must have the form data:audio/<format>;base64,<base64_data>")
+    return _validate_base64_audio_data(data), _normalize_audio_format(audio_format.lower())
+
+
 class Audio(Type):
     """An audio input type for DSPy.
 
-    Raw base64 is passed as ``Audio(data=..., audio_format=...)``. Construction and adapter
-    parsing never access the filesystem or network; use :meth:`from_path` to read a local file,
-    :meth:`from_url` to download a remote resource, :meth:`from_bytes` for audio bytes, or
-    :meth:`from_array` for array data.
+    Raw base64 is passed as ``Audio(data=..., audio_format=...)``. An audio data URI may instead be
+    passed as ``Audio(data=...)``; its format is inferred and its payload is normalized to raw
+    base64. Construction and adapter parsing never access the filesystem or network; use
+    :meth:`from_path` to read a local file, :meth:`from_url` to download a remote resource,
+    :meth:`from_bytes` for audio bytes, or :meth:`from_array` for array data.
     """
 
     data: str
@@ -48,6 +75,11 @@ class Audio(Type):
             raise ValueError("audio_format must be a non-empty string")
         return _normalize_audio_format(value)
 
+    @pydantic.field_validator("data")
+    @classmethod
+    def validate_data(cls, value: str) -> str:
+        return _validate_base64_audio_data(value)
+
     def format(self) -> list[dict[str, Any]]:
         try:
             data = self.data
@@ -64,7 +96,22 @@ class Audio(Type):
         if isinstance(values, cls):
             return {"data": values.data, "audio_format": values.audio_format}
         if isinstance(values, dict):
-            return dict(values)
+            normalized_values = dict(values)
+            data = normalized_values.get("data")
+            if isinstance(data, str) and data.startswith("data:"):
+                normalized_data, uri_format = _parse_audio_data_uri(data)
+                declared_format = normalized_values.get("audio_format")
+                if isinstance(declared_format, str):
+                    if _normalize_audio_format(declared_format).lower() != uri_format:
+                        raise ValueError(
+                            f"audio_format {declared_format!r} does not match data URI format {uri_format!r}"
+                        )
+                elif declared_format is not None:
+                    normalized_values["data"] = normalized_data
+                    return normalized_values
+                normalized_values["data"] = normalized_data
+                normalized_values["audio_format"] = uri_format
+            return normalized_values
         raise ValueError("Audio must be constructed from data and audio_format fields or an explicit from_* factory")
 
     @classmethod
@@ -173,17 +220,14 @@ def encode_audio(
 
     Accepts in-memory data: data URI, dict, Audio instance, numpy array, or bytes.
     """
-    if isinstance(audio, dict) and "data" in audio and "audio_format" in audio:
-        return dict(audio)
+    if isinstance(audio, dict):
+        encoded_audio = Audio(**audio)
+        return {"data": encoded_audio.data, "audio_format": encoded_audio.audio_format}
     elif isinstance(audio, Audio):
         return {"data": audio.data, "audio_format": audio.audio_format}
-    elif isinstance(audio, str) and audio.startswith("data:audio/"):
-        header, separator, b64data = audio.partition(",")
-        mime = header.removeprefix("data:").split(";", 1)[0]
-        _, format_separator, audio_format = mime.partition("/")
-        if not separator or not format_separator or not audio_format:
-            raise ValueError("Malformed audio data URI")
-        return {"data": b64data, "audio_format": _normalize_audio_format(audio_format)}
+    elif isinstance(audio, str) and audio.startswith("data:"):
+        encoded_audio = Audio(data=audio)
+        return {"data": encoded_audio.data, "audio_format": encoded_audio.audio_format}
     elif isinstance(audio, str):
         raise ValueError(
             "String audio inputs must be data URIs. "

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -2,6 +2,7 @@ import base64
 import io
 import mimetypes
 import os
+import warnings
 from typing import Any, Union
 from urllib.parse import urlparse
 
@@ -100,7 +101,7 @@ class Audio(Type):
         return cls(data=encoded_data, audio_format=audio_format)
 
     @classmethod
-    def from_file(cls, file_path: str) -> "Audio":
+    def from_path(cls, file_path: str) -> "Audio":
         """
         Read local audio file and encode it as base64.
         """
@@ -120,6 +121,16 @@ class Audio(Type):
 
         encoded_data = base64.b64encode(file_data).decode("utf-8")
         return cls(data=encoded_data, audio_format=audio_format)
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "Audio":
+        """Deprecated alias for :meth:`from_path`."""
+        warnings.warn(
+            "Audio.from_file is deprecated; use Audio.from_path instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.from_path(file_path)
 
     @classmethod
     def from_array(cls, array: Any, sampling_rate: int, format: str = "wav") -> "Audio":
@@ -177,7 +188,7 @@ def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: in
     elif isinstance(audio, str):
         raise ValueError(
             "String audio inputs must be data URIs. "
-            "Load local files with Audio.from_file() and remote resources with Audio.from_url()."
+            "Load local files with Audio.from_path() and remote resources with Audio.from_url()."
         )
     elif SF_AVAILABLE and hasattr(audio, "shape"):
         a = Audio.from_array(audio, sampling_rate=sampling_rate, format=format)

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -44,6 +44,11 @@ class File(Type):
             raise TypeError(f"File expected at most 1 positional argument, received {len(args)}")
         if args:
             normalized = encode_file_to_dict(args[0])
+            overlap = sorted(set(normalized) & set(data))
+            if overlap:
+                raise TypeError(
+                    f"File received {', '.join(overlap)} from both the positional source and keyword arguments"
+                )
             normalized.update(data)
             data = normalized
         super().__init__(**data)
@@ -155,7 +160,7 @@ def encode_file_to_dict(file_input: Any) -> dict:
     Encode various file inputs to a dict with file_data, file_id, and/or filename.
 
     Args:
-        file_input: Can be bytes, a structured dictionary, or a File instance.
+        file_input: Can be bytes, a data URI string, a structured dictionary, or a File instance.
 
     Returns:
         dict: A dictionary with file_data, file_id, and/or filename keys.
@@ -176,7 +181,12 @@ def encode_file_to_dict(file_input: Any) -> dict:
         raise ValueError("Value of `dspy.File` must contain at least one of: file_data, file_id, or filename")
 
     elif isinstance(file_input, str):
-        raise ValueError(f"String file inputs are not supported: {file_input}. Load local files with File.from_path().")
+        if file_input.startswith("data:"):
+            return {"file_data": file_input}
+        raise ValueError(
+            f"String file inputs must be data URIs, received: {file_input}. "
+            "Load local files with File.from_path()."
+        )
 
     elif isinstance(file_input, bytes):
         file_obj = File.from_bytes(file_input)

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -39,6 +39,15 @@ class File(Type):
         extra="forbid",
     )
 
+    def __init__(self, *args, **data):
+        if len(args) > 1:
+            raise TypeError(f"File expected at most 1 positional argument, received {len(args)}")
+        if args:
+            normalized = encode_file_to_dict(args[0])
+            normalized.update(data)
+            data = normalized
+        super().__init__(**data)
+
     @pydantic.model_validator(mode="before")
     @classmethod
     def validate_input(cls, values: Any) -> Any:
@@ -79,7 +88,9 @@ class File(Type):
             if self.file_data.startswith("data:"):
                 # file data has "data:text/plain;base64,..." format
                 mime_type = self.file_data.split(";")[0].split(":")[1]
-                len_data = len(self.file_data.split("base64,")[1]) if "base64," in self.file_data else len(self.file_data)
+                len_data = (
+                    len(self.file_data.split("base64,")[1]) if "base64," in self.file_data else len(self.file_data)
+                )
                 parts.append(f"file_data=<DATA_URI({mime_type}, {len_data} chars)>")
             else:
                 len_data = len(self.file_data)
@@ -144,7 +155,7 @@ def encode_file_to_dict(file_input: Any) -> dict:
     Encode various file inputs to a dict with file_data, file_id, and/or filename.
 
     Args:
-        file_input: Can be a file path (str), bytes, or File instance.
+        file_input: Can be bytes, a structured dictionary, or a File instance.
 
     Returns:
         dict: A dictionary with file_data, file_id, and/or filename keys.
@@ -159,16 +170,13 @@ def encode_file_to_dict(file_input: Any) -> dict:
             result["filename"] = file_input.filename
         return result
 
-    elif isinstance(file_input, str):
-        if os.path.isfile(file_input):
-            file_obj = File.from_path(file_input)
-        else:
-            raise ValueError(f"Unrecognized file string: {file_input}; must be a valid file path")
+    elif isinstance(file_input, dict):
+        if "file_data" in file_input or "file_id" in file_input or "filename" in file_input:
+            return file_input
+        raise ValueError("Value of `dspy.File` must contain at least one of: file_data, file_id, or filename")
 
-        return {
-            "file_data": file_obj.file_data,
-            "filename": file_obj.filename,
-        }
+    elif isinstance(file_input, str):
+        raise ValueError(f"String file inputs are not supported: {file_input}. Load local files with File.from_path().")
 
     elif isinstance(file_input, bytes):
         file_obj = File.from_bytes(file_input)

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 import mimetypes
 import os
 from typing import Any
@@ -42,6 +43,27 @@ class File(Type):
         validate_assignment=True,
         extra="forbid",
     )
+
+    @pydantic.field_validator("file_data")
+    @classmethod
+    def validate_file_data(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+
+        header, separator, data = value.partition(",")
+        media_type, *parameters = header.removeprefix("data:").split(";")
+        if (
+            not value.startswith("data:")
+            or not separator
+            or not media_type
+            or "base64" not in {parameter.lower() for parameter in parameters}
+        ):
+            raise ValueError("file_data must have the form data:<mime_type>;base64,<base64_data>")
+        try:
+            base64.b64decode(data, validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise ValueError("file_data must contain valid base64 data") from error
+        return value
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -174,13 +196,12 @@ def encode_file_to_dict(file_input: Any) -> dict:
         return result
 
     elif isinstance(file_input, dict):
-        if "file_data" in file_input or "file_id" in file_input or "filename" in file_input:
-            return dict(file_input)
-        raise ValueError("Value of `dspy.File` must contain at least one of: file_data, file_id, or filename")
+        file_obj = File(**file_input)
+        return encode_file_to_dict(file_obj)
 
     elif isinstance(file_input, str):
         if file_input.startswith("data:"):
-            return {"file_data": file_input}
+            return {"file_data": File(file_data=file_input).file_data}
         raise ValueError(
             f"String file inputs must be data URIs, received: {file_input}. Load local files with File.from_path()."
         )

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -15,6 +15,11 @@ class File(Type):
     The file_data field should be a data URI with the format:
         data:<mime_type>;base64,<base64_encoded_data>
 
+    Construct from in-memory values only: raw ``bytes``, a data URI string, a
+    ``{"file_data"|"file_id"|"filename"}`` dict, or another ``File``. Construction and adapter
+    parsing never access the filesystem; use :meth:`from_path` to read a local file,
+    :meth:`from_bytes` for raw bytes, or :meth:`from_file_id` to reference a preuploaded file.
+
     Examples:
         ```python
         import dspy

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -15,10 +15,9 @@ class File(Type):
     The file_data field should be a data URI with the format:
         data:<mime_type>;base64,<base64_encoded_data>
 
-    Construct from in-memory values only: raw ``bytes``, a data URI string, a
-    ``{"file_data"|"file_id"|"filename"}`` dict, or another ``File``. Construction and adapter
-    parsing never access the filesystem; use :meth:`from_path` to read a local file,
-    :meth:`from_bytes` for raw bytes, or :meth:`from_file_id` to reference a preuploaded file.
+    Construction and adapter parsing never access the filesystem; use :meth:`from_path` to read a
+    local file, :meth:`from_bytes` for raw bytes, or :meth:`from_file_id` to reference a preuploaded
+    file.
 
     Examples:
         ```python
@@ -44,20 +43,6 @@ class File(Type):
         extra="forbid",
     )
 
-    def __init__(self, *args, **data):
-        if len(args) > 1:
-            raise TypeError(f"File expected at most 1 positional argument, received {len(args)}")
-        if args:
-            normalized = encode_file_to_dict(args[0])
-            overlap = sorted(set(normalized) & set(data))
-            if overlap:
-                raise TypeError(
-                    f"File received {', '.join(overlap)} from both the positional source and keyword arguments"
-                )
-            normalized.update(data)
-            data = normalized
-        super().__init__(**data)
-
     @pydantic.model_validator(mode="before")
     @classmethod
     def validate_input(cls, values: Any) -> Any:
@@ -70,10 +55,10 @@ class File(Type):
 
         if isinstance(values, dict):
             if "file_data" in values or "file_id" in values or "filename" in values:
-                return values
+                return dict(values)
             raise ValueError("Value of `dspy.File` must contain at least one of: file_data, file_id, or filename")
 
-        return encode_file_to_dict(values)
+        raise ValueError("File must be constructed from named fields or an explicit from_* factory")
 
     def format(self) -> list[dict[str, Any]]:
         try:
@@ -112,25 +97,29 @@ class File(Type):
         return f"File({', '.join(parts)})"
 
     @classmethod
-    def from_path(cls, file_path: str, filename: str | None = None, mime_type: str | None = None) -> "File":
+    def from_path(
+        cls,
+        path: str | os.PathLike[str],
+        *,
+        filename: str | None = None,
+        mime_type: str | None = None,
+    ) -> "File":
         """Create a File from a local file path.
 
         Args:
-            file_path: Path to the file to read
+            path: Path to the file to read
             filename: Optional filename to use (defaults to basename of path)
             mime_type: Optional MIME type (defaults to auto-detection from file extension)
         """
-        if not os.path.isfile(file_path):
-            raise ValueError(f"File not found: {file_path}")
-
-        with open(file_path, "rb") as f:
+        with open(path, "rb") as f:
             file_bytes = f.read()
 
+        path_string = os.fspath(path)
         if filename is None:
-            filename = os.path.basename(file_path)
+            filename = os.path.basename(path_string)
 
         if mime_type is None:
-            mime_type, _ = mimetypes.guess_type(file_path)
+            mime_type, _ = mimetypes.guess_type(path_string)
             if mime_type is None:
                 mime_type = "application/octet-stream"
 
@@ -141,7 +130,11 @@ class File(Type):
 
     @classmethod
     def from_bytes(
-        cls, file_bytes: bytes, filename: str | None = None, mime_type: str = "application/octet-stream"
+        cls,
+        file_bytes: bytes,
+        *,
+        filename: str | None = None,
+        mime_type: str = "application/octet-stream",
     ) -> "File":
         """Create a File from raw bytes.
 
@@ -155,7 +148,7 @@ class File(Type):
         return cls(file_data=file_data, filename=filename)
 
     @classmethod
-    def from_file_id(cls, file_id: str, filename: str | None = None) -> "File":
+    def from_file_id(cls, file_id: str, *, filename: str | None = None) -> "File":
         """Create a File from an uploaded file ID."""
         return cls(file_id=file_id, filename=filename)
 
@@ -182,15 +175,14 @@ def encode_file_to_dict(file_input: Any) -> dict:
 
     elif isinstance(file_input, dict):
         if "file_data" in file_input or "file_id" in file_input or "filename" in file_input:
-            return file_input
+            return dict(file_input)
         raise ValueError("Value of `dspy.File` must contain at least one of: file_data, file_id, or filename")
 
     elif isinstance(file_input, str):
         if file_input.startswith("data:"):
             return {"file_data": file_input}
         raise ValueError(
-            f"String file inputs must be data URIs, received: {file_input}. "
-            "Load local files with File.from_path()."
+            f"String file inputs must be data URIs, received: {file_input}. Load local files with File.from_path()."
         )
 
     elif isinstance(file_input, bytes):

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -14,6 +14,7 @@ from dspy.adapters.types.base_type import Type
 
 try:
     from PIL import Image as PILImage
+    from PIL import UnidentifiedImageError
 
     PIL_AVAILABLE = True
 except ImportError:
@@ -86,6 +87,8 @@ class Image(Type):
     @classmethod
     def from_file(cls, file_path: str) -> "Image":
         """Read a local file and encode it as a data URI."""
+        if not os.path.isfile(file_path):
+            raise ValueError(f"File not found: {file_path}")
         return cls(_encode_image_from_file(file_path))
 
     @classmethod
@@ -156,7 +159,10 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
         # Raw bytes
         if not PIL_AVAILABLE:
             raise ImportError("Pillow is required to process image bytes.")
-        img = PILImage.open(io.BytesIO(image))
+        try:
+            img = PILImage.open(io.BytesIO(image))
+        except UnidentifiedImageError as e:
+            raise ValueError(f"Bytes could not be identified as an image: {e}") from e
         return _encode_pil_image(img)
     elif isinstance(image, Image):
         return image.url

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -30,7 +30,7 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, url: Any = None, *, download: bool = False, verify: bool = True, **data):
+    def __init__(self, url: Any = None, **data):
         """Create an Image.
 
         Parameters
@@ -38,20 +38,16 @@ class Image(Type):
         url:
             The image source. Supported values include
 
-            - ``str``: HTTP(S)/GS URL or local file path
+            - ``str``: HTTP(S)/GS URL or an encoded data URI
             - ``bytes``: raw image bytes
             - ``PIL.Image.Image``: a PIL image instance
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
 
-        download:
-            Whether remote URLs should be downloaded to infer their MIME type.
-
-        verify:
-            Whether to verify SSL certificates when downloading images from URLs.
-            Set to False for self-signed certificates. Default is True.
-
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
+
+        Local files and remote resources must be loaded explicitly with
+        :meth:`from_file` and :meth:`from_url`, respectively.
         """
 
         if url is not None and "url" not in data:
@@ -65,7 +61,7 @@ class Image(Type):
 
         if "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.
-            data["url"] = encode_image(data["url"], download_images=download, verify=verify)
+            data["url"] = encode_image(data["url"])
 
         # Delegate the rest of initialization to pydantic's BaseModel.
         super().__init__(**data)
@@ -79,22 +75,16 @@ class Image(Type):
         return [{"type": "image_url", "image_url": {"url": image_url}}]
 
     @classmethod
-    def from_url(cls, url: str, download: bool = False):
-        warnings.warn(
-            "Image.from_url is deprecated; use Image(url) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls(url, download=download)
+    def from_url(cls, url: str, verify: bool = True) -> "Image":
+        """Download an HTTP(S) resource and encode it as a data URI."""
+        if not _is_http_url(url):
+            raise ValueError(f"Image.from_url requires an HTTP(S) URL, received: {url}")
+        return cls(_encode_image_from_url(url, verify=verify))
 
     @classmethod
-    def from_file(cls, file_path: str):
-        warnings.warn(
-            "Image.from_file is deprecated; use Image(file_path) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls(file_path)
+    def from_file(cls, file_path: str) -> "Image":
+        """Read a local file and encode it as a data URI."""
+        return cls(_encode_image_from_file(file_path))
 
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
@@ -125,41 +115,38 @@ def is_url(string: str) -> bool:
         return False
 
 
-def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_images: bool = False, verify: bool = True) -> str:
+def _is_http_url(string: str) -> bool:
+    """Check if a string is an HTTP(S) URL."""
+    try:
+        result = urlparse(string)
+        return result.scheme in ("http", "https") and bool(result.netloc)
+    except ValueError:
+        return False
+
+
+def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
     """
-    Encode an image or file to a base64 data URI.
+    Normalize an in-memory image or preserve a remote image reference.
 
     Args:
-        image: The image or file to encode. Can be a PIL Image, file path, URL, or data URI.
-        download_images: Whether to download images from URLs.
-        verify: Whether to verify SSL certificates when downloading images.
+        image: A PIL Image, bytes, URL reference, data URI, or Image.
 
     Returns:
-        str: The data URI of the file or the URL if download_images is False.
+        str: A data URI or remote URL reference.
 
     Raises:
         ValueError: If the file type is not supported.
     """
     if isinstance(image, dict) and "url" in image:
-        # NOTE: Not doing other validation for now
-        return image["url"]
+        return encode_image(image["url"])
     elif isinstance(image, str):
         if image.startswith("data:"):
             # Already a data URI
             return image
-        elif os.path.isfile(image):
-            # File path
-            return _encode_image_from_file(image)
         elif is_url(image):
-            # URL
-            if download_images:
-                return _encode_image_from_url(image, verify=verify)
-            else:
-                # Return the URL as is
-                return image
+            return image
         else:
-            # Unsupported string format
-            raise ValueError(f"Unrecognized file string: {image}; If this file type should be supported, please open an issue.")
+            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_file().")
     elif PIL_AVAILABLE and isinstance(image, PILImage.Image):
         # PIL Image
         return _encode_pil_image(image)
@@ -172,7 +159,6 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_imag
     elif isinstance(image, Image):
         return image.url
     else:
-        print(f"Unsupported image type: {type(image)}")
         raise ValueError(f"Unsupported image type: {type(image)}")
 
 
@@ -192,7 +178,7 @@ def _encode_image_from_file(file_path: str) -> str:
 
 def _encode_image_from_url(image_url: str, verify: bool = True) -> str:
     """Encode a file from a URL to a base64 data URI.
-    
+
     Args:
         image_url: The URL of the image to download.
         verify: Whether to verify SSL certificates. Set to False for self-signed certs.
@@ -242,8 +228,6 @@ def is_image(obj) -> bool:
         return True
     if isinstance(obj, str):
         if obj.startswith("data:"):
-            return True
-        elif os.path.isfile(obj):
             return True
         elif is_url(obj):
             return True

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -30,12 +30,12 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, url: Any = None, **data):
+    def __init__(self, source: Any = None, **data):
         """Create an Image.
 
         Parameters
         ----------
-        url:
+        source:
             The image source. Supported values include
 
             - ``str``: HTTP(S)/GS URL or an encoded data URI
@@ -50,14 +50,16 @@ class Image(Type):
         :meth:`from_file` and :meth:`from_url`, respectively.
         """
 
-        if url is not None and "url" not in data:
-            # Support a positional argument while allowing ``url=`` in **data.
-            if isinstance(url, dict) and set(url.keys()) == {"url"}:
+        if source is not None and "url" in data:
+            raise TypeError("Image received both `source` and `url`; provide only one image source")
+
+        if source is not None:
+            # Support a positional source while retaining the Pydantic ``url`` field.
+            if isinstance(source, dict) and set(source.keys()) == {"url"}:
                 # Legacy dict form from previous model validator.
-                data["url"] = url["url"]
+                data["url"] = source["url"]
             else:
-                # ``url`` may be a string, bytes, or a PIL image.
-                data["url"] = url
+                data["url"] = source
 
         if "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -50,13 +50,13 @@ class Image(Type):
 
         download, verify:
             Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
-            remote image, or :meth:`from_file` for a local file. Accepted for one release
+            remote image, or :meth:`from_path` for a local file. Accepted for one release
             with a warning: ``download=True`` eagerly fetches an HTTP(S) ``source``.
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
         Local files and remote resources must be loaded explicitly with
-        :meth:`from_file` and :meth:`from_url`, respectively.
+        :meth:`from_path` and :meth:`from_url`, respectively.
         """
 
         download_requested = download is not _UNSET
@@ -65,7 +65,7 @@ class Image(Type):
             warnings.warn(
                 "The `download` and `verify` arguments to Image() are deprecated and will be removed in a "
                 "future release. Use Image.from_url(url, verify=...) to download a remote image, or "
-                "Image.from_file(path) for a local file.",
+                "Image.from_path(path) for a local file.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -115,11 +115,21 @@ class Image(Type):
         return cls(_encode_image_from_url(url, verify=verify))
 
     @classmethod
-    def from_file(cls, file_path: str) -> "Image":
+    def from_path(cls, file_path: str) -> "Image":
         """Read a local file and encode it as a data URI."""
         if not os.path.isfile(file_path):
             raise ValueError(f"File not found: {file_path}")
         return cls(_encode_image_from_file(file_path))
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "Image":
+        """Deprecated alias for :meth:`from_path`."""
+        warnings.warn(
+            "Image.from_file is deprecated; use Image.from_path instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.from_path(file_path)
 
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
@@ -181,7 +191,7 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
         elif is_url(image):
             return image
         else:
-            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_file().")
+            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_path().")
     elif PIL_AVAILABLE and isinstance(image, PILImage.Image):
         # PIL Image
         return _encode_pil_image(image)

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -79,7 +79,14 @@ class Image(Type):
 
     @classmethod
     def from_url(cls, url: str, verify: bool = True) -> "Image":
-        """Download an HTTP(S) resource and encode it as a data URI."""
+        """Download an HTTP(S) resource and encode it as a data URI.
+
+        Security: this performs an explicit, caller-initiated fetch and applies no
+        SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
+        will reach private, loopback, or cloud-metadata hosts and follow redirects to
+        them. When ``url`` is derived from untrusted input, the caller is responsible
+        for validating the host against an allowlist before calling this method.
+        """
         if not _is_http_url(url):
             raise ValueError(f"Image.from_url requires an HTTP(S) URL, received: {url}")
         return cls(_encode_image_from_url(url, verify=verify))

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -47,6 +47,7 @@ class Image(Type):
             - ``PIL.Image.Image``: a PIL image instance
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
+            - a local file path (deprecated; use :meth:`from_path`)
 
         download, verify:
             Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
@@ -55,8 +56,9 @@ class Image(Type):
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
-        Local files and remote resources must be loaded explicitly with
-        :meth:`from_path` and :meth:`from_url`, respectively.
+        Passing a local file path is deprecated; prefer :meth:`from_path`. Remote
+        resources must be loaded explicitly with :meth:`from_url`. Only this positional
+        convenience touches the filesystem — adapter parsing of untrusted values never does.
         """
 
         download_requested = download is not _UNSET
@@ -78,6 +80,23 @@ class Image(Type):
             if isinstance(source, dict) and set(source.keys()) == {"url"}:
                 # Legacy dict form from previous model validator.
                 data["url"] = source["url"]
+            elif (
+                isinstance(source, str)
+                and not source.startswith("data:")
+                and not is_url(source)
+                and os.path.isfile(source)
+            ):
+                # Deprecated positional-path convenience. This is the ONLY constructor path
+                # that reads the filesystem; it is reachable only from direct developer
+                # construction, never from adapter parsing of untrusted values (which passes
+                # `url=` and is rejected below).
+                warnings.warn(
+                    "Constructing Image from a local file path is deprecated and will be removed in 3.4; "
+                    "use Image.from_path(path) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                data["url"] = _encode_image_from_file(source)
             else:
                 data["url"] = source
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -21,6 +21,9 @@ except ImportError:
     PIL_AVAILABLE = False
 
 
+_UNSET = object()
+
+
 class Image(Type):
     url: str
 
@@ -31,7 +34,7 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, source: Any = None, **data):
+    def __init__(self, source: Any = None, *, download: Any = _UNSET, verify: Any = _UNSET, **data):
         """Create an Image.
 
         Parameters
@@ -45,11 +48,27 @@ class Image(Type):
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
 
+        download, verify:
+            Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
+            remote image, or :meth:`from_file` for a local file. Accepted for one release
+            with a warning: ``download=True`` eagerly fetches an HTTP(S) ``source``.
+
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
         Local files and remote resources must be loaded explicitly with
         :meth:`from_file` and :meth:`from_url`, respectively.
         """
+
+        download_requested = download is not _UNSET
+        verify_requested = verify is not _UNSET
+        if download_requested or verify_requested:
+            warnings.warn(
+                "The `download` and `verify` arguments to Image() are deprecated and will be removed in a "
+                "future release. Use Image.from_url(url, verify=...) to download a remote image, or "
+                "Image.from_file(path) for a local file.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if source is not None and "url" in data:
             raise TypeError("Image received both `source` and `url`; provide only one image source")
@@ -62,7 +81,11 @@ class Image(Type):
             else:
                 data["url"] = source
 
-        if "url" in data:
+        url = data.get("url")
+        if download_requested and download and isinstance(url, str) and _is_http_url(url):
+            # Legacy download=True path: eagerly fetch the remote URL.
+            data["url"] = _encode_image_from_url(url, verify=verify if verify_requested else True)
+        elif "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.
             data["url"] = encode_image(data["url"])
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -47,7 +47,6 @@ class Image(Type):
             - ``PIL.Image.Image``: a PIL image instance
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
-            - a local file path (deprecated; use :meth:`from_path`)
 
         download, verify:
             Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
@@ -56,9 +55,8 @@ class Image(Type):
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
-        Passing a local file path is deprecated; prefer :meth:`from_path`. Remote
-        resources must be loaded explicitly with :meth:`from_url`. Only this positional
-        convenience touches the filesystem — adapter parsing of untrusted values never does.
+        The constructor never touches the filesystem or network. Local files and remote
+        resources must be loaded explicitly with :meth:`from_path` and :meth:`from_url`.
         """
 
         download_requested = download is not _UNSET
@@ -80,23 +78,6 @@ class Image(Type):
             if isinstance(source, dict) and set(source.keys()) == {"url"}:
                 # Legacy dict form from previous model validator.
                 data["url"] = source["url"]
-            elif (
-                isinstance(source, str)
-                and not source.startswith("data:")
-                and not is_url(source)
-                and os.path.isfile(source)
-            ):
-                # Deprecated positional-path convenience. This is the ONLY constructor path
-                # that reads the filesystem; it is reachable only from direct developer
-                # construction, never from adapter parsing of untrusted values (which passes
-                # `url=` and is rejected below).
-                warnings.warn(
-                    "Constructing Image from a local file path is deprecated and will be removed in 3.4; "
-                    "use Image.from_path(path) instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                data["url"] = _encode_image_from_file(source)
             else:
                 data["url"] = source
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -64,7 +64,7 @@ class Image(Type):
         if download_requested or verify_requested:
             warnings.warn(
                 "The `download` and `verify` arguments to Image() are deprecated and will be removed in "
-                "3.5. Use Image.from_url(url, verify=...) to download a remote image, or "
+                "3.4. Use Image.from_url(url, verify=...) to download a remote image, or "
                 "Image.from_path(path) for a local file.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -125,7 +125,7 @@ class Image(Type):
     def from_file(cls, file_path: str) -> "Image":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Image.from_file is deprecated and will be removed in 3.5; use Image.from_path instead.",
+            "Image.from_file is deprecated and will be removed in 3.4; use Image.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -134,7 +134,7 @@ class Image(Type):
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
         warnings.warn(
-            "Image.from_PIL is deprecated and will be removed in 3.5; use Image(pil_image) instead.",
+            "Image.from_PIL is deprecated and will be removed in 3.4; use Image(pil_image) instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -63,8 +63,8 @@ class Image(Type):
         verify_requested = verify is not _UNSET
         if download_requested or verify_requested:
             warnings.warn(
-                "The `download` and `verify` arguments to Image() are deprecated and will be removed in a "
-                "future release. Use Image.from_url(url, verify=...) to download a remote image, or "
+                "The `download` and `verify` arguments to Image() are deprecated and will be removed in "
+                "3.5. Use Image.from_url(url, verify=...) to download a remote image, or "
                 "Image.from_path(path) for a local file.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -125,7 +125,7 @@ class Image(Type):
     def from_file(cls, file_path: str) -> "Image":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Image.from_file is deprecated; use Image.from_path instead.",
+            "Image.from_file is deprecated and will be removed in 3.5; use Image.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -134,7 +134,7 @@ class Image(Type):
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
         warnings.warn(
-            "Image.from_PIL is deprecated; use Image(pil_image) instead.",
+            "Image.from_PIL is deprecated and will be removed in 3.5; use Image(pil_image) instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -4,7 +4,7 @@ import mimetypes
 import os
 import warnings
 from functools import lru_cache
-from typing import Any, Union
+from typing import Any
 from urllib.parse import urlparse
 
 import pydantic
@@ -21,10 +21,15 @@ except ImportError:
     PIL_AVAILABLE = False
 
 
-_UNSET = object()
-
-
 class Image(Type):
+    """An image input represented by a remote URL or data URI.
+
+    Construction and adapter parsing never access the filesystem or network. Use
+    :meth:`from_path` to read a local file, :meth:`from_url` to download a remote
+    resource, :meth:`from_bytes` for encoded image bytes, or :meth:`from_pil` for a
+    PIL image.
+    """
+
     url: str
 
     model_config = pydantic.ConfigDict(
@@ -34,65 +39,14 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, source: Any = None, *, download: Any = _UNSET, verify: Any = _UNSET, **data):
-        """Create an Image.
+    @pydantic.field_validator("url", mode="before")
+    @classmethod
+    def validate_url(cls, value: Any) -> str:
+        if not isinstance(value, str):
+            raise ValueError("Image.url must be an HTTP(S)/GS URL or data URI string")
+        return encode_image(value)
 
-        Parameters
-        ----------
-        source:
-            The image source. Supported values include
-
-            - ``str``: HTTP(S)/GS URL or an encoded data URI
-            - ``bytes``: raw image bytes
-            - ``PIL.Image.Image``: a PIL image instance
-            - ``dict`` with a single ``{"url": value}`` entry (legacy form)
-            - already encoded data URI
-
-        download, verify:
-            Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
-            remote image, or :meth:`from_path` for a local file. Accepted for one release
-            with a warning: ``download=True`` eagerly fetches an HTTP(S) ``source``.
-
-        Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
-
-        The constructor never touches the filesystem or network. Local files and remote
-        resources must be loaded explicitly with :meth:`from_path` and :meth:`from_url`.
-        """
-
-        download_requested = download is not _UNSET
-        verify_requested = verify is not _UNSET
-        if download_requested or verify_requested:
-            warnings.warn(
-                "The `download` and `verify` arguments to Image() are deprecated and will be removed in "
-                "3.4. Use Image.from_url(url, verify=...) to download a remote image, or "
-                "Image.from_path(path) for a local file.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-
-        if source is not None and "url" in data:
-            raise TypeError("Image received both `source` and `url`; provide only one image source")
-
-        if source is not None:
-            # Support a positional source while retaining the Pydantic ``url`` field.
-            if isinstance(source, dict) and set(source.keys()) == {"url"}:
-                # Legacy dict form from previous model validator.
-                data["url"] = source["url"]
-            else:
-                data["url"] = source
-
-        url = data.get("url")
-        if download_requested and download and isinstance(url, str) and _is_http_url(url):
-            # Legacy download=True path: eagerly fetch the remote URL.
-            data["url"] = _encode_image_from_url(url, verify=verify if verify_requested else True)
-        elif "url" in data:
-            # Normalize any accepted input into a base64 data URI or plain URL.
-            data["url"] = encode_image(data["url"])
-
-        # Delegate the rest of initialization to pydantic's BaseModel.
-        super().__init__(**data)
-
-    @lru_cache(maxsize=32)
+    @lru_cache(maxsize=32)  # noqa: B019
     def format(self) -> list[dict[str, Any]] | str:
         try:
             image_url = encode_image(self.url)
@@ -101,44 +55,69 @@ class Image(Type):
         return [{"type": "image_url", "image_url": {"url": image_url}}]
 
     @classmethod
-    def from_url(cls, url: str, verify: bool = True) -> "Image":
+    def from_url(
+        cls,
+        url: str,
+        *,
+        timeout: float | tuple[float, float] = 30.0,
+        verify: bool | str = True,
+    ) -> "Image":
         """Download an HTTP(S) resource and encode it as a data URI.
+
+        This is a synchronous, blocking network operation.
 
         Security: this performs an explicit, caller-initiated fetch and applies no
         SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
         will reach private, loopback, or cloud-metadata hosts and follow redirects to
         them. When ``url`` is derived from untrusted input, the caller is responsible
         for validating the host against an allowlist before calling this method.
+
+        Args:
+            url: The HTTP(S) URL to download.
+            timeout: Connection and read timeout in seconds, either as one value or a tuple.
+            verify: Whether to verify TLS certificates, or a path to a CA bundle.
         """
         if not _is_http_url(url):
             raise ValueError(f"Image.from_url requires an HTTP(S) URL, received: {url}")
-        return cls(_encode_image_from_url(url, verify=verify))
+        return cls(url=_encode_image_from_url(url, timeout=timeout, verify=verify))
 
     @classmethod
-    def from_path(cls, file_path: str) -> "Image":
+    def from_path(cls, path: str | os.PathLike[str]) -> "Image":
         """Read a local file and encode it as a data URI."""
-        if not os.path.isfile(file_path):
-            raise ValueError(f"File not found: {file_path}")
-        return cls(_encode_image_from_file(file_path))
+        return cls(url=_encode_image_from_file(path))
 
     @classmethod
-    def from_file(cls, file_path: str) -> "Image":
+    def from_bytes(cls, image_bytes: bytes) -> "Image":
+        """Create an Image from encoded image bytes."""
+        return cls(url=_encode_image_from_bytes(image_bytes))
+
+    @classmethod
+    def from_pil(cls, pil_image: Any) -> "Image":
+        """Create an Image from a PIL image."""
+        if not PIL_AVAILABLE:
+            raise ImportError("Pillow is required to process PIL images.")
+        if not isinstance(pil_image, PILImage.Image):
+            raise TypeError(f"pil_image must be a PIL image, received: {type(pil_image)}")
+        return cls(url=_encode_pil_image(pil_image))
+
+    @classmethod
+    def from_file(cls, path: str | os.PathLike[str]) -> "Image":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
             "Image.from_file is deprecated and will be removed in 3.4; use Image.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return cls.from_path(file_path)
+        return cls.from_path(path)
 
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
         warnings.warn(
-            "Image.from_PIL is deprecated and will be removed in 3.4; use Image(pil_image) instead.",
+            "Image.from_PIL is deprecated and will be removed in 3.4; use Image.from_pil(pil_image) instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return cls(pil_image)
+        return cls.from_pil(pil_image)
 
     def __str__(self):
         return self.serialize_model()
@@ -169,12 +148,12 @@ def _is_http_url(string: str) -> bool:
         return False
 
 
-def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
+def encode_image(image: str | Image) -> str:
     """
     Normalize an in-memory image or preserve a remote image reference.
 
     Args:
-        image: A PIL Image, bytes, URL reference, data URI, or Image.
+        image: A URL reference, data URI, or Image.
 
     Returns:
         str: A data URI or remote URL reference.
@@ -182,9 +161,7 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
     Raises:
         ValueError: If the file type is not supported.
     """
-    if isinstance(image, dict) and "url" in image:
-        return encode_image(image["url"])
-    elif isinstance(image, str):
+    if isinstance(image, str):
         if image.startswith("data:"):
             # Already a data URI
             return image
@@ -192,52 +169,46 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
             return image
         else:
             raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_path().")
-    elif PIL_AVAILABLE and isinstance(image, PILImage.Image):
-        # PIL Image
-        return _encode_pil_image(image)
-    elif isinstance(image, bytes):
-        # Raw bytes
-        if not PIL_AVAILABLE:
-            raise ImportError("Pillow is required to process image bytes.")
-        try:
-            img = PILImage.open(io.BytesIO(image))
-        except UnidentifiedImageError as e:
-            raise ValueError(f"Bytes could not be identified as an image: {e}") from e
-        return _encode_pil_image(img)
     elif isinstance(image, Image):
         return image.url
     else:
         raise ValueError(f"Unsupported image type: {type(image)}")
 
 
-def _encode_image_from_file(file_path: str) -> str:
+def _encode_image_from_file(path: str | os.PathLike[str]) -> str:
     """Encode a file from a file path to a base64 data URI."""
-    with open(file_path, "rb") as file:
+    with open(path, "rb") as file:
         file_data = file.read()
 
-    # Use mimetypes to guess directly from the file path
-    mime_type, _ = mimetypes.guess_type(file_path)
+    path_string = os.fspath(path)
+    mime_type, _ = mimetypes.guess_type(path_string)
     if mime_type is None:
-        raise ValueError(f"Could not determine MIME type for file: {file_path}")
+        raise ValueError(f"Could not determine MIME type for file: {path_string}")
 
     encoded_data = base64.b64encode(file_data).decode("utf-8")
     return f"data:{mime_type};base64,{encoded_data}"
 
 
-def _encode_image_from_url(image_url: str, verify: bool = True) -> str:
+def _encode_image_from_url(
+    image_url: str,
+    *,
+    timeout: float | tuple[float, float],
+    verify: bool | str,
+) -> str:
     """Encode a file from a URL to a base64 data URI.
 
     Args:
         image_url: The URL of the image to download.
+        timeout: Connection and read timeout in seconds, either as one value or a tuple.
         verify: Whether to verify SSL certificates. Set to False for self-signed certs.
     """
-    response = requests.get(image_url, verify=verify)
+    response = requests.get(image_url, timeout=timeout, verify=verify)
     response.raise_for_status()
     content_type = response.headers.get("Content-Type", "")
 
     # Use the content type from the response headers if available
     if content_type:
-        mime_type = content_type
+        mime_type = content_type.split(";", 1)[0].strip()
     else:
         # Try to guess MIME type from URL
         mime_type, _ = mimetypes.guess_type(image_url)
@@ -246,6 +217,17 @@ def _encode_image_from_url(image_url: str, verify: bool = True) -> str:
 
     encoded_data = base64.b64encode(response.content).decode("utf-8")
     return f"data:{mime_type};base64,{encoded_data}"
+
+
+def _encode_image_from_bytes(image_bytes: bytes) -> str:
+    """Encode image bytes to a base64 data URI."""
+    if not PIL_AVAILABLE:
+        raise ImportError("Pillow is required to process image bytes.")
+    try:
+        image = PILImage.open(io.BytesIO(image_bytes))
+    except UnidentifiedImageError as e:
+        raise ValueError(f"Bytes could not be identified as an image: {e}") from e
+    return _encode_pil_image(image)
 
 
 def _encode_pil_image(image: "PILImage") -> str:

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -470,7 +470,7 @@ def test_chat_adapter_format_exact_messages_with_multimodal_custom_type_inputs()
         CustomTypeSignature,
         [],
         {
-            "image": dspy.Image("https://example.com/cat.png"),
+            "image": dspy.Image(url="https://example.com/cat.png"),
             "audio": dspy.Audio(data="QUJD", audio_format="wav"),
             "file": dspy.File.from_file_id("file-123", filename="notes.txt"),
             "document": Document(data="Alpha beta", title="Doc"),
@@ -585,7 +585,7 @@ def test_chat_adapter_format_exact_messages_with_history_demo_pydantic_tools_and
         RichRenderingSignature,
         demos=[
             {
-                "image": dspy.Image("https://example.com/demo.png"),
+                "image": dspy.Image(url="https://example.com/demo.png"),
                 "tools": [tool],
                 "profile": demo_profile,
                 "question": "What should we mention?",
@@ -594,7 +594,7 @@ def test_chat_adapter_format_exact_messages_with_history_demo_pydantic_tools_and
         ],
         inputs={
             "history": history,
-            "image": dspy.Image("https://example.com/current.png"),
+            "image": dspy.Image(url="https://example.com/current.png"),
             "tools": [tool],
             "profile": current_profile,
             "question": "What should the answer include?",
@@ -1752,7 +1752,7 @@ def test_chat_adapter_format_exact_messages_kitchen_sink():
         KitchenSinkSignature,
         demos=[
             {
-                "image": dspy.Image("https://example.com/demo.png"),
+                "image": dspy.Image(url="https://example.com/demo.png"),
                 "audio": dspy.Audio(data="REVNTw==", audio_format="wav"),
                 "file": dspy.File.from_file_id("file-demo", filename="demo.txt"),
                 "document": Document(data="Demo document", title="Demo Doc"),
@@ -1772,7 +1772,7 @@ def test_chat_adapter_format_exact_messages_kitchen_sink():
         ],
         inputs={
             "history": history,
-            "image": dspy.Image("https://example.com/current.png"),
+            "image": dspy.Image(url="https://example.com/current.png"),
             "audio": dspy.Audio(data="Q1VSUkVOVA==", audio_format="wav"),
             "file": dspy.File.from_file_id("file-current", filename="current.txt"),
             "document": Document(data="Current document", title="Current Doc"),

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -213,7 +213,7 @@ def test_json_adapter_format_exact_messages_with_history_demo_pydantic_tools_and
         RichRenderingSignature,
         demos=[
             {
-                "image": dspy.Image("https://example.com/demo.png"),
+                "image": dspy.Image(url="https://example.com/demo.png"),
                 "tools": [tool],
                 "profile": demo_profile,
                 "question": "What should we mention?",
@@ -222,7 +222,7 @@ def test_json_adapter_format_exact_messages_with_history_demo_pydantic_tools_and
         ],
         inputs={
             "history": history,
-            "image": dspy.Image("https://example.com/current.png"),
+            "image": dspy.Image(url="https://example.com/current.png"),
             "tools": [tool],
             "profile": current_profile,
             "question": "What should the answer include?",

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -1,0 +1,101 @@
+import base64
+import json
+
+import pytest
+
+import dspy
+from dspy.adapters.json_adapter import JSONAdapter
+
+
+@pytest.mark.parametrize(
+    ("annotation", "payload"),
+    [
+        (dspy.Image, lambda path: {"url": path}),
+        (dspy.Audio, lambda path: path),
+        (dspy.File, lambda path: path),
+    ],
+)
+def test_lm_output_cannot_read_local_resources(tmp_path, monkeypatch, annotation, payload):
+    secret = tmp_path / "secret.wav"
+    secret.write_bytes(b"TOP-SECRET")
+
+    class OutputSignature(dspy.Signature):
+        resource: annotation = dspy.OutputField()
+
+    def fail_open(*args, **kwargs):
+        pytest.fail("LM output parsing attempted to open a local resource")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    completion = '{"resource": ' + json.dumps(payload(str(secret))) + "}"
+
+    with pytest.raises((ValueError, TypeError)):
+        JSONAdapter().parse(OutputSignature, completion)
+
+
+def test_audio_lm_output_cannot_download_url(monkeypatch):
+    class OutputSignature(dspy.Signature):
+        audio: dspy.Audio = dspy.OutputField()
+
+    def fail_request(*args, **kwargs):
+        pytest.fail("LM output parsing attempted to download a remote resource")
+
+    monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
+
+    with pytest.raises(ValueError, match=r"Audio\.from_url"):
+        JSONAdapter().parse(OutputSignature, '{"audio": "https://example.com/secret.wav"}')
+
+
+def test_image_url_constructor_does_not_download(monkeypatch):
+    def fail_request(*args, **kwargs):
+        pytest.fail("Image construction attempted to download a remote resource")
+
+    monkeypatch.setattr("dspy.adapters.types.image.requests.get", fail_request)
+
+    image = dspy.Image("https://example.com/image.png")
+
+    assert image.url == "https://example.com/image.png"
+
+
+def test_explicit_local_resource_factories(tmp_path):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"image bytes")
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"audio bytes")
+    file_path = tmp_path / "document.txt"
+    file_path.write_bytes(b"file bytes")
+
+    assert base64.b64decode(dspy.Image.from_file(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
+    assert base64.b64decode(dspy.Audio.from_file(str(audio_path)).data) == b"audio bytes"
+    assert base64.b64decode(dspy.File.from_path(str(file_path)).file_data.split(",", 1)[1]) == b"file bytes"
+
+
+@pytest.mark.parametrize(
+    ("factory", "mime_type"), [(dspy.Image.from_url, "image/png"), (dspy.Audio.from_url, "audio/wav")]
+)
+def test_explicit_remote_resource_factories(monkeypatch, factory, mime_type):
+    class Response:
+        def __init__(self):
+            self.content = b"remote bytes"
+            self.headers = {"Content-Type": mime_type}
+
+        def raise_for_status(self):
+            return None
+
+    module = "image" if factory == dspy.Image.from_url else "audio"
+    monkeypatch.setattr(f"dspy.adapters.types.{module}.requests.get", lambda *args, **kwargs: Response())
+
+    resource = factory(f"https://example.com/resource.{mime_type.split('/', 1)[1]}")
+    encoded = resource.url.split(",", 1)[1] if isinstance(resource, dspy.Image) else resource.data
+    assert base64.b64decode(encoded) == b"remote bytes"
+
+
+def test_in_memory_resource_construction():
+    image = dspy.Image(
+        base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+    )
+    audio = dspy.Audio(b"audio bytes", audio_format="wav")
+    file = dspy.File(b"file bytes")
+
+    assert image.url.startswith("data:image/")
+    assert base64.b64decode(audio.data) == b"audio bytes"
+    assert file.file_data.startswith("data:application/octet-stream;base64,")

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -99,3 +99,53 @@ def test_in_memory_resource_construction():
     assert image.url.startswith("data:image/")
     assert base64.b64decode(audio.data) == b"audio bytes"
     assert file.file_data.startswith("data:application/octet-stream;base64,")
+
+
+@pytest.mark.parametrize(
+    ("source", "match"),
+    [("clip.wav", r"Audio\.from_file"), ("https://example.com/a.wav", r"Audio\.from_url")],
+)
+def test_audio_positional_string_must_be_data_uri_even_with_format(source, match):
+    with pytest.raises(ValueError, match=match):
+        dspy.Audio(source, audio_format="wav")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "data:audio/wav;base64,AA==",
+        {"data": "AA==", "audio_format": "wav"},
+        dspy.Audio(data="AA==", audio_format="wav"),
+    ],
+)
+def test_audio_rejects_audio_format_for_inputs_that_carry_one(source):
+    with pytest.raises(TypeError, match="already carries its format"):
+        dspy.Audio(source, audio_format="mp3")
+
+
+@pytest.mark.parametrize("source", [b"audio bytes", "data:audio/wav;base64,AA=="])
+def test_audio_rejects_sampling_rate_for_non_array_inputs(source):
+    with pytest.raises(TypeError, match="sampling_rate"):
+        dspy.Audio(source, sampling_rate=44100)
+
+
+def test_audio_from_url_passes_verify(monkeypatch):
+    captured = {}
+
+    class Response:
+        def __init__(self):
+            self.content = b"remote bytes"
+            self.headers = {"Content-Type": "audio/wav"}
+
+        def raise_for_status(self):
+            return None
+
+    def fake_get(url, **kwargs):
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fake_get)
+
+    dspy.Audio.from_url("https://example.com/a.wav", verify=False)
+
+    assert captured["verify"] is False

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -20,9 +20,9 @@ def _forbid_host_io(monkeypatch):
     monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
 
 
-# Locator-shaped inputs an attacker could supply. Through the validation/parse path none may
-# trigger host I/O, whether the call raises (paths, non-data-URI strings) or is retained as a
-# reference (Image URLs).
+# Locator-shaped inputs an attacker could supply. Neither construction nor the validation/parse
+# path may trigger host I/O, whether the call raises (paths, non-data-URI strings) or is retained
+# as a reference (Image URLs).
 _LOCATOR_INPUTS = [
     (dspy.Image, {"url": "/etc/passwd"}),
     (dspy.Image, "/etc/passwd"),
@@ -33,15 +33,11 @@ _LOCATOR_INPUTS = [
     (dspy.File, "https://evil.example/secret.bin"),
 ]
 
-# Direct construction is I/O-free for the same inputs, except the deprecated Image(positional path)
-# convenience (covered by test_image_positional_path_is_deprecated), which is excluded here.
-_CONSTRUCTION_INPUTS = [case for case in _LOCATOR_INPUTS if case != (dspy.Image, "/etc/passwd")]
 
-
-@pytest.mark.parametrize(("annotation", "value"), _CONSTRUCTION_INPUTS)
+@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_construction_performs_no_host_io(monkeypatch, annotation, value):
-    # Aside from the deprecated Image(path) convenience, constructing from a locator-shaped value
-    # must never dereference it.
+    # The constructor is reachable from untrusted application input (e.g. dspy.Image(user_string));
+    # it must never dereference a locator.
     _forbid_host_io(monkeypatch)
     try:
         annotation(value)
@@ -52,23 +48,12 @@ def test_construction_performs_no_host_io(monkeypatch, annotation, value):
 @pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_validation_performs_no_host_io(monkeypatch, annotation, value):
     # validate_python is the path adapters use to coerce untrusted LM output (and pydantic uses for
-    # nested models / deserialization); it must never dereference a locator. This is the security
-    # boundary: the deprecated Image(path) convenience is unreachable here.
+    # nested models / deserialization); it must never dereference a locator either.
     _forbid_host_io(monkeypatch)
     try:
         TypeAdapter(annotation).validate_python(value)
     except (ValueError, TypeError, ValidationError):
         pass
-
-
-def test_image_positional_path_is_deprecated(tmp_path):
-    image_path = tmp_path / "image.png"
-    image_path.write_bytes(b"image bytes")
-
-    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
-        image = dspy.Image(str(image_path))
-
-    assert base64.b64decode(image.url.split(",", 1)[1]) == b"image bytes"
 
 
 def test_image_url_constructor_does_not_download(monkeypatch):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -64,9 +64,19 @@ def test_explicit_local_resource_factories(tmp_path):
     file_path = tmp_path / "document.txt"
     file_path.write_bytes(b"file bytes")
 
-    assert base64.b64decode(dspy.Image.from_file(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
-    assert base64.b64decode(dspy.Audio.from_file(str(audio_path)).data) == b"audio bytes"
+    assert base64.b64decode(dspy.Image.from_path(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
+    assert base64.b64decode(dspy.Audio.from_path(str(audio_path)).data) == b"audio bytes"
     assert base64.b64decode(dspy.File.from_path(str(file_path)).file_data.split(",", 1)[1]) == b"file bytes"
+
+
+def test_audio_from_file_is_deprecated_alias(tmp_path):
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"audio bytes")
+
+    with pytest.warns(DeprecationWarning, match="Audio.from_file is deprecated"):
+        aliased = dspy.Audio.from_file(str(audio_path))
+
+    assert base64.b64decode(aliased.data) == b"audio bytes"
 
 
 @pytest.mark.parametrize(
@@ -103,7 +113,7 @@ def test_in_memory_resource_construction():
 
 @pytest.mark.parametrize(
     ("source", "match"),
-    [("clip.wav", r"Audio\.from_file"), ("https://example.com/a.wav", r"Audio\.from_url")],
+    [("clip.wav", r"Audio\.from_path"), ("https://example.com/a.wav", r"Audio\.from_url")],
 )
 def test_audio_positional_string_must_be_data_uri_even_with_format(source, match):
     with pytest.raises(ValueError, match=match):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -20,8 +20,9 @@ def _forbid_host_io(monkeypatch):
     monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
 
 
-# Locator-shaped inputs an attacker could supply. None may trigger host I/O, whether the call
-# raises (paths, non-data-URI strings) or is retained as a reference (Image URLs).
+# Locator-shaped inputs an attacker could supply. Through the validation/parse path none may
+# trigger host I/O, whether the call raises (paths, non-data-URI strings) or is retained as a
+# reference (Image URLs).
 _LOCATOR_INPUTS = [
     (dspy.Image, {"url": "/etc/passwd"}),
     (dspy.Image, "/etc/passwd"),
@@ -32,11 +33,15 @@ _LOCATOR_INPUTS = [
     (dspy.File, "https://evil.example/secret.bin"),
 ]
 
+# Direct construction is I/O-free for the same inputs, except the deprecated Image(positional path)
+# convenience (covered by test_image_positional_path_is_deprecated), which is excluded here.
+_CONSTRUCTION_INPUTS = [case for case in _LOCATOR_INPUTS if case != (dspy.Image, "/etc/passwd")]
 
-@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
+
+@pytest.mark.parametrize(("annotation", "value"), _CONSTRUCTION_INPUTS)
 def test_construction_performs_no_host_io(monkeypatch, annotation, value):
-    # The constructor is reachable from untrusted application input (e.g. dspy.Image(user_string));
-    # it must never dereference a locator.
+    # Aside from the deprecated Image(path) convenience, constructing from a locator-shaped value
+    # must never dereference it.
     _forbid_host_io(monkeypatch)
     try:
         annotation(value)
@@ -47,12 +52,23 @@ def test_construction_performs_no_host_io(monkeypatch, annotation, value):
 @pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_validation_performs_no_host_io(monkeypatch, annotation, value):
     # validate_python is the path adapters use to coerce untrusted LM output (and pydantic uses for
-    # nested models / deserialization); it must never dereference a locator either.
+    # nested models / deserialization); it must never dereference a locator. This is the security
+    # boundary: the deprecated Image(path) convenience is unreachable here.
     _forbid_host_io(monkeypatch)
     try:
         TypeAdapter(annotation).validate_python(value)
     except (ValueError, TypeError, ValidationError):
         pass
+
+
+def test_image_positional_path_is_deprecated(tmp_path):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"image bytes")
+
+    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
+        image = dspy.Image(str(image_path))
+
+    assert base64.b64decode(image.url.split(",", 1)[1]) == b"image bytes"
 
 
 def test_image_url_constructor_does_not_download(monkeypatch):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -48,6 +48,8 @@ _LOCATOR_INPUTS = [
     (dspy.File, {"file_data": "https://evil.example/secret.bin"}),
 ]
 
+_REJECTED_LOCATOR_INPUTS = _LOCATOR_INPUTS[2:]
+
 
 @pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_construction_performs_no_host_io(monkeypatch, annotation, value):
@@ -67,6 +69,56 @@ def test_validation_performs_no_host_io(monkeypatch, annotation, value):
         TypeAdapter(annotation).validate_python(value)
     except (ValueError, TypeError, ValidationError):
         pass
+
+
+@pytest.mark.parametrize(("annotation", "value"), _REJECTED_LOCATOR_INPUTS)
+def test_resource_construction_rejects_locator_payloads(annotation, value):
+    with pytest.raises(ValidationError):
+        annotation(**value)
+
+
+@pytest.mark.parametrize(("annotation", "value"), _REJECTED_LOCATOR_INPUTS)
+def test_resource_validation_rejects_locator_payloads(annotation, value):
+    with pytest.raises(ValidationError):
+        TypeAdapter(annotation).validate_python(value)
+
+
+def test_audio_data_uri_is_normalized_and_format_is_inferred():
+    audio = dspy.Audio(data="data:audio/x-wav;base64,YXVkaW8=")
+
+    assert audio.data == "YXVkaW8="
+    assert audio.audio_format == "wav"
+
+
+def test_audio_data_uri_rejects_mismatched_format():
+    with pytest.raises(ValidationError, match="does not match"):
+        dspy.Audio(data="data:audio/wav;base64,YXVkaW8=", audio_format="mp3")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"data": "not base64!", "audio_format": "wav"},
+        {"data": "data:audio/wav;base64,not base64!"},
+        {"data": "data:text/plain;base64,YXVkaW8="},
+    ],
+)
+def test_audio_rejects_malformed_payloads(value):
+    with pytest.raises(ValidationError):
+        TypeAdapter(dspy.Audio).validate_python(value)
+
+
+@pytest.mark.parametrize(
+    "file_data",
+    [
+        "data:text/plain,plain text",
+        "data:text/plain;base64,not base64!",
+        "data:;base64,",
+    ],
+)
+def test_file_rejects_malformed_data_uris(file_data):
+    with pytest.raises(ValidationError):
+        TypeAdapter(dspy.File).validate_python({"file_data": file_data})
 
 
 def test_image_validation_rejects_download_without_host_io(monkeypatch):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -1,9 +1,25 @@
 import base64
+import inspect
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
 import dspy
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "field_names"),
+    [
+        (dspy.Image, {"url"}),
+        (dspy.Audio, {"data", "audio_format"}),
+        (dspy.File, {"file_data", "file_id", "filename"}),
+    ],
+)
+def test_resource_constructor_signatures_are_keyword_only(resource_type, field_names):
+    parameters = inspect.signature(resource_type).parameters
+
+    assert set(parameters) == field_names
+    assert all(parameter.kind is inspect.Parameter.KEYWORD_ONLY for parameter in parameters.values())
 
 
 def _forbid_host_io(monkeypatch):
@@ -25,23 +41,20 @@ def _forbid_host_io(monkeypatch):
 # as a reference (Image URLs).
 _LOCATOR_INPUTS = [
     (dspy.Image, {"url": "/etc/passwd"}),
-    (dspy.Image, "/etc/passwd"),
     (dspy.Image, {"url": "https://evil.example/secret.png"}),
-    (dspy.Audio, "/etc/passwd"),
-    (dspy.Audio, "https://evil.example/secret.wav"),
-    (dspy.File, "/etc/passwd"),
-    (dspy.File, "https://evil.example/secret.bin"),
+    (dspy.Audio, {"data": "/etc/passwd", "audio_format": "wav"}),
+    (dspy.Audio, {"data": "https://evil.example/secret.wav", "audio_format": "wav"}),
+    (dspy.File, {"file_data": "/etc/passwd"}),
+    (dspy.File, {"file_data": "https://evil.example/secret.bin"}),
 ]
 
 
 @pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_construction_performs_no_host_io(monkeypatch, annotation, value):
-    # The constructor is reachable from untrusted application input (e.g. dspy.Image(user_string));
-    # it must never dereference a locator.
     _forbid_host_io(monkeypatch)
     try:
-        annotation(value)
-    except (ValueError, TypeError):
+        annotation(**value)
+    except (ValueError, TypeError, ValidationError):
         pass
 
 
@@ -56,13 +69,20 @@ def test_validation_performs_no_host_io(monkeypatch, annotation, value):
         pass
 
 
+def test_image_validation_rejects_download_without_host_io(monkeypatch):
+    _forbid_host_io(monkeypatch)
+
+    with pytest.raises(ValidationError, match="download"):
+        TypeAdapter(dspy.Image).validate_python({"url": "https://evil.example/secret.png", "download": True})
+
+
 def test_image_url_constructor_does_not_download(monkeypatch):
     def fail_request(*args, **kwargs):
         pytest.fail("Image construction attempted to download a remote resource")
 
     monkeypatch.setattr("dspy.adapters.types.image.requests.get", fail_request)
 
-    image = dspy.Image("https://example.com/image.png")
+    image = dspy.Image(url="https://example.com/image.png")
 
     assert image.url == "https://example.com/image.png"
 
@@ -75,9 +95,9 @@ def test_explicit_local_resource_factories(tmp_path):
     file_path = tmp_path / "document.txt"
     file_path.write_bytes(b"file bytes")
 
-    assert base64.b64decode(dspy.Image.from_path(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
-    assert base64.b64decode(dspy.Audio.from_path(str(audio_path)).data) == b"audio bytes"
-    assert base64.b64decode(dspy.File.from_path(str(file_path)).file_data.split(",", 1)[1]) == b"file bytes"
+    assert base64.b64decode(dspy.Image.from_path(image_path).url.split(",", 1)[1]) == b"image bytes"
+    assert base64.b64decode(dspy.Audio.from_path(audio_path).data) == b"audio bytes"
+    assert base64.b64decode(dspy.File.from_path(file_path).file_data.split(",", 1)[1]) == b"file bytes"
 
 
 def test_audio_from_file_is_deprecated_alias(tmp_path):
@@ -110,12 +130,12 @@ def test_explicit_remote_resource_factories(monkeypatch, factory, mime_type):
     assert base64.b64decode(encoded) == b"remote bytes"
 
 
-def test_in_memory_resource_construction():
-    image = dspy.Image(
+def test_in_memory_resource_factories():
+    image = dspy.Image.from_bytes(
         base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
     )
-    audio = dspy.Audio(b"audio bytes", audio_format="wav")
-    file = dspy.File(b"file bytes")
+    audio = dspy.Audio.from_bytes(b"audio bytes", audio_format="wav")
+    file = dspy.File.from_bytes(b"file bytes")
 
     assert image.url.startswith("data:image/")
     assert base64.b64decode(audio.data) == b"audio bytes"
@@ -123,31 +143,21 @@ def test_in_memory_resource_construction():
 
 
 @pytest.mark.parametrize(
-    ("source", "match"),
-    [("clip.wav", r"Audio\.from_path"), ("https://example.com/a.wav", r"Audio\.from_url")],
-)
-def test_audio_positional_string_must_be_data_uri_even_with_format(source, match):
-    with pytest.raises(ValueError, match=match):
-        dspy.Audio(source, audio_format="wav")
-
-
-@pytest.mark.parametrize(
-    "source",
+    "constructor",
     [
-        "data:audio/wav;base64,AA==",
-        {"data": "AA==", "audio_format": "wav"},
-        dspy.Audio(data="AA==", audio_format="wav"),
+        lambda: dspy.Image("https://example.com/image.png"),
+        lambda: dspy.Audio(b"audio bytes", audio_format="wav"),
+        lambda: dspy.File(b"file bytes"),
     ],
 )
-def test_audio_rejects_audio_format_for_inputs_that_carry_one(source):
-    with pytest.raises(TypeError, match="already carries its format"):
-        dspy.Audio(source, audio_format="mp3")
+def test_resource_constructors_reject_positional_sources(constructor):
+    with pytest.raises(TypeError):
+        constructor()
 
 
-@pytest.mark.parametrize("source", [b"audio bytes", "data:audio/wav;base64,AA=="])
-def test_audio_rejects_sampling_rate_for_non_array_inputs(source):
-    with pytest.raises(TypeError, match="sampling_rate"):
-        dspy.Audio(source, sampling_rate=44100)
+def test_audio_from_bytes_requires_nonempty_format():
+    with pytest.raises(ValueError, match="non-empty"):
+        dspy.Audio.from_bytes(b"audio bytes", audio_format="")
 
 
 def test_audio_from_url_passes_verify(monkeypatch):
@@ -170,3 +180,24 @@ def test_audio_from_url_passes_verify(monkeypatch):
     dspy.Audio.from_url("https://example.com/a.wav", verify=False)
 
     assert captured["verify"] is False
+    assert captured["timeout"] == 30.0
+
+
+def test_audio_from_url_strips_content_type_parameters(monkeypatch):
+    class Response:
+        def __init__(self):
+            self.content = b"remote bytes"
+            self.headers = {"Content-Type": "audio/x-wav; charset=binary"}
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr("dspy.adapters.types.audio.requests.get", lambda *args, **kwargs: Response())
+
+    assert dspy.Audio.from_url("https://example.com/a.wav").audio_format == "wav"
+
+
+@pytest.mark.parametrize("factory", [dspy.Image.from_path, dspy.Audio.from_path, dspy.File.from_path])
+def test_from_path_preserves_file_not_found_error(factory, tmp_path):
+    with pytest.raises(FileNotFoundError):
+        factory(tmp_path / "missing.resource")

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -1,48 +1,58 @@
 import base64
-import json
 
 import pytest
+from pydantic import TypeAdapter, ValidationError
 
 import dspy
-from dspy.adapters.json_adapter import JSONAdapter
 
 
-@pytest.mark.parametrize(
-    ("annotation", "payload"),
-    [
-        (dspy.Image, lambda path: {"url": path}),
-        (dspy.Audio, lambda path: path),
-        (dspy.File, lambda path: path),
-    ],
-)
-def test_lm_output_cannot_read_local_resources(tmp_path, monkeypatch, annotation, payload):
-    secret = tmp_path / "secret.wav"
-    secret.write_bytes(b"TOP-SECRET")
-
-    class OutputSignature(dspy.Signature):
-        resource: annotation = dspy.OutputField()
+def _forbid_host_io(monkeypatch):
+    """Make any filesystem read or outbound request fail the test."""
 
     def fail_open(*args, **kwargs):
-        pytest.fail("LM output parsing attempted to open a local resource")
-
-    monkeypatch.setattr("builtins.open", fail_open)
-    completion = '{"resource": ' + json.dumps(payload(str(secret))) + "}"
-
-    with pytest.raises((ValueError, TypeError)):
-        JSONAdapter().parse(OutputSignature, completion)
-
-
-def test_audio_lm_output_cannot_download_url(monkeypatch):
-    class OutputSignature(dspy.Signature):
-        audio: dspy.Audio = dspy.OutputField()
+        pytest.fail("resource handling attempted a filesystem read")
 
     def fail_request(*args, **kwargs):
-        pytest.fail("LM output parsing attempted to download a remote resource")
+        pytest.fail("resource handling attempted a network request")
 
+    monkeypatch.setattr("builtins.open", fail_open)
+    monkeypatch.setattr("dspy.adapters.types.image.requests.get", fail_request)
     monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
 
-    with pytest.raises(ValueError, match=r"Audio\.from_url"):
-        JSONAdapter().parse(OutputSignature, '{"audio": "https://example.com/secret.wav"}')
+
+# Locator-shaped inputs an attacker could supply. None may trigger host I/O, whether the call
+# raises (paths, non-data-URI strings) or is retained as a reference (Image URLs).
+_LOCATOR_INPUTS = [
+    (dspy.Image, {"url": "/etc/passwd"}),
+    (dspy.Image, "/etc/passwd"),
+    (dspy.Image, {"url": "https://evil.example/secret.png"}),
+    (dspy.Audio, "/etc/passwd"),
+    (dspy.Audio, "https://evil.example/secret.wav"),
+    (dspy.File, "/etc/passwd"),
+    (dspy.File, "https://evil.example/secret.bin"),
+]
+
+
+@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
+def test_construction_performs_no_host_io(monkeypatch, annotation, value):
+    # The constructor is reachable from untrusted application input (e.g. dspy.Image(user_string));
+    # it must never dereference a locator.
+    _forbid_host_io(monkeypatch)
+    try:
+        annotation(value)
+    except (ValueError, TypeError):
+        pass
+
+
+@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
+def test_validation_performs_no_host_io(monkeypatch, annotation, value):
+    # validate_python is the path adapters use to coerce untrusted LM output (and pydantic uses for
+    # nested models / deserialization); it must never dereference a locator either.
+    _forbid_host_io(monkeypatch)
+    try:
+        TypeAdapter(annotation).validate_python(value)
+    except (ValueError, TypeError, ValidationError):
+        pass
 
 
 def test_image_url_constructor_does_not_download(monkeypatch):

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -567,7 +567,7 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
         RichRenderingSignature,
         demos=[
             {
-                "image": dspy.Image("https://example.com/demo.png"),
+                "image": dspy.Image(url="https://example.com/demo.png"),
                 "tools": [tool],
                 "profile": demo_profile,
                 "question": "What should we mention?",
@@ -576,7 +576,7 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
         ],
         inputs={
             "history": history,
-            "image": dspy.Image("https://example.com/current.png"),
+            "image": dspy.Image(url="https://example.com/current.png"),
             "tools": [tool],
             "profile": current_profile,
             "question": "What should the answer include?",

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1144,7 +1144,7 @@ def test_warning_images(caplog):
     predict_instance = Predict("question:dspy.Image -> answer")
 
     with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
-        predict_instance(question=dspy.Image("https://example.com/image1.jpg"))
+        predict_instance(question=dspy.Image(url="https://example.com/image1.jpg"))
 
     assert "Type mismatch" not in caplog.text
 

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -23,8 +23,7 @@ def test_tool_observation_preserves_custom_type():
             return super().format_user_message_content(signature, inputs, *args, **kwargs)
 
     def make_images():
-        return dspy.Image("https://example.com/test.png"), dspy.Image(Image.new("RGB", (100, 100), "red"))
-
+        return dspy.Image(url="https://example.com/test.png"), dspy.Image.from_pil(Image.new("RGB", (100, 100), "red"))
 
     adapter = SpyChatAdapter()
     lm = DummyLM(

--- a/tests/signatures/test_adapter_file.py
+++ b/tests/signatures/test_adapter_file.py
@@ -152,11 +152,9 @@ def test_file_str():
     assert "<<CUSTOM-TYPE-END-IDENTIFIER>>" in str_repr
 
 
-def test_encode_file_to_dict_from_path(sample_text_file):
-    result = encode_file_to_dict(sample_text_file)
-    assert "file_data" in result
-    assert result["file_data"].startswith("data:text/plain;base64,")
-    assert "filename" in result
+def test_encode_file_to_dict_rejects_path(sample_text_file):
+    with pytest.raises(ValueError, match=r"File\.from_path"):
+        encode_file_to_dict(sample_text_file)
 
 
 def test_encode_file_to_dict_from_bytes():
@@ -165,8 +163,14 @@ def test_encode_file_to_dict_from_bytes():
     assert result["file_data"].startswith("data:application/octet-stream;base64,")
 
 
+def test_file_constructor_from_bytes():
+    file_obj = dspy.File(b"test content", filename="test.txt")
+    assert file_obj.file_data.startswith("data:application/octet-stream;base64,")
+    assert file_obj.filename == "test.txt"
+
+
 def test_invalid_file_string():
-    with pytest.raises(ValueError, match="Unrecognized"):
+    with pytest.raises(ValueError, match=r"File\.from_path"):
         encode_file_to_dict("https://this_is_not_a_file_path")
 
 

--- a/tests/signatures/test_adapter_file.py
+++ b/tests/signatures/test_adapter_file.py
@@ -169,6 +169,17 @@ def test_file_constructor_from_bytes():
     assert file_obj.filename == "test.txt"
 
 
+def test_file_constructor_from_data_uri():
+    data_uri = "data:text/plain;base64,aGVsbG8="
+    file_obj = dspy.File(data_uri)
+    assert file_obj.file_data == data_uri
+
+
+def test_file_constructor_rejects_conflicting_keyword():
+    with pytest.raises(TypeError, match="file_data"):
+        dspy.File(b"test content", file_data="data:text/plain;base64,aGVsbG8=")
+
+
 def test_invalid_file_string():
     with pytest.raises(ValueError, match=r"File\.from_path"):
         encode_file_to_dict("https://this_is_not_a_file_path")

--- a/tests/signatures/test_adapter_file.py
+++ b/tests/signatures/test_adapter_file.py
@@ -163,21 +163,21 @@ def test_encode_file_to_dict_from_bytes():
     assert result["file_data"].startswith("data:application/octet-stream;base64,")
 
 
-def test_file_constructor_from_bytes():
-    file_obj = dspy.File(b"test content", filename="test.txt")
+def test_file_from_bytes_factory_with_filename():
+    file_obj = dspy.File.from_bytes(b"test content", filename="test.txt")
     assert file_obj.file_data.startswith("data:application/octet-stream;base64,")
     assert file_obj.filename == "test.txt"
 
 
-def test_file_constructor_from_data_uri():
+def test_file_constructor_with_data_uri():
     data_uri = "data:text/plain;base64,aGVsbG8="
-    file_obj = dspy.File(data_uri)
+    file_obj = dspy.File(file_data=data_uri)
     assert file_obj.file_data == data_uri
 
 
-def test_file_constructor_rejects_conflicting_keyword():
-    with pytest.raises(TypeError, match="file_data"):
-        dspy.File(b"test content", file_data="data:text/plain;base64,aGVsbG8=")
+def test_file_constructor_rejects_positional_source():
+    with pytest.raises(TypeError):
+        dspy.File(b"test content")
 
 
 def test_invalid_file_string():
@@ -269,7 +269,7 @@ def test_file_with_all_fields():
 
 
 def test_file_path_not_found():
-    with pytest.raises(ValueError, match="File not found"):
+    with pytest.raises(FileNotFoundError):
         dspy.File.from_path("/nonexistent/path/file.txt")
 
 

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -507,3 +507,13 @@ def test_pil_image_rejects_download_parameter():
 
     with pytest.raises(pydantic.ValidationError, match="download"):
         dspy.Image(sample_pil, download=True)
+
+
+def test_from_file_missing_file():
+    with pytest.raises(ValueError, match="File not found"):
+        dspy.Image.from_file("/nonexistent/image.png")
+
+
+def test_unidentifiable_bytes_raise_value_error():
+    with pytest.raises(ValueError, match="could not be identified as an image"):
+        dspy.Image(b"not an image")

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import warnings
 from io import BytesIO
 
 import pydantic
@@ -24,7 +25,7 @@ def sample_pil_image():
 @pytest.fixture
 def sample_dspy_image_download():
     url = "https://images.dog.ceo/breeds/dane-great/n02109047_8912.jpg"
-    return dspy.Image(url, download=True)
+    return dspy.Image.from_url(url)
 
 
 @pytest.fixture
@@ -343,8 +344,8 @@ def test_pdf_url_support():
     """Test support for PDF files from URLs"""
     pdf_url = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
 
-    # Create a dspy.Image object from the PDF URL with download=True
-    pdf_image = dspy.Image(pdf_url, download=True)
+    # Download the PDF into a dspy.Image data URI.
+    pdf_image = dspy.Image.from_url(pdf_url)
 
     # The data URI should contain application/pdf in the MIME type
     assert "data:application/pdf" in pdf_image.url
@@ -381,7 +382,7 @@ def test_different_mime_types():
 
     for file_type, url in file_urls.items():
         # Download and encode
-        encoded = encode_image(url, download_images=True)
+        encoded = dspy.Image.from_url(url).url
 
         # Check for correct MIME type in the encoded data - using 'in' instead of startswith
         # to account for possible parameters in the MIME type
@@ -402,7 +403,7 @@ def test_mime_type_from_response_headers():
     assert "pdf" in expected_mime_type.lower()
 
     # Encode with download to test MIME type from headers
-    encoded = encode_image(pdf_url, download_images=True)
+    encoded = dspy.Image.from_url(pdf_url).url
 
     # The encoded data should contain the correct MIME type
     assert "application/pdf" in encoded
@@ -422,7 +423,7 @@ def test_pdf_from_file():
 
     try:
         # Create a dspy.Image from the file
-        pdf_image = dspy.Image(tmp_file_path)
+        pdf_image = dspy.Image.from_file(tmp_file_path)
 
         # The constructor encodes the file into a data URI we can inspect directly
         assert "data:application/pdf" in pdf_image.url
@@ -463,15 +464,20 @@ def test_image_repr():
     assert "base64" in str(pil_image)
 
 
-def test_from_methods_warn(tmp_path):
-    """Deprecated from_* methods emit warnings"""
+def test_resource_factories_do_not_warn(tmp_path):
     tmp_file = tmp_path / "test.png"
     tmp_file.write_bytes(b"pngdata")
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        response = type("Response", (), {"content": b"pngdata", "headers": {"Content-Type": "image/png"}})()
+        response.raise_for_status = lambda: None
+        monkeypatch.setattr("dspy.adapters.types.image.requests.get", lambda *args, **kwargs: response)
         dspy.Image.from_url("https://example.com/dog.jpg")
-    with pytest.warns(DeprecationWarning):
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
         dspy.Image.from_file(str(tmp_file))
+
     sample_pil = PILImage.new("RGB", (10, 10), color="blue")
     with pytest.warns(DeprecationWarning):
         dspy.Image.from_PIL(sample_pil)
@@ -482,22 +488,12 @@ def test_invalid_string_format():
     invalid_string = "this_is_not_a_url_or_file"
 
     # Should raise a ValueError and not pass the string through
-    with pytest.raises(ValueError, match="Unrecognized") as warning_info:
-        image = dspy.Image(invalid_string)
+    with pytest.raises(ValueError, match="Unrecognized"):
+        dspy.Image(invalid_string)
 
-def test_pil_image_with_download_parameter():
-    """Test behavior when PIL image is passed with download=True"""
+
+def test_pil_image_rejects_download_parameter():
     sample_pil = PILImage.new("RGB", (60, 30), color="red")
 
-    # PIL image should be encoded regardless of download parameter
-    image_no_download = dspy.Image(sample_pil)
-    image_with_download = dspy.Image(sample_pil, download=True)
-
-    # Both should result in base64 encoded data URIs
-    assert image_no_download.url.startswith("data:")
-    assert image_with_download.url.startswith("data:")
-    assert "base64," in image_no_download.url
-    assert "base64," in image_with_download.url
-
-    # They should be identical since PIL images are always encoded
-    assert image_no_download.url == image_with_download.url
+    with pytest.raises(pydantic.ValidationError, match="download"):
+        dspy.Image(sample_pil, download=True)

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -464,6 +464,16 @@ def test_image_repr():
     assert "base64" in str(pil_image)
 
 
+def test_image_constructor_supports_source_and_url_keywords():
+    source = "https://example.com/dog.jpg"
+
+    assert dspy.Image(source=source).url == source
+    assert dspy.Image(url=source).url == source
+
+    with pytest.raises(TypeError, match="both `source` and `url`"):
+        dspy.Image(source, url=source)
+
+
 def test_resource_factories_do_not_warn(tmp_path):
     tmp_file = tmp_path / "test.png"
     tmp_file.write_bytes(b"pngdata")

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -424,7 +424,7 @@ def test_pdf_from_file():
 
     try:
         # Create a dspy.Image from the file
-        pdf_image = dspy.Image.from_file(tmp_file_path)
+        pdf_image = dspy.Image.from_path(tmp_file_path)
 
         # The constructor encodes the file into a data URI we can inspect directly
         assert "data:application/pdf" in pdf_image.url
@@ -475,7 +475,7 @@ def test_image_constructor_supports_source_and_url_keywords():
         dspy.Image(source, url=source)
 
 
-def test_resource_factories_do_not_warn(tmp_path):
+def test_canonical_factories_do_not_warn(tmp_path):
     tmp_file = tmp_path / "test.png"
     tmp_file.write_bytes(b"pngdata")
 
@@ -487,6 +487,14 @@ def test_resource_factories_do_not_warn(tmp_path):
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
+        dspy.Image.from_path(str(tmp_file))
+
+
+def test_deprecated_factory_aliases_warn(tmp_path):
+    tmp_file = tmp_path / "test.png"
+    tmp_file.write_bytes(b"pngdata")
+
+    with pytest.warns(DeprecationWarning, match="Image.from_file is deprecated"):
         dspy.Image.from_file(str(tmp_file))
 
     sample_pil = PILImage.new("RGB", (10, 10), color="blue")
@@ -532,7 +540,7 @@ def test_deprecated_verify_warns_without_download():
 def test_deprecated_download_does_not_rescue_local_path():
     # The Image(path) hard break holds even with the deprecated download flag.
     with pytest.warns(DeprecationWarning):
-        with pytest.raises(ValueError, match=r"Image\.from_file"):
+        with pytest.raises(ValueError, match=r"Image\.from_path"):
             dspy.Image("/etc/passwd", download=True)
 
 
@@ -543,9 +551,9 @@ def test_pil_image_with_deprecated_download_still_encodes():
     assert image.url.startswith("data:image/")
 
 
-def test_from_file_missing_file():
+def test_from_path_missing_file():
     with pytest.raises(ValueError, match="File not found"):
-        dspy.Image.from_file("/nonexistent/image.png")
+        dspy.Image.from_path("/nonexistent/image.png")
 
 
 def test_unidentifiable_bytes_raise_value_error():

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -503,12 +503,22 @@ def test_deprecated_factory_aliases_warn(tmp_path):
 
 
 def test_invalid_string_format():
-    """Test that invalid string formats raise a ValueError"""
+    """A string that is neither a data URI, a URL, nor an existing local path raises."""
     invalid_string = "this_is_not_a_url_or_file"
 
     # Should raise a ValueError and not pass the string through
     with pytest.raises(ValueError, match="Unrecognized"):
         dspy.Image(invalid_string)
+
+
+def test_positional_local_path_is_deprecated(tmp_path):
+    tmp_file = tmp_path / "photo.png"
+    tmp_file.write_bytes(b"pngdata")
+
+    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
+        image = dspy.Image(str(tmp_file))
+
+    assert image.url.startswith("data:image/png;base64,")
 
 
 def test_deprecated_download_true_downloads(monkeypatch):
@@ -535,13 +545,6 @@ def test_deprecated_verify_warns_without_download():
     with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
         image = dspy.Image(source, verify=False)
     assert image.url == source
-
-
-def test_deprecated_download_does_not_rescue_local_path():
-    # The Image(path) hard break holds even with the deprecated download flag.
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(ValueError, match=r"Image\.from_path"):
-            dspy.Image("/etc/passwd", download=True)
 
 
 def test_pil_image_with_deprecated_download_still_encodes():

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -503,7 +503,7 @@ def test_deprecated_factory_aliases_warn(tmp_path):
 
 
 def test_invalid_string_format():
-    """A string that is neither a data URI, a URL, nor an existing local path raises."""
+    """A string that is neither a data URI nor a URL raises."""
     invalid_string = "this_is_not_a_url_or_file"
 
     # Should raise a ValueError and not pass the string through
@@ -511,14 +511,15 @@ def test_invalid_string_format():
         dspy.Image(invalid_string)
 
 
-def test_positional_local_path_is_deprecated(tmp_path):
+def test_positional_local_path_hard_breaks(tmp_path, monkeypatch):
+    """Image(path) raises pointing at from_path, and never touches the filesystem to decide."""
     tmp_file = tmp_path / "photo.png"
     tmp_file.write_bytes(b"pngdata")
 
-    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
-        image = dspy.Image(str(tmp_file))
+    monkeypatch.setattr("builtins.open", lambda *a, **k: pytest.fail("Image(path) read the filesystem"))
 
-    assert image.url.startswith("data:image/png;base64,")
+    with pytest.raises(ValueError, match=r"Image\.from_path"):
+        dspy.Image(str(tmp_file))
 
 
 def test_deprecated_download_true_downloads(monkeypatch):

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import tempfile
 import warnings
@@ -502,11 +503,44 @@ def test_invalid_string_format():
         dspy.Image(invalid_string)
 
 
-def test_pil_image_rejects_download_parameter():
-    sample_pil = PILImage.new("RGB", (60, 30), color="red")
+def test_deprecated_download_true_downloads(monkeypatch):
+    response = type("Response", (), {"content": b"pngdata", "headers": {"Content-Type": "image/png"}})()
+    response.raise_for_status = lambda: None
+    monkeypatch.setattr("dspy.adapters.types.image.requests.get", lambda *args, **kwargs: response)
 
-    with pytest.raises(pydantic.ValidationError, match="download"):
-        dspy.Image(sample_pil, download=True)
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image("https://example.com/dog.jpg", download=True)
+
+    assert image.url.startswith("data:image/png;base64,")
+    assert base64.b64decode(image.url.split(",", 1)[1]) == b"pngdata"
+
+
+def test_deprecated_download_false_keeps_reference():
+    source = "https://example.com/dog.jpg"
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image(source, download=False)
+    assert image.url == source
+
+
+def test_deprecated_verify_warns_without_download():
+    source = "https://example.com/dog.jpg"
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image(source, verify=False)
+    assert image.url == source
+
+
+def test_deprecated_download_does_not_rescue_local_path():
+    # The Image(path) hard break holds even with the deprecated download flag.
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError, match=r"Image\.from_file"):
+            dspy.Image("/etc/passwd", download=True)
+
+
+def test_pil_image_with_deprecated_download_still_encodes():
+    sample_pil = PILImage.new("RGB", (60, 30), color="red")
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image(sample_pil, download=True)
+    assert image.url.startswith("data:image/")
 
 
 def test_from_file_missing_file():

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -1,4 +1,3 @@
-import base64
 import os
 import tempfile
 import warnings
@@ -10,7 +9,6 @@ import requests
 from PIL import Image as PILImage
 
 import dspy
-from dspy.adapters.types.image import encode_image
 from dspy.utils.dummies import DummyLM
 
 
@@ -36,7 +34,7 @@ def sample_url():
 
 @pytest.fixture
 def sample_dspy_image_no_download():
-    return dspy.Image("https://images.dog.ceo/breeds/dane-great/n02109047_8912.jpg")
+    return dspy.Image(url="https://images.dog.ceo/breeds/dane-great/n02109047_8912.jpg")
 
 
 def count_messages_with_image_url_pattern(messages):
@@ -116,7 +114,7 @@ def test_basic_image_operations(test_case):
 
     # Convert string URLs to dspy.Image objects
     inputs = {
-        k: dspy.Image(v) if isinstance(v, str) and k in ["image", "ui_image"] else v
+        k: dspy.Image(url=v) if isinstance(v, str) and k in ["image", "ui_image"] else v
         for k, v in test_case["inputs"].items()
     }
 
@@ -147,7 +145,7 @@ def test_image_input_formats(
 
     input_map = {
         "pil_image": sample_pil_image,
-        "encoded_pil_image": encode_image(sample_pil_image),
+        "encoded_pil_image": dspy.Image.from_pil(sample_pil_image).url,
         "dspy_image_download": sample_dspy_image_download,
         "dspy_image_no_download": sample_dspy_image_no_download,
     }
@@ -166,7 +164,7 @@ def test_predictor_save_load(sample_url, sample_pil_image):
     """Test saving and loading predictors with image fields"""
     signature = "image: dspy.Image -> caption: str"
     examples = [
-        dspy.Example(image=dspy.Image(sample_url), caption="Example 1"),
+        dspy.Example(image=dspy.Image(url=sample_url), caption="Example 1"),
         dspy.Example(image=sample_pil_image, caption="Example 2"),
     ]
 
@@ -179,7 +177,7 @@ def test_predictor_save_load(sample_url, sample_pil_image):
         loaded_predictor = dspy.Predict(signature)
         loaded_predictor.load(temp_file.name)
 
-    loaded_predictor(image=dspy.Image("https://example.com/dog.jpg"))
+    loaded_predictor(image=dspy.Image(url="https://example.com/dog.jpg"))
     assert count_messages_with_image_url_pattern(lm.history[-1]["messages"]) == 2
     assert "<DSPY_IMAGE_START>" not in str(lm.history[-1]["messages"])
 
@@ -189,8 +187,8 @@ def test_save_load_complex_default_types():
     examples = [
         dspy.Example(
             image_list=[
-                dspy.Image("https://example.com/dog.jpg"),
-                dspy.Image("https://example.com/cat.jpg"),
+                dspy.Image(url="https://example.com/dog.jpg"),
+                dspy.Image(url="https://example.com/cat.jpg"),
             ],
             caption="Example 1",
         ).with_inputs("image_list"),
@@ -256,9 +254,9 @@ def test_save_load_complex_types(test_case):
     processed_input = {}
     for key, value in test_case["inputs"].items():
         if isinstance(value, str) and "http" in value:
-            processed_input[key] = dspy.Image(value)
+            processed_input[key] = dspy.Image(url=value)
         elif isinstance(value, list) and value and isinstance(value[0], str):
-            processed_input[key] = [dspy.Image(url) for url in value]
+            processed_input[key] = [dspy.Image(url=url) for url in value]
         else:
             processed_input[key] = value
 
@@ -301,8 +299,8 @@ def test_save_load_pydantic_model():
 
     # Create model instance
     model_input = ImageModel(
-        image=dspy.Image("https://example.com/dog.jpg"),
-        image_list=[dspy.Image("https://example.com/cat.jpg")],
+        image=dspy.Image(url="https://example.com/dog.jpg"),
+        image_list=[dspy.Image(url="https://example.com/cat.jpg")],
         output="Multiple photos",
     )
 
@@ -450,7 +448,7 @@ def test_pdf_from_file():
 
 def test_image_repr():
     """Test string representation of Image objects"""
-    url_image = dspy.Image("https://example.com/dog.jpg")
+    url_image = dspy.Image(url="https://example.com/dog.jpg")
     assert str(url_image) == (
         "<<CUSTOM-TYPE-START-IDENTIFIER>>"
         '[{"type": "image_url", "image_url": {"url": "https://example.com/dog.jpg"}}]'
@@ -459,20 +457,19 @@ def test_image_repr():
     assert repr(url_image) == "Image(url='https://example.com/dog.jpg')"
 
     sample_pil = PILImage.new("RGB", (60, 30), color="red")
-    pil_image = dspy.Image(sample_pil)
+    pil_image = dspy.Image.from_pil(sample_pil)
     assert str(pil_image).startswith('<<CUSTOM-TYPE-START-IDENTIFIER>>[{"type": "image_url",')
     assert str(pil_image).endswith("<<CUSTOM-TYPE-END-IDENTIFIER>>")
     assert "base64" in str(pil_image)
 
 
-def test_image_constructor_supports_source_and_url_keywords():
+def test_image_constructor_uses_url_field():
     source = "https://example.com/dog.jpg"
 
-    assert dspy.Image(source=source).url == source
     assert dspy.Image(url=source).url == source
 
-    with pytest.raises(TypeError, match="both `source` and `url`"):
-        dspy.Image(source, url=source)
+    with pytest.raises(TypeError):
+        dspy.Image(source)
 
 
 def test_canonical_factories_do_not_warn(tmp_path):
@@ -488,6 +485,7 @@ def test_canonical_factories_do_not_warn(tmp_path):
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
         dspy.Image.from_path(str(tmp_file))
+        dspy.Image.from_pil(PILImage.new("RGB", (10, 10), color="blue"))
 
 
 def test_deprecated_factory_aliases_warn(tmp_path):
@@ -507,8 +505,8 @@ def test_invalid_string_format():
     invalid_string = "this_is_not_a_url_or_file"
 
     # Should raise a ValueError and not pass the string through
-    with pytest.raises(ValueError, match="Unrecognized"):
-        dspy.Image(invalid_string)
+    with pytest.raises(pydantic.ValidationError, match="Unrecognized"):
+        dspy.Image(url=invalid_string)
 
 
 def test_positional_local_path_hard_breaks(tmp_path, monkeypatch):
@@ -518,48 +516,21 @@ def test_positional_local_path_hard_breaks(tmp_path, monkeypatch):
 
     monkeypatch.setattr("builtins.open", lambda *a, **k: pytest.fail("Image(path) read the filesystem"))
 
-    with pytest.raises(ValueError, match=r"Image\.from_path"):
+    with pytest.raises(TypeError):
         dspy.Image(str(tmp_file))
 
 
-def test_deprecated_download_true_downloads(monkeypatch):
-    response = type("Response", (), {"content": b"pngdata", "headers": {"Content-Type": "image/png"}})()
-    response.raise_for_status = lambda: None
-    monkeypatch.setattr("dspy.adapters.types.image.requests.get", lambda *args, **kwargs: response)
-
-    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
-        image = dspy.Image("https://example.com/dog.jpg", download=True)
-
-    assert image.url.startswith("data:image/png;base64,")
-    assert base64.b64decode(image.url.split(",", 1)[1]) == b"pngdata"
-
-
-def test_deprecated_download_false_keeps_reference():
-    source = "https://example.com/dog.jpg"
-    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
-        image = dspy.Image(source, download=False)
-    assert image.url == source
-
-
-def test_deprecated_verify_warns_without_download():
-    source = "https://example.com/dog.jpg"
-    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
-        image = dspy.Image(source, verify=False)
-    assert image.url == source
-
-
-def test_pil_image_with_deprecated_download_still_encodes():
-    sample_pil = PILImage.new("RGB", (60, 30), color="red")
-    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
-        image = dspy.Image(sample_pil, download=True)
-    assert image.url.startswith("data:image/")
+@pytest.mark.parametrize("option", [{"download": True}, {"download": False}, {"verify": False}])
+def test_constructor_rejects_removed_network_options(option):
+    with pytest.raises(pydantic.ValidationError):
+        dspy.Image(url="https://example.com/dog.jpg", **option)
 
 
 def test_from_path_missing_file():
-    with pytest.raises(ValueError, match="File not found"):
+    with pytest.raises(FileNotFoundError):
         dspy.Image.from_path("/nonexistent/image.png")
 
 
 def test_unidentifiable_bytes_raise_value_error():
     with pytest.raises(ValueError, match="could not be identified as an image"):
-        dspy.Image(b"not an image")
+        dspy.Image.from_bytes(b"not an image")

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -188,7 +188,6 @@ def test_workflow_with_custom_instruction_proposer_and_component_selector():
         Example(
             clock_photo=dspy.Image(
                 "https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg/500px-Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg",
-                download=False,
             ),
             hour=8,
             minute=18,
@@ -196,7 +195,6 @@ def test_workflow_with_custom_instruction_proposer_and_component_selector():
         Example(
             clock_photo=dspy.Image(
                 "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Telechron_clock_2H07-Br_Administrator.JPG/960px-Telechron_clock_2H07-Br_Administrator.JPG",
-                download=False,
             ),
             hour=4,
             minute=16,

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -187,14 +187,14 @@ def test_workflow_with_custom_instruction_proposer_and_component_selector():
     trainset = [
         Example(
             clock_photo=dspy.Image(
-                "https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg/500px-Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg",
+                url="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg/500px-Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg",
             ),
             hour=8,
             minute=18,
         ).with_inputs("clock_photo"),
         Example(
             clock_photo=dspy.Image(
-                "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Telechron_clock_2H07-Br_Administrator.JPG/960px-Telechron_clock_2H07-Br_Administrator.JPG",
+                url="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Telechron_clock_2H07-Br_Administrator.JPG/960px-Telechron_clock_2H07-Br_Administrator.JPG",
             ),
             hour=4,
             minute=16,

--- a/tests/teleprompt/test_gepa_instruction_proposer.py
+++ b/tests/teleprompt/test_gepa_instruction_proposer.py
@@ -77,7 +77,7 @@ def test_reflection_lm_gets_structured_images():
     Verify reflection LM receives structured image messages, not serialized text.
     """
     student = dspy.Predict("image: dspy.Image -> label: str")
-    image = dspy.Image("https://example.com/test.jpg")
+    image = dspy.Image(url="https://example.com/test.jpg")
     example = dspy.Example(image=image, label="dog").with_inputs("image")
 
     reflection_lm = DummyLM(
@@ -246,7 +246,7 @@ def test_image_serialization_into_strings():
 
     student = dspy.Predict("image -> label")
 
-    image = dspy.Image("https://picsum.photos/id/237/200/300")
+    image = dspy.Image(url="https://picsum.photos/id/237/200/300")
 
     examples = [
         dspy.Example(image=image, label="cat").with_inputs("image"),
@@ -304,7 +304,7 @@ def test_image_serialization_into_strings():
 def test_default_proposer(reasoning: bool, caplog):
     student = dspy.Predict("image -> label")
 
-    image = dspy.Image("https://picsum.photos/id/237/200/300")
+    image = dspy.Image(url="https://picsum.photos/id/237/200/300")
 
     examples = [
         dspy.Example(image=image, label="cat").with_inputs("image"),


### PR DESCRIPTION
## Before / after

Before, constructing or parsing a DSPy resource type could interpret a string as a locator and silently read a host file or fetch a remote URL; after, constructors and validation only normalize supplied values, while filesystem and network I/O require an explicit `from_path()` or `from_url()` call.

## Summary

- **[SECURITY HARDENING]** Make `Image`, `Audio`, and `File` construction and LM-output validation free of DSPy-initiated filesystem and network access.
- **[API]** Make all three resource constructors keyword-only and move external I/O behind explicit factories.
- **[VALIDATION]** Validate embedded audio/file payloads as base64 instead of accepting locator-shaped or malformed strings.
- **[BREAKING / DELIBERATE]** Remove ambiguous positional construction and implicit-I/O helper behavior for the 3.3.0 release.

## Why this boundary

DSPy adapters parse LM output through Pydantic. Previously, that validation path reused convenience coercion that could call `open()` or `requests.get()`. A value being validated as data could therefore cause host I/O merely because it resembled a path or URL.

This is defense-in-depth hardening, not a claim of a high-severity practical exploit. The reported PoCs require an unusual signature with `Image`/`Audio`/`File` output fields. The stronger and simpler invariant is valuable independently: **construction and validation do not dereference locators; explicitly named factories do.**

### Python and ecosystem rationale

Python does not prohibit side effects in `__init__`; this is an API-design choice for this boundary:

- [PEP 20](https://peps.python.org/pep-0020/) says “Explicit is better than implicit.” A call named `from_path()` or `from_url()` makes host I/O visible at the call site; ordinary model construction does not.
- Python's [`pathlib` design](https://docs.python.org/3/library/pathlib.html#pure-paths) separates path representation and computation from filesystem access, while methods such as [`Path.open()` and `Path.read_bytes()`](https://docs.python.org/3/library/pathlib.html#reading-and-writing-files) explicitly perform I/O. DSPy's resource APIs now follow the same locator-versus-dereference distinction.
- Pydantic documents [`TypeAdapter`](https://docs.pydantic.dev/latest/concepts/type_adapter/) as a validation/parsing boundary for arbitrary types and shows it parsing data returned by an API. DSPy uses this same path for LM output, nested models, and deserialization; keeping validation local and deterministic prevents parsing external data from becoming an implicit capability to access the host.
- The [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html) treats application-initiated requests to caller-controlled URLs as a security boundary and recommends allowlisting trusted destinations where possible. `from_url()` therefore remains explicit and caller-owned; DSPy checks the HTTP(S) scheme, but callers must validate untrusted destinations for their environment.

## Security and I/O contract

| Input | Construction / validation | Explicit operation |
|---|---|---|
| Local image path | rejected without touching the filesystem | `Image.from_path(path)` |
| Local audio path | rejected without touching the filesystem | `Audio.from_path(path)` |
| Local file path | rejected without touching the filesystem | `File.from_path(path)` |
| HTTP(S) image URL | retained as a provider-fetched reference | `Image.from_url(url)` downloads into a data URI |
| HTTP(S) audio URL | rejected as embedded audio data | `Audio.from_url(url)` downloads and embeds it |
| URL-shaped file data | rejected | no `File.from_url()` in this PR |
| Raw bytes / arrays / PIL objects | not accepted positionally | use the matching `from_bytes()`, `from_array()`, or `from_pil()` factory |

`from_url()` is a synchronous, caller-initiated network request. It follows redirects and provides no SSRF protection beyond requiring an HTTP(S) URL. If a URL is derived from untrusted input, the caller owns destination validation or allowlisting.

## Public API after this PR

| Capability | Image | Audio | File |
|---|---|---|---|
| Keyword constructor | `Image(url=<URL or data URI>)` | `Audio(data=<base64>, audio_format=...)`; audio data URIs infer format | `File(file_data=<data URI>, file_id=..., filename=...)` |
| Non-fetching remote reference | keyword `url=` | — | provider `file_id=` only |
| Read local resource | `from_path()` | `from_path()` | `from_path()` |
| Download remote resource | `from_url()` | `from_url()` | — |
| Encoded bytes | `from_bytes()` | `from_bytes(..., audio_format=...)` | `from_bytes()` |
| PIL / array | `from_pil()` | `from_array(..., sampling_rate, audio_format=...)` | — |
| Provider file ID | — | — | `from_file_id()` |

Deprecated aliases retained through 3.3 and scheduled for removal in 3.4:

- `Image.from_file()` → `Image.from_path()`
- `Image.from_PIL()` → `Image.from_pil()`
- `Audio.from_file()` → `Audio.from_path()`

## Breaking changes in 3.3.0

### Constructors and validation

| Previous call / behavior | New behavior | Migration |
|---|---|---|
| `Image(value)` for a URL, data URI, path, bytes, PIL image, or dict | positional construction raises `TypeError` | use `Image(url=...)` for URL/data-URI references or an explicit factory |
| `Image(url=local_path)` | rejects without reading | `Image.from_path(path)` |
| `Image(url=bytes_or_pil)` | rejects non-string `url` values | `Image.from_bytes()` / `Image.from_pil()` |
| `Image(..., download=..., verify=...)` | constructor options removed; no compatibility shim | `Image.from_url(url, verify=...)` to download, or `Image(url=url)` to retain a reference |
| `Audio` validation of a path or URL string | rejects without reading/fetching | `Audio.from_path()` / `Audio.from_url()` |
| `Audio(data=...)` with malformed or non-base64 data | raises `ValidationError` | supply valid raw base64 or an audio data URI |
| `File` validation of a local path | rejects without reading | `File.from_path()` |
| `File(file_data=...)` with a path, URL, or malformed payload | raises `ValidationError` | supply a valid `data:<mime>;base64,...` URI, use `from_path()`, or use `file_id=` |
| LM-output parsing of locator-shaped `Audio`/`File` values | raises `ValidationError`; never dereferences | no implicit-I/O migration by design |
| LM-output parsing of an HTTP(S) `Image.url` | remains a non-fetching reference | unchanged |

### Factories and helpers

| Previous call / behavior | New behavior | Migration |
|---|---|---|
| `Image.from_url(url)` retained a reference by default | always downloads and returns a data URI | use `Image(url=url)` for a reference |
| `Image.from_url(url, download=...)` | `download` removed | choose `Image(url=url)` or `Image.from_url(url)` explicitly |
| `encode_image(path)` | rejects local paths | `Image.from_path(path)` |
| `encode_image(bytes_or_pil_or_dict)` | no longer accepted | use `Image.from_bytes()`, `Image.from_pil()`, or `Image(url=...)` |
| `encode_image(..., download_images=..., verify=...)` | options removed | use `Image.from_url(..., verify=...)` for a fetch |
| `encode_audio(path_or_url)` | rejects locator strings | `Audio.from_path()` / `Audio.from_url()` |
| `encode_audio(bytes)` relied on default WAV; arrays relied on default sampling rate | bytes require `audio_format=`; arrays require `sampling_rate=` | pass the required metadata explicitly |
| `encode_audio(..., format=...)` or positional config arguments | `audio_format=` and keyword-only configuration | rename/pass keywords |
| `Audio.from_array(..., format=...)` or positional third argument | `audio_format=` is keyword-only | rename/pass as a keyword |
| `encode_file_to_dict(path)` | rejects local paths | `File.from_path(path)` |
| positional optional args to `File.from_path`, `File.from_bytes`, or `File.from_file_id` | optional args are keyword-only | pass `filename=` / `mime_type=` explicitly |
| `File.from_path(file_path=...)` | first parameter is now named `path` | use `path=` or pass the path positionally |
| `is_image(local_path)` | returns `False` without probing the filesystem | use `Image.from_path()` when a read is intended |

## Unchanged / intentionally out of scope

- Keyword construction remains available for already-embedded, valid resource values and provider references.
- `Image(url="https://...")` remains a non-fetching reference; the downstream model provider may fetch it.
- `Image.from_file()`, `Image.from_PIL()`, and `Audio.from_file()` remain functional for one deprecation cycle.
- `Audio.from_url()` and `File.from_path()` / `from_bytes()` / `from_file_id()` remain available, subject to the signature changes listed above.
- No `File.from_url()` is added.
- DSPy does not implement a universal SSRF allowlist in this PR; trust policy is application-specific and belongs to the caller invoking `from_url()`.

## Review guide

1. `dspy/adapters/types/image.py`: keyword-only URL/data-URI model plus explicit image factories.
2. `dspy/adapters/types/audio.py`: strict base64/data-URI validation and explicit path/URL/bytes/array factories.
3. `dspy/adapters/types/file.py`: strict file data-URI validation and explicit file factories.
4. `tests/adapters/test_resource_loading.py`: construction and `TypeAdapter.validate_python()` host-I/O boundary, malformed payload rejection, and public signature tests.
5. Resource documentation under `docs/docs/api/primitives/` and `docs/docs/diving-deeper/adapters.md`.

## Validation

- Full GitHub test matrix passes on Python 3.10–3.14 at head `9213b22b7`.
- Package builds, Ruff, workflow lint, docs build, real-LM job, zizmor, and Greptile checks pass.
- `test_construction_performs_no_host_io` and `test_validation_performs_no_host_io` forbid `open()` and `requests.get()` for locator-shaped inputs.
- Dedicated tests cover malformed audio/file payloads, explicit local/remote factories, keyword-only constructor signatures, and positional-constructor rejection.

Fixes #10067
