### PR TITLE
docs: fix non-standard word in section heading

### DIFF
--- a/docs/docs/deep-dive/data-handling/examples.md
+++ b/docs/docs/deep-dive/data-handling/examples.md
@@ -55,7 +55,7 @@ This flexibility allows for customized tailoring of the `Example` object for dif
 When you call `with_inputs()`, you get a new copy of the example. The original object is kept unchanged.
 
 
-## Element Access and Updation
+## Element Access and Updates
 
 Values can be accessed using the `.`(dot) operator. You can access the value of key `name` in defined object `Example(name="John Doe", job="sleep")` through `object.name`. 
 


### PR DESCRIPTION
'Element Access and Updation' -> 'Element Access and Updates' -- 'Updation' is not standard English; 'Updates' matches the parallel noun form of 'Access'.