### PR TITLE
fix(teleprompt): propagate DSPy context into AvatarOptimizer worker threads

### DIFF
--- a/dspy/teleprompt/avatar_optimizer.py
+++ b/dspy/teleprompt/avatar_optimizer.py
@@ -1,3 +1,4 @@
+import contextvars
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from random import sample
@@ -118,7 +119,8 @@ class AvatarOptimizer(Teleprompter):
         num_threads = num_threads or dspy.settings.num_threads
 
         with ThreadPoolExecutor(max_workers=num_threads) as executor:
-            futures = [executor.submit(self.process_example, actor, example, return_outputs) for example in devset]
+            ctx = contextvars.copy_context()
+            futures = [executor.submit(ctx.run, self.process_example, actor, example, return_outputs) for example in devset]
 
             for future in tqdm(futures, total=total_examples, desc="Processing examples"):
                 result = future.result()

--- a/dspy/teleprompt/avatar_optimizer.py
+++ b/dspy/teleprompt/avatar_optimizer.py
@@ -119,8 +119,7 @@ class AvatarOptimizer(Teleprompter):
         num_threads = num_threads or dspy.settings.num_threads
 
         with ThreadPoolExecutor(max_workers=num_threads) as executor:
-            ctx = contextvars.copy_context()
-            futures = [executor.submit(ctx.run, self.process_example, actor, example, return_outputs) for example in devset]
+            futures = [executor.submit(contextvars.copy_context().run, self.process_example, actor, example, return_outputs) for example in devset]
 
             for future in tqdm(futures, total=total_examples, desc="Processing examples"):
                 result = future.result()


### PR DESCRIPTION
## Summary

Fixes context propagation in `AvatarOptimizer` when using `ThreadPoolExecutor`. Python's `concurrent.futures` does not automatically copy `contextvars` state to worker threads, so DSPy context (active LM, settings) was silently unavailable to workers.

Fixes #10053

## Changes

- Use `contextvars.copy_context()` to capture context before submitting to the thread pool
- Each worker runs inside `ctx.run(...)` so it sees the same DSPy context as the calling thread

## Testing

Existing test suite covers optimizer correctness. This is a thread-safety fix with no behavioral change when running single-threaded.