### PR TITLE
fix(streaming): re-bind stream listeners to the program's live predictor

### DIFF
--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -378,12 +378,22 @@ def find_predictor_for_stream_listeners(
     This is a utility function to automatically find the predictor for each stream listener. It is used when some
     listeners don't specify the predictor they want to listen to. If a listener's `signature_field_name` is not
     unique in the program, this function will raise an error.
+
+    A listener that was given a `predict` which is not part of `program` is re-bound to the matching predictor
+    inside `program`, by `predict_name` when one was provided and by unique signature field name otherwise. Without
+    this, `Predict.forward` compares the listener's predictor against itself by identity and silently falls back to
+    a non-streaming call, so the listener never emits anything.
     """
     predictors = program.named_predictors()
+    name_to_predictor = dict(predictors)
+    live_predictor_ids = {id(predictor) for _, predictor in predictors}
+
+    def needs_resolution(listener: StreamListener) -> bool:
+        return listener.predict is None or id(listener.predict) not in live_predictor_ids
 
     field_name_to_named_predictor = {}
     for listener in stream_listeners:
-        if listener.predict:
+        if not needs_resolution(listener):
             continue
         field_name_to_named_predictor[listener.signature_field_name] = None
 
@@ -401,15 +411,36 @@ def find_predictor_for_stream_listeners(
 
     predict_id_to_listener = defaultdict(list)
     for listener in stream_listeners:
-        if listener.predict:
+        if not needs_resolution(listener):
             predict_id_to_listener[id(listener.predict)].append(listener)
             continue
-        if listener.signature_field_name not in field_name_to_named_predictor:
+
+        stale_predict = listener.predict is not None
+
+        if stale_predict and listener.predict_name in name_to_predictor:
+            # The listener holds a predictor that is not the one the program will execute, which happens whenever
+            # the program was copied (every optimizer's `compile()` returns a copy) or the inner predictor of a
+            # module like `dspy.ChainOfThought` was replaced after the listener was built. Re-bind by name.
+            listener.predict = name_to_predictor[listener.predict_name]
+            predict_id_to_listener[id(listener.predict)].append(listener)
+            continue
+
+        # Check the resolved value rather than key membership: the key is inserted for every listener that needs
+        # resolution, so a missing-field lookup lands here with a `None` value, not a missing key.
+        named_predictor = field_name_to_named_predictor.get(listener.signature_field_name)
+        if named_predictor is None:
+            if stale_predict:
+                raise ValueError(
+                    f"The predictor passed to the stream listener for signature field "
+                    f"{listener.signature_field_name} is not part of the program being streamed, and no predictor in "
+                    "the program produces that field. Pass a predictor that belongs to the program, or omit `predict` "
+                    "to resolve it automatically."
+                )
             raise ValueError(
                 f"Signature field {listener.signature_field_name} is not a field of any predictor in the program, "
                 "cannot automatically determine which predictor to use for streaming. Please verify your field name or "
                 "specify the predictor to listen to."
             )
-        listener.predict_name, listener.predict = field_name_to_named_predictor[listener.signature_field_name]
+        listener.predict_name, listener.predict = named_predictor
         predict_id_to_listener[id(listener.predict)].append(listener)
     return predict_id_to_listener

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -397,16 +397,17 @@ def find_predictor_for_stream_listeners(
             continue
         field_name_to_named_predictor[listener.signature_field_name] = None
 
+    ambiguous_field_names = set()
     for name, predictor in predictors:
         for field_name in predictor.signature.output_fields:
             if field_name not in field_name_to_named_predictor:
                 continue
 
             if field_name_to_named_predictor[field_name] is not None:
-                raise ValueError(
-                    f"Signature field {field_name} is not unique in the program, cannot automatically determine which "
-                    "predictor to use for streaming. Please specify the predictor to listen to."
-                )
+                # Raised per listener below, so that a listener which did pass a predictor gets advice it can act
+                # on rather than being told to do what it already did.
+                ambiguous_field_names.add(field_name)
+                continue
             field_name_to_named_predictor[field_name] = (name, predictor)
 
     predict_id_to_listener = defaultdict(list)
@@ -424,6 +425,19 @@ def find_predictor_for_stream_listeners(
             listener.predict = name_to_predictor[listener.predict_name]
             predict_id_to_listener[id(listener.predict)].append(listener)
             continue
+
+        if listener.signature_field_name in ambiguous_field_names:
+            if stale_predict:
+                raise ValueError(
+                    f"The predictor passed to the stream listener for signature field "
+                    f"{listener.signature_field_name} is not part of the program being streamed, and that field is "
+                    "produced by more than one predictor, so the listener cannot be re-bound automatically. Pass "
+                    "`predict_name` to identify the predictor, or pass a predictor that belongs to the program."
+                )
+            raise ValueError(
+                f"Signature field {listener.signature_field_name} is not unique in the program, cannot automatically "
+                "determine which predictor to use for streaming. Please specify the predictor to listen to."
+            )
 
         # Check the resolved value rather than key membership: the key is inserted for every listener that needs
         # resolution, so a missing-field lookup lands here with a `None` value, not a missing key.

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -422,7 +422,18 @@ def find_predictor_for_stream_listeners(
             # The listener holds a predictor that is not the one the program will execute, which happens whenever
             # the program was copied (every optimizer's `compile()` returns a copy) or the inner predictor of a
             # module like `dspy.ChainOfThought` was replaced after the listener was built. Re-bind by name.
-            listener.predict = name_to_predictor[listener.predict_name]
+            candidate = name_to_predictor[listener.predict_name]
+            if listener.signature_field_name not in candidate.signature.output_fields:
+                # Binding anyway would reproduce the bug this function fixes: the predictor streams, the listener
+                # never sees its field marker, and nothing is emitted.
+                raise ValueError(
+                    f"The predictor passed to the stream listener for signature field "
+                    f"{listener.signature_field_name} is not part of the program being streamed, and the predictor "
+                    f"named {listener.predict_name} in the program does not produce that field, so the listener "
+                    "cannot be re-bound by name. Pass a `predict_name` whose predictor produces the field, or pass "
+                    "a predictor that belongs to the program."
+                )
+            listener.predict = candidate
             predict_id_to_listener[id(listener.predict)].append(listener)
             continue
 

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2061,3 +2061,87 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+def _chain_of_thought_stream_chunks():
+    for content in [
+        "[[", " ##", " reasoning", " ##", " ]]\n\n",
+        "Step", " by", " step", ".",
+        "\n\n[[ ##", " answer", " ##", " ]]\n\n",
+        "Because", " of", " gravity", ".",
+        "\n\n[[ ##", " completed", " ##", " ]]",
+    ]:
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=content))])
+
+
+async def _collect_answer_chunks(program, listeners):
+    async def chain_of_thought_stream(*args, **kwargs):
+        for chunk in _chain_of_thought_stream_chunks():
+            yield chunk
+
+    async def completion_side_effect(*args, **kwargs):
+        return chain_of_thought_stream()
+
+    with mock.patch("litellm.acompletion", side_effect=completion_side_effect):
+        streamed_program = dspy.streamify(program, stream_listeners=listeners)
+        with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False), adapter=dspy.ChatAdapter()):
+            all_chunks = []
+            async for value in streamed_program(question="why do things fall?"):
+                if isinstance(value, dspy.streaming.StreamResponse):
+                    all_chunks.append(value)
+    return all_chunks
+
+
+@pytest.mark.anyio
+async def test_stream_listener_rebinds_to_predictor_of_copied_program():
+    """Regression test for https://github.com/stanfordnlp/dspy/issues/8736.
+
+    Every optimizer's `compile()` returns a copy of the program, so a listener built from the original
+    holds a predictor that the copy never executes. `Predict.forward` compares by identity, so streaming
+    was silently disabled and the listener emitted nothing.
+    """
+    program = dspy.ChainOfThought("question->answer")
+    listener = dspy.streaming.StreamListener(
+        signature_field_name="answer", predict=program.predict, predict_name="predict"
+    )
+
+    compiled_program = program.deepcopy()
+    all_chunks = await _collect_answer_chunks(compiled_program, [listener])
+
+    assert listener.predict is compiled_program.predict
+    assert "".join(chunk.chunk for chunk in all_chunks) == "Because of gravity."
+    assert all_chunks[-1].is_last_chunk is True
+
+
+@pytest.mark.anyio
+async def test_stream_listener_rebinds_when_inner_predictor_is_replaced():
+    """A listener built before `ChainOfThought.predict` is replaced must still stream."""
+    program = dspy.ChainOfThought("question->answer")
+    listener = dspy.streaming.StreamListener(signature_field_name="answer", predict=program.predict)
+
+    program.predict = dspy.Predict(program.predict.signature)
+    all_chunks = await _collect_answer_chunks(program, [listener])
+
+    assert listener.predict is program.predict
+    assert "".join(chunk.chunk for chunk in all_chunks) == "Because of gravity."
+
+
+@pytest.mark.anyio
+async def test_stream_listener_raises_when_predictor_is_not_in_program():
+    """An unresolvable predictor must fail loudly instead of silently disabling streaming."""
+    other_program = dspy.Predict("question->judgement")
+    listener = dspy.streaming.StreamListener(
+        signature_field_name="judgement", predict=other_program, predict_name="not_in_program"
+    )
+
+    with pytest.raises(ValueError, match="is not part of the program being streamed"):
+        await _collect_answer_chunks(dspy.ChainOfThought("question->answer"), [listener])
+
+
+@pytest.mark.anyio
+async def test_stream_listener_raises_clear_error_for_unknown_field():
+    """An unknown signature field must raise the documented ValueError, not a TypeError."""
+    listener = dspy.streaming.StreamListener(signature_field_name="nonexistent_field")
+
+    with pytest.raises(ValueError, match="is not a field of any predictor in the program"):
+        await _collect_answer_chunks(dspy.ChainOfThought("question->answer"), [listener])

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2178,3 +2178,19 @@ async def test_stream_listener_ambiguous_field_keeps_original_error_without_pred
 
     with pytest.raises(ValueError, match="is not unique in the program"):
         await _collect_answer_chunks(TwoAnswers(), [listener])
+
+
+@pytest.mark.anyio
+async def test_stream_listener_raises_when_named_predictor_lacks_the_field():
+    """Re-binding by name must not accept a predictor that does not produce the listened-to field.
+
+    Binding anyway would leave the listener attached to a predictor whose stream never carries its field
+    marker, which is the silent no-op this function exists to prevent.
+    """
+    other_program = dspy.Predict("question->judgement")
+    listener = dspy.streaming.StreamListener(
+        signature_field_name="judgement", predict=other_program, predict_name="predict"
+    )
+
+    with pytest.raises(ValueError, match="does not produce that field"):
+        await _collect_answer_chunks(dspy.ChainOfThought("question->answer"), [listener])

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2145,3 +2145,36 @@ async def test_stream_listener_raises_clear_error_for_unknown_field():
 
     with pytest.raises(ValueError, match="is not a field of any predictor in the program"):
         await _collect_answer_chunks(dspy.ChainOfThought("question->answer"), [listener])
+
+
+@pytest.mark.anyio
+async def test_stream_listener_ambiguous_field_error_mentions_predict_name():
+    """A listener that did pass a predictor must get advice it can act on, not 'specify the predictor'."""
+
+    class TwoAnswers(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.first = dspy.Predict("question->answer")
+            self.second = dspy.Predict("context->answer")
+
+    program = TwoAnswers()
+    listener = dspy.streaming.StreamListener(signature_field_name="answer", predict=program.first)
+
+    with pytest.raises(ValueError, match="Pass `predict_name` to identify the predictor"):
+        await _collect_answer_chunks(program.deepcopy(), [listener])
+
+
+@pytest.mark.anyio
+async def test_stream_listener_ambiguous_field_keeps_original_error_without_predict():
+    """The pre-existing message is unchanged for listeners that never passed a predictor."""
+
+    class TwoAnswers(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.first = dspy.Predict("question->answer")
+            self.second = dspy.Predict("context->answer")
+
+    listener = dspy.streaming.StreamListener(signature_field_name="answer")
+
+    with pytest.raises(ValueError, match="is not unique in the program"):
+        await _collect_answer_chunks(TwoAnswers(), [listener])


### PR DESCRIPTION
## Changes Description

Fixes #8736.

`Predict.forward` decides whether to stream by comparing each listener's predictor against itself:

```python
should_stream = any(stream_listener.predict == self for stream_listener in stream_listeners)
```

That is an identity comparison. A listener holding a predictor which is *not* the one being executed
therefore sets `send_stream` to `None` and issues a plain non-streaming request — the listener emits
nothing, and nothing is logged. Silence is the reported symptom.

Two ordinary paths land there:

1. **The program was copied.** Every optimizer's `compile()` returns a deep copy, so a listener built
   from the pre-compile program points at a predictor the compiled program never runs.
2. **The inner predictor was replaced** after the listener was constructed — `ChainOfThought.predict`,
   `ReAct.react`.

`find_predictor_for_stream_listeners` already resolved listeners that *omit* `predict`, but left an
explicitly passed stale one untouched. It now treats a listener whose predictor is absent from the
program as needing resolution:

1. re-bind by `predict_name` when that names a predictor in the program;
2. otherwise fall back to the existing unique-signature-field resolution;
3. otherwise raise a `ValueError` naming the field and saying what to do.

### Also fixes a latent `TypeError` in the same function

The unknown-field guard tested key membership:

```python
if listener.signature_field_name not in field_name_to_named_predictor:
    raise ValueError(f"Signature field {...} is not a field of any predictor in the program, ...")
```

The key is inserted for every listener that needs resolution, so an unknown field never misses it. The
branch is unreachable; execution falls through and unpacks `None`, and the user sees
`TypeError: cannot unpack non-iterable NoneType` instead of the intended message. The check now tests
the resolved *value*, which makes that error message reachable for the first time.

### Tests

Four tests added to `tests/streaming/test_streaming.py`, all failing on `main` and passing here:

| Test | Asserts |
|---|---|
| `test_stream_listener_rebinds_to_predictor_of_copied_program` | A listener built before `deepcopy()` still streams against the copy, and is re-bound to the copy's predictor |
| `test_stream_listener_rebinds_when_inner_predictor_is_replaced` | Replacing `ChainOfThought.predict` after listener construction still streams |
| `test_stream_listener_raises_when_predictor_is_not_in_program` | An unresolvable predictor fails loudly instead of silently disabling streaming |
| `test_stream_listener_raises_clear_error_for_unknown_field` | An unknown field raises the documented `ValueError`, not `TypeError` |

`uv run pytest tests/streaming/ -q` → 38 passed, 3 skipped.

## Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## Warnings

Two behaviour changes worth calling out, both intentional:

- A listener whose predictor is not in the program used to silently produce no output; it now either
  re-binds and streams, or raises. Anyone relying on the silent no-op will see an error instead — but
  that no-op is the bug being fixed.
- An unknown `signature_field_name` previously raised `TypeError`; it now raises the `ValueError` the
  code always intended.
