### PR TITLE
ci(llm): remove AMX backend variant to fix Real LM segfault on Sapphire Rapids runners

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -150,6 +150,12 @@ jobs:
             -p 11434:11434 \
             -v "$GITHUB_WORKSPACE/ollama-data:/root/.ollama" \
             ollama/ollama:0.31.2
+          # Some GitHub runners are Sapphire-Rapids-class machines with AMX. llama.cpp's
+          # AMX-repacked weight path segfaults there during model load (llama-server dies
+          # with SIGSEGV in warm-up), while all non-AMX runners pass. Removing the AMX
+          # backend variant makes ggml's autodetection fall back to the icelake kernels
+          # that every other runner already uses.
+          docker exec ollama rm /usr/lib/ollama/libggml-cpu-sapphirerapids.so
           timeout 60 bash -c 'until curl -f http://localhost:11434/api/version; do sleep 2; done'
       - name: Pull LLM
         if: steps.cache-ollama.outputs.cache-hit != 'true'


### PR DESCRIPTION
# ci(llm): fix intermittent Real LM segfault on AMX runners

## Symptom

`Run Tests with Real LM` intermittently fails at the "Warm up LLM" step — all 3 attempts return HTTP 500, and the ollama logs show llama-server dying during model load:

```
error="llama-server process has terminated: signal: segmentation fault (core dumped)"
```

Recent occurrences: run 30084553121 (2026-07-24, PR #10078) and run 30027258907 (2026-07-23), while runs in between passed unchanged. Rerunning the identical failed commit on a fresh runner passed.

## Root cause

The crash is machine-dependent. On the failing runners, llama-server's system info shows `AMX_INT8 = 1` (Sapphire-Rapids-class hardware) and the weights get repacked into an AMX buffer:

```
CPU : ... AVX512_BF16 = 1 | AMX_INT8 = 1 | ...
load_tensors: AMX model buffer size = 1953.78 MiB
```

The segfault fires in the first inference after that repack. This matches [ggml-org/llama.cpp#20824](https://github.com/ggml-org/llama.cpp/issues/20824) — "segfault in `ggml_backend_amx_mul_mat`", same machine-dependence ("works fine on another machine"), same quant family (Q4_K_M). That issue was **closed as stale without a fix** — the reporter stopped reproducing it but never bisected.

**An image bump cannot fix this:** ollama 0.31.2 pins llama.cpp build `b9888` (2026-07-06), and no commit has touched `ggml/src/ggml-cpu/amx` upstream since. Every current ollama release ships the same kernel, and our own crash logs are from that build. The CPU variant also can't be steered by env: `OLLAMA_LLM_LIBRARY` only affects GPU library discovery in 0.31.2; the CPU microarch variant is chosen by ggml's CPUID scoring inside llama-server, with no exclusion knob.

## Fix

Remove `/usr/lib/ollama/libggml-cpu-sapphirerapids.so` from the container before the first model load. Per llama.cpp's build definitions, `sapphirerapids` is the **only** x86 variant compiled with `AMX_TILE AMX_INT8`; with it gone, ggml's scoring deterministically falls back to the non-AMX AVX-512 kernels (`zen4`/`cooperlake`/`icelake`) — the same code paths every currently-passing runner uses. This disables the defective code path rather than retrying until the job lands on healthy hardware.

The `rm` is intentionally **not** `-f`: if a future image bump changes the backend layout, the job fails loudly at that line instead of silently reverting to flaky.

## Validation

- Verified `libggml-cpu-sapphirerapids.so` exists at that path in `ollama/ollama:0.31.2` (image filesystem inspected), alongside 12 non-AMX x86 variants for fallback.
- Started the container locally, ran the `rm`, and confirmed the server still comes up and serves `/api/version`.
- `actionlint` clean.

Note: this job's runner assignment is luck-of-the-draw, so a green run here doesn't by itself prove the fix — the proof is that non-AMX kernels have never produced this crash. If you want the upstream bug revived, I can comment on llama.cpp#20824 with our stack traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
