### PR TITLE
fix(usage_tracker): roll nested track_usage() up into the outer tracker

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -54,6 +54,15 @@ class UsageTracker:
         if len(usage_entry) > 0:
             self.usage_data[lm].append(self._flatten_usage_entry(usage_entry))
 
+    def merge(self, other: "UsageTracker") -> None:
+        """Absorb every usage entry recorded by another tracker.
+
+        Used to roll a nested `track_usage()` block's usage up into the enclosing
+        tracker, so that an outer block reflects everything that happened inside it.
+        """
+        for lm, usage_entries in other.usage_data.items():
+            self.usage_data[lm].extend(usage_entries)
+
     def get_total_tokens(self) -> dict[str, dict[str, Any]]:
         """Calculate total tokens from all tracked usage."""
         total_usage_by_lm = {}
@@ -67,8 +76,19 @@ class UsageTracker:
 
 @contextmanager
 def track_usage() -> Generator[UsageTracker, None, None]:
-    """Context manager for tracking LM usage."""
-    tracker = UsageTracker()
+    """Context manager for tracking LM usage.
 
-    with settings.context(usage_tracker=tracker):
-        yield tracker
+    Nested blocks roll up: on exit, the usage recorded by an inner `track_usage()` is also
+    added to the enclosing tracker, so an outer block accounts for everything that happened
+    inside it. The roll-up happens even when the block exits with an exception, because the
+    tokens were spent either way.
+    """
+    tracker = UsageTracker()
+    parent_tracker = settings.usage_tracker
+
+    try:
+        with settings.context(usage_tracker=tracker):
+            yield tracker
+    finally:
+        if parent_tracker is not None:
+            parent_tracker.merge(tracker)

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from pydantic import BaseModel
 
 import dspy
@@ -153,6 +154,74 @@ def test_track_usage_context_manager(lm_for_test):
     assert lm_for_test in total_usage
     assert len(total_usage.keys()) == 1
     assert isinstance(total_usage[lm_for_test], dict)
+
+
+def _record_lm_call(model, prompt_tokens, completion_tokens):
+    """Record usage the same way `BaseLM` does on each call."""
+    dspy.settings.usage_tracker.add_usage(
+        model,
+        {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    )
+
+
+def test_nested_track_usage_rolls_up_to_outer_tracker():
+    """An outer tracker must account for usage recorded inside a nested block."""
+    with track_usage() as outer_tracker:
+        _record_lm_call("gpt-4o-mini", 100, 10)
+
+        with track_usage() as inner_tracker:
+            _record_lm_call("gpt-4o-mini", 1000, 100)
+
+        _record_lm_call("gpt-4o-mini", 5, 1)
+
+    # The inner block only sees its own usage.
+    assert inner_tracker.get_total_tokens()["gpt-4o-mini"]["prompt_tokens"] == 1000
+
+    # The outer block sees everything, including the nested block's usage.
+    outer_total = outer_tracker.get_total_tokens()["gpt-4o-mini"]
+    assert outer_total["prompt_tokens"] == 1105
+    assert outer_total["completion_tokens"] == 111
+    assert len(outer_tracker.usage_data["gpt-4o-mini"]) == 3
+
+
+def test_nested_track_usage_rolls_up_multiple_models_and_levels():
+    """Roll-up is per-model and survives more than one level of nesting."""
+    with track_usage() as outer_tracker:
+        _record_lm_call("gpt-4o-mini", 100, 10)
+
+        with track_usage():
+            _record_lm_call("gpt-3.5-turbo", 200, 20)
+
+            with track_usage():
+                _record_lm_call("gpt-4o-mini", 300, 30)
+
+    total = outer_tracker.get_total_tokens()
+    assert total["gpt-4o-mini"]["prompt_tokens"] == 400
+    assert total["gpt-3.5-turbo"]["prompt_tokens"] == 200
+
+
+def test_nested_track_usage_rolls_up_on_exception():
+    """Tokens spent before an exception still count against the outer tracker."""
+    with track_usage() as outer_tracker:
+        with pytest.raises(ValueError):
+            with track_usage():
+                _record_lm_call("gpt-4o-mini", 1000, 100)
+                raise ValueError("boom")
+
+    assert outer_tracker.get_total_tokens()["gpt-4o-mini"]["prompt_tokens"] == 1000
+
+
+def test_track_usage_restores_outer_tracker_as_active():
+    """Leaving a nested block puts the enclosing tracker back in `settings`."""
+    with track_usage() as outer_tracker:
+        with track_usage() as inner_tracker:
+            assert dspy.settings.usage_tracker is inner_tracker
+        assert dspy.settings.usage_tracker is outer_tracker
+    assert dspy.settings.usage_tracker is None
 
 
 def test_merge_usage_entries_with_new_keys():


### PR DESCRIPTION
## 📝 Changes Description

Fixes #10064.

Each LM call is recorded only by the innermost active tracker: `track_usage()` replaces
`settings.usage_tracker` for the duration of its block and discards the child on exit. Nested blocks
therefore make the outer scope silently under-count — the repro in the issue bills 105 tokens for a
workflow that actually cost 1605.

This implements the roll-up the issue proposes:

- **`UsageTracker.merge(other)`** — absorbs every usage entry from another tracker, per LM key.
- **`track_usage()`** captures the enclosing tracker before entering its own context and merges the
  child into it on exit.

Design notes, since these are the likely review questions:

- **The merge is entry-level, not total-level.** `get_total_tokens()` aggregation and the per-call
  granularity of `usage_data` are unchanged, so the pydantic/nested-dict flattening logic keeps a single
  code path.
- **It runs in a `finally`.** Tokens spent before an exception were still spent.
- **It is skipped when there is no parent.** The paths `BaseLM` deliberately runs under
  `settings.context(usage_tracker=None)` stay unbilled.
- **`ParallelExecutor` is unaffected.** It deep-copies the tracker into each worker
  (`dspy/utils/parallelizer.py`) instead of going through `track_usage()`, so workers remain independent
  of the parent — the existing `test_parallel_executor_with_usage_tracker` assertion that the parent stays
  empty still holds.
- **`Module.forward` is unaffected.** It only opens a tracker when none is active, so it never nests.

### Tests

Four tests added to `tests/utils/test_usage_tracker.py`:

| Test | Asserts |
|---|---|
| `test_nested_track_usage_rolls_up_to_outer_tracker` | Outer sees all three calls; the inner block still reports only its own usage |
| `test_nested_track_usage_rolls_up_multiple_models_and_levels` | Roll-up is per-model and survives three levels of nesting |
| `test_nested_track_usage_rolls_up_on_exception` | Tokens spent before a raise still bill the outer scope |
| `test_track_usage_restores_outer_tracker_as_active` | Leaving a nested block restores the enclosing tracker in `settings` |

The first three fail on `main` and pass with this change; the fourth guards the context stack against
regression.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Nothing behaviour-changing beyond the roll-up itself. Anyone who nests `track_usage()` and relies on the
outer tracker excluding inner blocks would see higher outer totals — but that is the bug being fixed.


## 🤖 AI assistance disclosure

Added after the fact, per `CONTRIBUTING.md` — apologies for the omission on the original submission.

Tool: Claude Code (Opus). Used to sweep the repo's open issues, to draft the reproduction and the patch,
and for test scaffolding. I reviewed and ran everything myself and can explain every line.

Prompt trail: a request to find a contributable issue in this repo, then to reproduce #10064 offline and
work out where the outer-scope total is lost. The diagnosis — that `UsageTracker` never rolls inner-scope
usage back up to the outer tracker — I confirmed by reading `dspy/utils/usage_tracker.py` and by watching
the assertion fail on `main` before writing the fix.
