### PR TITLE
fix(teleprompt): make COPRO.compile eval_kwargs optional

### DIFF
--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -121,7 +121,7 @@ class COPRO(Teleprompter):
         assert hasattr(predictor, "signature")
         predictor.signature = updated_signature
 
-    def compile(self, student, *, trainset, eval_kwargs):
+    def compile(self, student, *, trainset, eval_kwargs=None):
         """
         optimizes `signature` of `student` program - note that it may be zero-shot or already pre-optimized (demos already chosen - `demos != []`)
 
@@ -133,6 +133,7 @@ class COPRO(Teleprompter):
 
         Returns optimized version of `student`.
         """
+        eval_kwargs = eval_kwargs or {}
         module = student.deepcopy()
         evaluate = Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)
         total_calls = 0

--- a/dspy/teleprompt/copro_optimizer.py
+++ b/dspy/teleprompt/copro_optimizer.py
@@ -128,7 +128,7 @@ class COPRO(Teleprompter):
         parameters:
         student: program to optimize and left modified.
         trainset: iterable of `Example`s
-        eval_kwargs: optional, dict
+        eval_kwargs: optional, dict, defaults to None (no extra kwargs)
            Additional keywords to go into `Evaluate` for the metric.
 
         Returns optimized version of `student`.

--- a/tests/teleprompt/test_copro_optimizer.py
+++ b/tests/teleprompt/test_copro_optimizer.py
@@ -65,6 +65,28 @@ def test_signature_optimizer_optimization_process():
     # such as checking the instructions of the optimized student's predictors.
 
 
+def test_compile_without_eval_kwargs():
+    # `eval_kwargs` is documented as optional, so compile() must run when it is omitted.
+    # Regression test for #9080 (previously raised TypeError: missing keyword-only argument).
+    optimizer = COPRO(metric=simple_metric, breadth=2, depth=1, init_temperature=1.4)
+    dspy.configure(
+        lm=DummyLM(
+            [
+                {
+                    "proposed_instruction": "Optimized instruction 1",
+                    "proposed_prefix_for_output_field": "Optimized instruction 2",
+                },
+            ]
+        )
+    )
+
+    student = SimpleModule("input -> output")
+
+    optimized_student = optimizer.compile(student, trainset=trainset)
+
+    assert optimized_student is not student, "Optimization did not modify the student"
+
+
 def test_signature_optimizer_statistics_tracking():
     optimizer = COPRO(metric=simple_metric, breadth=2, depth=1, init_temperature=1.4)
     optimizer.track_stats = True  # Enable statistics tracking


### PR DESCRIPTION
Fixes #9080.

`COPRO.compile` documents `eval_kwargs` as optional, but the signature marked it as a required keyword-only argument, so `compile(student, trainset=...)` raised `TypeError: missing 1 required keyword-only argument: 'eval_kwargs'`.

This defaults `eval_kwargs` to `None` and normalizes it with `eval_kwargs = eval_kwargs or {}` at the top of `compile()`.

`eval_kwargs` is splatted in **two** places, not one: `Evaluate(devset=trainset, metric=self.metric, **eval_kwargs)` at `copro_optimizer.py:138`, and `evaluate(module_clone, devset=trainset, **eval_kwargs)` at `:227` inside the depth/candidate loop. The normalization rebinds the local before either is reached, so both call sites are covered and an empty dict is a no-op for both.

The docstring now states the default: `eval_kwargs: optional, dict, defaults to None (no extra kwargs)`.

Adds `test_compile_without_eval_kwargs`, which calls `compile()` without `eval_kwargs` (fails with TypeError on current main, passes with this change).

Thanks @TomeHirata for confirming this was welcome in the issue thread.
