### PR TITLE
refactor: bootstrap tracing as a direct ParallelExecutor map, not an Evaluate run

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -317,17 +317,8 @@ class Module(BaseModule, metaclass=ProgramMeta):
             return results
 
     def _set_lm_usage(self, tokens: dict[str, Any], output: Any):
-        # Some optimizers (e.g., GEPA bootstrap tracing) temporarily patch
-        # module.forward to return a tuple: (prediction, trace).
-        # When usage tracking is enabled, ensure we attach usage to the
-        # prediction object if present.
-        prediction_in_output = None
         if isinstance(output, Prediction):
-            prediction_in_output = output
-        elif isinstance(output, tuple) and len(output) > 0 and isinstance(output[0], Prediction):
-            prediction_in_output = output[0]
-        if prediction_in_output:
-            prediction_in_output.set_lm_usage(tokens)
+            output.set_lm_usage(tokens)
         else:
             logger.warning("Failed to set LM usage. Please return `dspy.Prediction` object from dspy.Module to enable usage tracking.")
 

--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -1,14 +1,13 @@
 import logging
 from dataclasses import dataclass
-from types import MethodType
 from typing import Any, Callable, TypedDict
 
-import dspy
-from dspy.evaluate.evaluate import Evaluate
+from dspy.dsp.utils.settings import settings
 from dspy.primitives.example import Example
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
 from dspy.utils.exceptions import AdapterParseError
+from dspy.utils.parallelizer import ParallelExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -37,108 +36,84 @@ def bootstrap_trace_data(
     failure_score: float = 0,
     format_failure_score: float = -1,
     log_format_failures: bool = False,
-    callback_metadata: dict[str, Any] | None = None,
 ) -> list[TraceData]:
     # Return a list of dicts with the following keys: example_ind, example, prediction, trace, and score
     # (if metric != None)
-    evaluator = Evaluate(
-        devset=dataset,
-        num_threads=num_threads,
-        display_progress=True,
-        provide_traceback=False,  # TODO(check with team)
-        max_errors=len(dataset) * 10,  # TODO(check with team)
-        failure_score=failure_score,
-    )
 
-    def wrapped_metric(example, prediction, trace=None):
-        prediction, _ = prediction
-        if isinstance(prediction, FailedPrediction):
-            return prediction.format_reward or format_failure_score
-        return metric(example, prediction, trace) if metric else True
+    def process_example(example):
+        inputs = {**example.inputs()}
+        trace = []
+        try:
+            with settings.context(trace=trace):
+                prediction = program(**inputs)
+        except AdapterParseError as e:
+            present = list(e.parsed_result.keys()) if e.parsed_result else None
+            expected = list(e.signature.output_fields.keys())
 
-    # Use `object.__getattribute__` to bypass the custom hook `Module.__getattribute__` so that we avoid
-    # the warning that `forward` is not accessed through `__call__`.
-    original_forward = object.__getattribute__(program, "forward")
+            found_pred = None
+            for pred in program.predictors():
+                if pred.signature == e.signature:
+                    found_pred = pred
+                    break
+            if found_pred is None:
+                raise ValueError(f"Failed to find the predictor for the failed signature: {e.signature}")
 
-    def patched_forward(program_to_use: Module, **kwargs):
-        with dspy.context(trace=[]):
-            try:
-                return original_forward(**kwargs), dspy.settings.trace.copy()
-            except AdapterParseError as e:
-                completion_str = e.lm_response
-                parsed_result = e.parsed_result
-                failed_signature = e.signature
-                failed_inputs = kwargs
+            if present:
+                prediction = FailedPrediction(
+                    completion_text=e.lm_response,
+                    format_reward=format_failure_score + (failure_score - format_failure_score) * (present / expected),
+                )
+            else:
+                prediction = FailedPrediction(completion_text=e.lm_response, format_reward=format_failure_score)
 
-                present = list(parsed_result.keys()) if parsed_result else None
-                expected = list(failed_signature.output_fields.keys())
+            trace.append((found_pred, inputs, prediction))
 
-                found_pred = None
-                for pred in program_to_use.predictors():
-                    if pred.signature == failed_signature:
-                        found_pred = pred
-                        break
-                if found_pred is None:
-                    raise ValueError(f"Failed to find the predictor for the failed signature: {failed_signature}")
-
-                trace = dspy.settings.trace.copy()
-                # Trace is Tuple[signature, inputs, prediction outputs]
-                if present:
-                    failed_pred = FailedPrediction(
-                        completion_text=completion_str,
-                        format_reward=format_failure_score
-                        + (failure_score - format_failure_score) * (present / expected),
-                    )
-                else:
-                    failed_pred = FailedPrediction(completion_text=completion_str, format_reward=format_failure_score)
-
-                trace.append(
-                    (
-                        found_pred,
-                        failed_inputs,
-                        failed_pred,
-                    )
+            if log_format_failures:
+                logging.warning(
+                    "Failed to parse output for example. This is likely due to the LLM response not following "
+                    "the adapter's formatting."
                 )
 
-                if log_format_failures:
-                    logging.warning(
-                        "Failed to parse output for example. This is likely due to the LLM response not following "
-                        "the adapter's formatting."
-                    )
+        if isinstance(prediction, FailedPrediction):
+            score = prediction.format_reward or format_failure_score
+        else:
+            score = metric(example, prediction, None) if metric else True
 
-                return failed_pred, trace
+        return {"prediction": prediction, "trace": trace, "score": score}
 
-    program.forward = MethodType(patched_forward, program)
-
-    try:
-        results = evaluator(
-            program,
-            metric=wrapped_metric,
-            callback_metadata=callback_metadata,
-        ).results
-    finally:
-        program.forward = original_forward
+    executor = ParallelExecutor(
+        num_threads=num_threads,
+        disable_progress_bar=False,
+        provide_traceback=False,  # TODO(check with team)
+        max_errors=len(dataset) * 10,  # TODO(check with team)
+    )
+    results = executor.execute(process_example, dataset)
 
     data = []
-    for example_ind, (example, prediction, score) in enumerate(results):
-        try:
-            prediction, trace = prediction
-        except ValueError as ve:
-            # TODO(GRPO Team): Often during GRPO bootstrapping, the LLM response does not follow dspy formatting. This
-            # leads to a value error. To reproduce this issue, try Qwen/Qwen2.5-Coder-0.5B-Instruct with MATH dataset.
+    for example_ind, (example, result) in enumerate(zip(dataset, results, strict=True)):
+        if result is None:
+            # TODO(GRPO Team): Often during GRPO bootstrapping, the LLM response does not follow dspy formatting.
+            # To reproduce this issue, try Qwen/Qwen2.5-Coder-0.5B-Instruct with MATH dataset.
             # Proposal(Lakshya): We should capture the incorrectly-formatted LLM response, and store it in the trace,
             # and pass it to in the GRPO group with a high-negative user-configurable score.
-            logger.warning(
-                "Failed to unpack prediction and trace. This is likely due to the LLM response not following "
-                "dspy formatting."
-            )
+            exception = executor.exceptions_map.get(example_ind)
+            logger.warning("Failed to run the program on an example during bootstrapping: %r", exception)
             if raise_on_error:
-                raise ve
+                if exception is None:
+                    raise RuntimeError(
+                        f"Example {example_ind} failed during bootstrapping without a recorded exception."
+                    )
+                raise exception
             else:
                 continue
-        data_dict = {"example": example, "prediction": prediction, "trace": trace, "example_ind": example_ind}
+        data_dict = {
+            "example": example,
+            "prediction": result["prediction"],
+            "trace": result["trace"],
+            "example_ind": example_ind,
+        }
         if metric:
-            data_dict["score"] = score
+            data_dict["score"] = result["score"]
         data.append(data_dict)
 
     return data

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -163,7 +163,6 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 capture_failed_parses=True,
                 failure_score=self.failure_score,
                 format_failure_score=self.failure_score,
-                callback_metadata=callback_metadata,
             )
             scores = []
             outputs = []

--- a/tests/teleprompt/test_bootstrap_trace.py
+++ b/tests/teleprompt/test_bootstrap_trace.py
@@ -1,6 +1,6 @@
-from typing import Any, ClassVar
 from unittest import mock
 
+import pytest
 from litellm import Choices, Message, ModelResponse
 
 import dspy
@@ -121,33 +121,18 @@ def test_bootstrap_trace_data():
             assert len(trace_entry) == 3, "Trace entry should have 3 elements"
 
 
-def test_bootstrap_trace_data_passes_callback_metadata(monkeypatch):
-    from dspy.teleprompt import bootstrap_trace as bootstrap_trace_module
+def test_bootstrap_trace_data_raise_on_error():
+    """A program failure re-raises the original exception, or skips the example when tolerated."""
 
-    class DummyProgram(dspy.Module):
-        def forward(self, **kwargs):  # pragma: no cover - stub forward
-            return dspy.Prediction()
+    class ExplodingModule(dspy.Module):
+        def forward(self, **kwargs):
+            raise RuntimeError("program blew up")
 
-    captured_metadata: dict[str, Any] = {}
+    program = ExplodingModule()
+    dataset = [Example(text="one").with_inputs("text")]
 
-    class DummyEvaluate:
-        def __init__(self, *args, **kwargs):
-            pass
+    with pytest.raises(RuntimeError, match="program blew up"):
+        bootstrap_trace_data(program=program, dataset=dataset, num_threads=1, raise_on_error=True)
 
-        def __call__(self, *args, callback_metadata=None, **kwargs):
-            captured_metadata["value"] = callback_metadata
-
-            class _Result:
-                results: ClassVar[list[Any]] = []
-
-            return _Result()
-
-    monkeypatch.setattr(bootstrap_trace_module, "Evaluate", DummyEvaluate)
-
-    bootstrap_trace_module.bootstrap_trace_data(
-        program=DummyProgram(),
-        dataset=[],
-        callback_metadata={"disable_logging": True},
-    )
-
-    assert captured_metadata["value"] == {"disable_logging": True}
+    results = bootstrap_trace_data(program=program, dataset=dataset, num_threads=1, raise_on_error=False)
+    assert results == []

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -53,7 +53,6 @@ def bad_metric(example, prediction):
     ], {"metric_key": "eval_full"}),
 ])
 def test_gepa_adapter_disables_logging_on_minibatch_eval(monkeypatch, reflection_minibatch_size, batch, expected_callback_metadata):
-    from dspy.teleprompt import bootstrap_trace as bootstrap_trace_module
     from dspy.teleprompt.gepa import gepa_utils
 
     class DummyModule(dspy.Module):
@@ -71,18 +70,25 @@ def test_gepa_adapter_disables_logging_on_minibatch_eval(monkeypatch, reflection
 
     captured_kwargs: dict[str, Any] = {}
 
-    def dummy_bootstrap_trace_data(*args, **kwargs):
-        captured_kwargs.update(kwargs)
-        return []
+    class DummyEvaluate:
+        def __init__(self, *args, **kwargs):
+            captured_kwargs.update(kwargs)
 
-    monkeypatch.setattr(bootstrap_trace_module, "bootstrap_trace_data", dummy_bootstrap_trace_data)
+        def __call__(self, *args, **kwargs):
+            class _Result:
+                def __init__(self):
+                    self.results = []
+
+            return _Result()
+
+    monkeypatch.setattr(gepa_utils, "Evaluate", DummyEvaluate)
     monkeypatch.setattr(
         gepa_utils.DspyAdapter,
         "build_program",
         lambda self, candidate: DummyModule(),
     )
 
-    adapter.evaluate(batch=batch, candidate={}, capture_traces=True)
+    adapter.evaluate(batch=batch, candidate={}, capture_traces=False)
 
     assert captured_kwargs["callback_metadata"] == expected_callback_metadata
 


### PR DESCRIPTION
## What

Bootstrap tracing (`bootstrap_trace_data`, used by GEPA, GRPO, and BootstrapFinetune) routed trace capture through `Evaluate`, whose data path (`prediction = program(**inputs)` → `metric(example, prediction)`) has no channel for per-example artifacts. The trace was therefore smuggled inside the prediction: `program.forward` was monkeypatched to return a `(prediction, trace)` tuple (using `object.__getattribute__` to dodge the `Module.__getattribute__` direct-forward-call warning), the metric unwrapped the tuple, results were re-unpacked post-hoc behind a `ValueError` guard — and `Module._set_lm_usage` in **primitives** special-cased the tuple shape with a comment naming GEPA, i.e. the base class knew about a specific optimizer's patching trick.

Bootstrapping is data collection, not evaluation — so this PR implements it as one:

- **`bootstrap_trace_data` maps over the dataset with `ParallelExecutor` directly.** Each worker captures the trace with the standard `with settings.context(trace=[]):` idiom around a plain `program(**inputs)` call and returns a complete `{prediction, trace, score}` record. The `AdapterParseError` → `FailedPrediction` conversion happens inside the worker, with the partial trace naturally in hand.
- **No forward patching, no wrapper module, no tuple contract, no new API.** The `object.__getattribute__` dodge, the `MethodType` patch/restore, `wrapped_metric`'s unwrapping, and the post-hoc `prediction, trace = prediction` unpack all delete. The GRPO-team TODO (Lakshya's proposal to capture malformed LLM responses into the trace) is retained at the failure-handling branch it describes.
- **`Module._set_lm_usage` drops the tuple special case** (and the comment naming GEPA). Usage attaches to the prediction via the program's own `__call__`, untouched.

## Behavior notes

- Return shape of `bootstrap_trace_data` and the `(predictor, inputs, prediction)` trace tuples are unchanged; GRPO/BootstrapFinetune/GEPA consumers need no changes.
- **`raise_on_error=True` now re-raises the program's actual exception** (via `ParallelExecutor.exceptions_map`) instead of the `ValueError` the old code produced by failing to unpack an empty `Prediction`. Strictly more informative; exception type changes for anyone catching the old `ValueError`.
- **Trace-capturing runs no longer emit `on_evaluate_start/end`.** Bootstrapping no longer masquerades as an evaluation to callback handlers (e.g. MLflow-style loggers). Consequently the `callback_metadata` parameter lost its only consumer and is removed; `gepa_utils` no longer passes it. Note GEPA's trace-capturing calls are mostly its reflective minibatch evals, which passed `{\"disable_logging\": True}` — events handlers were told to ignore. GEPA's full evaluations (`capture_traces=False`) still go through `Evaluate` and keep their events/metadata — `test_gepa_adapter_disables_logging_on_minibatch_eval` is re-pointed at that surviving path (asserting the metadata still reaches `Evaluate`), and the old bootstrap-forwards-metadata test is replaced by a new test pinning the `raise_on_error` contract (original exception re-raised, or example skipped when tolerated).
- The progress bar shows `Processed n / N` rather than `Evaluate`'s running average-metric description.
- A user module returning a bare `(Prediction, ...)` tuple no longer gets usage attached to element 0 under `track_usage` — that branch existed only for the optimizer patch (per its own comment) and now warns instead, like any non-`Prediction` return.
- Pre-existing latent bug preserved as-is (happy to fix here or separately): in the `AdapterParseError` partial-credit path, `present / expected` divides two **lists**, so it would raise `TypeError` whenever `parsed_result` is non-empty. Presumably it should be `len(present) / len(expected)`.
- The failed-example warning now includes the actual exception, and the re-raise guards against a missing `exceptions_map` entry (possible if a `ParallelExecutor` worker dies outside its per-item error handling, e.g. during the `usage_tracker` deepcopy) with an explicit `RuntimeError` instead of a masking `KeyError`.
- Open question for reviewers: `capture_failed_parses` was already dead before this PR (accepted, never read — parse capture is unconditionally on), and `failure_score`'s only remaining effect after this PR is the broken partial-credit branch above. Happy to drop both parameters here or in a follow-up.

## Testing

- `uv run pytest tests/teleprompt/ tests/primitives/test_base_module.py tests/predict/test_predict.py tests/utils/test_usage_tracker.py --deno` — 179 passed, 4 skipped.
- `ruff check` clean; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
