### PR TITLE
fix(usage_tracker): roll nested track_usage() usage up into the enclosing tracker

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -67,8 +67,20 @@ class UsageTracker:
 
 @contextmanager
 def track_usage() -> Generator[UsageTracker, None, None]:
-    """Context manager for tracking LM usage."""
+    """Context manager for tracking LM usage.
+
+    If this is used inside another `track_usage()` block, the usage recorded here is
+    also rolled up into the enclosing tracker on exit, so the outer block's totals
+    reflect everything that happened within it, not just what happened outside the
+    nested block.
+    """
+    parent_tracker = settings.usage_tracker
     tracker = UsageTracker()
 
     with settings.context(usage_tracker=tracker):
         yield tracker
+
+    if parent_tracker is not None:
+        for lm, usage_entries in tracker.usage_data.items():
+            for usage_entry in usage_entries:
+                parent_tracker.add_usage(lm, usage_entry)

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -155,6 +155,45 @@ def test_track_usage_context_manager(lm_for_test):
     assert isinstance(total_usage[lm_for_test], dict)
 
 
+def test_nested_track_usage_rolls_up_into_outer_tracker():
+    """Regression test for #10064: usage recorded inside a nested
+    track_usage() block must also be reflected in the enclosing tracker,
+    not just the innermost one.
+    """
+    model = "openai/gpt-4o-mini"
+
+    def record(prompt_tokens, completion_tokens):
+        dspy.settings.usage_tracker.add_usage(
+            model, {"prompt_tokens": prompt_tokens, "completion_tokens": completion_tokens}
+        )
+
+    def subagent(prompt_tokens, completion_tokens):
+        with track_usage() as usage:
+            record(prompt_tokens, completion_tokens)
+        return usage.get_total_tokens()[model]["prompt_tokens"]
+
+    with track_usage() as orchestrator_cost:
+        record(100, 10)
+        a = subagent(1000, 100)
+        b = subagent(500, 50)
+        record(5, 1)
+
+    billed = orchestrator_cost.get_total_tokens()[model]["prompt_tokens"]
+    assert billed == 100 + a + b + 5  # 1605, not 105
+
+
+def test_top_level_track_usage_unaffected_by_rollup():
+    """A track_usage() block with no enclosing tracker should behave exactly
+    as before: nothing to roll up into, so its own totals are unaffected.
+    """
+    model = "openai/gpt-4o-mini"
+
+    with track_usage() as tracker:
+        dspy.settings.usage_tracker.add_usage(model, {"prompt_tokens": 42, "completion_tokens": 7})
+
+    assert tracker.get_total_tokens()[model]["prompt_tokens"] == 42
+
+
 def test_merge_usage_entries_with_new_keys():
     """Ensure merging usage entries preserves unseen keys."""
     tracker = UsageTracker()


### PR DESCRIPTION
Fixes #10064

## Problem
dspy.settings.usage_tracker is a single slot. When track_usage() blocks
are nested (e.g. an orchestrator with its own tracking, calling
sub-agents that also track their own usage), each LM call is only
recorded by the innermost active tracker. The outer tracker never
learns about anything that happened inside the nested block, silently
under-counting.

Using the issue's own repro (orchestrator + 2 subagents):
    orchestrator billed:  105
    actual workflow cost: 1605

## Fix
track_usage() now captures the enclosing tracker (if any) before
overriding settings.usage_tracker, and on exit rolls its own recorded
usage up into that parent tracker.

## Why this doesn't break dspy.Parallel's usage isolation
There's an existing test (test_parallel_executor_with_usage_tracker)
that explicitly checks that dspy.Parallel() workers do NOT pollute a
shared parent tracker. I checked this carefully: Parallel's
ThreadPoolExecutor runs workers in separate OS threads without copying
contextvars, so settings.usage_tracker correctly evaluates to None
inside each worker thread regardless of this change -- the isolation
comes from Python's threading/contextvars model itself, not from
track_usage() avoiding roll-up. Confirmed empirically: this test still
passes.

## Testing
Ran the exact repro script from the issue -- billed now matches actual
cost (1605 instead of 105).

Added a regression test for the nested case. It fails against
unmodified dspy (105 != 1605) and passes after this fix (verified
against a separate, untouched checkout). Added a companion test
confirming top-level (non-nested) tracking is unaffected.

Ran the full tests/utils/test_usage_tracker.py suite (all pass) plus a
broader sweep of every other file that references track_usage
(test_gepa.py, test_base_module.py, test_predict.py, test_lm.py,
test_settings.py): identical pass/fail/error counts to unmodified
dspy -- no new failures introduced. ruff check on the changed source
file: clean.