### PR TITLE
feat(evaluate): support population metrics in MIPROv2 optimization

### DIFF
--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -88,9 +88,9 @@ class Evaluate:
         Args:
             devset (list[dspy.Example]): the evaluation dataset.
             metric (Callable): The per-example metric function to use for evaluation.
-            population_metric (Optional[Callable]): An optional metric that receives all examples and predictions
-                and determines the aggregate evaluation score. Its return value is scaled by 100 when stored in
-                `EvaluationResult.score`.
+            population_metric (Optional[Callable]): An optional metric that receives successfully evaluated examples
+                and predictions and determines the aggregate evaluation score. Items with tolerated per-example failures
+                are omitted. Its return value is scaled by 100 when stored in `EvaluationResult.score`.
             num_threads (Optional[int]): The number of threads to use for parallel evaluation.
             display_progress (bool): Whether to display progress during evaluation.
             display_table (Union[bool, int]): Whether to display the evaluation results in a table.
@@ -144,9 +144,10 @@ class Evaluate:
             display_table (Union[bool, int]): Whether to display the evaluation results in a table. if not provided, use
                 `self.display_table`. If a number is passed, the evaluation results will be truncated to that number before displayed.
             callback_metadata (dict): Metadata to be used for evaluate callback handlers.
-            population_metric (Optional[Callable]): An optional metric that receives all examples and predictions
-                and determines the aggregate evaluation score. Its return value is scaled by 100 when stored in
-                `EvaluationResult.score`. if not provided, use `self.population_metric`.
+            population_metric (Optional[Callable]): An optional metric that receives successfully evaluated examples
+                and predictions and determines the aggregate evaluation score. Items with tolerated per-example failures
+                are omitted. Its return value is scaled by 100 when stored in `EvaluationResult.score`. if not provided,
+                use `self.population_metric`.
 
         Returns:
             The evaluation results are returned as a dspy.EvaluationResult object containing the following attributes:
@@ -193,10 +194,20 @@ class Evaluate:
         logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
 
         if population_metric is not None:
-            examples = [example for example, _, _ in results]
-            predictions = [prediction for _, prediction, _ in results]
-            overall_score = round(100 * population_metric(examples, predictions), 2)
-            logger.info(f"Population Metric: {overall_score}%")
+            failed_indices = set(executor.failed_indices)
+            population_results = [
+                result for index, result in enumerate(results) if index not in failed_indices
+            ]
+            if population_results:
+                examples = [example for example, _, _ in population_results]
+                predictions = [prediction for _, prediction, _ in population_results]
+                overall_score = round(100 * population_metric(examples, predictions), 2)
+                logger.info(f"Population Metric: {overall_score}%")
+            else:
+                logger.warning(
+                    "Skipping population metric because all examples failed; "
+                    "using the average failure score instead."
+                )
 
         if display_table:
             if importlib.util.find_spec("pandas") is not None:

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -73,6 +73,7 @@ class Evaluate:
         *,
         devset: list["dspy.Example"],
         metric: Callable | None = None,
+        population_metric: Callable | None = None,
         num_threads: int | None = None,
         display_progress: bool = False,
         display_table: bool | int = False,
@@ -86,7 +87,10 @@ class Evaluate:
         """
         Args:
             devset (list[dspy.Example]): the evaluation dataset.
-            metric (Callable): The metric function to use for evaluation.
+            metric (Callable): The per-example metric function to use for evaluation.
+            population_metric (Optional[Callable]): An optional metric that receives all examples and predictions
+                and determines the aggregate evaluation score. Its return value is scaled by 100 when stored in
+                `EvaluationResult.score`.
             num_threads (Optional[int]): The number of threads to use for parallel evaluation.
             display_progress (bool): Whether to display progress during evaluation.
             display_table (Union[bool, int]): Whether to display the evaluation results in a table.
@@ -101,6 +105,7 @@ class Evaluate:
         """
         self.devset = devset
         self.metric = metric
+        self.population_metric = population_metric
         self.num_threads = num_threads
         self.display_progress = display_progress
         self.display_table = display_table
@@ -125,11 +130,12 @@ class Evaluate:
         callback_metadata: dict[str, Any] | None = None,
         save_as_csv: str | None = None,
         save_as_json: str | None = None,
+        population_metric: Callable | None = None,
     ) -> EvaluationResult:
         """
         Args:
             program (dspy.Module): The DSPy program to evaluate.
-            metric (Callable): The metric function to use for evaluation. if not provided, use `self.metric`.
+            metric (Callable): The per-example metric function to use for evaluation. if not provided, use `self.metric`.
             devset (list[dspy.Example]): the evaluation dataset. if not provided, use `self.devset`.
             num_threads (Optional[int]): The number of threads to use for parallel evaluation. if not provided, use
                 `self.num_threads`.
@@ -138,6 +144,9 @@ class Evaluate:
             display_table (Union[bool, int]): Whether to display the evaluation results in a table. if not provided, use
                 `self.display_table`. If a number is passed, the evaluation results will be truncated to that number before displayed.
             callback_metadata (dict): Metadata to be used for evaluate callback handlers.
+            population_metric (Optional[Callable]): An optional metric that receives all examples and predictions
+                and determines the aggregate evaluation score. Its return value is scaled by 100 when stored in
+                `EvaluationResult.score`. if not provided, use `self.population_metric`.
 
         Returns:
             The evaluation results are returned as a dspy.EvaluationResult object containing the following attributes:
@@ -147,6 +156,7 @@ class Evaluate:
             - results: a list of (example, prediction, score) tuples for each example in devset
         """
         metric = metric if metric is not None else self.metric
+        population_metric = population_metric if population_metric is not None else self.population_metric
         devset = devset if devset is not None else self.devset
         num_threads = num_threads if num_threads is not None else self.num_threads
         display_progress = display_progress if display_progress is not None else self.display_progress
@@ -178,8 +188,15 @@ class Evaluate:
         results = [((dspy.Prediction(), self.failure_score) if r is None else r) for r in results]
         results = [(example, prediction, score) for example, (prediction, score) in zip(devset, results, strict=False)]
         ncorrect, ntotal = sum(score for *_, score in results), len(devset)
+        overall_score = round(100 * ncorrect / ntotal, 2)
 
         logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
+
+        if population_metric is not None:
+            examples = [example for example, _, _ in results]
+            predictions = [prediction for _, prediction, _ in results]
+            overall_score = round(100 * population_metric(examples, predictions), 2)
+            logger.info(f"Population Metric: {overall_score}%")
 
         if display_table:
             if importlib.util.find_spec("pandas") is not None:
@@ -221,7 +238,7 @@ class Evaluate:
                 json.dump(data, f)
 
         return EvaluationResult(
-            score=round(100 * ncorrect / ntotal, 2),
+            score=overall_score,
             results=results,
         )
 

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -180,7 +180,7 @@ class Evaluate:
 
         def process_item(example):
             prediction = program(**example.inputs())
-            score = metric(example, prediction)
+            score = metric(example, prediction) if metric is not None else 0.0
             return prediction, score
 
         results = executor.execute(process_item, devset)
@@ -191,7 +191,8 @@ class Evaluate:
         ncorrect, ntotal = sum(score for *_, score in results), len(devset)
         overall_score = round(100 * ncorrect / ntotal, 2)
 
-        logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
+        if metric is not None:
+            logger.info(f"Average Metric: {ncorrect} / {ntotal} ({round(100 * ncorrect / ntotal, 1)}%)")
 
         if population_metric is not None:
             failed_indices = set(executor.failed_indices)
@@ -212,7 +213,11 @@ class Evaluate:
         if display_table:
             if importlib.util.find_spec("pandas") is not None:
                 # Rename the 'correct' column to the name of the metric object
-                metric_name = metric.__name__ if isinstance(metric, types.FunctionType) else metric.__class__.__name__
+                metric_name = (
+                    metric.__name__
+                    if isinstance(metric, types.FunctionType)
+                    else metric.__class__.__name__ if metric is not None else "score"
+                )
                 # Construct a pandas DataFrame from the results
                 result_df = self._construct_result_table(results, metric_name)
 
@@ -224,7 +229,7 @@ class Evaluate:
             metric_name = (
                 metric.__name__
                 if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__
+                else metric.__class__.__name__ if metric is not None else "score"
             )
             data = self._prepare_results_output(results, metric_name)
 
@@ -239,7 +244,7 @@ class Evaluate:
             metric_name = (
                 metric.__name__
                 if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__
+                else metric.__class__.__name__ if metric is not None else "score"
             )
             data = self._prepare_results_output(results, metric_name)
             with open(

--- a/dspy/evaluate/evaluate.py
+++ b/dspy/evaluate/evaluate.py
@@ -210,14 +210,14 @@ class Evaluate:
                     "using the average failure score instead."
                 )
 
+        metric_name = (
+            metric.__name__
+            if isinstance(metric, types.FunctionType)
+            else metric.__class__.__name__ if metric is not None else None
+        )
+
         if display_table:
             if importlib.util.find_spec("pandas") is not None:
-                # Rename the 'correct' column to the name of the metric object
-                metric_name = (
-                    metric.__name__
-                    if isinstance(metric, types.FunctionType)
-                    else metric.__class__.__name__ if metric is not None else "score"
-                )
                 # Construct a pandas DataFrame from the results
                 result_df = self._construct_result_table(results, metric_name)
 
@@ -226,26 +226,16 @@ class Evaluate:
                 logger.warning("Skipping table display since `pandas` is not installed.")
 
         if save_as_csv:
-            metric_name = (
-                metric.__name__
-                if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__ if metric is not None else "score"
-            )
             data = self._prepare_results_output(results, metric_name)
 
             with open(save_as_csv, "w", newline="") as csvfile:
-                fieldnames = data[0].keys()
+                fieldnames = list(dict.fromkeys(key for row in data for key in row))
                 writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
 
                 writer.writeheader()
                 for row in data:
                     writer.writerow(row)
         if save_as_json:
-            metric_name = (
-                metric.__name__
-                if isinstance(metric, types.FunctionType)
-                else metric.__class__.__name__ if metric is not None else "score"
-            )
             data = self._prepare_results_output(results, metric_name)
             with open(
                     save_as_json,
@@ -260,19 +250,20 @@ class Evaluate:
 
     @staticmethod
     def _prepare_results_output(
-            results: list[tuple["dspy.Example", "dspy.Example", Any]], metric_name: str
+            results: list[tuple["dspy.Example", "dspy.Example", Any]], metric_name: str | None
     ):
         return [
             (
-                merge_dicts(example, prediction) | {metric_name: score}
+                merge_dicts(example, prediction)
                 if prediction_is_dictlike(prediction)
-                else example.toDict() | {"prediction": prediction, metric_name: score}
+                else example.toDict() | {"prediction": prediction}
             )
+            | ({metric_name: score} if metric_name is not None else {})
             for example, prediction, score in results
         ]
 
     def _construct_result_table(
-        self, results: list[tuple["dspy.Example", "dspy.Example", Any]], metric_name: str
+        self, results: list[tuple["dspy.Example", "dspy.Example", Any]], metric_name: str | None
     ) -> "pd.DataFrame":
         """
         Construct a pandas DataFrame from the specified result list.
@@ -280,7 +271,8 @@ class Evaluate:
 
         Args:
             results: The list of results to construct the result DataFrame from.
-            metric_name: The name of the metric used for evaluation.
+            metric_name: The name of the per-example metric used for evaluation. If `None`, no synthetic metric
+                column is added to the table.
 
         Returns:
             The constructed pandas DataFrame.
@@ -293,9 +285,9 @@ class Evaluate:
         result_df = pd.DataFrame(data)
         result_df = result_df.map(truncate_cell) if hasattr(result_df, "map") else result_df.applymap(truncate_cell)
 
-        return result_df.rename(columns={"correct": metric_name})
+        return result_df.rename(columns={"correct": metric_name}) if metric_name is not None else result_df
 
-    def _display_result_table(self, result_df: "pd.DataFrame", display_table: bool | int, metric_name: str):
+    def _display_result_table(self, result_df: "pd.DataFrame", display_table: bool | int, metric_name: str | None):
         """
         Display the specified result DataFrame in a table format.
 
@@ -303,7 +295,8 @@ class Evaluate:
             result_df: The result DataFrame to display.
             display_table: Whether to display the evaluation results in a table.
                 If a number is passed, the evaluation results will be truncated to that number before displayed.
-            metric_name: The name of the metric used for evaluation.
+            metric_name: The name of the per-example metric used for evaluation. If `None`, no metric column is
+                styled.
         """
         if isinstance(display_table, bool):
             df_to_display = result_df.copy()
@@ -312,7 +305,8 @@ class Evaluate:
             df_to_display = result_df.head(display_table).copy()
             truncated_rows = len(result_df) - display_table
 
-        df_to_display = stylize_metric_name(df_to_display, metric_name)
+        if metric_name is not None:
+            df_to_display = stylize_metric_name(df_to_display, metric_name)
 
         display_dataframe(df_to_display)
 

--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -76,6 +76,7 @@ class MIPROv2(Teleprompter):
         track_stats: bool = True,
         log_dir: str | None = None,
         metric_threshold: float | None = None,
+        population_metric: Callable | None = None,
     ):
         # Validate 'auto' parameter
         allowed_modes = {None, "light", "medium", "heavy"}
@@ -86,6 +87,7 @@ class MIPROv2(Teleprompter):
         self.num_instruct_candidates = num_candidates
         self.num_candidates = num_candidates
         self.metric = metric
+        self.population_metric = population_metric
         self.init_temperature = init_temperature
         self.task_model = task_model if task_model else dspy.settings.lm
         self.prompt_model = prompt_model if prompt_model else dspy.settings.lm
@@ -219,6 +221,7 @@ class MIPROv2(Teleprompter):
         evaluate = Evaluate(
             devset=valset,
             metric=self.metric,
+            population_metric=self.population_metric,
             num_threads=self.num_threads,
             max_errors=effective_max_errors,
             display_table=False,

--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -237,6 +237,9 @@ class ParallelExecutor:
                 self.exceptions_map[idx] = outcome
         else:
             results[idx] = outcome
+            with self.error_lock:
+                self.failed_indices = [failed_idx for failed_idx in self.failed_indices if failed_idx != idx]
+                self.exceptions_map.pop(idx, None)
 
     def _report_progress(self, pbar, results, total):
         """Compute metrics and update the progress bar."""

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -543,3 +543,65 @@ def test_evaluate_population_metric_per_call_override():
 
     assert result.score == 75.0
     assert [score for _, _, score in result.results] == [True, True]
+
+
+def test_evaluate_population_metric_skips_tolerated_program_failures():
+    devset = [new_example("broken", "correct"), new_example("healthy", "correct")]
+    captured = {}
+
+    def program(question):
+        if question == "broken":
+            raise ValueError("program failure")
+        return dspy.Prediction(answer="correct")
+
+    def sample_metric(example, prediction):
+        return example.answer == prediction.answer
+
+    def population_metric(examples, predictions):
+        captured["questions"] = [example.question for example in examples]
+        captured["answers"] = [prediction.answer for prediction in predictions]
+        return 1.0
+
+    evaluator = Evaluate(
+        devset=devset,
+        metric=sample_metric,
+        population_metric=population_metric,
+        max_errors=2,
+        display_progress=False,
+    )
+    result = evaluator(program)
+
+    assert result.score == 100.0
+    assert [score for _, _, score in result.results] == [0.0, True]
+    assert captured == {"questions": ["healthy"], "answers": ["correct"]}
+
+
+def test_evaluate_population_metric_skips_tolerated_metric_failures():
+    devset = [new_example("broken", "correct"), new_example("healthy", "correct")]
+    captured = {}
+
+    def program(question):
+        return dspy.Prediction(answer="correct")
+
+    def sample_metric(example, prediction):
+        if example.question == "broken":
+            raise ValueError("metric failure")
+        return example.answer == prediction.answer
+
+    def population_metric(examples, predictions):
+        captured["questions"] = [example.question for example in examples]
+        captured["answers"] = [prediction.answer for prediction in predictions]
+        return 0.75
+
+    evaluator = Evaluate(
+        devset=devset,
+        metric=sample_metric,
+        population_metric=population_metric,
+        max_errors=2,
+        display_progress=False,
+    )
+    result = evaluator(program)
+
+    assert result.score == 75.0
+    assert [score for _, _, score in result.results] == [0.0, True]
+    assert captured == {"questions": ["healthy"], "answers": ["correct"]}

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -22,6 +22,22 @@ def new_example(question, answer):
     ).with_inputs("question")
 
 
+def _population_only_score_case():
+    devset = [
+        dspy.Example(question="no-score", answer="c").with_inputs("question"),
+        dspy.Example(question="example-owned", answer="a", score=0.25).with_inputs("question"),
+        dspy.Example(question="prediction-owned", answer="b").with_inputs("question"),
+    ]
+    answers = {"no-score": "c", "example-owned": "a", "prediction-owned": "b"}
+
+    def program(question):
+        if question == "prediction-owned":
+            return dspy.Prediction(answer=answers[question], score=0.75)
+        return dspy.Prediction(answer=answers[question])
+
+    return devset, program
+
+
 def test_evaluate_initialization():
     devset = [new_example("What is 1+1?", "2")]
     ev = Evaluate(
@@ -484,6 +500,75 @@ def test_evaluate_population_metric_without_per_example_metric():
         "questions": ["first", "second"],
         "answers": ["a", "wrong"],
     }
+
+def test_evaluate_population_only_output_preserves_user_scores():
+    devset, program = _population_only_score_case()
+    evaluator = Evaluate(devset=devset, population_metric=lambda examples, predictions: 1.0)
+
+    result = evaluator(program)
+    data = evaluator._prepare_results_output(result.results, metric_name=None)
+
+    assert [score for _, _, score in result.results] == [0.0, 0.0, 0.0]
+    assert "score" not in data[0]
+    assert data[1]["score"] == 0.25
+    assert data[2]["score"] == 0.75
+
+
+@pytest.mark.extra
+def test_evaluate_population_only_table_preserves_user_scores():
+    import pandas as pd
+
+    devset, program = _population_only_score_case()
+    evaluator = Evaluate(devset=devset, population_metric=lambda examples, predictions: 1.0)
+
+    with patch.object(evaluator, "_display_result_table") as display_result_table:
+        result = evaluator(program, display_table=True)
+
+    result_df, display_table, metric_name = display_result_table.call_args.args
+    assert display_table is True
+    assert metric_name is None
+    assert pd.isna(result_df.loc[0, "score"])
+    assert result_df.loc[1, "score"] == 0.25
+    assert result_df.loc[2, "score"] == 0.75
+    assert [score for _, _, score in result.results] == [0.0, 0.0, 0.0]
+
+
+def test_evaluate_population_only_json_preserves_user_scores(tmp_path):
+    devset, program = _population_only_score_case()
+    output_path = tmp_path / "population-results.json"
+    evaluator = Evaluate(
+        devset=devset,
+        population_metric=lambda examples, predictions: 1.0,
+        save_as_json=str(output_path),
+    )
+
+    result = evaluator(program)
+    data = json.loads(output_path.read_text())
+
+    assert [score for _, _, score in result.results] == [0.0, 0.0, 0.0]
+    assert "score" not in data[0]
+    assert data[1]["score"] == 0.25
+    assert data[2]["score"] == 0.75
+
+
+def test_evaluate_population_only_csv_preserves_user_scores(tmp_path):
+    import csv
+
+    devset, program = _population_only_score_case()
+    output_path = tmp_path / "population-results.csv"
+    evaluator = Evaluate(
+        devset=devset,
+        population_metric=lambda examples, predictions: 1.0,
+        save_as_csv=str(output_path),
+    )
+
+    result = evaluator(program)
+    with output_path.open(newline="") as file:
+        rows = list(csv.DictReader(file))
+
+    assert [score for _, _, score in result.results] == [0.0, 0.0, 0.0]
+    assert [row["score"] for row in rows] == ["", "0.25", "0.75"]
+
 
 def test_evaluate_population_metric_overrides_sample_mean():
     devset = [new_example("first", "correct"), new_example("second", "correct")]

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -461,3 +461,85 @@ def test_evaluate_save_as_csv_with_history():
         if os.path.exists(temp_csv):
             os.unlink(temp_csv)
 
+
+def test_evaluate_population_metric_overrides_sample_mean():
+    devset = [new_example("first", "correct"), new_example("second", "correct")]
+    answers = {"first": "correct", "second": "incorrect"}
+
+    def program(question):
+        return dspy.Prediction(answer=answers[question])
+
+    def sample_metric(example, prediction):
+        return example.answer == prediction.answer
+
+    def population_metric(examples, predictions):
+        assert examples == devset
+        assert [prediction.answer for prediction in predictions] == ["correct", "incorrect"]
+        return 0.25
+
+    evaluator = Evaluate(devset=devset, metric=sample_metric, population_metric=population_metric)
+    result = evaluator(program)
+
+    assert result.score == 25.0
+    assert [score for _, _, score in result.results] == [True, False]
+
+
+def test_evaluate_population_metric_preserves_parallel_order():
+    import time
+
+    devset = [new_example("slow", "slow-result"), new_example("fast", "fast-result")]
+    captured = {}
+
+    def program(question):
+        if question == "slow":
+            time.sleep(0.05)
+        return dspy.Prediction(answer=f"{question}-result")
+
+    def sample_metric(example, prediction):
+        return example.answer == prediction.answer
+
+    def population_metric(examples, predictions):
+        captured["questions"] = [example.question for example in examples]
+        captured["answers"] = [prediction.answer for prediction in predictions]
+        return 1.0
+
+    evaluator = Evaluate(
+        devset=devset,
+        metric=sample_metric,
+        population_metric=population_metric,
+        num_threads=2,
+        display_progress=False,
+    )
+    result = evaluator(program)
+
+    assert result.score == 100.0
+    assert captured == {
+        "questions": ["slow", "fast"],
+        "answers": ["slow-result", "fast-result"],
+    }
+
+
+def test_evaluate_population_metric_per_call_override():
+    devset = [new_example("first", "correct"), new_example("second", "correct")]
+
+    def program(question):
+        return dspy.Prediction(answer="correct")
+
+    def sample_metric(example, prediction):
+        return example.answer == prediction.answer
+
+    def default_population_metric(examples, predictions):
+        return 0.1
+
+    def override_population_metric(examples, predictions):
+        return 0.75
+
+    evaluator = Evaluate(
+        devset=devset,
+        metric=sample_metric,
+        population_metric=default_population_metric,
+    )
+    result = evaluator(program, population_metric=override_population_metric)
+
+    assert result.score == 75.0
+    assert [score for _, _, score in result.results] == [True, True]

--- a/tests/evaluate/test_evaluate.py
+++ b/tests/evaluate/test_evaluate.py
@@ -462,6 +462,29 @@ def test_evaluate_save_as_csv_with_history():
             os.unlink(temp_csv)
 
 
+
+def test_evaluate_population_metric_without_per_example_metric():
+    devset = [new_example("first", "a"), new_example("second", "b")]
+    captured = {}
+
+    def program(question):
+        return dspy.Prediction(answer={"first": "a", "second": "wrong"}[question])
+
+    def population_metric(examples, predictions):
+        captured["questions"] = [example.question for example in examples]
+        captured["answers"] = [prediction.answer for prediction in predictions]
+        return 0.6
+
+    evaluator = Evaluate(devset=devset, population_metric=population_metric)
+    result = evaluator(program)
+
+    assert result.score == 60.0
+    assert [score for _, _, score in result.results] == [0.0, 0.0]
+    assert captured == {
+        "questions": ["first", "second"],
+        "answers": ["a", "wrong"],
+    }
+
 def test_evaluate_population_metric_overrides_sample_mean():
     devset = [new_example("first", "correct"), new_example("second", "correct")]
     answers = {"first": "correct", "second": "incorrect"}

--- a/tests/teleprompt/test_mipro_optimizer_v2.py
+++ b/tests/teleprompt/test_mipro_optimizer_v2.py
@@ -1,0 +1,89 @@
+from unittest.mock import Mock
+
+from dspy.teleprompt import mipro_optimizer_v2
+from dspy.teleprompt.mipro_optimizer_v2 import MIPROv2
+from dspy.utils.dummies import DummyLM
+
+
+def _make_optimizer(sample_metric, population_metric):
+    return MIPROv2(
+        metric=sample_metric,
+        population_metric=population_metric,
+        prompt_model=DummyLM({}),
+        task_model=DummyLM({}),
+        auto=None,
+        num_candidates=1,
+    )
+
+
+def test_mipro_compile_wires_population_metric_into_evaluate(monkeypatch):
+    def sample_metric(example, prediction):
+        return True
+
+    def population_metric(examples, predictions):
+        return 1.0
+
+    captured = {}
+
+    class FakeEvaluate:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    class Student:
+        def deepcopy(self):
+            return self
+
+    optimizer = _make_optimizer(sample_metric, population_metric)
+    monkeypatch.setattr(mipro_optimizer_v2, "Evaluate", FakeEvaluate)
+    monkeypatch.setattr(optimizer, "_bootstrap_fewshot_examples", Mock(return_value=[]))
+    monkeypatch.setattr(optimizer, "_propose_instructions", Mock(return_value={}))
+    monkeypatch.setattr(optimizer, "_optimize_prompt_parameters", Mock(side_effect=lambda program, *args: program))
+
+    optimizer.compile(
+        Student(),
+        trainset=[object()],
+        valset=[object()],
+        num_trials=1,
+        max_bootstrapped_demos=0,
+        max_labeled_demos=0,
+        minibatch=False,
+        program_aware_proposer=False,
+        data_aware_proposer=False,
+        tip_aware_proposer=False,
+        fewshot_aware_proposer=False,
+    )
+
+    assert captured["metric"] is sample_metric
+    assert captured["population_metric"] is population_metric
+
+
+def test_mipro_bootstrapping_uses_only_sample_metric(monkeypatch):
+    def sample_metric(example, prediction):
+        return True
+
+    def population_metric(examples, predictions):
+        return 1.0
+
+    captured = {}
+
+    def fake_create_n_fewshot_demo_sets(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    optimizer = _make_optimizer(sample_metric, population_metric)
+    monkeypatch.setattr(mipro_optimizer_v2, "create_n_fewshot_demo_sets", fake_create_n_fewshot_demo_sets)
+
+    optimizer._bootstrap_fewshot_examples(
+        program=object(),
+        trainset=[object()],
+        seed=9,
+        teacher=None,
+        num_fewshot_candidates=1,
+        max_bootstrapped_demos=1,
+        max_labeled_demos=1,
+        max_errors=1,
+        metric_threshold=None,
+    )
+
+    assert captured["metric"] is sample_metric
+    assert "population_metric" not in captured

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -102,6 +102,20 @@ def test_parallel_executor_tracks_failed_indices_and_exceptions():
     assert str(executor.exceptions_map[4]) == "test error for 5"
 
 
+
+def test_successful_retry_clears_failure_bookkeeping():
+    executor = ParallelExecutor(num_threads=2, max_errors=3)
+    results = [None]
+
+    executor._process_outcome(results, 0, ValueError("first attempt failed"))
+    executor._process_outcome(results, 0, RuntimeError("retry attempt failed"))
+    executor._process_outcome(results, 0, "recovered")
+
+    assert results == ["recovered"]
+    assert executor.failed_indices == []
+    assert executor.exceptions_map == {}
+
+
 def test_sequential_execution_runs_on_main_thread():
     """With num_threads=1, all work should run on the main thread (not in a ThreadPoolExecutor)."""
     execution_threads = []


### PR DESCRIPTION
Fixes #9076

Summary

- Adds optional "population_metric(examples, predictions)" support to "Evaluate".
- Preserves the existing per-example metric and "(example, prediction, score)" evaluation results.
- Uses the population metric for aggregate "EvaluationResult.score" when provided.
- Threads the population metric into MIPROv2 so it drives candidate scoring and the existing Optuna objective.
- Keeps bootstrap trace filtering on the ordinary per-example metric.
- Preserves existing behavior when "population_metric" is omitted.
- Omits tolerated per-example failures from population-metric inputs; if every item fails, keeps the existing average failure score.

Population metric values follow DSPy's existing percentage convention: a return value of "0.82" becomes an evaluation score of "82.0".

For minibatch MIPRO trials, the population metric operates over the evaluated minibatch. Full evaluations operate over the full validation set.

Tests

- "uv run pytest tests/evaluate/test_evaluate.py -q"
  - 16 passed, 25 skipped
- "uv run pytest tests/teleprompt/test_mipro_optimizer_v2.py -q"
  - 2 passed
- "uv run pytest tests/teleprompt -q"
  - 79 passed
- "uv run pre-commit run --files dspy/evaluate/evaluate.py dspy/teleprompt/mipro_optimizer_v2.py tests/evaluate/test_evaluate.py tests/teleprompt/test_mipro_optimizer_v2.py"
  - passed
- "git diff --check"
  - passed

AI assistance

I used ChatGPT to help inspect DSPy's evaluation and MIPROv2 code paths, reason about the API design, implement the change, and review the test plan. I personally reviewed the submitted code, reproduced the behavior, ran the tests listed above, and understand the implementation.

Latest population-only output repair

Commit `9665aa35a09f126d9d90f7ac309881297671f5fd` addresses the reproduced score-field collision:

- Population-only evaluation no longer creates a synthetic per-example `score=0.0` output column when no per-example metric is supplied.
- User-owned `score` fields from either an `Example` or a `Prediction` are preserved in table/DataFrame construction, CSV export, and JSON export.
- `EvaluationResult.results` tuple scores remain unchanged.
- Existing output behavior remains unchanged when a normal per-example metric is present.
- Focused regressions cover example-owned score, prediction-owned score, JSON, CSV, and table/DataFrame output.

Latest validation

- `uv run --with pytest pytest tests/evaluate/test_evaluate.py -q`
  - 20 passed, 26 skipped
- `uv run --with pytest pytest tests/teleprompt/test_mipro_optimizer_v2.py -q`
  - 2 passed
- `uv run --with pytest pytest tests/utils/test_parallelizer.py -q`
  - 13 passed
- `uv run --with pytest --with pandas pytest tests/evaluate/test_evaluate.py --extra -q -k population_only_table_preserves_user_scores`
  - 1 passed, 45 deselected
- `uv run pre-commit run --files dspy/evaluate/evaluate.py tests/evaluate/test_evaluate.py`
  - passed
- Validation did not modify the worktree.

Human review confirmation

I reviewed the exact latest diff through commit `9665aa35a09f126d9d90f7ac309881297671f5fd` and confirm that I understand every changed line and take responsibility for the submission.

Prompt used for the latest repair

> Repair DSPy PR #10107. In population-only evaluation, do not create a synthetic per-example `score=0.0` output column when no per-example metric is supplied. Preserve user-owned `score` fields originating from either an `Example` or a `Prediction` in table/DataFrame construction, CSV export, and JSON export. Keep `EvaluationResult.results` tuple scores unchanged. Preserve existing output behavior when a normal per-example metric exists. Add focused regressions for example-owned score, prediction-owned score, JSON output, CSV output, and table/DataFrame construction. Recheck the already-addressed retry/failure behavior and all latest review findings. Run focused and broader relevant tests, pre-commit, and diff checks.

