### PR TITLE
fix(adapters): XMLAdapter.parse no longer truncates values containing their own closing tag

### DIFF
--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -9,7 +9,11 @@ from dspy.signatures.signature import Signature
 
 
 class XMLAdapter(ChatAdapter):
-    field_pattern = re.compile(r"<(?P<name>\w+)>((?P<content>.*?))</\1>", re.DOTALL)
+    # Greedy `.*` with backreference `\1` matches the LAST closing tag for
+    # each field name, so content containing the field's own closing tag
+    # (e.g. code with `</code>`) is captured in full instead of being
+    # truncated at the first occurrence (#10102).
+    field_pattern = re.compile(r"<(?P<name>\w+)>((?P<content>.*))</\1>", re.DOTALL)
 
     def format_field_with_value(self, fields_with_values: dict[FieldInfoWithName, Any]) -> str:
         output = []

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -841,3 +841,51 @@ All interactions will be structured in the following way, with the appropriate v
 In adhering to this structure, your objective is:\x20
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+def test_xml_adapter_parse_content_containing_own_closing_tag():
+    """Regression #10102: a field value containing its own closing tag must
+    be captured in full, not truncated at the first occurrence."""
+
+    class CodeSig(dspy.Signature):
+        task: str = dspy.InputField()
+        code: str = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    completion = "<code>\nif x:\n    print('</code>')\n</code>\n"
+    parsed = adapter.parse(CodeSig, completion)
+    assert parsed == {"code": "if x:\n    print('</code>')"}
+
+
+def test_xml_adapter_parse_two_fields_with_nested_closing_tag():
+    """Regression #10102: with two output fields, the second field's value
+    containing its own closing tag must not be truncated."""
+
+    class Two(dspy.Signature):
+        q: str = dspy.InputField()
+        reasoning: str = dspy.OutputField()
+        answer: str = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    completion = (
+        "<reasoning>\nthink\n</reasoning>\n"
+        "<answer>\nsee </answer> above\n</answer>\n"
+    )
+    parsed = adapter.parse(Two, completion)
+    assert parsed == {"reasoning": "think", "answer": "see </answer> above"}
+
+
+def test_xml_adapter_parse_round_trip_with_closing_tag_in_value():
+    """Regression #10102: round-tripping through the adapter's own formatter
+    must preserve a value that contains the closing tag."""
+
+    class CodeSig(dspy.Signature):
+        task: str = dspy.InputField()
+        code: str = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    formatted = adapter.format_assistant_message_content(
+        CodeSig, {"code": "before </code> after"}
+    )
+    parsed = adapter.parse(CodeSig, formatted)
+    assert parsed == {"code": "before </code> after"}


### PR DESCRIPTION
## Summary

Fixes #10102

`XMLAdapter.parse` used a non-greedy quantifier (`.*?`) in `field_pattern`, which stopped at the **first** occurrence of the field's closing tag. When a field value contained its own closing tag (e.g. code with `</code>`, HTML with `</div>`, or a quoted log line), everything after the first occurrence was silently dropped. Because the field still matched, no `AdapterParseError` was raised and the caller received a truncated string.

```python
# Before
field_pattern = re.compile(r"<(?P<name>\w+)>((?P<content>.*?))</\1>", re.DOTALL)
# After
field_pattern = re.compile(r"<(?P<name>\w+)>((?P<content>.*))</\1>", re.DOTALL)
```

## Fix

Switch to a greedy quantifier (`.*`) with the existing backreference `\1`. The backreference ensures the closing tag matches the opening tag name, and greediness makes it match the **last** such closing tag — capturing the full content. The `parse` method's `name not in fields` guard already handles duplicate field names, so multiple fields still parse correctly.

This brings `XMLAdapter` in line with `ChatAdapter` and `JSONAdapter`, which handle the same content without truncation.

## Tests

Added three regression tests in `test_xml_adapter.py`:

- content containing its own closing tag (single field)
- two fields where the second contains its own closing tag
- round-trip through `format_assistant_message_content`

```
$ pytest tests/adapters/test_xml_adapter.py -q
22 passed
```

All three new tests **fail** on the unfixed code and **pass** with the fix.