### PR TITLE
fix(usage): roll nested track_usage() up into the enclosing tracker

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -70,5 +70,19 @@ def track_usage() -> Generator[UsageTracker, None, None]:
     """Context manager for tracking LM usage."""
     tracker = UsageTracker()
 
-    with settings.context(usage_tracker=tracker):
-        yield tracker
+    # Capture any tracker already active in an enclosing `track_usage()` block.
+    # While this block is open it shadows the enclosing one in settings, so each
+    # LM call is recorded only by the innermost active tracker. Rolling this
+    # tracker's usage up into the parent on exit keeps an outer block reflecting
+    # everything that happened inside it, including work done in nested blocks
+    # (e.g. sub-agents or per-epoch tracking under a top-level cost tracker).
+    parent_tracker = settings.usage_tracker
+
+    try:
+        with settings.context(usage_tracker=tracker):
+            yield tracker
+    finally:
+        if parent_tracker is not None:
+            for lm, usage_entries in tracker.usage_data.items():
+                for usage_entry in usage_entries:
+                    parent_tracker.add_usage(lm, usage_entry)

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 
 import dspy
 from dspy.utils.usage_tracker import UsageTracker, track_usage
+from dspy.dsp.utils.settings import settings
 
 
 def test_add_usage_entry():
@@ -392,3 +393,66 @@ def test_parallel_executor_with_usage_tracker():
 
     # Parent tracker should remain unchanged (workers have independent copies)
     assert len(parent_tracker.usage_data) == 0
+
+
+def _record_lm_usage(model, prompt_tokens, completion_tokens):
+    """Mirror what dspy/clients/lm.py does on each LM call: record against the
+    innermost active usage tracker, if any."""
+    if settings.usage_tracker:
+        settings.usage_tracker.add_usage(
+            model, {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens}
+        )
+
+
+def test_nested_track_usage_rolls_up_into_outer_tracker():
+    """A nested `track_usage()` block must not hide its usage from the enclosing
+    block. Each LM call is recorded only by the innermost active tracker, so
+    without roll-up an outer block silently under-counts everything that happened
+    inside a nested block (e.g. sub-agents, or per-epoch tracking under a
+    top-level cost tracker). Regression test for #10064."""
+    model = "gpt"
+
+    def subagent(prompt_tokens, completion_tokens):
+        with track_usage() as inner:
+            _record_lm_usage(model, prompt_tokens, completion_tokens)
+        # The inner block still reports exactly its own usage, nothing more.
+        return inner.get_total_tokens()[model]["prompt_tokens"]
+
+    with track_usage() as outer:
+        _record_lm_usage(model, 100, 10)
+        a = subagent(1000, 100)
+        b = subagent(500, 50)
+        _record_lm_usage(model, 5, 1)
+
+    assert a == 1000
+    assert b == 500
+
+    outer_total = outer.get_total_tokens()[model]
+    assert outer_total["prompt_tokens"] == 100 + 1000 + 500 + 5
+    assert outer_total["completion_tokens"] == 10 + 100 + 50 + 1
+
+
+def test_nested_track_usage_rolls_up_on_exception():
+    """Usage incurred before an exception inside a nested block still rolls up,
+    since the tokens were spent regardless of how the block exited."""
+    model = "gpt"
+
+    with track_usage() as outer:
+        _record_lm_usage(model, 3, 1)
+        try:
+            with track_usage():
+                _record_lm_usage(model, 50, 5)
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+
+    assert outer.get_total_tokens()[model]["prompt_tokens"] == 3 + 50
+
+
+def test_top_level_track_usage_has_no_parent_to_roll_up_into():
+    """A single (non-nested) block has no enclosing tracker, so it must record
+    its own usage once and not error on exit."""
+    model = "gpt"
+    with track_usage() as tracker:
+        _record_lm_usage(model, 9, 1)
+    assert tracker.get_total_tokens()[model]["prompt_tokens"] == 9


### PR DESCRIPTION
## What

Fixes #10064.

`track_usage()` records each LM call against the innermost active tracker only. When two blocks are nested, the inner `settings.context(usage_tracker=...)` shadows the outer tracker for the duration of the inner scope, so LM calls made inside the inner block never reach the outer one. The outer block silently under-counts.

This shows up whenever cost tracking exists at two levels, which the issue lays out well: a coordinator tracking its own usage while spawning sub-agents that track theirs, or a top-level training-cost tracker with per-epoch tracking underneath.

## Reproduction

From the issue, recording usage the same way `dspy/clients/lm.py` does on each call (no live LM needed):

```python
with track_usage() as orchestrator:
    record_lm_call(100, 10)
    a = subagent(1000, 100)   # each subagent opens its own track_usage() block
    b = subagent(500, 50)
    record_lm_call(5, 1)
```

```
before:  orchestrator billed:  105     # only the two direct calls
         actual workflow cost: 1605
after:   orchestrator billed:  1605
```

## Fix

Capture the tracker already active in an enclosing block before swapping in the new one, then on exit roll this tracker's usage up into it:

```python
parent_tracker = settings.usage_tracker
try:
    with settings.context(usage_tracker=tracker):
        yield tracker
finally:
    if parent_tracker is not None:
        for lm, usage_entries in tracker.usage_data.items():
            for usage_entry in usage_entries:
                parent_tracker.add_usage(lm, usage_entry)
```

The roll-up runs in `finally`, so usage incurred before an exception inside the inner scope still counts (those tokens were spent regardless of how the block exited). A top-level block has no parent, so nothing rolls up and its behavior is unchanged. Each inner block still reports exactly its own usage while it is open, so there is no double counting within a scope.

This matches the roll-up-on-exit approach the issue proposed.

## Tests

Added three regression tests to `tests/utils/test_usage_tracker.py`:

- `test_nested_track_usage_rolls_up_into_outer_tracker` (the main case, checks both prompt and completion tokens)
- `test_nested_track_usage_rolls_up_on_exception`
- `test_top_level_track_usage_has_no_parent_to_roll_up_into`

The first two fail on current `main` and pass with the fix; the third is the no-op case and passes either way (I confirmed the first two go red when only the source change is reverted). Existing usage-tracker tests still pass: 7 passed, 1 skipped.

I also checked three-level nesting by hand (each level correctly sees the innermost cost) and that a solo top-level block still records its own usage once without erroring.