### PR TITLE
fix(clients): scrub LM secrets and call history from save_program pickles

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,3 +1,5 @@
+import contextlib
+import contextvars
 import copy as copy_module
 import datetime
 import importlib
@@ -24,6 +26,41 @@ GLOBAL_HISTORY = []
 LM_CLASS_STATE_KEY = "_dspy_lm_class"
 _BUILTIN_LM_CLASS_PATH = "dspy.clients.lm.LM"
 ForwardContract = Literal["legacy", "typed_lm"]
+
+# Kwarg names that hold credentials and must never reach a saved artifact.
+SENSITIVE_LM_KWARG_NAMES = frozenset(
+    {"api_key", "azure_ad_token", "aws_access_key_id", "aws_secret_access_key", "aws_session_token"}
+)
+# Header names (lowercase) that hold credentials and must never reach a saved artifact.
+SENSITIVE_HEADER_NAMES = frozenset(
+    {"authorization", "proxy-authorization", "api-key", "x-api-key", "cookie", "set-cookie"}
+)
+
+# Scrubbing is scoped to program-artifact pickling only: `copy.copy`,
+# `copy.deepcopy`, and in-process pickling (optimizer copies, the
+# transactional-load trial run) must keep working credentials and history.
+_scrub_lm_state_on_pickle = contextvars.ContextVar("_scrub_lm_state_on_pickle", default=False)
+
+
+@contextlib.contextmanager
+def scrub_lm_state_on_pickle():
+    """Scrub credentials and history from LMs pickled inside this context.
+
+    `BaseModule.save(save_program=True)` wraps its cloudpickle dump in this
+    context so program artifacts never embed API keys, credential callables,
+    sensitive headers, or call history.
+    """
+    token = _scrub_lm_state_on_pickle.set(True)
+    try:
+        yield
+    finally:
+        _scrub_lm_state_on_pickle.reset(token)
+
+
+def _scrub_sensitive_headers(headers):
+    if not isinstance(headers, dict):
+        return headers
+    return {key: value for key, value in headers.items() if str(key).lower() not in SENSITIVE_HEADER_NAMES}
 
 
 def _import_lm_class(class_path: str) -> type:
@@ -204,6 +241,32 @@ class BaseLM:
 
     def _get_initial_kwargs(self, *, temperature, max_tokens, **kwargs) -> dict[str, Any]:
         return dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if not _scrub_lm_state_on_pickle.get():
+            return state
+
+        # Program-artifact hygiene: the pickle travels, so credentials and the
+        # call log must not. The loading side configures credentials fresh,
+        # exactly as on the JSON state path.
+        state["history"] = []
+        state["callbacks"] = []
+        kwargs = {
+            key: value
+            for key, value in (state.get("kwargs") or {}).items()
+            if key not in SENSITIVE_LM_KWARG_NAMES
+        }
+        for header_field in ("extra_headers", "headers"):
+            if header_field in kwargs:
+                kwargs[header_field] = _scrub_sensitive_headers(kwargs[header_field])
+        state["kwargs"] = kwargs
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.__dict__.setdefault("history", [])
+        self.__dict__.setdefault("callbacks", [])
 
     def _declares_forward_contract(self) -> bool:
         """Return whether this concrete LM class declares `forward_contract`."""

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -213,11 +213,13 @@ class BaseModule:
             logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
                           'this, prefer saving using json format using module.save("module.json").')
             try:
+                from dspy.clients.base_lm import scrub_lm_state_on_pickle
+
                 modules_to_serialize = modules_to_serialize or []
                 for module in modules_to_serialize:
                     cloudpickle.register_pickle_by_value(module)
 
-                with open(path / "program.pkl", "wb") as f:
+                with open(path / "program.pkl", "wb") as f, scrub_lm_state_on_pickle():
                     cloudpickle.dump(self, f)
             except Exception as e:
                 raise RuntimeError(

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -2078,3 +2078,39 @@ def test_lm_responses_does_not_validate_reasoning_temperature_client_side():
     sent = responses.call_args.kwargs
     assert sent["temperature"] == 0.7
     assert sent["reasoning"] == {"effort": "low", "summary": "auto"}
+
+
+def test_program_pickle_scrubs_lm_secrets_and_history(tmp_path):
+    lm = dspy.LM(
+        "openai/gpt-4o-mini",
+        api_key="sk-live-SECRET",
+        cache=False,
+        extra_headers={"Authorization": "Bearer header-SECRET", "X-Route": "blue"},
+    )
+    lm.history.append({"prompt": "PRIVATE-PROMPT"})
+    predict = dspy.Predict("q -> a")
+    predict.lm = lm
+    predict.save(tmp_path / "program", save_program=True)
+
+    raw = (tmp_path / "program" / "program.pkl").read_bytes()
+    assert b"SECRET" not in raw
+    assert b"PRIVATE-PROMPT" not in raw
+
+    loaded = dspy.load(str(tmp_path / "program"), allow_pickle=True)
+    assert "api_key" not in loaded.lm.kwargs
+    assert loaded.lm.kwargs["extra_headers"] == {"X-Route": "blue"}
+    assert loaded.lm.history == []
+
+
+def test_copy_and_deepcopy_keep_lm_credentials_and_history():
+    import copy
+
+    lm = dspy.LM("openai/gpt-4o-mini", api_key="sk-keep", cache=False)
+    lm.history.append("entry")
+
+    deep = copy.deepcopy(lm)
+    assert deep.kwargs["api_key"] == "sk-keep"
+    assert deep.history == ["entry"]
+
+    shallow = lm.copy()
+    assert shallow.kwargs["api_key"] == "sk-keep"


### PR DESCRIPTION
> **Stacked PR 1/3** — #10104 and #10116 build on this.

## Problem

`module.save(path, save_program=True)` embeds live secrets and private data into `program.pkl` in cleartext:

- explicit `api_key` strings (and sibling credentials such as `azure_ad_token`, `aws_secret_access_key`)
- credential **callables**, closure included — serializing the very object whose purpose is keeping the secret out of the process image
- `Authorization`-style headers passed via `extra_headers` / `headers`
- the entire `lm.history` — every prompt and completion the LM made before saving

`allow_pickle=True` gates the *loader's* trust in the file, but nothing gated what the file carries to whoever receives it — and full-program artifacts exist precisely to be shipped to other teams and services. The JSON state path has always excluded `api_key` (`LM.dump_state`); the pickle path silently didn't.

Repro:

```python
lm = dspy.LM("openai/gpt-4o-mini", api_key="sk-live-SECRET")
predict = dspy.Predict("q -> a")
predict.lm = lm
predict.save("prog/", save_program=True)
assert b"sk-live-SECRET" in open("prog/program.pkl", "rb").read()  # passes before this fix
```

## Fix

`BaseLM` gains `__getstate__` / `__setstate__`. When pickling a program artifact, they scrub credentials (a named `SENSITIVE_LM_KWARG_NAMES` set), sensitive headers (`SENSITIVE_HEADER_NAMES`), `callbacks`, and `history`. Loaded programs work, but resolve credentials fresh on the loading side — the same contract the JSON state path already documents.

The subtle part: `__getstate__` also fires during `copy.copy` / `copy.deepcopy`, which optimizers and the transactional `load_state` trial run rely on — an unconditional scrub would strip working credentials mid-optimization. Scrubbing is therefore scoped by a contextvar that only `BaseModule.save`'s cloudpickle dump sets. In-process copies keep credentials and history; only saved artifacts are scrubbed. Both behaviors are pinned by tests.

## Tests

- `test_program_pickle_scrubs_lm_secrets_and_history` — no secret/header/history bytes in `program.pkl`; loaded program has no `api_key` kwarg, scrubbed headers, empty history.
- `test_copy_and_deepcopy_keep_lm_credentials_and_history` — `deepcopy` and `lm.copy()` keep credentials and history.

Note: `tests/evaluate/test_evaluate.py::test_multi_thread_evaluate_call_cancelled` is flaky/environment-sensitive on current `main` in my test setup, independent of this change.