### PR TITLE
feat(primitives): refuse untrusted LM endpoint state; add lm= override on load

### DIFF
--- a/docs/docs/diving-deeper/saving-and-loading.md
+++ b/docs/docs/diving-deeper/saving-and-loading.md
@@ -6,6 +6,23 @@ Saving a DSPy program preserves what an optimizer produced: the rewritten signat
 
 Read this when you’re shipping an optimized program to another team, version-controlling optimizer output, or trying to figure out why a `.json` save round-trips but a `.pkl` save needs an extra flag to load.
 
+The examples below use this two-predictor program:
+
+```python
+import dspy
+
+
+class HaikuEnsemble(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.draft = dspy.ChainOfThought("topic -> haiku")
+        self.critique = dspy.Predict("haiku -> improved_haiku")
+
+    def forward(self, topic):
+        draft = self.draft(topic=topic)
+        return self.critique(haiku=draft.haiku)
+```
+
 ## Design decisions
 
 ### 1. Two paths: state-only and full-program
@@ -24,9 +41,31 @@ When the loader doesn’t have your `class HaikuEnsemble(dspy.Module)` definitio
 
 Loading any pickle — state-PKL or full-program — requires `allow_pickle=True`. The default is `False` so an unsuspecting caller can’t deserialize an arbitrary file and silently execute code. The flag is a forcing function: it makes the trust decision explicit at the call site, not buried in defaults.
 
-### 5. `allow_unsafe_lm_state` strips endpoints by default
+### 5. Endpoint configuration in saved state refuses to load by default
 
-When loading state, three LM-config keys are dropped unless you opt in: `api_base`, `base_url`, and `model_list`. The reasoning: a saved program might point at an internal endpoint that the loading side shouldn’t be talking to, or that’s no longer reachable. Pass `allow_unsafe_lm_state=True` when you want the original endpoint configuration to ride along.
+When loading state, LM-config keys that carry endpoint routing — `api_base`, `base_url`, and `model_list` — cause the load to fail with a typed `dspy.LMStateError` unless you opt in. The reasoning: a tampered file could reroute requests (and the prompts inside them) to an attacker's endpoint, and silently dropping the keys instead would reroute a local-server program to the provider's default endpoint — working, but differently. The error names both exits, and both are fully supported:
+
+**The trusted path — "just works", any number of LMs.** For a file you trust (you saved it, or it comes from a source you control), pass `allow_unsafe_lm_state=True`. Every saved LM — however many the program has — is reconstructed exactly as saved: same endpoints, same configuration. This is the right call for your own checkpoints and optimization artifacts.
+
+```python
+program = HaikuEnsemble()
+program.load("haiku_ensemble.json", allow_unsafe_lm_state=True)
+```
+
+**The safe path — routes come from your code.** For a file you don't fully trust, supply the LMs yourself with `lm=`. A single LM applies to every predictor; a dict keyed by predictor name (the names `program.named_predictors()` returns) covers multi-LM programs. Predictors you leave out of the dict load their saved LM state normally, so you only need to supply LMs for the ones that carried endpoint configuration.
+
+```python
+program = HaikuEnsemble()
+program.load(
+    "haiku_ensemble.json",
+    lm={
+        "draft.predict": dspy.LM("openai/local-model", api_base="http://localhost:8000/v1"),
+        "critique": dspy.LM("anthropic/claude-sonnet-5"),
+    },
+)
+```
+
+This is deliberately manual: the safe path's whole point is that endpoint routes are typed into your code, where you can read them, not carried by a file you didn't write.
 
 ### 6. API keys are never serialized
 
@@ -76,11 +115,11 @@ Registers each entry with `cloudpickle.register_pickle_by_value` before pickling
 
 Two entry points, matching the two save modes.
 
-**`Module.load(path, allow_pickle=False, allow_unsafe_lm_state=False)`**  
-Loads state into an existing module instance. You instantiate the program the same way you built it, then call `.load()` on it. JSON paths load freely; `.pkl` paths require `allow_pickle=True`. `allow_unsafe_lm_state=True` keeps `api_base`, `base_url`, and `model_list` instead of stripping them.
+**`Module.load(path, allow_pickle=False, allow_unsafe_lm_state=False, lm=None)`**  
+Loads state into an existing module instance. You instantiate the program the same way you built it, then call `.load()` on it. JSON paths load freely; `.pkl` paths require `allow_pickle=True`. If the saved LM state carries endpoint configuration (`api_base`, `base_url`, `model_list`), the load raises `dspy.LMStateError` unless you pass `allow_unsafe_lm_state=True` (trusted file) or `lm=` (a single LM for every predictor, or a dict of predictor names to LMs; matching predictors ignore their saved LM state).
 
 ```python
-program = HaikuEnsemble(n=5)        # same construction as when saved
+program = HaikuEnsemble()           # same construction as when saved
 program.load("haiku_ensemble.json") # state slots in
 ```
 
@@ -98,7 +137,7 @@ You rarely call these directly — `Module.save` / `Module.load` are the user-fa
 **`Module.dump_state(json_mode=True)` → `dict`**  
 Returns `{name: parameter.dump_state(...)}` for every named parameter in the tree. `json_mode=True` (the default) forces JSON-serializable shapes; `False` allows pickle-only objects through (used internally by the `.pkl` save path).
 
-**`Module.load_state(state, *, allow_unsafe_lm_state=False)`**  
+**`Module.load_state(state, *, allow_unsafe_lm_state=False, lm=None)`**  
 Applies a state dict. Runs the load on a deep copy first to validate, then commits to the live module. Failure on the trial leaves the live module unchanged.
 
 **`Predict.dump_state(json_mode=True)`**  
@@ -118,7 +157,7 @@ Two flags, two different concerns.
 Refuses to load any `.pkl` or full-program directory. Loading a pickle can execute arbitrary code; the flag forces the caller to acknowledge that the file is trusted. Applies to both `Module.load` and `dspy.load`.
 
 **`allow_unsafe_lm_state=False` (default)**  
-On state load, drops `api_base`, `base_url`, and `model_list` from the LM config. Pass `True` to restore the original endpoint configuration. The split exists because a saved program’s endpoint may not match where the loader wants to run — an internal-only URL, a deprecated host, a model list that’s no longer available.
+On state load, refuses LM config containing `api_base`, `base_url`, or `model_list`, raising a typed `dspy.LMStateError`. Pass `True` to honor the original endpoint configuration from a trusted file, or pass `lm=` to supply the route from code instead. The refusal exists because a saved program's endpoint may not be one the loader should talk to — and because a program must never load "successfully" onto a different endpoint than it was saved with.
 
 API keys are never re-enabled by either flag. The loading side configures credentials fresh.
 

--- a/dspy/__init__.py
+++ b/dspy/__init__.py
@@ -33,6 +33,7 @@ from dspy.utils.exceptions import (
     LMProviderError,
     LMRateLimitError,
     LMServerError,
+    LMStateError,
     LMTimeoutError,
     LMTransportError,
     LMUnexpectedError,

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -1,3 +1,5 @@
+import contextlib
+import contextvars
 import copy as copy_module
 import datetime
 import importlib
@@ -24,6 +26,41 @@ GLOBAL_HISTORY = []
 LM_CLASS_STATE_KEY = "_dspy_lm_class"
 _BUILTIN_LM_CLASS_PATH = "dspy.clients.lm.LM"
 ForwardContract = Literal["legacy", "typed_lm"]
+
+# Kwarg names that hold credentials and must never reach a saved artifact.
+SENSITIVE_LM_KWARG_NAMES = frozenset(
+    {"api_key", "azure_ad_token", "aws_access_key_id", "aws_secret_access_key", "aws_session_token"}
+)
+# Header names (lowercase) that hold credentials and must never reach a saved artifact.
+SENSITIVE_HEADER_NAMES = frozenset(
+    {"authorization", "proxy-authorization", "api-key", "x-api-key", "cookie", "set-cookie"}
+)
+
+# Scrubbing is scoped to program-artifact pickling only: `copy.copy`,
+# `copy.deepcopy`, and in-process pickling (optimizer copies, the
+# transactional-load trial run) must keep working credentials and history.
+_scrub_lm_state_on_pickle = contextvars.ContextVar("_scrub_lm_state_on_pickle", default=False)
+
+
+@contextlib.contextmanager
+def scrub_lm_state_on_pickle():
+    """Scrub credentials and history from LMs pickled inside this context.
+
+    `BaseModule.save(save_program=True)` wraps its cloudpickle dump in this
+    context so program artifacts never embed API keys, credential callables,
+    sensitive headers, or call history.
+    """
+    token = _scrub_lm_state_on_pickle.set(True)
+    try:
+        yield
+    finally:
+        _scrub_lm_state_on_pickle.reset(token)
+
+
+def _scrub_sensitive_headers(headers):
+    if not isinstance(headers, dict):
+        return headers
+    return {key: value for key, value in headers.items() if str(key).lower() not in SENSITIVE_HEADER_NAMES}
 
 
 def _import_lm_class(class_path: str) -> type:
@@ -204,6 +241,32 @@ class BaseLM:
 
     def _get_initial_kwargs(self, *, temperature, max_tokens, **kwargs) -> dict[str, Any]:
         return dict(temperature=temperature, max_tokens=max_tokens, **kwargs)
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        if not _scrub_lm_state_on_pickle.get():
+            return state
+
+        # Program-artifact hygiene: the pickle travels, so credentials and the
+        # call log must not. The loading side configures credentials fresh,
+        # exactly as on the JSON state path.
+        state["history"] = []
+        state["callbacks"] = []
+        kwargs = {
+            key: value
+            for key, value in (state.get("kwargs") or {}).items()
+            if key not in SENSITIVE_LM_KWARG_NAMES
+        }
+        for header_field in ("extra_headers", "headers"):
+            if header_field in kwargs:
+                kwargs[header_field] = _scrub_sensitive_headers(kwargs[header_field])
+        state["kwargs"] = kwargs
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.__dict__.setdefault("history", [])
+        self.__dict__.setdefault("callbacks", [])
 
     def _declares_forward_contract(self) -> bool:
         """Return whether this concrete LM class declares `forward_contract`."""

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -15,6 +15,7 @@ from dspy.primitives.prediction import Prediction
 from dspy.signatures.signature import Signature, ensure_signature
 from dspy.utils.callback import BaseCallback
 from dspy.utils.constants import IS_TYPE_UNDEFINED
+from dspy.utils.exceptions import LMStateError
 
 logger = logging.getLogger(__name__)
 
@@ -30,13 +31,12 @@ def _sanitize_lm_state(lm_state: dict, allow_unsafe_lm_state: bool) -> dict:
     if not unsafe_keys:
         return lm_state
 
-    sanitized_lm_state = {k: v for k, v in lm_state.items() if k not in UNSAFE_LM_STATE_KEYS}
-    logger.warning(
-        "Ignoring unsafe LM config key(s) during state load: %s. "
-        "Pass allow_unsafe_lm_state=True to preserve these keys for trusted files.",
-        unsafe_keys,
+    raise LMStateError(
+        f"Refusing to load serialized LM state containing endpoint configuration: {unsafe_keys}. "
+        "A tampered file could reroute requests, and the prompts inside them, to an attacker's endpoint, "
+        "so these keys are only honored from trusted files. Either pass allow_unsafe_lm_state=True if you "
+        "trust this file, or pass lm=<a configured LM> to load()/load_state() to supply the route from code."
     )
-    return sanitized_lm_state
 
 
 class Predict(Module, Parameter):
@@ -88,17 +88,25 @@ class Predict(Module, Parameter):
         state["lm"] = self.lm.dump_state() if self.lm else None
         return state
 
-    def load_state(self, state: dict, *, allow_unsafe_lm_state: bool = False) -> "Predict":
+    def load_state(self, state: dict, *, allow_unsafe_lm_state: bool = False, lm: BaseLM | None = None) -> "Predict":
         """Load the saved state of a `Predict` object.
 
         Args:
             state: The saved state of a `Predict` object.
-            allow_unsafe_lm_state: If True, preserves `api_base`, `base_url`, and `model_list` from
-                serialized LM state and allows importing custom LM classes. Enable only when loading trusted files.
+            allow_unsafe_lm_state: If True, preserves endpoint configuration (`api_base`, `base_url`,
+                and `model_list`) from serialized LM state and allows importing
+                custom LM classes. Enable only when loading trusted files. Without it, state whose LM
+                carries endpoint configuration fails with a typed `dspy.LMStateError`.
+            lm: If provided, use this LM instead of reconstructing one from the saved state. This is
+                the safe way to load a program whose saved LM pointed at a custom endpoint: the route
+                comes from your code, not from the file.
 
         Returns:
             Self to allow method chaining.
         """
+        if lm is not None and not isinstance(lm, BaseLM):
+            raise ValueError(f"lm must be an instance of `dspy.BaseLM`, not {type(lm)}.")
+
         excluded_keys = ["signature", "extended_signature", "lm"]
         for name, value in state.items():
             # `excluded_keys` are fields that go through special handling.
@@ -106,12 +114,15 @@ class Predict(Module, Parameter):
                 setattr(self, name, value)
 
         self.signature = self.signature.load_state(state["signature"])
-        sanitized_lm_state = _sanitize_lm_state(state["lm"], allow_unsafe_lm_state) if state["lm"] else None
-        self.lm = (
-            BaseLM.load_state(sanitized_lm_state, allow_custom_lm_class=allow_unsafe_lm_state)
-            if sanitized_lm_state
-            else None
-        )
+        if lm is not None:
+            self.lm = lm
+        else:
+            sanitized_lm_state = _sanitize_lm_state(state["lm"], allow_unsafe_lm_state) if state["lm"] else None
+            self.lm = (
+                BaseLM.load_state(sanitized_lm_state, allow_custom_lm_class=allow_unsafe_lm_state)
+                if sanitized_lm_state
+                else None
+            )
 
         if "extended_signature" in state:  # legacy, up to and including 2.5, for CoT.
             raise NotImplementedError("Loading extended_signature is no longer supported in DSPy 2.6+")

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -156,13 +156,33 @@ class BaseModule:
     def dump_state(self, json_mode=True):
         return {name: param.dump_state(json_mode=json_mode) for name, param in self.named_parameters()}
 
-    def load_state(self, state, *, allow_unsafe_lm_state=False):
+    def load_state(self, state, *, allow_unsafe_lm_state=False, lm=None):
+        from dspy.clients.base_lm import BaseLM
         from dspy.predict.predict import Predict
+
+        if lm is None or isinstance(lm, BaseLM):
+            def resolve_lm(name):
+                return lm
+        elif isinstance(lm, dict):
+            predictor_names = [name for name, param in self.named_parameters() if isinstance(param, Predict)]
+            unknown = sorted(set(lm) - set(predictor_names))
+            if unknown:
+                raise ValueError(
+                    f"lm mapping contains unknown predictor name(s): {unknown}. "
+                    f"This module's predictors are: {sorted(predictor_names)}."
+                )
+
+            def resolve_lm(name):
+                return lm.get(name)
+        else:
+            raise ValueError(
+                f"lm must be a `dspy.BaseLM` or a dict mapping predictor names to LMs, not {type(lm)}."
+            )
 
         def _apply(module):
             for name, param in module.named_parameters():
                 if isinstance(param, Predict):
-                    param.load_state(state[name], allow_unsafe_lm_state=allow_unsafe_lm_state)
+                    param.load_state(state[name], allow_unsafe_lm_state=allow_unsafe_lm_state, lm=resolve_lm(name))
                 else:
                     param.load_state(state[name])
 
@@ -253,7 +273,7 @@ class BaseModule:
         else:
             raise ValueError(f"`path` must end with `.json` or `.pkl` when `save_program=False`, but received: {path}")
 
-    def load(self, path, allow_pickle=False, allow_unsafe_lm_state=False):
+    def load(self, path, allow_pickle=False, allow_unsafe_lm_state=False, lm=None):
         """Load the saved module. You may also want to check out dspy.load, if you want to
         load an entire program, not just the state for an existing program.
 
@@ -262,8 +282,15 @@ class BaseModule:
             allow_pickle (bool): If True, allow loading .pkl files, which can run arbitrary code.
                 This is dangerous and should only be used if you are sure about the source of the file and in a trusted environment.
             allow_unsafe_lm_state (bool): If True, preserves unsafe LM endpoint keys (e.g.,
-                `api_base`, `base_url`, and `model_list`) from loaded state and allows importing custom LM classes.
-                Enable only for trusted files.
+                `api_base`, `base_url`, and `model_list`) from loaded state and
+                allows importing custom LM classes. Enable only for trusted files. Without it, saved
+                LM state carrying endpoint configuration fails with a typed `dspy.LMStateError`.
+            lm (BaseLM | dict): If provided, use this instead of reconstructing LMs from the saved
+                state. A single `dspy.BaseLM` applies to every predictor; a dict maps predictor
+                names (as returned by `named_predictors()`) to LMs for multi-LM programs, and
+                predictors absent from the dict load their saved LM state normally. This is the
+                safe way to load a program whose saved LMs pointed at custom endpoints: the routes
+                come from your code, not from the file.
         """
         path = Path(path)
 
@@ -291,4 +318,4 @@ class BaseModule:
                     "on the loaded model, please consider loading the model in the same environment as the "
                     "saving environment."
                 )
-        self.load_state(state, allow_unsafe_lm_state=allow_unsafe_lm_state)
+        self.load_state(state, allow_unsafe_lm_state=allow_unsafe_lm_state, lm=lm)

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -213,11 +213,13 @@ class BaseModule:
             logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
                           'this, prefer saving using json format using module.save("module.json").')
             try:
+                from dspy.clients.base_lm import scrub_lm_state_on_pickle
+
                 modules_to_serialize = modules_to_serialize or []
                 for module in modules_to_serialize:
                     cloudpickle.register_pickle_by_value(module)
 
-                with open(path / "program.pkl", "wb") as f:
+                with open(path / "program.pkl", "wb") as f, scrub_lm_state_on_pickle():
                     cloudpickle.dump(self, f)
             except Exception as e:
                 raise RuntimeError(

--- a/dspy/utils/exceptions.py
+++ b/dspy/utils/exceptions.py
@@ -80,6 +80,18 @@ class LMNotConfiguredError(LMConfigurationError):
     default_code = "not_configured"
 
 
+class LMStateError(LMConfigurationError):
+    """Serialized LM state cannot be loaded safely.
+
+    Raised when a saved program's LM state contains endpoint configuration
+    that untrusted loads refuse to honor. The message names the offending
+    keys and the exits: `allow_unsafe_lm_state=True` for trusted files, or
+    passing `lm=` to `load()` / `load_state()` to supply the route from code.
+    """
+
+    default_code = "lm_state_error"
+
+
 class LMUnsupportedFeatureError(LMError):
     """The LM, provider, or DSPy provider wrapper does not support a requested feature.
 

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -2078,3 +2078,39 @@ def test_lm_responses_does_not_validate_reasoning_temperature_client_side():
     sent = responses.call_args.kwargs
     assert sent["temperature"] == 0.7
     assert sent["reasoning"] == {"effort": "low", "summary": "auto"}
+
+
+def test_program_pickle_scrubs_lm_secrets_and_history(tmp_path):
+    lm = dspy.LM(
+        "openai/gpt-4o-mini",
+        api_key="sk-live-SECRET",
+        cache=False,
+        extra_headers={"Authorization": "Bearer header-SECRET", "X-Route": "blue"},
+    )
+    lm.history.append({"prompt": "PRIVATE-PROMPT"})
+    predict = dspy.Predict("q -> a")
+    predict.lm = lm
+    predict.save(tmp_path / "program", save_program=True)
+
+    raw = (tmp_path / "program" / "program.pkl").read_bytes()
+    assert b"SECRET" not in raw
+    assert b"PRIVATE-PROMPT" not in raw
+
+    loaded = dspy.load(str(tmp_path / "program"), allow_pickle=True)
+    assert "api_key" not in loaded.lm.kwargs
+    assert loaded.lm.kwargs["extra_headers"] == {"X-Route": "blue"}
+    assert loaded.lm.history == []
+
+
+def test_copy_and_deepcopy_keep_lm_credentials_and_history():
+    import copy
+
+    lm = dspy.LM("openai/gpt-4o-mini", api_key="sk-keep", cache=False)
+    lm.history.append("entry")
+
+    deep = copy.deepcopy(lm)
+    assert deep.kwargs["api_key"] == "sk-keep"
+    assert deep.history == ["entry"]
+
+    shallow = lm.copy()
+    assert shallow.kwargs["api_key"] == "sk-keep"

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -329,7 +329,7 @@ def test_lm_field_after_dump_and_load_state(tmp_path, filename):
 
 
 @pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
-def test_load_ignores_serialized_endpoint_override_by_default(tmp_path, endpoint_override_key):
+def test_load_refuses_serialized_endpoint_override_by_default(tmp_path, endpoint_override_key):
     file_path = tmp_path / "model.json"
     override_url = "http://override.local/v1"
     original_predict = dspy.Predict("q->a")
@@ -342,14 +342,77 @@ def test_load_ignores_serialized_endpoint_override_by_default(tmp_path, endpoint
     with open(file_path, "wb") as f:
         f.write(orjson.dumps(saved_state))
 
-    with patch("dspy.predict.predict.logger.warning") as warning_mock:
-        loaded_predict = dspy.Predict("q->a")
+    loaded_predict = dspy.Predict("q->a")
+    with pytest.raises(dspy.LMStateError, match=endpoint_override_key):
         loaded_predict.load(file_path)
 
-    assert loaded_predict.lm is not None
-    assert endpoint_override_key not in loaded_predict.lm.kwargs
-    warning_mock.assert_called_once()
-    assert warning_mock.call_args.args[1] == [endpoint_override_key]
+
+def test_load_with_explicit_lm_bypasses_saved_lm_state(tmp_path):
+    file_path = tmp_path / "model.json"
+    original_predict = dspy.Predict("q->a")
+    original_predict.lm = dspy.LM(model="openai/gpt-4o-mini")
+    original_predict.save(file_path)
+
+    with open(file_path, "rb") as f:
+        saved_state = orjson.loads(f.read())
+    saved_state["lm"]["api_base"] = "http://override.local/v1"
+    with open(file_path, "wb") as f:
+        f.write(orjson.dumps(saved_state))
+
+    trusted_lm = dspy.LM(model="openai/gpt-4o")
+    loaded_predict = dspy.Predict("q->a")
+    loaded_predict.load(file_path, lm=trusted_lm)
+
+    assert loaded_predict.lm is trusted_lm
+
+
+def test_load_with_lm_mapping_assigns_per_predictor(tmp_path):
+    class TwoStage(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.draft = dspy.Predict("q->a")
+            self.critique = dspy.Predict("a->b")
+
+    file_path = tmp_path / "model.json"
+    original = TwoStage()
+    original.draft.lm = dspy.LM(model="openai/local-model", api_base="http://internal.local/v1")
+    original.critique.lm = dspy.LM(model="openai/gpt-4o-mini")
+    original.save(file_path)
+
+    # Default load refuses: one predictor's LM carries endpoint configuration.
+    with pytest.raises(dspy.LMStateError, match="api_base"):
+        TwoStage().load(file_path)
+
+    # A partial mapping supplies the endpoint-carrying LM from code; the other
+    # predictor loads its saved (safe) LM state normally.
+    draft_lm = dspy.LM(model="openai/local-model", api_base="http://localhost:8000/v1")
+    loaded = TwoStage()
+    loaded.load(file_path, lm={"draft": draft_lm})
+
+    assert loaded.draft.lm is draft_lm
+    assert isinstance(loaded.critique.lm, dspy.LM)
+    assert loaded.critique.lm.model == "openai/gpt-4o-mini"
+
+    # The trusted path still "just works" for any number of LMs.
+    trusted = TwoStage()
+    trusted.load(file_path, allow_unsafe_lm_state=True)
+    assert trusted.draft.lm.kwargs["api_base"] == "http://internal.local/v1"
+    assert trusted.critique.lm.model == "openai/gpt-4o-mini"
+
+
+def test_load_with_lm_mapping_rejects_unknown_predictor_names(tmp_path):
+    class TwoStage(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.draft = dspy.Predict("q->a")
+            self.critique = dspy.Predict("a->b")
+
+    file_path = tmp_path / "model.json"
+    original = TwoStage()
+    original.save(file_path)
+
+    with pytest.raises(ValueError, match="unknown predictor name"):
+        TwoStage().load(file_path, lm={"typo_name": dspy.LM(model="openai/gpt-4o-mini")})
 
 
 @pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
@@ -376,21 +439,16 @@ def test_load_allows_serialized_endpoint_override_with_opt_in(tmp_path, endpoint
 
 
 @pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
-def test_load_state_ignores_serialized_endpoint_override_by_default(endpoint_override_key):
+def test_load_state_refuses_serialized_endpoint_override_by_default(endpoint_override_key):
     override_url = "http://override.local/v1"
     original_predict = dspy.Predict("q->a")
     original_predict.lm = dspy.LM(model="openai/gpt-4o-mini")
     saved_state = copy.deepcopy(original_predict.dump_state())
     saved_state["lm"][endpoint_override_key] = override_url
 
-    with patch("dspy.predict.predict.logger.warning") as warning_mock:
-        loaded_predict = dspy.Predict("q->a")
+    loaded_predict = dspy.Predict("q->a")
+    with pytest.raises(dspy.LMStateError, match=endpoint_override_key):
         loaded_predict.load_state(saved_state)
-
-    assert loaded_predict.lm is not None
-    assert endpoint_override_key not in loaded_predict.lm.kwargs
-    warning_mock.assert_called_once()
-    assert warning_mock.call_args.args[1] == [endpoint_override_key]
 
 
 @pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
@@ -410,7 +468,7 @@ def test_load_state_allows_serialized_endpoint_override_with_opt_in(endpoint_ove
     warning_mock.assert_not_called()
 
 
-def test_load_state_ignores_serialized_model_list_endpoint_override_by_default():
+def test_load_state_refuses_serialized_model_list_endpoint_override_by_default():
     override_url = "http://override.local/v1"
     original_predict = dspy.Predict("q->a")
     original_predict.lm = dspy.LM(model="openai/gpt-4o-mini")
@@ -425,18 +483,13 @@ def test_load_state_ignores_serialized_model_list_endpoint_override_by_default()
         }
     ]
 
-    with patch("dspy.predict.predict.logger.warning") as warning_mock:
-        loaded_predict = dspy.Predict("q->a")
+    loaded_predict = dspy.Predict("q->a")
+    with pytest.raises(dspy.LMStateError, match="model_list"):
         loaded_predict.load_state(saved_state)
-
-    assert loaded_predict.lm is not None
-    assert "model_list" not in loaded_predict.lm.kwargs
-    warning_mock.assert_called_once()
-    assert "model_list" in warning_mock.call_args.args[1]
 
 
 @pytest.mark.parametrize("endpoint_override_key", ["api_base", "base_url"])
-def test_load_prevents_serialized_endpoint_override_reaching_litellm(tmp_path, endpoint_override_key):
+def test_explicit_lm_prevents_serialized_endpoint_override_reaching_litellm(tmp_path, endpoint_override_key):
     file_path = tmp_path / "model.json"
     override_url = "http://override.local/v1"
     original_predict = dspy.Predict("q->a")
@@ -450,7 +503,7 @@ def test_load_prevents_serialized_endpoint_override_reaching_litellm(tmp_path, e
         f.write(orjson.dumps(saved_state))
 
     loaded_predict = dspy.Predict("q->a")
-    loaded_predict.load(file_path)
+    loaded_predict.load(file_path, lm=dspy.LM(model="openai/gpt-4o-mini"))
 
     class FakeResp(dict):
         cache_hit = False
@@ -466,7 +519,7 @@ def test_load_prevents_serialized_endpoint_override_reaching_litellm(tmp_path, e
     assert completion_mock.call_args.kwargs.get(endpoint_override_key) != override_url
 
 
-def test_load_blocks_serialized_model_list_unless_opted_in(tmp_path):
+def test_load_honors_serialized_model_list_only_when_opted_in(tmp_path):
     file_path = tmp_path / "model.json"
     override_url = "http://override.local/v1"
     original_predict = dspy.Predict("q->a")
@@ -495,13 +548,8 @@ def test_load_blocks_serialized_model_list_unless_opted_in(tmp_path):
             super().__init__({"choices": []})
 
     safe_loaded_predict = dspy.Predict("q->a")
-    safe_loaded_predict.load(file_path)
-    with patch("litellm.batch_completion_models", return_value=FakeResp()) as batch_completion_mock:
-        with patch("litellm.completion", return_value=FakeResp()) as completion_mock:
-            safe_loaded_predict.lm.forward(prompt="hello", cache=False)
-
-    assert completion_mock.called
-    assert not batch_completion_mock.called
+    with pytest.raises(dspy.LMStateError, match="model_list"):
+        safe_loaded_predict.load(file_path)
 
     opt_in_loaded_predict = dspy.Predict("q->a")
     opt_in_loaded_predict.load(file_path, allow_unsafe_lm_state=True)
@@ -512,7 +560,7 @@ def test_load_blocks_serialized_model_list_unless_opted_in(tmp_path):
     assert opt_in_deployments[0]["api_base"] == override_url
 
 
-def test_load_uses_env_api_key_without_honoring_serialized_endpoint_override(tmp_path, monkeypatch):
+def test_serialized_endpoint_override_cannot_capture_env_api_key_by_default(tmp_path, monkeypatch):
     file_path = tmp_path / "model.json"
     override_url = "http://override.local/v1"
     env_api_key = "sk-live-test-secret"
@@ -537,7 +585,7 @@ def test_load_uses_env_api_key_without_honoring_serialized_endpoint_override(tmp
         def __init__(self):
             super().__init__({"choices": []})
 
-    # Simulates legacy behavior by allowing serialized endpoint overrides.
+    # Trusted opt-in honors the serialized endpoint, and the ambient key goes with it.
     opt_in_loaded_predict = dspy.Predict("q->a")
     opt_in_loaded_predict.load(file_path, allow_unsafe_lm_state=True)
     with patch("litellm.text_completion", return_value=FakeResp()) as text_completion_mock:
@@ -546,14 +594,11 @@ def test_load_uses_env_api_key_without_honoring_serialized_endpoint_override(tmp
     assert text_completion_mock.call_args.kwargs["api_base"] == override_url
     assert text_completion_mock.call_args.kwargs["api_key"] == env_api_key
 
+    # The default path refuses the file outright, so the ambient key can never
+    # be sent to the overriding endpoint.
     safe_loaded_predict = dspy.Predict("q->a")
-    safe_loaded_predict.load(file_path)
-    with patch("litellm.text_completion", return_value=FakeResp()) as text_completion_mock:
-        safe_loaded_predict.lm.forward(prompt="hello", cache=False)
-
-    # In the safe path, the key still comes from the environment, but the serialized endpoint override does not.
-    assert text_completion_mock.call_args.kwargs["api_key"] == env_api_key
-    assert text_completion_mock.call_args.kwargs["api_base"] != override_url
+    with pytest.raises(dspy.LMStateError, match="api_base"):
+        safe_loaded_predict.load(file_path)
 
 
 def test_forward_method():


### PR DESCRIPTION
> **Stacked PR 2/3** — builds on #10103; #10116 builds on this. This diff includes #10103's commit until it merges.

## Problem

Loading saved state whose LM config carries endpoint routing (`api_base`, `base_url`, `model_list`) strips those keys with a warning and continues. For anyone using a local or self-hosted server — vLLM, SGLang, Ollama, a gateway — the endpoint lives in exactly those keys, so this is the default experience for that entire population, and it produces the worst possible failure mode:

```python
lm = dspy.LM("openai/my-local-model", api_base="http://localhost:8000/v1")
predict = dspy.Predict("q -> a")
predict.lm = lm
predict.save("prog.json")

loaded = dspy.Predict("q -> a")
loaded.load("prog.json")   # warning, then "success"
loaded(q="hello")          # → api.openai.com, under ambient OPENAI_API_KEY
```

The reloaded program silently sends requests — and the prompts inside them — to the provider's default endpoint under whatever ambient key resolves. If the model name happens to exist there (a real model name behind a corporate proxy, say), it *works*, rerouted, bypassing the gateway and billed to the ambient key with no signal beyond one load-time warning. If not, it fails later with a misleading model-not-found error far from the cause.

## Change

**Untrusted loads refuse, typed.** State whose LM carries endpoint configuration now raises `dspy.LMStateError` (new, under `LMConfigurationError`) naming the offending keys and both exits. A program loads exactly as it was saved, or fails naming the gap — it never loads "successfully" onto a different endpoint than it was saved with.

**`lm=` is the safe exit.** `load()` / `load_state()` accept:

- a single `BaseLM` — applied to every predictor, saved LM state ignored;
- a dict mapping predictor names (as returned by `named_predictors()`) to LMs — for multi-LM programs. Predictors absent from the dict load their saved LM state normally, so callers supply routes only for the predictors that carried endpoint configuration. Unknown names fail fast, listing the module's actual predictor names.

```python
program.load("prog.json", lm={
    "draft.predict": dspy.LM("openai/local-model", api_base="http://localhost:8000/v1"),
    "critique": dspy.LM("anthropic/claude-sonnet-5"),
})
```

Routes come from the caller's code, never from the file.

**`allow_unsafe_lm_state=True` keeps its meaning** for trusted files: every saved LM — however many the program has — reconstructs exactly as saved.

## Behavior change

The previous strip-and-warn tests (`test_load_ignores_serialized_endpoint_override_by_default` and friends) asserted the silent-degrade behavior; they are rewritten to assert the typed refusal, plus new coverage for the `lm=` single/mapping paths and the unknown-name error. The `saving-and-loading` docs now present the two exits side by side.

Note: `tests/primitives/test_base_module.py::test_usage_tracker_in_parallel` and `tests/evaluate/test_evaluate.py::test_multi_thread_evaluate_call_cancelled` fail on current `main` in my environment independent of this change.

Related: #10103 (artifact-side hygiene for the pickle path).