### PR TITLE
refactor(adapters): name I/O factories open()/download() (ergonomics follow-up)

### DIFF
--- a/docs/docs/api/primitives/Audio.md
+++ b/docs/docs/api/primitives/Audio.md
@@ -10,8 +10,8 @@
             - extract_custom_type_from_annotation
             - format
             - from_array
-            - from_path
-            - from_url
+            - open
+            - download
             - is_streamable
             - parse_lm_response
             - parse_stream_chunk

--- a/docs/docs/api/primitives/Image.md
+++ b/docs/docs/api/primitives/Image.md
@@ -10,8 +10,8 @@
             - extract_custom_type_from_annotation
             - format
             - from_PIL
-            - from_path
-            - from_url
+            - open
+            - download
             - is_streamable
             - parse_lm_response
             - parse_stream_chunk

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -125,15 +125,15 @@ The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `forma
 
 **`dspy.Image(source)`**
 
-URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_path(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
+URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.open(path)` to read a local file or `Image.download(url)` to fetch and base64-encode a remote resource.
 
 **`dspy.Audio(source)`**
 
-A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_path(path)` or `Audio.from_url(url)` for resource loading.
+A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.open(path)` or `Audio.download(url)` for resource loading.
 
 **`dspy.File(file_data=None, file_id=None, filename=None)`**
 
-Either in-memory bytes, a data URI, or a file ID (some providers preupload files and reference them by ID). Use `File.from_path(path)` to read a local file.
+Either in-memory bytes, a data URI, or a file ID (some providers preupload files and reference them by ID). Use `File.open(path)` to read a local file.
 
 **`dspy.Code(code, language="python")`**  
 Code with a class-level `language` parameter. `dspy.Code["java"]` produces a Code subclass typed for Java. `format()` returns the raw string — no wrapper, no fencing.

--- a/docs/docs/tutorials/image_generation_prompting/index.ipynb
+++ b/docs/docs/tutorials/image_generation_prompting/index.ipynb
@@ -101,7 +101,7 @@
     "    result = fal_client.result(\"fal-ai/flux-pro/v1.1-ultra\", request_id)\n",
     "    url = result[\"images\"][0][\"url\"]\n",
     "\n",
-    "    return dspy.Image.from_url(url)\n",
+    "    return dspy.Image.download(url)\n",
     "\n",
     "def display_image(image):\n",
     "    url = image.url\n",

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -30,8 +30,8 @@ class Audio(Type):
     Construct from in-memory values only: a data URI string, raw ``bytes`` (with
     ``audio_format=``), a numpy-like array, a ``{"data", "audio_format"}`` dict, or another
     ``Audio``. Raw base64 is passed as ``Audio(data=..., audio_format=...)``. Construction and
-    adapter parsing never access the filesystem or network; use :meth:`from_path` to read a local
-    file, :meth:`from_url` to download a remote resource, or :meth:`from_array` for array data.
+    adapter parsing never access the filesystem or network; use :meth:`open` to read a local
+    file, :meth:`download` to fetch a remote resource, or :meth:`from_array` for array data.
     """
 
     data: str
@@ -80,37 +80,7 @@ class Audio(Type):
         return encode_audio(values)
 
     @classmethod
-    def from_url(cls, url: str, verify: bool = True) -> "Audio":
-        """
-        Download an audio file from URL and encode it as base64.
-
-        Security: this performs an explicit, caller-initiated fetch and applies no
-        SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
-        will reach private, loopback, or cloud-metadata hosts and follow redirects to
-        them. When ``url`` is derived from untrusted input, the caller is responsible
-        for validating the host against an allowlist before calling this method.
-
-        Args:
-            url: The URL of the audio to download.
-            verify: Whether to verify SSL certificates. Set to False for self-signed certs.
-        """
-        parsed_url = urlparse(url)
-        if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
-            raise ValueError(f"Audio.from_url requires an HTTP(S) URL, received: {url}")
-        response = requests.get(url, verify=verify)
-        response.raise_for_status()
-        mime_type = response.headers.get("Content-Type", "audio/wav")
-        if not mime_type.startswith("audio/"):
-            raise ValueError(f"Unsupported MIME type for audio: {mime_type}")
-        audio_format = mime_type.split("/")[1]
-
-        audio_format = _normalize_audio_format(audio_format)
-
-        encoded_data = base64.b64encode(response.content).decode("utf-8")
-        return cls(data=encoded_data, audio_format=audio_format)
-
-    @classmethod
-    def from_path(cls, file_path: str) -> "Audio":
+    def open(cls, file_path: str) -> "Audio":
         """
         Read local audio file and encode it as base64.
         """
@@ -132,14 +102,64 @@ class Audio(Type):
         return cls(data=encoded_data, audio_format=audio_format)
 
     @classmethod
-    def from_file(cls, file_path: str) -> "Audio":
-        """Deprecated alias for :meth:`from_path`."""
+    def download(cls, url: str, verify: bool = True) -> "Audio":
+        """
+        Download an audio file from URL and encode it as base64.
+
+        Security: this performs an explicit, caller-initiated fetch and applies no
+        SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
+        will reach private, loopback, or cloud-metadata hosts and follow redirects to
+        them. When ``url`` is derived from untrusted input, the caller is responsible
+        for validating the host against an allowlist before calling this method.
+
+        Args:
+            url: The URL of the audio to download.
+            verify: Whether to verify SSL certificates. Set to False for self-signed certs.
+        """
+        parsed_url = urlparse(url)
+        if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
+            raise ValueError(f"Audio.download requires an HTTP(S) URL, received: {url}")
+        response = requests.get(url, verify=verify)
+        response.raise_for_status()
+        mime_type = response.headers.get("Content-Type", "audio/wav")
+        if not mime_type.startswith("audio/"):
+            raise ValueError(f"Unsupported MIME type for audio: {mime_type}")
+        audio_format = mime_type.split("/")[1]
+
+        audio_format = _normalize_audio_format(audio_format)
+
+        encoded_data = base64.b64encode(response.content).decode("utf-8")
+        return cls(data=encoded_data, audio_format=audio_format)
+
+    @classmethod
+    def from_path(cls, file_path: str) -> "Audio":
+        """Deprecated alias for :meth:`open`."""
         warnings.warn(
-            "Audio.from_file is deprecated and will be removed in 3.4; use Audio.from_path instead.",
+            "Audio.from_path is deprecated and will be removed in 3.4; use Audio.open instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return cls.from_path(file_path)
+        return cls.open(file_path)
+
+    @classmethod
+    def from_url(cls, url: str, verify: bool = True) -> "Audio":
+        """Deprecated alias for :meth:`download`."""
+        warnings.warn(
+            "Audio.from_url is deprecated and will be removed in 3.4; use Audio.download instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.download(url, verify=verify)
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "Audio":
+        """Deprecated alias for :meth:`open`."""
+        warnings.warn(
+            "Audio.from_file is deprecated and will be removed in 3.4; use Audio.open instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.open(file_path)
 
     @classmethod
     def from_array(cls, array: Any, sampling_rate: int, format: str = "wav") -> "Audio":
@@ -197,7 +217,7 @@ def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: in
     elif isinstance(audio, str):
         raise ValueError(
             "String audio inputs must be data URIs. "
-            "Load local files with Audio.from_path() and remote resources with Audio.from_url()."
+            "Load local files with Audio.open() and remote resources with Audio.download()."
         )
     elif SF_AVAILABLE and hasattr(audio, "shape"):
         a = Audio.from_array(audio, sampling_rate=sampling_rate, format=format)

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -1,6 +1,7 @@
 import base64
 import mimetypes
 import os
+import warnings
 from typing import Any
 
 import pydantic
@@ -17,7 +18,7 @@ class File(Type):
 
     Construct from in-memory values only: raw ``bytes``, a data URI string, a
     ``{"file_data"|"file_id"|"filename"}`` dict, or another ``File``. Construction and adapter
-    parsing never access the filesystem; use :meth:`from_path` to read a local file,
+    parsing never access the filesystem; use :meth:`open` to read a local file,
     :meth:`from_bytes` for raw bytes, or :meth:`from_file_id` to reference a preuploaded file.
 
     Examples:
@@ -28,7 +29,7 @@ class File(Type):
             file: dspy.File = dspy.InputField()
             summary = dspy.OutputField()
         program = dspy.Predict(QA)
-        result = program(file=dspy.File.from_path("./research.pdf"))
+        result = program(file=dspy.File.open("./research.pdf"))
         print(result.summary)
         ```
     """
@@ -112,7 +113,7 @@ class File(Type):
         return f"File({', '.join(parts)})"
 
     @classmethod
-    def from_path(cls, file_path: str, filename: str | None = None, mime_type: str | None = None) -> "File":
+    def open(cls, file_path: str, filename: str | None = None, mime_type: str | None = None) -> "File":
         """Create a File from a local file path.
 
         Args:
@@ -138,6 +139,16 @@ class File(Type):
         file_data = f"data:{mime_type};base64,{encoded_data}"
 
         return cls(file_data=file_data, filename=filename)
+
+    @classmethod
+    def from_path(cls, file_path: str, filename: str | None = None, mime_type: str | None = None) -> "File":
+        """Deprecated alias for :meth:`open`."""
+        warnings.warn(
+            "File.from_path is deprecated and will be removed in 3.4; use File.open instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.open(file_path, filename=filename, mime_type=mime_type)
 
     @classmethod
     def from_bytes(
@@ -190,7 +201,7 @@ def encode_file_to_dict(file_input: Any) -> dict:
             return {"file_data": file_input}
         raise ValueError(
             f"String file inputs must be data URIs, received: {file_input}. "
-            "Load local files with File.from_path()."
+            "Load local files with File.open()."
         )
 
     elif isinstance(file_input, bytes):

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -49,14 +49,14 @@ class Image(Type):
             - already encoded data URI
 
         download, verify:
-            Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
-            remote image, or :meth:`from_path` for a local file. Accepted for one release
+            Deprecated. Use :meth:`download` (which accepts ``verify``) to fetch a
+            remote image, or :meth:`open` for a local file. Accepted for one release
             with a warning: ``download=True`` eagerly fetches an HTTP(S) ``source``.
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
         Local files and remote resources must be loaded explicitly with
-        :meth:`from_path` and :meth:`from_url`, respectively.
+        :meth:`open` and :meth:`download`, respectively.
         """
 
         download_requested = download is not _UNSET
@@ -64,8 +64,8 @@ class Image(Type):
         if download_requested or verify_requested:
             warnings.warn(
                 "The `download` and `verify` arguments to Image() are deprecated and will be removed in "
-                "3.4. Use Image.from_url(url, verify=...) to download a remote image, or "
-                "Image.from_path(path) for a local file.",
+                "3.4. Use Image.download(url, verify=...) to fetch a remote image, or "
+                "Image.open(path) for a local file.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -101,7 +101,14 @@ class Image(Type):
         return [{"type": "image_url", "image_url": {"url": image_url}}]
 
     @classmethod
-    def from_url(cls, url: str, verify: bool = True) -> "Image":
+    def open(cls, file_path: str) -> "Image":
+        """Read a local file and encode it as a data URI."""
+        if not os.path.isfile(file_path):
+            raise ValueError(f"File not found: {file_path}")
+        return cls(_encode_image_from_file(file_path))
+
+    @classmethod
+    def download(cls, url: str, verify: bool = True) -> "Image":
         """Download an HTTP(S) resource and encode it as a data URI.
 
         Security: this performs an explicit, caller-initiated fetch and applies no
@@ -111,25 +118,38 @@ class Image(Type):
         for validating the host against an allowlist before calling this method.
         """
         if not _is_http_url(url):
-            raise ValueError(f"Image.from_url requires an HTTP(S) URL, received: {url}")
+            raise ValueError(f"Image.download requires an HTTP(S) URL, received: {url}")
         return cls(_encode_image_from_url(url, verify=verify))
 
     @classmethod
     def from_path(cls, file_path: str) -> "Image":
-        """Read a local file and encode it as a data URI."""
-        if not os.path.isfile(file_path):
-            raise ValueError(f"File not found: {file_path}")
-        return cls(_encode_image_from_file(file_path))
-
-    @classmethod
-    def from_file(cls, file_path: str) -> "Image":
-        """Deprecated alias for :meth:`from_path`."""
+        """Deprecated alias for :meth:`open`."""
         warnings.warn(
-            "Image.from_file is deprecated and will be removed in 3.4; use Image.from_path instead.",
+            "Image.from_path is deprecated and will be removed in 3.4; use Image.open instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return cls.from_path(file_path)
+        return cls.open(file_path)
+
+    @classmethod
+    def from_url(cls, url: str, verify: bool = True) -> "Image":
+        """Deprecated alias for :meth:`download`."""
+        warnings.warn(
+            "Image.from_url is deprecated and will be removed in 3.4; use Image.download instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.download(url, verify=verify)
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "Image":
+        """Deprecated alias for :meth:`open`."""
+        warnings.warn(
+            "Image.from_file is deprecated and will be removed in 3.4; use Image.open instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.open(file_path)
 
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
@@ -191,7 +211,7 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
         elif is_url(image):
             return image
         else:
-            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_path().")
+            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.open().")
     elif PIL_AVAILABLE and isinstance(image, PILImage.Image):
         # PIL Image
         return _encode_pil_image(image)

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -74,23 +74,31 @@ def test_explicit_local_resource_factories(tmp_path):
     file_path = tmp_path / "document.txt"
     file_path.write_bytes(b"file bytes")
 
-    assert base64.b64decode(dspy.Image.from_path(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
-    assert base64.b64decode(dspy.Audio.from_path(str(audio_path)).data) == b"audio bytes"
-    assert base64.b64decode(dspy.File.from_path(str(file_path)).file_data.split(",", 1)[1]) == b"file bytes"
-
-
-def test_audio_from_file_is_deprecated_alias(tmp_path):
-    audio_path = tmp_path / "audio.wav"
-    audio_path.write_bytes(b"audio bytes")
-
-    with pytest.warns(DeprecationWarning, match="Audio.from_file is deprecated"):
-        aliased = dspy.Audio.from_file(str(audio_path))
-
-    assert base64.b64decode(aliased.data) == b"audio bytes"
+    assert base64.b64decode(dspy.Image.open(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
+    assert base64.b64decode(dspy.Audio.open(str(audio_path)).data) == b"audio bytes"
+    assert base64.b64decode(dspy.File.open(str(file_path)).file_data.split(",", 1)[1]) == b"file bytes"
 
 
 @pytest.mark.parametrize(
-    ("factory", "mime_type"), [(dspy.Image.from_url, "image/png"), (dspy.Audio.from_url, "audio/wav")]
+    ("annotation", "alias", "canonical"),
+    [
+        (dspy.Image, "from_path", "open"),
+        (dspy.Image, "from_file", "open"),
+        (dspy.Audio, "from_path", "open"),
+        (dspy.Audio, "from_file", "open"),
+        (dspy.File, "from_path", "open"),
+    ],
+)
+def test_local_read_aliases_are_deprecated(tmp_path, annotation, alias, canonical):
+    path = tmp_path / "resource.wav"
+    path.write_bytes(b"audio bytes")
+
+    with pytest.warns(DeprecationWarning, match=rf"{annotation.__name__}\.{alias} is deprecated"):
+        getattr(annotation, alias)(str(path))
+
+
+@pytest.mark.parametrize(
+    ("factory", "mime_type"), [(dspy.Image.download, "image/png"), (dspy.Audio.download, "audio/wav")]
 )
 def test_explicit_remote_resource_factories(monkeypatch, factory, mime_type):
     class Response:
@@ -101,7 +109,7 @@ def test_explicit_remote_resource_factories(monkeypatch, factory, mime_type):
         def raise_for_status(self):
             return None
 
-    module = "image" if factory == dspy.Image.from_url else "audio"
+    module = "image" if factory == dspy.Image.download else "audio"
     monkeypatch.setattr(f"dspy.adapters.types.{module}.requests.get", lambda *args, **kwargs: Response())
 
     resource = factory(f"https://example.com/resource.{mime_type.split('/', 1)[1]}")
@@ -123,7 +131,7 @@ def test_in_memory_resource_construction():
 
 @pytest.mark.parametrize(
     ("source", "match"),
-    [("clip.wav", r"Audio\.from_path"), ("https://example.com/a.wav", r"Audio\.from_url")],
+    [("clip.wav", r"Audio\.open"), ("https://example.com/a.wav", r"Audio\.download")],
 )
 def test_audio_positional_string_must_be_data_uri_even_with_format(source, match):
     with pytest.raises(ValueError, match=match):
@@ -149,7 +157,7 @@ def test_audio_rejects_sampling_rate_for_non_array_inputs(source):
         dspy.Audio(source, sampling_rate=44100)
 
 
-def test_audio_from_url_passes_verify(monkeypatch):
+def test_audio_download_passes_verify(monkeypatch):
     captured = {}
 
     class Response:
@@ -166,6 +174,6 @@ def test_audio_from_url_passes_verify(monkeypatch):
 
     monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fake_get)
 
-    dspy.Audio.from_url("https://example.com/a.wav", verify=False)
+    dspy.Audio.download("https://example.com/a.wav", verify=False)
 
     assert captured["verify"] is False

--- a/tests/signatures/test_adapter_file.py
+++ b/tests/signatures/test_adapter_file.py
@@ -53,21 +53,21 @@ def setup_predictor(signature, expected_output):
 
 
 def test_file_from_local_path(sample_text_file):
-    file_obj = dspy.File.from_path(sample_text_file)
+    file_obj = dspy.File.open(sample_text_file)
     assert file_obj.file_data is not None
     assert file_obj.file_data.startswith("data:text/plain;base64,")
     assert file_obj.filename == os.path.basename(sample_text_file)
 
 
-def test_file_from_path_method(sample_text_file):
-    file_obj = dspy.File.from_path(sample_text_file)
+def test_file_open_method(sample_text_file):
+    file_obj = dspy.File.open(sample_text_file)
     assert file_obj.file_data is not None
     assert file_obj.file_data.startswith("data:text/plain;base64,")
     assert file_obj.filename == os.path.basename(sample_text_file)
 
 
-def test_file_from_path_with_custom_filename(sample_text_file):
-    file_obj = dspy.File.from_path(sample_text_file, filename="custom.txt")
+def test_file_open_with_custom_filename(sample_text_file):
+    file_obj = dspy.File.open(sample_text_file, filename="custom.txt")
     assert file_obj.file_data is not None
     assert file_obj.file_data.startswith("data:text/plain;base64,")
     assert file_obj.filename == "custom.txt"
@@ -153,7 +153,7 @@ def test_file_str():
 
 
 def test_encode_file_to_dict_rejects_path(sample_text_file):
-    with pytest.raises(ValueError, match=r"File\.from_path"):
+    with pytest.raises(ValueError, match=r"File\.open"):
         encode_file_to_dict(sample_text_file)
 
 
@@ -181,7 +181,7 @@ def test_file_constructor_rejects_conflicting_keyword():
 
 
 def test_invalid_file_string():
-    with pytest.raises(ValueError, match=r"File\.from_path"):
+    with pytest.raises(ValueError, match=r"File\.open"):
         encode_file_to_dict("https://this_is_not_a_file_path")
 
 
@@ -195,7 +195,7 @@ def test_file_in_signature(sample_text_file):
     expected = {"summary": "This is a summary"}
     predictor, lm = setup_predictor(signature, expected)
 
-    file_obj = dspy.File.from_path(sample_text_file)
+    file_obj = dspy.File.open(sample_text_file)
     result = predictor(document=file_obj)
 
     assert result.summary == "This is a summary"
@@ -211,7 +211,7 @@ def test_file_list_in_signature(sample_text_file):
     predictor, lm = setup_predictor(FileListSignature, expected)
 
     files = [
-        dspy.File.from_path(sample_text_file),
+        dspy.File.open(sample_text_file),
         dspy.File.from_file_id("file-123"),
     ]
     result = predictor(documents=files)
@@ -233,7 +233,7 @@ def test_optional_file_field():
 
 def test_save_load_file_signature(sample_text_file):
     signature = "document: dspy.File -> summary: str"
-    file_obj = dspy.File.from_path(sample_text_file)
+    file_obj = dspy.File.open(sample_text_file)
     examples = [dspy.Example(document=file_obj, summary="Test summary")]
 
     predictor, lm = setup_predictor(signature, {"summary": "A summary"})
@@ -270,11 +270,11 @@ def test_file_with_all_fields():
 
 def test_file_path_not_found():
     with pytest.raises(ValueError, match="File not found"):
-        dspy.File.from_path("/nonexistent/path/file.txt")
+        dspy.File.open("/nonexistent/path/file.txt")
 
 
 def test_file_custom_mime_type(sample_text_file):
-    file_obj = dspy.File.from_path(sample_text_file, mime_type="text/custom")
+    file_obj = dspy.File.open(sample_text_file, mime_type="text/custom")
     assert file_obj.file_data.startswith("data:text/custom;base64,")
 
 

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -26,7 +26,7 @@ def sample_pil_image():
 @pytest.fixture
 def sample_dspy_image_download():
     url = "https://images.dog.ceo/breeds/dane-great/n02109047_8912.jpg"
-    return dspy.Image.from_url(url)
+    return dspy.Image.download(url)
 
 
 @pytest.fixture
@@ -346,7 +346,7 @@ def test_pdf_url_support():
     pdf_url = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
 
     # Download the PDF into a dspy.Image data URI.
-    pdf_image = dspy.Image.from_url(pdf_url)
+    pdf_image = dspy.Image.download(pdf_url)
 
     # The data URI should contain application/pdf in the MIME type
     assert "data:application/pdf" in pdf_image.url
@@ -383,7 +383,7 @@ def test_different_mime_types():
 
     for file_type, url in file_urls.items():
         # Download and encode
-        encoded = dspy.Image.from_url(url).url
+        encoded = dspy.Image.download(url).url
 
         # Check for correct MIME type in the encoded data - using 'in' instead of startswith
         # to account for possible parameters in the MIME type
@@ -404,7 +404,7 @@ def test_mime_type_from_response_headers():
     assert "pdf" in expected_mime_type.lower()
 
     # Encode with download to test MIME type from headers
-    encoded = dspy.Image.from_url(pdf_url).url
+    encoded = dspy.Image.download(pdf_url).url
 
     # The encoded data should contain the correct MIME type
     assert "application/pdf" in encoded
@@ -424,7 +424,7 @@ def test_pdf_from_file():
 
     try:
         # Create a dspy.Image from the file
-        pdf_image = dspy.Image.from_path(tmp_file_path)
+        pdf_image = dspy.Image.open(tmp_file_path)
 
         # The constructor encodes the file into a data URI we can inspect directly
         assert "data:application/pdf" in pdf_image.url
@@ -483,19 +483,20 @@ def test_canonical_factories_do_not_warn(tmp_path):
         response = type("Response", (), {"content": b"pngdata", "headers": {"Content-Type": "image/png"}})()
         response.raise_for_status = lambda: None
         monkeypatch.setattr("dspy.adapters.types.image.requests.get", lambda *args, **kwargs: response)
-        dspy.Image.from_url("https://example.com/dog.jpg")
+        dspy.Image.download("https://example.com/dog.jpg")
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
-        dspy.Image.from_path(str(tmp_file))
+        dspy.Image.open(str(tmp_file))
 
 
 def test_deprecated_factory_aliases_warn(tmp_path):
     tmp_file = tmp_path / "test.png"
     tmp_file.write_bytes(b"pngdata")
 
-    with pytest.warns(DeprecationWarning, match="Image.from_file is deprecated"):
-        dspy.Image.from_file(str(tmp_file))
+    for alias in ("from_path", "from_file"):
+        with pytest.warns(DeprecationWarning, match=rf"Image.{alias} is deprecated"):
+            getattr(dspy.Image, alias)(str(tmp_file))
 
     sample_pil = PILImage.new("RGB", (10, 10), color="blue")
     with pytest.warns(DeprecationWarning):
@@ -540,7 +541,7 @@ def test_deprecated_verify_warns_without_download():
 def test_deprecated_download_does_not_rescue_local_path():
     # The Image(path) hard break holds even with the deprecated download flag.
     with pytest.warns(DeprecationWarning):
-        with pytest.raises(ValueError, match=r"Image\.from_path"):
+        with pytest.raises(ValueError, match=r"Image\.open"):
             dspy.Image("/etc/passwd", download=True)
 
 
@@ -551,9 +552,9 @@ def test_pil_image_with_deprecated_download_still_encodes():
     assert image.url.startswith("data:image/")
 
 
-def test_from_path_missing_file():
+def test_open_missing_file():
     with pytest.raises(ValueError, match="File not found"):
-        dspy.Image.from_path("/nonexistent/image.png")
+        dspy.Image.open("/nonexistent/image.png")
 
 
 def test_unidentifiable_bytes_raise_value_error():


### PR DESCRIPTION
## Summary

Follow-up to #10069 that addresses reviewer feedback on API ergonomics. Renames the two **I/O** factories to verbs and keeps the in-memory `from_*` constructors, so the resource types read like the rest of the Python ecosystem:

- `Image.open(path)` / `Image.download(url)` (was `from_path` / `from_url`)
- `Audio.open(path)` / `Audio.download(url)`
- `File.open(path)` (File has no remote-fetch content block, so no `download`)
- in-memory constructors unchanged: `from_bytes`, `from_array`, `from_file_id`

The old names — `from_path`, `from_url`, `from_file` — remain as **deprecated aliases** (warn, delegate, removed in 3.4), so this is non-breaking on top of #10069.

## Why (the ecosystem convention)

pandas and the stdlib draw a line this PR follows: `from_*` classmethods construct from **in-memory Python data** (`DataFrame.from_records`, `int.from_bytes`, `datetime.fromisoformat`), while **I/O** — reading a file or a URL — lives behind a differently-named callable (`open`, `read_csv`, `load`). pandas even *removed* `DataFrame.from_csv` in favor of `pd.read_csv` for exactly this reason. Under that convention, `from_path`/`from_url` were the misfits: they do disk/network I/O but wore the in-memory `from_*` prefix.

Their own reference libraries agree on the other half too — a *constructor* never reads a file: `np.array("x.npy")` returns a string array, `pd.DataFrame("x.csv")` raises, and `PIL.Image` reads via the named `Image.open()`. So keeping I/O out of `__init__` (from #10069) is idiomatic; this PR only fixes the *naming* of the explicit loaders.

Net surface:

| | Image | Audio | File |
|---|---|---|---|
| local file (I/O) | `open` | `open` | `open` |
| remote (I/O) | `download` | `download` | — |
| in-memory | `Image(bytes/PIL/data-URI)` | `from_array`, `Audio(bytes,…)` | `from_bytes`, `from_file_id`, `File(bytes)` |

## Migration

- `Image.from_path` → `Image.open`; `Image.from_url` → `Image.download` (same for `Audio`)
- `File.from_path` → `File.open`
- `from_file` (already deprecated in #10069) now points at `open`
- all deprecated aliases warn and are scheduled for removal in **3.4**

## Validation

- `uv run --frozen pytest --deno -q tests/adapters tests/signatures` (`370 passed, 2 xfailed`)
- deprecation of every alias is covered (`test_local_read_aliases_are_deprecated`, `test_deprecated_factory_aliases_warn`)
- Ruff lint/format; pre-commit hooks

Stacked on #10069 (merge that first). Also advances the convergence tracked in #10093.
