### PR TITLE
ci(tests): parallelize pytest with xdist and simplify CI jobs

### DIFF
--- a/.github/workflows/dependency-range.yml
+++ b/.github/workflows/dependency-range.yml
@@ -13,6 +13,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   dependency-range:
     name: Dependencies (${{ matrix.profile }})
@@ -84,7 +88,7 @@ jobs:
           PROFILE: ${{ matrix.profile }}
         run: |
           set +e
-          uv run --frozen --no-sync pytest -q tests/ --extra --deno 2>&1 \
+          uv run --frozen --no-sync pytest -q -n auto --dist worksteal tests/ --extra --deno 2>&1 \
             | tee "$RUNNER_TEMP/pytest-$PROFILE.log"
           TEST_STATUS=${PIPESTATUS[0]}
           set -e

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   workflow-lint:
     name: Lint GitHub Actions Workflows
@@ -99,16 +103,12 @@ jobs:
         run: |
           uv sync --dev -p .venv --extra dev
           uv pip list
-      - name: Run lint with tests
-        uses: chartboost/ruff-action@e18ae971ccee1b2d7bbef113930f00c670b78da4 # v1
-        with:
-          args: check --fix-only
       - name: Run tests with pytest
-        run: uv run -p .venv pytest -vv tests/
+        run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
       - name: Install optional dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno
+        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
   
   llm_call_test:
     name: Run Tests with Real LM
@@ -201,15 +201,11 @@ jobs:
           cache-dependency-glob: |
             **/pyproject.toml
             **/uv.lock
-      - name: Create and activate virtual environment
+      - name: Build
+        run: uv build
+      - name: Install built package
         run: |
           uv venv .venv
-          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
-      - name: Install dependencies
-        run: uv sync --dev -p .venv --extra dev
-      - name: Build
-        run: uv run -p .venv python -m build
-      - name: Install built package
-        run: uv pip install dist/*.whl -p .venv
+          uv pip install dist/*.whl -p .venv
       - name: Test import dspy
-        run: uv run -p .venv python -c "import dspy"
+        run: .venv/bin/python -c "import dspy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "pytest>=6.2.5",
     "pytest-mock>=3.12.0",
     "pytest-asyncio>=0.26.0",
+    "pytest-xdist>=3.5.0",
     "ruff>=0.3.0",
     "pre-commit>=3.7.0",
     "pillow>=10.1.0",

--- a/tests/test_utils/server/__init__.py
+++ b/tests/test_utils/server/__init__.py
@@ -76,7 +76,7 @@ def _get_random_port():
         return s.getsockname()[1]
 
 
-def _wait_for_port(host, port, timeout=10):
+def _wait_for_port(host, port, timeout=60):
     start_time = time.time()
     while time.time() - start_time < timeout:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:

--- a/uv.lock
+++ b/uv.lock
@@ -761,7 +761,7 @@ wheels = [
 
 [[package]]
 name = "dspy"
-version = "3.2.1"
+version = "3.3.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -798,6 +798,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 langchain = [
@@ -866,6 +867,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=6.2.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.12.0" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "regex", specifier = ">=2023.10.3" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.3.0" },
@@ -898,6 +900,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -2803,6 +2814,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241, upload-time = "2025-05-26T13:58:45.167Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923, upload-time = "2025-05-26T13:58:43.487Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# ci: parallelize pytest, drop no-op lint step, simplify build job

## Motivation

The five `Run Tests` matrix jobs are the wall-clock bottleneck of every CI run. Over the last 3 successful `main` runs they took **470–552s each**, while every other job finished in ≤160s. Inside a representative job (`Run Tests (3.12)` on run 29527102985):

| Step | Time |
|---|---|
| Setup (checkout, python, deno, uv, sync) | ~12s |
| Main pytest run (1041 tests) | **171s** |
| Extra + deno tests (161 tests) | **322s** |

The extra/deno step is dominated by `test_python_interpreter.py` (~194s) and `test_rlm.py` (~90s) — each test boots a fresh Deno/Pyodide subprocess, so the step is subprocess-bound and embarrassingly parallel.

## Changes

**1. Run pytest with `pytest-xdist` (`-n auto --dist worksteal`)**

Both pytest invocations in the test job now run one worker per core. `worksteal` scheduling matters here because test durations are heavily skewed (multi-second Deno boots next to millisecond unit tests). Local validation (both suites fully green, run twice — once at `-n auto`, once at `-n 4` to mirror the 4-vCPU runner):

| Suite | Serial (CI) | Parallel (local) |
|---|---|---|
| Main suite | 171s | 1032 passed in **29–38s** |
| Extra + deno | 322s | 161 passed in **31–32s** |

The suite is already parallel-safe by construction: the autouse `clear_settings` fixture gives every test an isolated tmp-path cache, and `litellm_test_server` binds a random free port. xdist workers are separate processes, so the per-process global `dspy.settings` is unaffected.

Measured on this PR's own CI run (run 30084553121): main suite **171s → 84s**, extra/deno **322s → 224s**, whole test job **~520s → ~330s** (~37% off the workflow's critical path). The deno suite scales sublinearly because each Deno/Pyodide boot is itself multi-threaded, so the 4 vCPUs saturate; the remaining ceiling is per-test interpreter boots, not scheduling.

**1b. Same treatment for the `Dependency Range` workflow**

On any PR touching `pyproject.toml`/`uv.lock`, the `Dependencies (minimum-direct)` job runs the *full* suite (main + extra + deno) in one serial pytest invocation on a lowest-versions environment — it took ~15+ min on this PR's first run, roughly twice the parallelized test matrix. It now uses the same `-n auto --dist worksteal` flags (lowest-direct resolution keeps `pytest-xdist` at 3.5.0, which supports `worksteal`), plus the same concurrency group. Test phase measured at ~5 min vs the 16.7 min serial baseline.

Parallelizing this workflow resurfaced a known flake: the `litellm_test_server` fixture's 10s readiness deadline is too tight when the proxy's multi-second cold start competes with Deno/Pyodide boots on sibling workers (this workflow runs both in a single pytest invocation). The deadline is now 60s — the wait polls and returns as soon as the port opens, so passing runs pay nothing.

**2. Add a `concurrency` group (cancel superseded PR runs)**

Pushing to a PR now cancels the in-flight run for that PR instead of letting ~13 stale jobs run to completion. `main` pushes are never cancelled (`cancel-in-progress` is false for non-PR events), so every main commit keeps a complete run.

**3. Remove the `chartboost/ruff-action` step from the test job**

The step ran `ruff check --fix-only` (exit code 0, fixes discarded) — a no-op that gated nothing. It also pinned an **archived** action (chartboost/ruff-action was superseded by astral-sh/ruff-action). Lint enforcement already lives in the `Check Ruff Fix` job, which uses the repo-locked ruff version with `--exit-non-zero-on-fix`.

**4. Simplify `build_package`**

The job installed the full dev environment (pytest, ruff, pre-commit, litellm\[proxy], …) on all 5 Python versions just to run `python -m build`. It now runs `uv build` (same PEP 517 / setuptools backend, build isolation included) with no project sync at all, then installs the wheel into a bare venv. This is also a *stricter* packaging test than before: previously the wheel was installed into a venv that already had all dependencies synced, so broken wheel metadata could not have been caught; now the wheel must resolve its own dependencies.

## Validation

- `pytest tests/ -n auto` and `-n 4 --dist worksteal`: 1032 passed, 376 skipped, 2 xfailed — green both times
- `pytest tests/ -m 'extra or deno' --extra --deno -n auto` and `-n 4`: 161 passed — green both times
- `uv build` + wheel install + import verified locally
- `actionlint` and `zizmor` both clean on the edited workflow

Not touched: the Ollama `llm_call` job (its bottleneck is the CPU-bound model server, not pytest), the `fix` job (keeps the repo-locked ruff), and `workflow-lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
