### PR TITLE
docs: fix article usage in best-of-n-and-refine.md

### DIFF
--- a/docs/docs/tutorials/output_refinement/best-of-n-and-refine.md
+++ b/docs/docs/tutorials/output_refinement/best-of-n-and-refine.md
@@ -87,7 +87,7 @@ refine = dspy.Refine(
 Both modules serve similar purposes but differ in their approach:
 
 - `BestOfN` simply tries different rollout IDs and selects the best resulting prediction as defined by the `reward_fn`.
-- `Refine` adds an feedback loop, using the lm to generate a detailed feedback about the module's own performance using the previous prediction and the code in the `reward_fn`. This feedback is then used as hints for subsequent runs.
+- `Refine` adds a feedback loop, using the lm to generate a detailed feedback about the module's own performance using the previous prediction and the code in the `reward_fn`. This feedback is then used as hints for subsequent runs.
 
 ## Practical Examples
 


### PR DESCRIPTION
'adds an feedback loop' -> 'adds a feedback loop' -- 'feedback' starts with a consonant sound, so it takes 'a' not 'an'.