### PR TITLE
docs: fix article usage in modules.md

### DIFF
--- a/docs/docs/learn/programming/modules.md
+++ b/docs/docs/learn/programming/modules.md
@@ -229,7 +229,7 @@ class Hop(dspy.Module):
         return dspy.Prediction(notes=notes, titles=list(set(titles)))
 ```
 
-Then you can create a instance of the custom module class `Hop`, then invoke it by the `__call__` method:
+Then you can create an instance of the custom module class `Hop`, then invoke it by the `__call__` method:
 
 ```
 hop = Hop()


### PR DESCRIPTION
'create a instance' -> 'create an instance' -- 'instance' starts with a vowel sound, so it takes 'an' not 'a'.