### PR TITLE
fix(tool): exclude args with default values from required in native function-calling schema

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -150,6 +150,9 @@ class Tool(Type):
         return str(self)
 
     def format_as_litellm_function_call(self):
+        # Args with a default value are optional: they shouldn't be listed as "required",
+        # even though they're still advertised (with their default) in "properties".
+        required = [name for name, schema in self.args.items() if "default" not in schema]
         return {
             "type": "function",
             "function": {
@@ -158,7 +161,7 @@ class Tool(Type):
                 "parameters": {
                     "type": "object",
                     "properties": self.args,
-                    "required": list(self.args.keys()),
+                    "required": required,
                 },
             },
         }

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -1165,7 +1165,7 @@ def test_chat_adapter_format_exact_messages_and_lm_kwargs_with_native_tool_calli
                              "parameters": {"type": "object",
                                             "properties": {"query": {"type": "string"},
                                                            "k": {"type": "integer", "default": 3}},
-                                            "required": ["query", "k"]}}}]}
+                                            "required": ["query"]}}}]}
     assert lm_kwargs == expected_lm_kwargs
 
 

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -604,7 +604,7 @@ def test_json_adapter_format_exact_messages_and_lm_kwargs_with_native_tool_calli
                              "parameters": {"type": "object",
                                             "properties": {"query": {"type": "string"},
                                                            "k": {"type": "integer", "default": 3}},
-                                            "required": ["query", "k"]}}}]}
+                                            "required": ["query"]}}}]}
     assert lm_kwargs == expected_lm_kwargs
 
 def test_json_adapter_format_exact_messages_with_tool_calls_output_demo():

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -146,6 +146,21 @@ def test_tool_from_function():
     assert tool.args["y"]["default"] == "hello"
 
 
+def test_format_as_litellm_function_call_excludes_defaulted_args_from_required():
+    """Regression test for #9882: args with a default value should not be
+    listed as "required" in the native function-calling schema, even though
+    they're still advertised (with their default) in "properties".
+    """
+    tool = Tool(dummy_function)
+
+    function_call = tool.format_as_litellm_function_call()
+
+    parameters = function_call["function"]["parameters"]
+    assert set(parameters["properties"].keys()) == {"x", "y"}
+    assert parameters["required"] == ["x"]
+    assert "y" not in parameters["required"]
+
+
 def test_tool_from_class():
     class Foo:
         def __init__(self, user_id: str):


### PR DESCRIPTION
Fixes #9882

## Problem
Tool.format_as_litellm_function_call() listed every argument in the
schema's "required" list, even arguments that already had a "default"
key in their own schema entry:

    "required": list(self.args.keys())

For example, `def search(query: str, k: int = 3)` produced a schema
where `k` had `{"type": "integer", "default": 3}` in "properties", but
was still listed in "required" -- contradicting the schema itself and
never actually telling the LM it could omit `k`.

## Fix
"required" now only includes args that don't have a "default" key,
matching standard JSON Schema / OpenAI function-calling conventions:

    required = [name for name, schema in self.args.items() if "default" not in schema]

## Testing
Added a regression test with a defaulted arg. It fails against
unmodified dspy (produces ["x", "y"] instead of ["x"]) and passes
after this fix (verified against a separate, untouched checkout).

Found 2 existing tests (test_chat_adapter.py, test_json_adapter.py)
that had hardcoded the old, incorrect behavior ("required": ["query",
"k"] where k has a default) as their expected output -- updated both
to reflect the corrected behavior.

Ran the full tests/adapters/ suite (231 tests, all pass) plus
tests/predict/ and tests/primitives/ (296 tests, all pass) for extra
confidence, since Tool is used broadly (ReAct, native tool calling,
etc.). ruff check on the changed source file: clean.