### PR TITLE
fix(streaming): propagate exceptions from apply_sync_streaming instead of swallowing them

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -228,6 +228,18 @@ def streamify(
         return sync_streamer
 
 
+class _StreamingException:
+    """Wraps an exception raised inside apply_sync_streaming's producer thread.
+
+    A distinct wrapper (rather than checking isinstance(item, Exception) directly)
+    avoids any ambiguity with a legitimately-yielded stream item that happens to be
+    an exception instance itself.
+    """
+
+    def __init__(self, exc: Exception):
+        self.exc = exc
+
+
 def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
     """Convert the async streaming generator to a sync generator."""
     queue = Queue()  # Queue to hold items from the async generator
@@ -243,6 +255,10 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
             try:
                 async for item in async_generator:
                     queue.put(item)
+            except Exception as e:
+                # Propagate the exception to the consumer instead of letting it
+                # vanish into the background thread once the stream ends.
+                queue.put(_StreamingException(e))
             finally:
                 # Signal completion
                 queue.put(stop_sentinel)
@@ -258,6 +274,8 @@ def apply_sync_streaming(async_generator: AsyncGenerator) -> Generator:
         item = queue.get()  # Block until an item is available
         if item is stop_sentinel:
             break
+        if isinstance(item, _StreamingException):
+            raise item.exc
         yield item
 
 

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -415,6 +415,38 @@ def test_sync_status_streaming():
     assert status_messages[1].message == "Tool calling finished! Querying the LLM with tool calling results..."
 
 
+def test_apply_sync_streaming_propagates_exceptions():
+    """Regression test for #9142: apply_sync_streaming used to silently
+    swallow exceptions raised by the async generator -- the consumer just
+    saw the stream end normally, with no indication anything went wrong.
+    """
+
+    async def flaky_generator():
+        yield "chunk1"
+        yield "chunk2"
+        raise ValueError("boom")
+
+    chunks = []
+    with pytest.raises(ValueError, match="boom"):
+        for item in dspy.streaming.apply_sync_streaming(flaky_generator()):
+            chunks.append(item)
+
+    # Items produced before the failure should still have been yielded.
+    assert chunks == ["chunk1", "chunk2"]
+
+
+def test_apply_sync_streaming_no_exception_still_completes_normally():
+    """A generator that completes without raising should still be consumed
+    to completion (no regression from the exception-propagation change).
+    """
+
+    async def clean_generator():
+        yield "a"
+        yield "b"
+
+    assert list(dspy.streaming.apply_sync_streaming(clean_generator())) == ["a", "b"]
+
+
 @pytest.mark.anyio
 async def test_stream_listener_returns_correct_chunk_chat_adapter():
     class MyProgram(dspy.Module):


### PR DESCRIPTION
Fixes #9142

## Problem
When using `dspy.streamify(..., async_streaming=False)`,
`apply_sync_streaming` runs the async generator in a background thread
and bridges it to a sync generator via a Queue. Its `finally` block
always sent the `stop_sentinel`, regardless of whether the generator
raised. This meant any exception was completely invisible to the sync
consumer -- iterating over the stream just looked like it ended
normally. The actual traceback only appeared on stderr via Python's
default `threading.excepthook`, in a different thread, which is easy
to miss or not connect to the calling code at all.

## Fix
Wrap exceptions raised in the producer thread in a distinct
`_StreamingException` marker before putting them on the queue (this
avoids any ambiguity with a legitimately-yielded stream item that
happens to be an `Exception` instance itself), and re-raise on the
consumer side when that marker is seen.

## Testing
Added a minimal, isolated regression test using a plain async
generator that raises partway through (no LM/program needed to
reproduce this). It fails against unmodified dspy -- the exception
never reaches `pytest.raises`, only a
`PytestUnhandledThreadExceptionWarning` shows up -- and passes after
this fix (verified against a separate, untouched checkout). Added a
companion test confirming normal (non-erroring) streams still complete
correctly, with no regression.

Ran the full `tests/streaming/` suite, plus `tests/predict/`,
`tests/primitives/`, and `tests/adapters/` (560+ tests total): all
pass, except 2 pre-existing errors unrelated to this change (missing
`litellm` CLI binary needed by a local-proxy-server test fixture in my
sandbox; confirmed identical on unmodified dspy). `ruff check` on the
changed source file: clean.