### PR TITLE
fix(streaming): resolve streaming markers through the adapter's MRO

### DIFF
--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -118,16 +118,21 @@ class StreamListener:
     def _resolve_adapter_name(self) -> str | None:
         """Find the `adapter_identifiers` entry that applies to the adapter in the current settings.
 
-        The lookup walks the adapter's MRO instead of matching its exact class name, so a subclass of a
-        supported adapter inherits that adapter's field markers. `BAMLAdapter` for instance only changes how
-        the schema is rendered in the prompt, so its wire format is `JSONAdapter`'s and the JSON markers
-        apply verbatim. Returns `None` when no ancestor is a supported adapter.
+        The lookup walks the adapter's MRO, so a subclass of a supported adapter inherits that adapter's
+        field markers. `BAMLAdapter` for instance only changes how the schema is rendered in the prompt, so
+        its wire format is `JSONAdapter`'s and the JSON markers apply verbatim. MRO order resolves the
+        nearest ancestor first, which matches the precedence of the `isinstance` checks in `flush()` and in
+        the end-of-field detection: `JSONAdapter` and `XMLAdapter` both subclass `ChatAdapter`.
+
+        Ancestors are matched by class identity rather than by name, so an unrelated adapter that happens to
+        be called `JSONAdapter` is rejected here instead of being accepted and then failing downstream where
+        the same decision is made with `isinstance`. Returns `None` when no ancestor is a supported adapter.
         """
         if settings.adapter is None:
             return "ChatAdapter"
 
         for adapter_class in type(settings.adapter).__mro__:
-            if adapter_class.__name__ in self.adapter_identifiers:
+            if adapter_class in ADAPTER_SUPPORT_STREAMING:
                 return adapter_class.__name__
         return None
 

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -115,11 +115,28 @@ class StreamListener:
 
         return False
 
+    def _resolve_adapter_name(self) -> str | None:
+        """Find the `adapter_identifiers` entry that applies to the adapter in the current settings.
+
+        The lookup walks the adapter's MRO instead of matching its exact class name, so a subclass of a
+        supported adapter inherits that adapter's field markers. `BAMLAdapter` for instance only changes how
+        the schema is rendered in the prompt, so its wire format is `JSONAdapter`'s and the JSON markers
+        apply verbatim. Returns `None` when no ancestor is a supported adapter.
+        """
+        if settings.adapter is None:
+            return "ChatAdapter"
+
+        for adapter_class in type(settings.adapter).__mro__:
+            if adapter_class.__name__ in self.adapter_identifiers:
+                return adapter_class.__name__
+        return None
+
     def receive(self, chunk: ModelResponseStream):
-        adapter_name = settings.adapter.__class__.__name__ if settings.adapter else "ChatAdapter"
-        if adapter_name not in self.adapter_identifiers:
+        adapter_name = self._resolve_adapter_name()
+        if adapter_name is None:
             raise ValueError(
-                f"Unsupported adapter for streaming: {adapter_name}, please use one of the following adapters: "
+                f"Unsupported adapter for streaming: {settings.adapter.__class__.__name__}, please use one of the "
+                f"following adapters or a subclass of them: "
                 f"{', '.join([a.__name__ for a in ADAPTER_SUPPORT_STREAMING])}"
             )
         start_identifier = self.adapter_identifiers[adapter_name]["start_identifier"]

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -10,6 +10,7 @@ import pytest
 from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
 
 import dspy
+from dspy.adapters.baml_adapter import BAMLAdapter
 from dspy.adapters.types import Type
 from dspy.experimental import Citations, Document
 from dspy.streaming import StatusMessage, StatusMessageProvider, StreamResponse, streaming_response
@@ -2061,3 +2062,52 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+async def _stream_answer_json_chunks(*args, **kwargs):
+    for content in ['{"', 'answer": "', "Because", " of", " gravity", '."}']:
+        yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content=content))])
+
+
+async def _collect_chunks_with_adapter(adapter):
+    program = dspy.streamify(
+        dspy.Predict("question->answer"),
+        stream_listeners=[dspy.streaming.StreamListener(signature_field_name="answer")],
+    )
+    with mock.patch("litellm.acompletion", side_effect=_stream_answer_json_chunks):
+        with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False), adapter=adapter):
+            chunks = []
+            async for value in program(question="why do things fall?"):
+                if isinstance(value, StreamResponse):
+                    chunks.append(value)
+    return chunks
+
+
+@pytest.mark.anyio
+async def test_streaming_supports_subclass_of_supported_adapter():
+    """Regression test for https://github.com/stanfordnlp/dspy/issues/8629.
+
+    `BAMLAdapter` subclasses `JSONAdapter` and only changes how the schema is rendered in the prompt, so
+    its wire format is JSON. Resolving the field markers by exact class name rejected it outright with
+    `ValueError: Unsupported adapter for streaming: BAMLAdapter`.
+    """
+    baml_chunks = await _collect_chunks_with_adapter(BAMLAdapter())
+    json_chunks = await _collect_chunks_with_adapter(dspy.JSONAdapter())
+
+    assert "".join(chunk.chunk for chunk in baml_chunks) == "".join(chunk.chunk for chunk in json_chunks)
+    assert baml_chunks[-1].is_last_chunk is True
+
+
+@pytest.mark.anyio
+async def test_streaming_rejects_adapter_without_a_supported_ancestor():
+    """An adapter that shares no ancestor with a supported one must still be rejected, with a clear error."""
+
+    class CustomAdapter(dspy.Adapter):
+        pass
+
+    listener = dspy.streaming.StreamListener(signature_field_name="answer")
+    chunk = ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="hello"))])
+
+    with dspy.context(adapter=CustomAdapter()):
+        with pytest.raises(ValueError, match="Unsupported adapter for streaming: CustomAdapter"):
+            listener.receive(chunk)

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2111,3 +2111,21 @@ async def test_streaming_rejects_adapter_without_a_supported_ancestor():
     with dspy.context(adapter=CustomAdapter()):
         with pytest.raises(ValueError, match="Unsupported adapter for streaming: CustomAdapter"):
             listener.receive(chunk)
+
+
+@pytest.mark.anyio
+async def test_streaming_rejects_unrelated_adapter_with_a_colliding_class_name():
+    """Ancestors are matched by class identity, not by name.
+
+    An adapter that merely shares a name with a supported one has no reason to share its wire format, and
+    accepting it here would defer the failure to `flush()`, where the same decision is made with
+    `isinstance`.
+    """
+    JSONAdapter = type("JSONAdapter", (dspy.Adapter,), {})  # noqa: N806 - deliberate name collision
+
+    listener = dspy.streaming.StreamListener(signature_field_name="answer")
+    chunk = ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content='"answer": "'))])
+
+    with dspy.context(adapter=JSONAdapter()):
+        with pytest.raises(ValueError, match="Unsupported adapter for streaming: JSONAdapter"):
+            listener.receive(chunk)


### PR DESCRIPTION
## Changes Description

Fixes #8629.

`StreamListener.receive` resolved its field markers by the adapter's exact class name:

```python
adapter_name = settings.adapter.__class__.__name__ if settings.adapter else "ChatAdapter"
if adapter_name not in self.adapter_identifiers:
    raise ValueError(f"Unsupported adapter for streaming: {adapter_name}, ...")
```

`BAMLAdapter` subclasses `JSONAdapter` and overrides only `format_field_structure` and
`format_user_message_content` — both prompt-side. Its wire format is plain JSON, so the `JSONAdapter`
start/end markers apply verbatim, but the exact-name lookup misses and streaming is refused:

```
ValueError: Unsupported adapter for streaming: BAMLAdapter, please use one of the following adapters:
ChatAdapter, XMLAdapter, JSONAdapter
```

The rest of the listener was already subclass-safe — `flush()` and the end-of-field detection branch on
`isinstance(settings.adapter, JSONAdapter)`, which is true for `BAMLAdapter`. The name lookup was the only
thing standing in the way.

This resolves the entry by walking the adapter's MRO, so a subclass inherits the markers of the supported
adapter it derives from. Ancestors are matched by class identity, not by name — an unrelated adapter that
happens to be called `JSONAdapter` has no reason to share its wire format, and accepting it would defer the
failure to `flush()`, where the same decision is made with `isinstance`. MRO order also resolves the nearest
ancestor first, matching that same precedence (`JSONAdapter` and `XMLAdapter` both subclass `ChatAdapter`).
An adapter that shares no ancestor with a supported one still raises, and the message now names its own
class rather than the resolved one.

### Tests

Three tests added to `tests/streaming/test_streaming.py`:

| Test | Asserts |
|---|---|
| `test_streaming_supports_subclass_of_supported_adapter` | `BAMLAdapter` streams, and its chunks are byte-identical to `JSONAdapter`'s on the same mocked stream. **Fails on `main`** with the `ValueError` above |
| `test_streaming_rejects_adapter_without_a_supported_ancestor` | An adapter deriving straight from `dspy.Adapter` is still rejected, with its own class name in the message. Passes on `main` too — it guards the branch this change makes conditional |
| `test_streaming_rejects_unrelated_adapter_with_a_colliding_class_name` | `type("JSONAdapter", (dspy.Adapter,), {})` is rejected up front rather than streamed with JSON markers. **Fails on `main`**, where the name lookup accepts it |

`uv run pytest tests/streaming/ -q` → 37 passed, 3 skipped. `uv run pre-commit run --files ...` clean.

## Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## AI assistance disclosure

Per `CONTRIBUTING.md`. Tool: Claude Code (Opus). Used for the repo sweep that surfaced this issue, for
drafting the reproduction script and validating the proposed patch and for the test scaffolding. Finally, I reviewed and validate the proposed tests and ran everything. I can properly explain every line; the diagnosis below is the part I checked by hand.

## ⚠️ Warnings

One behaviour change: any user-defined adapter subclassing `ChatAdapter`, `JSONAdapter` or `XMLAdapter`
previously raised under `streamify` and now streams using its parent's markers. That is the intent of the
fix, but a subclass that changes the *wire* format (rather than just the prompt) while keeping a supported
parent would now stream with markers that do not match its output, instead of failing loudly. No such
adapter exists in the repo today — `BAMLAdapter` is the only subclass of a supported adapter.
