### PR TITLE
fix: roll up nested track_usage() into enclosing tracker

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -67,8 +67,20 @@ class UsageTracker:
 
 @contextmanager
 def track_usage() -> Generator[UsageTracker, None, None]:
-    """Context manager for tracking LM usage."""
+    """Context manager for tracking LM usage.
+
+    When nested, the inner tracker rolls its recorded usage up into the
+    enclosing tracker on exit so that outer scopes observe the full cost
+    of the workflow (fixes #10064).
+    """
     tracker = UsageTracker()
+    parent_tracker = settings.usage_tracker  # may be None if not nested
 
     with settings.context(usage_tracker=tracker):
         yield tracker
+
+    # Roll up into the enclosing tracker so outer scopes see nested usage.
+    if parent_tracker is not None:
+        for lm, entries in tracker.usage_data.items():
+            for entry in entries:
+                parent_tracker.add_usage(lm, entry)

--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -76,11 +76,13 @@ def track_usage() -> Generator[UsageTracker, None, None]:
     tracker = UsageTracker()
     parent_tracker = settings.usage_tracker  # may be None if not nested
 
-    with settings.context(usage_tracker=tracker):
-        yield tracker
-
-    # Roll up into the enclosing tracker so outer scopes see nested usage.
-    if parent_tracker is not None:
-        for lm, entries in tracker.usage_data.items():
-            for entry in entries:
-                parent_tracker.add_usage(lm, entry)
+    try:
+        with settings.context(usage_tracker=tracker):
+            yield tracker
+    finally:
+        # Roll up into the enclosing tracker so outer scopes see nested usage.
+        # This runs even if the nested block raises an exception.
+        if parent_tracker is not None:
+            for lm, entries in tracker.usage_data.items():
+                for entry in entries:
+                    parent_tracker.add_usage(lm, entry)


### PR DESCRIPTION
## Summary

Fixes #10064.

When two `dspy.track_usage()` blocks are nested, the outer tracker previously did not include LM usage that occurred inside the inner block. Each LM call was recorded only by the innermost active tracker, so the outer scope silently under-counted.

This is a real-world scenario in multi-agent setups (coordinator + sub-agents both tracking cost) and training loops (top-level + per-epoch tracking).

## Root Cause

`track_usage()` sets a new `UsageTracker` via `settings.context(usage_tracker=tracker)`. When nested, the inner tracker replaces the outer one in settings. LM calls inside the inner block go only to the inner tracker. On exit, the outer tracker is restored but never received the inner block's usage.

## Fix

On exit of the inner `track_usage()` context, roll up all recorded usage entries into the parent tracker (if one exists). This ensures outer scopes observe the full workflow cost while inner scopes still report their own isolated usage.

## Changes

- `dspy/utils/usage_tracker.py`: Save reference to enclosing tracker before entering context; on exit, iterate inner tracker's `usage_data` and call `parent_tracker.add_usage()` for each entry.

## Testing

The fix was verified against the reproduction script from the issue:

```python
with track_usage() as orchestrator_cost:
    record_lm_call(100, 10)
    a = subagent(1000, 100)  # nested track_usage
    b = subagent(500, 50)
    record_lm_call(5, 1)

# Before: orchestrator billed 105
# After:  orchestrator billed 1605 (correct)
```

Backward compatible: non-nested usage of `track_usage()` is unaffected (parent_tracker is None).