### PR TITLE
fix(adapters): prevent implicit resource loading during validation

### DIFF
--- a/docs/docs/api/primitives/Audio.md
+++ b/docs/docs/api/primitives/Audio.md
@@ -10,7 +10,7 @@
             - extract_custom_type_from_annotation
             - format
             - from_array
-            - from_file
+            - from_path
             - from_url
             - is_streamable
             - parse_lm_response

--- a/docs/docs/api/primitives/Audio.md
+++ b/docs/docs/api/primitives/Audio.md
@@ -10,6 +10,7 @@
             - extract_custom_type_from_annotation
             - format
             - from_array
+            - from_file
             - from_path
             - from_url
             - is_streamable

--- a/docs/docs/api/primitives/Image.md
+++ b/docs/docs/api/primitives/Image.md
@@ -10,6 +10,7 @@
             - extract_custom_type_from_annotation
             - format
             - from_PIL
+            - from_file
             - from_path
             - from_url
             - is_streamable

--- a/docs/docs/api/primitives/Image.md
+++ b/docs/docs/api/primitives/Image.md
@@ -10,7 +10,7 @@
             - extract_custom_type_from_annotation
             - format
             - from_PIL
-            - from_file
+            - from_path
             - from_url
             - is_streamable
             - parse_lm_response

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -127,9 +127,9 @@ The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `forma
 
 URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 
-**`dspy.Audio(data, audio_format)`**
+**`dspy.Audio(source)`**
 
-Base64 audio data plus format string (`"wav"`, `"mp3"`), or in-memory bytes/array data. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
+A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
 
 **`dspy.File(file_data=None, file_id=None, filename=None)`**
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -123,14 +123,17 @@ Types adapters know how to render and parse beyond Python’s standard ones. Eac
 **`dspy.adapters.types.Type`**  
 The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `format()` to plug in a new type. Adapters wrap the output of `format()` with `<<CUSTOM-TYPE-START-IDENTIFIER>>...<<END-IDENTIFIER>>` so multi-modal content can be inserted into a single message stream and later split out.
 
-**`dspy.Image(url, download=False, verify=True)`**  
-URL, local path, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). `download=True` fetches the image and base64-encodes it, useful when the LM provider can’t reach the URL.
+**`dspy.Image(url)`**
 
-**`dspy.Audio(data, audio_format)`**  
-Base64 audio data plus format string (`"wav"`, `"mp3"`). Renders as the provider’s audio content block.
+URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 
-**`dspy.File(file_data=None, file_id=None, filename=None)`**  
-Either a data URI or a file ID (some providers preupload files and reference them by ID).
+**`dspy.Audio(data, audio_format)`**
+
+Base64 audio data plus format string (`"wav"`, `"mp3"`), or in-memory bytes/array data. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
+
+**`dspy.File(file_data=None, file_id=None, filename=None)`**
+
+Either in-memory bytes, a data URI, or a file ID (some providers preupload files and reference them by ID). Use `File.from_path(path)` to read a local file.
 
 **`dspy.Code(code, language="python")`**  
 Code with a class-level `language` parameter. `dspy.Code["java"]` produces a Code subclass typed for Java. `format()` returns the raw string — no wrapper, no fencing.

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -123,7 +123,7 @@ Types adapters know how to render and parse beyond Python’s standard ones. Eac
 **`dspy.adapters.types.Type`**  
 The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `format()` to plug in a new type. Adapters wrap the output of `format()` with `<<CUSTOM-TYPE-START-IDENTIFIER>>...<<END-IDENTIFIER>>` so multi-modal content can be inserted into a single message stream and later split out.
 
-**`dspy.Image(url)`**
+**`dspy.Image(source)`**
 
 URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -153,6 +153,25 @@ The list of tool calls the LM produced, parsed from native function-calling resp
 **`dspy.adapters.types.Citations`**  
 Declared as a default native response type. When the provider returns citations natively (e.g., Anthropic), adapters extract them through the type’s `parse_lm_response`.
 
+### Migrating resource loading in 3.3
+
+In DSPy 3.3, constructing or validating `Image`, `Audio`, and `File` values no longer interprets locator-shaped strings as instructions to read a local file or fetch a remote URL. This keeps LM output parsing and other validation paths from implicitly granting access to the host. Resource loading now requires an explicit factory:
+
+| Before 3.3 | 3.3 replacement | Behavior |
+| --- | --- | --- |
+| `Image(path)` | `Image.from_path(path)` | Read and embed a local image |
+| `Image(url, download=True)` | `Image.from_url(url)` | Download and embed a remote image |
+| `Image.from_url(url)` or `Image.from_url(url, download=False)` | `Image(url)` | Keep a non-downloading URL reference |
+| `Audio(path)` | `Audio.from_path(path)` | Read and embed a local audio file |
+| `Audio(url)` | `Audio.from_url(url)` | Download and embed remote audio |
+| `File(path)` | `File.from_path(path)` | Read and embed a local file |
+| `Image.from_file(path)` | `Image.from_path(path)` | Replace the deprecated alias |
+| `Audio.from_file(path)` | `Audio.from_path(path)` | Replace the deprecated alias |
+
+Safe in-memory inputs such as data URIs, bytes, PIL images, audio arrays, and structured dictionaries remain supported. The deprecated direct call `Image(url, download=True)` continues to work with a warning through 3.3; `Image.from_file()`, `Image.from_PIL()`, and `Audio.from_file()` are also scheduled for removal in 3.4.
+
+`Image.from_url()` and `Audio.from_url()` perform synchronous, caller-initiated HTTP requests and follow redirects. They do not validate destinations against an SSRF allowlist, so applications must validate or allowlist URLs derived from untrusted input before calling them.
+
 ### Configuring which adapter to use
 
 - **`dspy.configure(adapter=dspy.JSONAdapter())`** — process-wide default.

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -125,11 +125,11 @@ The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `forma
 
 **`dspy.Image(source)`**
 
-URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_file(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
+URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_path(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
 
 **`dspy.Audio(source)`**
 
-A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_file(path)` or `Audio.from_url(url)` for resource loading.
+A data URI, in-memory bytes, or array data; raw base64 must be passed as `Audio(data=..., audio_format=...)`. Renders as the provider’s audio content block. Use `Audio.from_path(path)` or `Audio.from_url(url)` for resource loading.
 
 **`dspy.File(file_data=None, file_id=None, filename=None)`**
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -125,7 +125,7 @@ The base class. Subclass it (it’s a `pydantic.BaseModel`) and implement `forma
 
 **`dspy.Image(source)`**
 
-URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Constructors and adapter parsing never access the filesystem or network. Use `Image.from_path(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource.
+URL reference, data URI, bytes, or PIL image. `format()` returns the provider’s image content block (`{"type": "image_url", "image_url": {"url": ...}}`). Ordinary construction and adapter parsing never access the filesystem or network. Use `Image.from_path(path)` to read a local file or `Image.from_url(url)` to download and base64-encode a remote resource. The deprecated direct call `Image(url, download=True)` also downloads for compatibility through 3.3; migrate it to `Image.from_url(url)`.
 
 **`dspy.Audio(source)`**
 

--- a/docs/docs/learn/programming/signatures.md
+++ b/docs/docs/learn/programming/signatures.md
@@ -164,7 +164,7 @@ class DogPictureSignature(dspy.Signature):
 
 image_url = "https://picsum.photos/id/237/200/300"
 classify = dspy.Predict(DogPictureSignature)
-classify(image_1=dspy.Image.from_url(image_url))
+classify(image_1=dspy.Image(image_url))
 ```
 
 **Possible Output:**

--- a/docs/docs/tutorials/audio/index.ipynb
+++ b/docs/docs/tutorials/audio/index.ipynb
@@ -301,7 +301,7 @@
     "            f.write(response.content)\n",
     "    with open(wav_path, \"rb\") as f:\n",
     "        encoded = base64.b64encode(f.read()).decode(\"utf-8\")\n",
-    "    return dspy.Audio(data=encoded, format=\"wav\")"
+    "    return dspy.Audio(data=encoded, audio_format=\"wav\")"
    ]
   },
   {

--- a/docs/docs/tutorials/image_generation_prompting/index.ipynb
+++ b/docs/docs/tutorials/image_generation_prompting/index.ipynb
@@ -101,7 +101,7 @@
     "    result = fal_client.result(\"fal-ai/flux-pro/v1.1-ultra\", request_id)\n",
     "    url = result[\"images\"][0][\"url\"]\n",
     "\n",
-    "    return dspy.Image.from_url(url)\n",
+    "    return dspy.Image(url)\n",
     "\n",
     "def display_image(image):\n",
     "    url = image.url\n",

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -39,16 +39,15 @@ class Audio(Type):
             if "data" in data:
                 raise TypeError("Audio received data as both a positional and keyword argument")
             value = args[0]
-            sampling_rate = data.pop("sampling_rate", 16000)
+            sampling_rate = data.pop("sampling_rate", None)
             audio_format = data.pop("audio_format", None)
-            if audio_format is not None and isinstance(value, str) and not value.startswith("data:audio/"):
-                normalized = {"data": value, "audio_format": audio_format}
-            else:
-                normalized = encode_audio(
-                    value,
-                    sampling_rate=sampling_rate,
-                    format=audio_format or data.pop("format", "wav"),
+            if audio_format is not None and _carries_own_format(value):
+                raise TypeError(
+                    "Audio received audio_format alongside an input that already carries its format; provide only one"
                 )
+            if sampling_rate is not None and not hasattr(value, "shape"):
+                raise TypeError("Audio received sampling_rate for a non-array input; it only applies to array data")
+            normalized = encode_audio(value, sampling_rate=sampling_rate or 16000, format=audio_format or "wav")
             normalized.update(data)
             data = normalized
         super().__init__(**data)
@@ -71,14 +70,18 @@ class Audio(Type):
         return encode_audio(values)
 
     @classmethod
-    def from_url(cls, url: str) -> "Audio":
+    def from_url(cls, url: str, verify: bool = True) -> "Audio":
         """
         Download an audio file from URL and encode it as base64.
+
+        Args:
+            url: The URL of the audio to download.
+            verify: Whether to verify SSL certificates. Set to False for self-signed certs.
         """
         parsed_url = urlparse(url)
         if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
             raise ValueError(f"Audio.from_url requires an HTTP(S) URL, received: {url}")
-        response = requests.get(url)
+        response = requests.get(url, verify=verify)
         response.raise_for_status()
         mime_type = response.headers.get("Content-Type", "audio/wav")
         if not mime_type.startswith("audio/"):
@@ -137,6 +140,15 @@ class Audio(Type):
     def __repr__(self) -> str:
         length = len(self.data)
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
+
+
+def _carries_own_format(value: Any) -> bool:
+    """Whether an audio input already carries its own format (making audio_format redundant)."""
+    if isinstance(value, Audio):
+        return True
+    if isinstance(value, dict) and "audio_format" in value:
+        return True
+    return isinstance(value, str) and value.startswith("data:audio/")
 
 
 def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -3,6 +3,7 @@ import io
 import mimetypes
 import os
 from typing import Any, Union
+from urllib.parse import urlparse
 
 import pydantic
 import requests
@@ -31,19 +32,33 @@ class Audio(Type):
         extra="forbid",
     )
 
+    def __init__(self, *args, **data):
+        if len(args) > 1:
+            raise TypeError(f"Audio expected at most 1 positional argument, received {len(args)}")
+        if args:
+            if "data" in data:
+                raise TypeError("Audio received data as both a positional and keyword argument")
+            value = args[0]
+            sampling_rate = data.pop("sampling_rate", 16000)
+            audio_format = data.pop("audio_format", None)
+            if audio_format is not None and isinstance(value, str) and not value.startswith("data:audio/"):
+                normalized = {"data": value, "audio_format": audio_format}
+            else:
+                normalized = encode_audio(
+                    value,
+                    sampling_rate=sampling_rate,
+                    format=audio_format or data.pop("format", "wav"),
+                )
+            normalized.update(data)
+            data = normalized
+        super().__init__(**data)
+
     def format(self) -> list[dict[str, Any]]:
         try:
             data = self.data
         except Exception as e:
             raise ValueError(f"Failed to format audio for DSPy: {e}")
-        return [{
-            "type": "input_audio",
-            "input_audio": {
-                "data": data,
-                "format": self.audio_format
-            }
-        }]
-
+        return [{"type": "input_audio", "input_audio": {"data": data, "format": self.audio_format}}]
 
     @pydantic.model_validator(mode="before")
     @classmethod
@@ -60,6 +75,9 @@ class Audio(Type):
         """
         Download an audio file from URL and encode it as base64.
         """
+        parsed_url = urlparse(url)
+        if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
+            raise ValueError(f"Audio.from_url requires an HTTP(S) URL, received: {url}")
         response = requests.get(url)
         response.raise_for_status()
         mime_type = response.headers.get("Content-Type", "audio/wav")
@@ -95,9 +113,7 @@ class Audio(Type):
         return cls(data=encoded_data, audio_format=audio_format)
 
     @classmethod
-    def from_array(
-        cls, array: Any, sampling_rate: int, format: str = "wav"
-    ) -> "Audio":
+    def from_array(cls, array: Any, sampling_rate: int, format: str = "wav") -> "Audio":
         """
         Process numpy-like array and encode it as base64. Uses sampling rate and audio format for encoding.
         """
@@ -122,33 +138,29 @@ class Audio(Type):
         length = len(self.data)
         return f"Audio(data=<AUDIO_BASE_64_ENCODED({length})>, audio_format='{self.audio_format}')"
 
+
 def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: int = 16000, format: str = "wav") -> dict:
     """
     Encode audio to a dict with 'data' and 'audio_format'.
-    
-    Accepts: local file path, URL, data URI, dict, Audio instance, numpy array, or bytes (with known format).
+
+    Accepts in-memory data: data URI, dict, Audio instance, numpy array, or bytes.
     """
     if isinstance(audio, dict) and "data" in audio and "audio_format" in audio:
         return audio
     elif isinstance(audio, Audio):
         return {"data": audio.data, "audio_format": audio.audio_format}
     elif isinstance(audio, str) and audio.startswith("data:audio/"):
-        try:
-            header, b64data = audio.split(",", 1)
-            mime = header.split(";")[0].split(":")[1]
-            audio_format = mime.split("/")[1]
-
-            audio_format = _normalize_audio_format(audio_format)
-
-            return {"data": b64data, "audio_format": audio_format}
-        except Exception as e:
-            raise ValueError(f"Malformed audio data URI: {e}")
-    elif isinstance(audio, str) and os.path.isfile(audio):
-        a = Audio.from_file(audio)
-        return {"data": a.data, "audio_format": a.audio_format}
-    elif isinstance(audio, str) and audio.startswith("http"):
-        a = Audio.from_url(audio)
-        return {"data": a.data, "audio_format": a.audio_format}
+        header, separator, b64data = audio.partition(",")
+        mime = header.removeprefix("data:").split(";", 1)[0]
+        _, format_separator, audio_format = mime.partition("/")
+        if not separator or not format_separator or not audio_format:
+            raise ValueError("Malformed audio data URI")
+        return {"data": b64data, "audio_format": _normalize_audio_format(audio_format)}
+    elif isinstance(audio, str):
+        raise ValueError(
+            "String audio inputs must be data URIs. "
+            "Load local files with Audio.from_file() and remote resources with Audio.from_url()."
+        )
     elif SF_AVAILABLE and hasattr(audio, "shape"):
         a = Audio.from_array(audio, sampling_rate=sampling_rate, format=format)
         return {"data": a.data, "audio_format": a.audio_format}

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -135,7 +135,7 @@ class Audio(Type):
     def from_file(cls, file_path: str) -> "Audio":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Audio.from_file is deprecated and will be removed in 3.5; use Audio.from_path instead.",
+            "Audio.from_file is deprecated and will be removed in 3.4; use Audio.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -74,6 +74,12 @@ class Audio(Type):
         """
         Download an audio file from URL and encode it as base64.
 
+        Security: this performs an explicit, caller-initiated fetch and applies no
+        SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
+        will reach private, loopback, or cloud-metadata hosts and follow redirects to
+        them. When ``url`` is derived from untrusted input, the caller is responsible
+        for validating the host against an allowlist before calling this method.
+
         Args:
             url: The URL of the audio to download.
             verify: Whether to verify SSL certificates. Set to False for self-signed certs.

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -25,6 +25,15 @@ def _normalize_audio_format(audio_format: str) -> str:
 
 
 class Audio(Type):
+    """An audio input type for DSPy.
+
+    Construct from in-memory values only: a data URI string, raw ``bytes`` (with
+    ``audio_format=``), a numpy-like array, a ``{"data", "audio_format"}`` dict, or another
+    ``Audio``. Raw base64 is passed as ``Audio(data=..., audio_format=...)``. Construction and
+    adapter parsing never access the filesystem or network; use :meth:`from_path` to read a local
+    file, :meth:`from_url` to download a remote resource, or :meth:`from_array` for array data.
+    """
+
     data: str
     audio_format: str
 
@@ -126,7 +135,7 @@ class Audio(Type):
     def from_file(cls, file_path: str) -> "Audio":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Audio.from_file is deprecated; use Audio.from_path instead.",
+            "Audio.from_file is deprecated and will be removed in 3.5; use Audio.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -2,6 +2,7 @@ import base64
 import io
 import mimetypes
 import os
+import warnings
 from typing import Any, Union
 from urllib.parse import urlparse
 
@@ -100,7 +101,7 @@ class Audio(Type):
         return cls(data=encoded_data, audio_format=audio_format)
 
     @classmethod
-    def from_file(cls, file_path: str) -> "Audio":
+    def from_path(cls, file_path: str) -> "Audio":
         """
         Read local audio file and encode it as base64.
         """
@@ -120,6 +121,16 @@ class Audio(Type):
 
         encoded_data = base64.b64encode(file_data).decode("utf-8")
         return cls(data=encoded_data, audio_format=audio_format)
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "Audio":
+        """Deprecated alias for :meth:`from_path`."""
+        warnings.warn(
+            "Audio.from_file is deprecated; use Audio.from_path instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.from_path(file_path)
 
     @classmethod
     def from_array(cls, array: Any, sampling_rate: int, format: str = "wav") -> "Audio":
@@ -177,7 +188,7 @@ def encode_audio(audio: Union[str, bytes, dict, "Audio", Any], sampling_rate: in
     elif isinstance(audio, str):
         raise ValueError(
             "String audio inputs must be data URIs. "
-            "Load local files with Audio.from_file() and remote resources with Audio.from_url()."
+            "Load local files with Audio.from_path() and remote resources with Audio.from_url()."
         )
     elif SF_AVAILABLE and hasattr(audio, "shape"):
         a = Audio.from_array(audio, sampling_rate=sampling_rate, format=format)

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -44,6 +44,11 @@ class File(Type):
             raise TypeError(f"File expected at most 1 positional argument, received {len(args)}")
         if args:
             normalized = encode_file_to_dict(args[0])
+            overlap = sorted(set(normalized) & set(data))
+            if overlap:
+                raise TypeError(
+                    f"File received {', '.join(overlap)} from both the positional source and keyword arguments"
+                )
             normalized.update(data)
             data = normalized
         super().__init__(**data)
@@ -155,7 +160,7 @@ def encode_file_to_dict(file_input: Any) -> dict:
     Encode various file inputs to a dict with file_data, file_id, and/or filename.
 
     Args:
-        file_input: Can be bytes, a structured dictionary, or a File instance.
+        file_input: Can be bytes, a data URI string, a structured dictionary, or a File instance.
 
     Returns:
         dict: A dictionary with file_data, file_id, and/or filename keys.
@@ -176,7 +181,12 @@ def encode_file_to_dict(file_input: Any) -> dict:
         raise ValueError("Value of `dspy.File` must contain at least one of: file_data, file_id, or filename")
 
     elif isinstance(file_input, str):
-        raise ValueError(f"String file inputs are not supported: {file_input}. Load local files with File.from_path().")
+        if file_input.startswith("data:"):
+            return {"file_data": file_input}
+        raise ValueError(
+            f"String file inputs must be data URIs, received: {file_input}. "
+            "Load local files with File.from_path()."
+        )
 
     elif isinstance(file_input, bytes):
         file_obj = File.from_bytes(file_input)

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -39,6 +39,15 @@ class File(Type):
         extra="forbid",
     )
 
+    def __init__(self, *args, **data):
+        if len(args) > 1:
+            raise TypeError(f"File expected at most 1 positional argument, received {len(args)}")
+        if args:
+            normalized = encode_file_to_dict(args[0])
+            normalized.update(data)
+            data = normalized
+        super().__init__(**data)
+
     @pydantic.model_validator(mode="before")
     @classmethod
     def validate_input(cls, values: Any) -> Any:
@@ -79,7 +88,9 @@ class File(Type):
             if self.file_data.startswith("data:"):
                 # file data has "data:text/plain;base64,..." format
                 mime_type = self.file_data.split(";")[0].split(":")[1]
-                len_data = len(self.file_data.split("base64,")[1]) if "base64," in self.file_data else len(self.file_data)
+                len_data = (
+                    len(self.file_data.split("base64,")[1]) if "base64," in self.file_data else len(self.file_data)
+                )
                 parts.append(f"file_data=<DATA_URI({mime_type}, {len_data} chars)>")
             else:
                 len_data = len(self.file_data)
@@ -144,7 +155,7 @@ def encode_file_to_dict(file_input: Any) -> dict:
     Encode various file inputs to a dict with file_data, file_id, and/or filename.
 
     Args:
-        file_input: Can be a file path (str), bytes, or File instance.
+        file_input: Can be bytes, a structured dictionary, or a File instance.
 
     Returns:
         dict: A dictionary with file_data, file_id, and/or filename keys.
@@ -159,16 +170,13 @@ def encode_file_to_dict(file_input: Any) -> dict:
             result["filename"] = file_input.filename
         return result
 
-    elif isinstance(file_input, str):
-        if os.path.isfile(file_input):
-            file_obj = File.from_path(file_input)
-        else:
-            raise ValueError(f"Unrecognized file string: {file_input}; must be a valid file path")
+    elif isinstance(file_input, dict):
+        if "file_data" in file_input or "file_id" in file_input or "filename" in file_input:
+            return file_input
+        raise ValueError("Value of `dspy.File` must contain at least one of: file_data, file_id, or filename")
 
-        return {
-            "file_data": file_obj.file_data,
-            "filename": file_obj.filename,
-        }
+    elif isinstance(file_input, str):
+        raise ValueError(f"String file inputs are not supported: {file_input}. Load local files with File.from_path().")
 
     elif isinstance(file_input, bytes):
         file_obj = File.from_bytes(file_input)

--- a/dspy/adapters/types/file.py
+++ b/dspy/adapters/types/file.py
@@ -15,6 +15,11 @@ class File(Type):
     The file_data field should be a data URI with the format:
         data:<mime_type>;base64,<base64_encoded_data>
 
+    Construct from in-memory values only: raw ``bytes``, a data URI string, a
+    ``{"file_data"|"file_id"|"filename"}`` dict, or another ``File``. Construction and adapter
+    parsing never access the filesystem; use :meth:`from_path` to read a local file,
+    :meth:`from_bytes` for raw bytes, or :meth:`from_file_id` to reference a preuploaded file.
+
     Examples:
         ```python
         import dspy

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -14,6 +14,7 @@ from dspy.adapters.types.base_type import Type
 
 try:
     from PIL import Image as PILImage
+    from PIL import UnidentifiedImageError
 
     PIL_AVAILABLE = True
 except ImportError:
@@ -86,6 +87,8 @@ class Image(Type):
     @classmethod
     def from_file(cls, file_path: str) -> "Image":
         """Read a local file and encode it as a data URI."""
+        if not os.path.isfile(file_path):
+            raise ValueError(f"File not found: {file_path}")
         return cls(_encode_image_from_file(file_path))
 
     @classmethod
@@ -156,7 +159,10 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
         # Raw bytes
         if not PIL_AVAILABLE:
             raise ImportError("Pillow is required to process image bytes.")
-        img = PILImage.open(io.BytesIO(image))
+        try:
+            img = PILImage.open(io.BytesIO(image))
+        except UnidentifiedImageError as e:
+            raise ValueError(f"Bytes could not be identified as an image: {e}") from e
         return _encode_pil_image(img)
     elif isinstance(image, Image):
         return image.url

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -30,7 +30,7 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, url: Any = None, *, download: bool = False, verify: bool = True, **data):
+    def __init__(self, url: Any = None, **data):
         """Create an Image.
 
         Parameters
@@ -38,20 +38,16 @@ class Image(Type):
         url:
             The image source. Supported values include
 
-            - ``str``: HTTP(S)/GS URL or local file path
+            - ``str``: HTTP(S)/GS URL or an encoded data URI
             - ``bytes``: raw image bytes
             - ``PIL.Image.Image``: a PIL image instance
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
 
-        download:
-            Whether remote URLs should be downloaded to infer their MIME type.
-
-        verify:
-            Whether to verify SSL certificates when downloading images from URLs.
-            Set to False for self-signed certificates. Default is True.
-
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
+
+        Local files and remote resources must be loaded explicitly with
+        :meth:`from_file` and :meth:`from_url`, respectively.
         """
 
         if url is not None and "url" not in data:
@@ -65,7 +61,7 @@ class Image(Type):
 
         if "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.
-            data["url"] = encode_image(data["url"], download_images=download, verify=verify)
+            data["url"] = encode_image(data["url"])
 
         # Delegate the rest of initialization to pydantic's BaseModel.
         super().__init__(**data)
@@ -79,22 +75,16 @@ class Image(Type):
         return [{"type": "image_url", "image_url": {"url": image_url}}]
 
     @classmethod
-    def from_url(cls, url: str, download: bool = False):
-        warnings.warn(
-            "Image.from_url is deprecated; use Image(url) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls(url, download=download)
+    def from_url(cls, url: str, verify: bool = True) -> "Image":
+        """Download an HTTP(S) resource and encode it as a data URI."""
+        if not _is_http_url(url):
+            raise ValueError(f"Image.from_url requires an HTTP(S) URL, received: {url}")
+        return cls(_encode_image_from_url(url, verify=verify))
 
     @classmethod
-    def from_file(cls, file_path: str):
-        warnings.warn(
-            "Image.from_file is deprecated; use Image(file_path) instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return cls(file_path)
+    def from_file(cls, file_path: str) -> "Image":
+        """Read a local file and encode it as a data URI."""
+        return cls(_encode_image_from_file(file_path))
 
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
@@ -125,41 +115,38 @@ def is_url(string: str) -> bool:
         return False
 
 
-def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_images: bool = False, verify: bool = True) -> str:
+def _is_http_url(string: str) -> bool:
+    """Check if a string is an HTTP(S) URL."""
+    try:
+        result = urlparse(string)
+        return result.scheme in ("http", "https") and bool(result.netloc)
+    except ValueError:
+        return False
+
+
+def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
     """
-    Encode an image or file to a base64 data URI.
+    Normalize an in-memory image or preserve a remote image reference.
 
     Args:
-        image: The image or file to encode. Can be a PIL Image, file path, URL, or data URI.
-        download_images: Whether to download images from URLs.
-        verify: Whether to verify SSL certificates when downloading images.
+        image: A PIL Image, bytes, URL reference, data URI, or Image.
 
     Returns:
-        str: The data URI of the file or the URL if download_images is False.
+        str: A data URI or remote URL reference.
 
     Raises:
         ValueError: If the file type is not supported.
     """
     if isinstance(image, dict) and "url" in image:
-        # NOTE: Not doing other validation for now
-        return image["url"]
+        return encode_image(image["url"])
     elif isinstance(image, str):
         if image.startswith("data:"):
             # Already a data URI
             return image
-        elif os.path.isfile(image):
-            # File path
-            return _encode_image_from_file(image)
         elif is_url(image):
-            # URL
-            if download_images:
-                return _encode_image_from_url(image, verify=verify)
-            else:
-                # Return the URL as is
-                return image
+            return image
         else:
-            # Unsupported string format
-            raise ValueError(f"Unrecognized file string: {image}; If this file type should be supported, please open an issue.")
+            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_file().")
     elif PIL_AVAILABLE and isinstance(image, PILImage.Image):
         # PIL Image
         return _encode_pil_image(image)
@@ -172,7 +159,6 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict], download_imag
     elif isinstance(image, Image):
         return image.url
     else:
-        print(f"Unsupported image type: {type(image)}")
         raise ValueError(f"Unsupported image type: {type(image)}")
 
 
@@ -192,7 +178,7 @@ def _encode_image_from_file(file_path: str) -> str:
 
 def _encode_image_from_url(image_url: str, verify: bool = True) -> str:
     """Encode a file from a URL to a base64 data URI.
-    
+
     Args:
         image_url: The URL of the image to download.
         verify: Whether to verify SSL certificates. Set to False for self-signed certs.
@@ -242,8 +228,6 @@ def is_image(obj) -> bool:
         return True
     if isinstance(obj, str):
         if obj.startswith("data:"):
-            return True
-        elif os.path.isfile(obj):
             return True
         elif is_url(obj):
             return True

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -30,12 +30,12 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, url: Any = None, **data):
+    def __init__(self, source: Any = None, **data):
         """Create an Image.
 
         Parameters
         ----------
-        url:
+        source:
             The image source. Supported values include
 
             - ``str``: HTTP(S)/GS URL or an encoded data URI
@@ -50,14 +50,16 @@ class Image(Type):
         :meth:`from_file` and :meth:`from_url`, respectively.
         """
 
-        if url is not None and "url" not in data:
-            # Support a positional argument while allowing ``url=`` in **data.
-            if isinstance(url, dict) and set(url.keys()) == {"url"}:
+        if source is not None and "url" in data:
+            raise TypeError("Image received both `source` and `url`; provide only one image source")
+
+        if source is not None:
+            # Support a positional source while retaining the Pydantic ``url`` field.
+            if isinstance(source, dict) and set(source.keys()) == {"url"}:
                 # Legacy dict form from previous model validator.
-                data["url"] = url["url"]
+                data["url"] = source["url"]
             else:
-                # ``url`` may be a string, bytes, or a PIL image.
-                data["url"] = url
+                data["url"] = source
 
         if "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -61,6 +61,17 @@ class Image(Type):
 
         download_requested = download is not _UNSET
         verify_requested = verify is not _UNSET
+        if (download_requested or verify_requested) and source is None:
+            # `download`/`verify` are a compatibility shim for the positional constructor
+            # `Image(url, download=True)`. They must never be honored through the validation
+            # path: pydantic routes dict data into `__init__`, so an untrusted value such as
+            # `{"url": "http://169.254.169.254/...", "download": true}` would otherwise trigger
+            # a server-side fetch during output parsing. Requiring a positional source keeps the
+            # shim reachable only from direct developer construction.
+            raise TypeError(
+                "`download` and `verify` are only valid with a positional image source; "
+                "use Image.from_url(url, verify=...) to download a remote image."
+            )
         if download_requested or verify_requested:
             warnings.warn(
                 "The `download` and `verify` arguments to Image() are deprecated and will be removed in "

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -50,13 +50,13 @@ class Image(Type):
 
         download, verify:
             Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
-            remote image, or :meth:`from_file` for a local file. Accepted for one release
+            remote image, or :meth:`from_path` for a local file. Accepted for one release
             with a warning: ``download=True`` eagerly fetches an HTTP(S) ``source``.
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
         Local files and remote resources must be loaded explicitly with
-        :meth:`from_file` and :meth:`from_url`, respectively.
+        :meth:`from_path` and :meth:`from_url`, respectively.
         """
 
         download_requested = download is not _UNSET
@@ -65,7 +65,7 @@ class Image(Type):
             warnings.warn(
                 "The `download` and `verify` arguments to Image() are deprecated and will be removed in a "
                 "future release. Use Image.from_url(url, verify=...) to download a remote image, or "
-                "Image.from_file(path) for a local file.",
+                "Image.from_path(path) for a local file.",
                 DeprecationWarning,
                 stacklevel=2,
             )
@@ -115,11 +115,21 @@ class Image(Type):
         return cls(_encode_image_from_url(url, verify=verify))
 
     @classmethod
-    def from_file(cls, file_path: str) -> "Image":
+    def from_path(cls, file_path: str) -> "Image":
         """Read a local file and encode it as a data URI."""
         if not os.path.isfile(file_path):
             raise ValueError(f"File not found: {file_path}")
         return cls(_encode_image_from_file(file_path))
+
+    @classmethod
+    def from_file(cls, file_path: str) -> "Image":
+        """Deprecated alias for :meth:`from_path`."""
+        warnings.warn(
+            "Image.from_file is deprecated; use Image.from_path instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls.from_path(file_path)
 
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
@@ -181,7 +191,7 @@ def encode_image(image: Union[str, bytes, "PILImage.Image", dict]) -> str:
         elif is_url(image):
             return image
         else:
-            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_file().")
+            raise ValueError(f"Unrecognized image string: {image}. Local files must be loaded with Image.from_path().")
     elif PIL_AVAILABLE and isinstance(image, PILImage.Image):
         # PIL Image
         return _encode_pil_image(image)

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -79,7 +79,14 @@ class Image(Type):
 
     @classmethod
     def from_url(cls, url: str, verify: bool = True) -> "Image":
-        """Download an HTTP(S) resource and encode it as a data URI."""
+        """Download an HTTP(S) resource and encode it as a data URI.
+
+        Security: this performs an explicit, caller-initiated fetch and applies no
+        SSRF protection beyond requiring an HTTP(S) scheme. Like ``requests.get``, it
+        will reach private, loopback, or cloud-metadata hosts and follow redirects to
+        them. When ``url`` is derived from untrusted input, the caller is responsible
+        for validating the host against an allowlist before calling this method.
+        """
         if not _is_http_url(url):
             raise ValueError(f"Image.from_url requires an HTTP(S) URL, received: {url}")
         return cls(_encode_image_from_url(url, verify=verify))

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -47,6 +47,7 @@ class Image(Type):
             - ``PIL.Image.Image``: a PIL image instance
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
+            - a local file path (deprecated; use :meth:`from_path`)
 
         download, verify:
             Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
@@ -55,8 +56,9 @@ class Image(Type):
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
-        Local files and remote resources must be loaded explicitly with
-        :meth:`from_path` and :meth:`from_url`, respectively.
+        Passing a local file path is deprecated; prefer :meth:`from_path`. Remote
+        resources must be loaded explicitly with :meth:`from_url`. Only this positional
+        convenience touches the filesystem — adapter parsing of untrusted values never does.
         """
 
         download_requested = download is not _UNSET
@@ -78,6 +80,23 @@ class Image(Type):
             if isinstance(source, dict) and set(source.keys()) == {"url"}:
                 # Legacy dict form from previous model validator.
                 data["url"] = source["url"]
+            elif (
+                isinstance(source, str)
+                and not source.startswith("data:")
+                and not is_url(source)
+                and os.path.isfile(source)
+            ):
+                # Deprecated positional-path convenience. This is the ONLY constructor path
+                # that reads the filesystem; it is reachable only from direct developer
+                # construction, never from adapter parsing of untrusted values (which passes
+                # `url=` and is rejected below).
+                warnings.warn(
+                    "Constructing Image from a local file path is deprecated and will be removed in 3.4; "
+                    "use Image.from_path(path) instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                data["url"] = _encode_image_from_file(source)
             else:
                 data["url"] = source
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -34,13 +34,13 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, source: Any = None, *, download: Any = _UNSET, verify: Any = _UNSET, **data):
+    def __init__(self, source: Any = None, /, *, download: Any = _UNSET, verify: Any = _UNSET, **data):
         """Create an Image.
 
         Parameters
         ----------
         source:
-            The image source. Supported values include
+            The positional-only image source. Supported values include
 
             - ``str``: HTTP(S)/GS URL or an encoded data URI
             - ``bytes``: raw image bytes

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -21,6 +21,9 @@ except ImportError:
     PIL_AVAILABLE = False
 
 
+_UNSET = object()
+
+
 class Image(Type):
     url: str
 
@@ -31,7 +34,7 @@ class Image(Type):
         extra="forbid",
     )
 
-    def __init__(self, source: Any = None, **data):
+    def __init__(self, source: Any = None, *, download: Any = _UNSET, verify: Any = _UNSET, **data):
         """Create an Image.
 
         Parameters
@@ -45,11 +48,27 @@ class Image(Type):
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
 
+        download, verify:
+            Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
+            remote image, or :meth:`from_file` for a local file. Accepted for one release
+            with a warning: ``download=True`` eagerly fetches an HTTP(S) ``source``.
+
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
         Local files and remote resources must be loaded explicitly with
         :meth:`from_file` and :meth:`from_url`, respectively.
         """
+
+        download_requested = download is not _UNSET
+        verify_requested = verify is not _UNSET
+        if download_requested or verify_requested:
+            warnings.warn(
+                "The `download` and `verify` arguments to Image() are deprecated and will be removed in a "
+                "future release. Use Image.from_url(url, verify=...) to download a remote image, or "
+                "Image.from_file(path) for a local file.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if source is not None and "url" in data:
             raise TypeError("Image received both `source` and `url`; provide only one image source")
@@ -62,7 +81,11 @@ class Image(Type):
             else:
                 data["url"] = source
 
-        if "url" in data:
+        url = data.get("url")
+        if download_requested and download and isinstance(url, str) and _is_http_url(url):
+            # Legacy download=True path: eagerly fetch the remote URL.
+            data["url"] = _encode_image_from_url(url, verify=verify if verify_requested else True)
+        elif "url" in data:
             # Normalize any accepted input into a base64 data URI or plain URL.
             data["url"] = encode_image(data["url"])
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -47,7 +47,6 @@ class Image(Type):
             - ``PIL.Image.Image``: a PIL image instance
             - ``dict`` with a single ``{"url": value}`` entry (legacy form)
             - already encoded data URI
-            - a local file path (deprecated; use :meth:`from_path`)
 
         download, verify:
             Deprecated. Use :meth:`from_url` (which accepts ``verify``) to download a
@@ -56,9 +55,8 @@ class Image(Type):
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
-        Passing a local file path is deprecated; prefer :meth:`from_path`. Remote
-        resources must be loaded explicitly with :meth:`from_url`. Only this positional
-        convenience touches the filesystem — adapter parsing of untrusted values never does.
+        The constructor never touches the filesystem or network. Local files and remote
+        resources must be loaded explicitly with :meth:`from_path` and :meth:`from_url`.
         """
 
         download_requested = download is not _UNSET
@@ -80,23 +78,6 @@ class Image(Type):
             if isinstance(source, dict) and set(source.keys()) == {"url"}:
                 # Legacy dict form from previous model validator.
                 data["url"] = source["url"]
-            elif (
-                isinstance(source, str)
-                and not source.startswith("data:")
-                and not is_url(source)
-                and os.path.isfile(source)
-            ):
-                # Deprecated positional-path convenience. This is the ONLY constructor path
-                # that reads the filesystem; it is reachable only from direct developer
-                # construction, never from adapter parsing of untrusted values (which passes
-                # `url=` and is rejected below).
-                warnings.warn(
-                    "Constructing Image from a local file path is deprecated and will be removed in 3.4; "
-                    "use Image.from_path(path) instead.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                data["url"] = _encode_image_from_file(source)
             else:
                 data["url"] = source
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -64,7 +64,7 @@ class Image(Type):
         if download_requested or verify_requested:
             warnings.warn(
                 "The `download` and `verify` arguments to Image() are deprecated and will be removed in "
-                "3.5. Use Image.from_url(url, verify=...) to download a remote image, or "
+                "3.4. Use Image.from_url(url, verify=...) to download a remote image, or "
                 "Image.from_path(path) for a local file.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -125,7 +125,7 @@ class Image(Type):
     def from_file(cls, file_path: str) -> "Image":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Image.from_file is deprecated and will be removed in 3.5; use Image.from_path instead.",
+            "Image.from_file is deprecated and will be removed in 3.4; use Image.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -134,7 +134,7 @@ class Image(Type):
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
         warnings.warn(
-            "Image.from_PIL is deprecated and will be removed in 3.5; use Image(pil_image) instead.",
+            "Image.from_PIL is deprecated and will be removed in 3.4; use Image(pil_image) instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -55,8 +55,9 @@ class Image(Type):
 
         Any additional keyword arguments are passed to :class:`pydantic.BaseModel`.
 
-        The constructor never touches the filesystem or network. Local files and remote
-        resources must be loaded explicitly with :meth:`from_path` and :meth:`from_url`.
+        Ordinary construction never touches the filesystem or network. Local files and remote
+        resources must be loaded explicitly with :meth:`from_path` and :meth:`from_url`. The
+        deprecated positional ``Image(url, download=True)`` compatibility call also downloads.
         """
 
         download_requested = download is not _UNSET

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -63,8 +63,8 @@ class Image(Type):
         verify_requested = verify is not _UNSET
         if download_requested or verify_requested:
             warnings.warn(
-                "The `download` and `verify` arguments to Image() are deprecated and will be removed in a "
-                "future release. Use Image.from_url(url, verify=...) to download a remote image, or "
+                "The `download` and `verify` arguments to Image() are deprecated and will be removed in "
+                "3.5. Use Image.from_url(url, verify=...) to download a remote image, or "
                 "Image.from_path(path) for a local file.",
                 DeprecationWarning,
                 stacklevel=2,
@@ -125,7 +125,7 @@ class Image(Type):
     def from_file(cls, file_path: str) -> "Image":
         """Deprecated alias for :meth:`from_path`."""
         warnings.warn(
-            "Image.from_file is deprecated; use Image.from_path instead.",
+            "Image.from_file is deprecated and will be removed in 3.5; use Image.from_path instead.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -134,7 +134,7 @@ class Image(Type):
     @classmethod
     def from_PIL(cls, pil_image):  # noqa: N802
         warnings.warn(
-            "Image.from_PIL is deprecated; use Image(pil_image) instead.",
+            "Image.from_PIL is deprecated and will be removed in 3.5; use Image(pil_image) instead.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -1,0 +1,101 @@
+import base64
+import json
+
+import pytest
+
+import dspy
+from dspy.adapters.json_adapter import JSONAdapter
+
+
+@pytest.mark.parametrize(
+    ("annotation", "payload"),
+    [
+        (dspy.Image, lambda path: {"url": path}),
+        (dspy.Audio, lambda path: path),
+        (dspy.File, lambda path: path),
+    ],
+)
+def test_lm_output_cannot_read_local_resources(tmp_path, monkeypatch, annotation, payload):
+    secret = tmp_path / "secret.wav"
+    secret.write_bytes(b"TOP-SECRET")
+
+    class OutputSignature(dspy.Signature):
+        resource: annotation = dspy.OutputField()
+
+    def fail_open(*args, **kwargs):
+        pytest.fail("LM output parsing attempted to open a local resource")
+
+    monkeypatch.setattr("builtins.open", fail_open)
+    completion = '{"resource": ' + json.dumps(payload(str(secret))) + "}"
+
+    with pytest.raises((ValueError, TypeError)):
+        JSONAdapter().parse(OutputSignature, completion)
+
+
+def test_audio_lm_output_cannot_download_url(monkeypatch):
+    class OutputSignature(dspy.Signature):
+        audio: dspy.Audio = dspy.OutputField()
+
+    def fail_request(*args, **kwargs):
+        pytest.fail("LM output parsing attempted to download a remote resource")
+
+    monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
+
+    with pytest.raises(ValueError, match=r"Audio\.from_url"):
+        JSONAdapter().parse(OutputSignature, '{"audio": "https://example.com/secret.wav"}')
+
+
+def test_image_url_constructor_does_not_download(monkeypatch):
+    def fail_request(*args, **kwargs):
+        pytest.fail("Image construction attempted to download a remote resource")
+
+    monkeypatch.setattr("dspy.adapters.types.image.requests.get", fail_request)
+
+    image = dspy.Image("https://example.com/image.png")
+
+    assert image.url == "https://example.com/image.png"
+
+
+def test_explicit_local_resource_factories(tmp_path):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"image bytes")
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"audio bytes")
+    file_path = tmp_path / "document.txt"
+    file_path.write_bytes(b"file bytes")
+
+    assert base64.b64decode(dspy.Image.from_file(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
+    assert base64.b64decode(dspy.Audio.from_file(str(audio_path)).data) == b"audio bytes"
+    assert base64.b64decode(dspy.File.from_path(str(file_path)).file_data.split(",", 1)[1]) == b"file bytes"
+
+
+@pytest.mark.parametrize(
+    ("factory", "mime_type"), [(dspy.Image.from_url, "image/png"), (dspy.Audio.from_url, "audio/wav")]
+)
+def test_explicit_remote_resource_factories(monkeypatch, factory, mime_type):
+    class Response:
+        def __init__(self):
+            self.content = b"remote bytes"
+            self.headers = {"Content-Type": mime_type}
+
+        def raise_for_status(self):
+            return None
+
+    module = "image" if factory == dspy.Image.from_url else "audio"
+    monkeypatch.setattr(f"dspy.adapters.types.{module}.requests.get", lambda *args, **kwargs: Response())
+
+    resource = factory(f"https://example.com/resource.{mime_type.split('/', 1)[1]}")
+    encoded = resource.url.split(",", 1)[1] if isinstance(resource, dspy.Image) else resource.data
+    assert base64.b64decode(encoded) == b"remote bytes"
+
+
+def test_in_memory_resource_construction():
+    image = dspy.Image(
+        base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=")
+    )
+    audio = dspy.Audio(b"audio bytes", audio_format="wav")
+    file = dspy.File(b"file bytes")
+
+    assert image.url.startswith("data:image/")
+    assert base64.b64decode(audio.data) == b"audio bytes"
+    assert file.file_data.startswith("data:application/octet-stream;base64,")

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -99,3 +99,53 @@ def test_in_memory_resource_construction():
     assert image.url.startswith("data:image/")
     assert base64.b64decode(audio.data) == b"audio bytes"
     assert file.file_data.startswith("data:application/octet-stream;base64,")
+
+
+@pytest.mark.parametrize(
+    ("source", "match"),
+    [("clip.wav", r"Audio\.from_file"), ("https://example.com/a.wav", r"Audio\.from_url")],
+)
+def test_audio_positional_string_must_be_data_uri_even_with_format(source, match):
+    with pytest.raises(ValueError, match=match):
+        dspy.Audio(source, audio_format="wav")
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "data:audio/wav;base64,AA==",
+        {"data": "AA==", "audio_format": "wav"},
+        dspy.Audio(data="AA==", audio_format="wav"),
+    ],
+)
+def test_audio_rejects_audio_format_for_inputs_that_carry_one(source):
+    with pytest.raises(TypeError, match="already carries its format"):
+        dspy.Audio(source, audio_format="mp3")
+
+
+@pytest.mark.parametrize("source", [b"audio bytes", "data:audio/wav;base64,AA=="])
+def test_audio_rejects_sampling_rate_for_non_array_inputs(source):
+    with pytest.raises(TypeError, match="sampling_rate"):
+        dspy.Audio(source, sampling_rate=44100)
+
+
+def test_audio_from_url_passes_verify(monkeypatch):
+    captured = {}
+
+    class Response:
+        def __init__(self):
+            self.content = b"remote bytes"
+            self.headers = {"Content-Type": "audio/wav"}
+
+        def raise_for_status(self):
+            return None
+
+    def fake_get(url, **kwargs):
+        captured.update(kwargs)
+        return Response()
+
+    monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fake_get)
+
+    dspy.Audio.from_url("https://example.com/a.wav", verify=False)
+
+    assert captured["verify"] is False

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -20,9 +20,9 @@ def _forbid_host_io(monkeypatch):
     monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
 
 
-# Locator-shaped inputs an attacker could supply. Through the validation/parse path none may
-# trigger host I/O, whether the call raises (paths, non-data-URI strings) or is retained as a
-# reference (Image URLs).
+# Locator-shaped inputs an attacker could supply. Neither construction nor the validation/parse
+# path may trigger host I/O, whether the call raises (paths, non-data-URI strings) or is retained
+# as a reference (Image URLs).
 _LOCATOR_INPUTS = [
     (dspy.Image, {"url": "/etc/passwd"}),
     (dspy.Image, "/etc/passwd"),
@@ -33,15 +33,11 @@ _LOCATOR_INPUTS = [
     (dspy.File, "https://evil.example/secret.bin"),
 ]
 
-# Direct construction is I/O-free for the same inputs, except the deprecated Image(positional path)
-# convenience (covered by test_image_positional_path_is_deprecated), which is excluded here.
-_CONSTRUCTION_INPUTS = [case for case in _LOCATOR_INPUTS if case != (dspy.Image, "/etc/passwd")]
 
-
-@pytest.mark.parametrize(("annotation", "value"), _CONSTRUCTION_INPUTS)
+@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_construction_performs_no_host_io(monkeypatch, annotation, value):
-    # Aside from the deprecated Image(path) convenience, constructing from a locator-shaped value
-    # must never dereference it.
+    # The constructor is reachable from untrusted application input (e.g. dspy.Image(user_string));
+    # it must never dereference a locator.
     _forbid_host_io(monkeypatch)
     try:
         annotation(value)
@@ -52,23 +48,12 @@ def test_construction_performs_no_host_io(monkeypatch, annotation, value):
 @pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_validation_performs_no_host_io(monkeypatch, annotation, value):
     # validate_python is the path adapters use to coerce untrusted LM output (and pydantic uses for
-    # nested models / deserialization); it must never dereference a locator. This is the security
-    # boundary: the deprecated Image(path) convenience is unreachable here.
+    # nested models / deserialization); it must never dereference a locator either.
     _forbid_host_io(monkeypatch)
     try:
         TypeAdapter(annotation).validate_python(value)
     except (ValueError, TypeError, ValidationError):
         pass
-
-
-def test_image_positional_path_is_deprecated(tmp_path):
-    image_path = tmp_path / "image.png"
-    image_path.write_bytes(b"image bytes")
-
-    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
-        image = dspy.Image(str(image_path))
-
-    assert base64.b64decode(image.url.split(",", 1)[1]) == b"image bytes"
 
 
 def test_image_url_constructor_does_not_download(monkeypatch):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -64,9 +64,19 @@ def test_explicit_local_resource_factories(tmp_path):
     file_path = tmp_path / "document.txt"
     file_path.write_bytes(b"file bytes")
 
-    assert base64.b64decode(dspy.Image.from_file(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
-    assert base64.b64decode(dspy.Audio.from_file(str(audio_path)).data) == b"audio bytes"
+    assert base64.b64decode(dspy.Image.from_path(str(image_path)).url.split(",", 1)[1]) == b"image bytes"
+    assert base64.b64decode(dspy.Audio.from_path(str(audio_path)).data) == b"audio bytes"
     assert base64.b64decode(dspy.File.from_path(str(file_path)).file_data.split(",", 1)[1]) == b"file bytes"
+
+
+def test_audio_from_file_is_deprecated_alias(tmp_path):
+    audio_path = tmp_path / "audio.wav"
+    audio_path.write_bytes(b"audio bytes")
+
+    with pytest.warns(DeprecationWarning, match="Audio.from_file is deprecated"):
+        aliased = dspy.Audio.from_file(str(audio_path))
+
+    assert base64.b64decode(aliased.data) == b"audio bytes"
 
 
 @pytest.mark.parametrize(
@@ -103,7 +113,7 @@ def test_in_memory_resource_construction():
 
 @pytest.mark.parametrize(
     ("source", "match"),
-    [("clip.wav", r"Audio\.from_file"), ("https://example.com/a.wav", r"Audio\.from_url")],
+    [("clip.wav", r"Audio\.from_path"), ("https://example.com/a.wav", r"Audio\.from_url")],
 )
 def test_audio_positional_string_must_be_data_uri_even_with_format(source, match):
     with pytest.raises(ValueError, match=match):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -71,9 +71,14 @@ def test_image_validation_rejects_download_without_host_io(monkeypatch):
     _forbid_host_io(monkeypatch)
 
     with pytest.raises((TypeError, ValidationError), match="only valid with a positional image source"):
-        TypeAdapter(dspy.Image).validate_python(
-            {"url": "http://169.254.169.254/latest/meta-data", "download": True}
-        )
+        TypeAdapter(dspy.Image).validate_python({"url": "http://169.254.169.254/latest/meta-data", "download": True})
+
+
+def test_image_validation_rejects_download_with_source_keyword_without_host_io(monkeypatch):
+    _forbid_host_io(monkeypatch)
+
+    with pytest.raises((TypeError, ValidationError), match="only valid with a positional image source"):
+        TypeAdapter(dspy.Image).validate_python({"source": "http://169.254.169.254/latest/meta-data", "download": True})
 
 
 def test_image_positional_download_compatibility_shim(monkeypatch):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -67,6 +67,31 @@ def test_image_url_constructor_does_not_download(monkeypatch):
     assert image.url == "https://example.com/image.png"
 
 
+def test_image_validation_rejects_download_without_host_io(monkeypatch):
+    _forbid_host_io(monkeypatch)
+
+    with pytest.raises((TypeError, ValidationError), match="only valid with a positional image source"):
+        TypeAdapter(dspy.Image).validate_python(
+            {"url": "http://169.254.169.254/latest/meta-data", "download": True}
+        )
+
+
+def test_image_positional_download_compatibility_shim(monkeypatch):
+    class Response:
+        content = b"remote bytes"
+        headers = {"Content-Type": "image/png"}
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr("dspy.adapters.types.image.requests.get", lambda *args, **kwargs: Response())
+
+    with pytest.warns(DeprecationWarning, match="download.*deprecated"):
+        image = dspy.Image("https://example.com/image.png", download=True)
+
+    assert base64.b64decode(image.url.split(",", 1)[1]) == b"remote bytes"
+
+
 def test_explicit_local_resource_factories(tmp_path):
     image_path = tmp_path / "image.png"
     image_path.write_bytes(b"image bytes")

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -20,8 +20,9 @@ def _forbid_host_io(monkeypatch):
     monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
 
 
-# Locator-shaped inputs an attacker could supply. None may trigger host I/O, whether the call
-# raises (paths, non-data-URI strings) or is retained as a reference (Image URLs).
+# Locator-shaped inputs an attacker could supply. Through the validation/parse path none may
+# trigger host I/O, whether the call raises (paths, non-data-URI strings) or is retained as a
+# reference (Image URLs).
 _LOCATOR_INPUTS = [
     (dspy.Image, {"url": "/etc/passwd"}),
     (dspy.Image, "/etc/passwd"),
@@ -32,11 +33,15 @@ _LOCATOR_INPUTS = [
     (dspy.File, "https://evil.example/secret.bin"),
 ]
 
+# Direct construction is I/O-free for the same inputs, except the deprecated Image(positional path)
+# convenience (covered by test_image_positional_path_is_deprecated), which is excluded here.
+_CONSTRUCTION_INPUTS = [case for case in _LOCATOR_INPUTS if case != (dspy.Image, "/etc/passwd")]
 
-@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
+
+@pytest.mark.parametrize(("annotation", "value"), _CONSTRUCTION_INPUTS)
 def test_construction_performs_no_host_io(monkeypatch, annotation, value):
-    # The constructor is reachable from untrusted application input (e.g. dspy.Image(user_string));
-    # it must never dereference a locator.
+    # Aside from the deprecated Image(path) convenience, constructing from a locator-shaped value
+    # must never dereference it.
     _forbid_host_io(monkeypatch)
     try:
         annotation(value)
@@ -47,12 +52,23 @@ def test_construction_performs_no_host_io(monkeypatch, annotation, value):
 @pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
 def test_validation_performs_no_host_io(monkeypatch, annotation, value):
     # validate_python is the path adapters use to coerce untrusted LM output (and pydantic uses for
-    # nested models / deserialization); it must never dereference a locator either.
+    # nested models / deserialization); it must never dereference a locator. This is the security
+    # boundary: the deprecated Image(path) convenience is unreachable here.
     _forbid_host_io(monkeypatch)
     try:
         TypeAdapter(annotation).validate_python(value)
     except (ValueError, TypeError, ValidationError):
         pass
+
+
+def test_image_positional_path_is_deprecated(tmp_path):
+    image_path = tmp_path / "image.png"
+    image_path.write_bytes(b"image bytes")
+
+    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
+        image = dspy.Image(str(image_path))
+
+    assert base64.b64decode(image.url.split(",", 1)[1]) == b"image bytes"
 
 
 def test_image_url_constructor_does_not_download(monkeypatch):

--- a/tests/adapters/test_resource_loading.py
+++ b/tests/adapters/test_resource_loading.py
@@ -1,48 +1,58 @@
 import base64
-import json
 
 import pytest
+from pydantic import TypeAdapter, ValidationError
 
 import dspy
-from dspy.adapters.json_adapter import JSONAdapter
 
 
-@pytest.mark.parametrize(
-    ("annotation", "payload"),
-    [
-        (dspy.Image, lambda path: {"url": path}),
-        (dspy.Audio, lambda path: path),
-        (dspy.File, lambda path: path),
-    ],
-)
-def test_lm_output_cannot_read_local_resources(tmp_path, monkeypatch, annotation, payload):
-    secret = tmp_path / "secret.wav"
-    secret.write_bytes(b"TOP-SECRET")
-
-    class OutputSignature(dspy.Signature):
-        resource: annotation = dspy.OutputField()
+def _forbid_host_io(monkeypatch):
+    """Make any filesystem read or outbound request fail the test."""
 
     def fail_open(*args, **kwargs):
-        pytest.fail("LM output parsing attempted to open a local resource")
-
-    monkeypatch.setattr("builtins.open", fail_open)
-    completion = '{"resource": ' + json.dumps(payload(str(secret))) + "}"
-
-    with pytest.raises((ValueError, TypeError)):
-        JSONAdapter().parse(OutputSignature, completion)
-
-
-def test_audio_lm_output_cannot_download_url(monkeypatch):
-    class OutputSignature(dspy.Signature):
-        audio: dspy.Audio = dspy.OutputField()
+        pytest.fail("resource handling attempted a filesystem read")
 
     def fail_request(*args, **kwargs):
-        pytest.fail("LM output parsing attempted to download a remote resource")
+        pytest.fail("resource handling attempted a network request")
 
+    monkeypatch.setattr("builtins.open", fail_open)
+    monkeypatch.setattr("dspy.adapters.types.image.requests.get", fail_request)
     monkeypatch.setattr("dspy.adapters.types.audio.requests.get", fail_request)
 
-    with pytest.raises(ValueError, match=r"Audio\.from_url"):
-        JSONAdapter().parse(OutputSignature, '{"audio": "https://example.com/secret.wav"}')
+
+# Locator-shaped inputs an attacker could supply. None may trigger host I/O, whether the call
+# raises (paths, non-data-URI strings) or is retained as a reference (Image URLs).
+_LOCATOR_INPUTS = [
+    (dspy.Image, {"url": "/etc/passwd"}),
+    (dspy.Image, "/etc/passwd"),
+    (dspy.Image, {"url": "https://evil.example/secret.png"}),
+    (dspy.Audio, "/etc/passwd"),
+    (dspy.Audio, "https://evil.example/secret.wav"),
+    (dspy.File, "/etc/passwd"),
+    (dspy.File, "https://evil.example/secret.bin"),
+]
+
+
+@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
+def test_construction_performs_no_host_io(monkeypatch, annotation, value):
+    # The constructor is reachable from untrusted application input (e.g. dspy.Image(user_string));
+    # it must never dereference a locator.
+    _forbid_host_io(monkeypatch)
+    try:
+        annotation(value)
+    except (ValueError, TypeError):
+        pass
+
+
+@pytest.mark.parametrize(("annotation", "value"), _LOCATOR_INPUTS)
+def test_validation_performs_no_host_io(monkeypatch, annotation, value):
+    # validate_python is the path adapters use to coerce untrusted LM output (and pydantic uses for
+    # nested models / deserialization); it must never dereference a locator either.
+    _forbid_host_io(monkeypatch)
+    try:
+        TypeAdapter(annotation).validate_python(value)
+    except (ValueError, TypeError, ValidationError):
+        pass
 
 
 def test_image_url_constructor_does_not_download(monkeypatch):

--- a/tests/signatures/test_adapter_file.py
+++ b/tests/signatures/test_adapter_file.py
@@ -152,11 +152,9 @@ def test_file_str():
     assert "<<CUSTOM-TYPE-END-IDENTIFIER>>" in str_repr
 
 
-def test_encode_file_to_dict_from_path(sample_text_file):
-    result = encode_file_to_dict(sample_text_file)
-    assert "file_data" in result
-    assert result["file_data"].startswith("data:text/plain;base64,")
-    assert "filename" in result
+def test_encode_file_to_dict_rejects_path(sample_text_file):
+    with pytest.raises(ValueError, match=r"File\.from_path"):
+        encode_file_to_dict(sample_text_file)
 
 
 def test_encode_file_to_dict_from_bytes():
@@ -165,8 +163,14 @@ def test_encode_file_to_dict_from_bytes():
     assert result["file_data"].startswith("data:application/octet-stream;base64,")
 
 
+def test_file_constructor_from_bytes():
+    file_obj = dspy.File(b"test content", filename="test.txt")
+    assert file_obj.file_data.startswith("data:application/octet-stream;base64,")
+    assert file_obj.filename == "test.txt"
+
+
 def test_invalid_file_string():
-    with pytest.raises(ValueError, match="Unrecognized"):
+    with pytest.raises(ValueError, match=r"File\.from_path"):
         encode_file_to_dict("https://this_is_not_a_file_path")
 
 

--- a/tests/signatures/test_adapter_file.py
+++ b/tests/signatures/test_adapter_file.py
@@ -169,6 +169,17 @@ def test_file_constructor_from_bytes():
     assert file_obj.filename == "test.txt"
 
 
+def test_file_constructor_from_data_uri():
+    data_uri = "data:text/plain;base64,aGVsbG8="
+    file_obj = dspy.File(data_uri)
+    assert file_obj.file_data == data_uri
+
+
+def test_file_constructor_rejects_conflicting_keyword():
+    with pytest.raises(TypeError, match="file_data"):
+        dspy.File(b"test content", file_data="data:text/plain;base64,aGVsbG8=")
+
+
 def test_invalid_file_string():
     with pytest.raises(ValueError, match=r"File\.from_path"):
         encode_file_to_dict("https://this_is_not_a_file_path")

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -507,3 +507,13 @@ def test_pil_image_rejects_download_parameter():
 
     with pytest.raises(pydantic.ValidationError, match="download"):
         dspy.Image(sample_pil, download=True)
+
+
+def test_from_file_missing_file():
+    with pytest.raises(ValueError, match="File not found"):
+        dspy.Image.from_file("/nonexistent/image.png")
+
+
+def test_unidentifiable_bytes_raise_value_error():
+    with pytest.raises(ValueError, match="could not be identified as an image"):
+        dspy.Image(b"not an image")

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+import warnings
 from io import BytesIO
 
 import pydantic
@@ -24,7 +25,7 @@ def sample_pil_image():
 @pytest.fixture
 def sample_dspy_image_download():
     url = "https://images.dog.ceo/breeds/dane-great/n02109047_8912.jpg"
-    return dspy.Image(url, download=True)
+    return dspy.Image.from_url(url)
 
 
 @pytest.fixture
@@ -343,8 +344,8 @@ def test_pdf_url_support():
     """Test support for PDF files from URLs"""
     pdf_url = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
 
-    # Create a dspy.Image object from the PDF URL with download=True
-    pdf_image = dspy.Image(pdf_url, download=True)
+    # Download the PDF into a dspy.Image data URI.
+    pdf_image = dspy.Image.from_url(pdf_url)
 
     # The data URI should contain application/pdf in the MIME type
     assert "data:application/pdf" in pdf_image.url
@@ -381,7 +382,7 @@ def test_different_mime_types():
 
     for file_type, url in file_urls.items():
         # Download and encode
-        encoded = encode_image(url, download_images=True)
+        encoded = dspy.Image.from_url(url).url
 
         # Check for correct MIME type in the encoded data - using 'in' instead of startswith
         # to account for possible parameters in the MIME type
@@ -402,7 +403,7 @@ def test_mime_type_from_response_headers():
     assert "pdf" in expected_mime_type.lower()
 
     # Encode with download to test MIME type from headers
-    encoded = encode_image(pdf_url, download_images=True)
+    encoded = dspy.Image.from_url(pdf_url).url
 
     # The encoded data should contain the correct MIME type
     assert "application/pdf" in encoded
@@ -422,7 +423,7 @@ def test_pdf_from_file():
 
     try:
         # Create a dspy.Image from the file
-        pdf_image = dspy.Image(tmp_file_path)
+        pdf_image = dspy.Image.from_file(tmp_file_path)
 
         # The constructor encodes the file into a data URI we can inspect directly
         assert "data:application/pdf" in pdf_image.url
@@ -463,15 +464,20 @@ def test_image_repr():
     assert "base64" in str(pil_image)
 
 
-def test_from_methods_warn(tmp_path):
-    """Deprecated from_* methods emit warnings"""
+def test_resource_factories_do_not_warn(tmp_path):
     tmp_file = tmp_path / "test.png"
     tmp_file.write_bytes(b"pngdata")
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        response = type("Response", (), {"content": b"pngdata", "headers": {"Content-Type": "image/png"}})()
+        response.raise_for_status = lambda: None
+        monkeypatch.setattr("dspy.adapters.types.image.requests.get", lambda *args, **kwargs: response)
         dspy.Image.from_url("https://example.com/dog.jpg")
-    with pytest.warns(DeprecationWarning):
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
         dspy.Image.from_file(str(tmp_file))
+
     sample_pil = PILImage.new("RGB", (10, 10), color="blue")
     with pytest.warns(DeprecationWarning):
         dspy.Image.from_PIL(sample_pil)
@@ -482,22 +488,12 @@ def test_invalid_string_format():
     invalid_string = "this_is_not_a_url_or_file"
 
     # Should raise a ValueError and not pass the string through
-    with pytest.raises(ValueError, match="Unrecognized") as warning_info:
-        image = dspy.Image(invalid_string)
+    with pytest.raises(ValueError, match="Unrecognized"):
+        dspy.Image(invalid_string)
 
-def test_pil_image_with_download_parameter():
-    """Test behavior when PIL image is passed with download=True"""
+
+def test_pil_image_rejects_download_parameter():
     sample_pil = PILImage.new("RGB", (60, 30), color="red")
 
-    # PIL image should be encoded regardless of download parameter
-    image_no_download = dspy.Image(sample_pil)
-    image_with_download = dspy.Image(sample_pil, download=True)
-
-    # Both should result in base64 encoded data URIs
-    assert image_no_download.url.startswith("data:")
-    assert image_with_download.url.startswith("data:")
-    assert "base64," in image_no_download.url
-    assert "base64," in image_with_download.url
-
-    # They should be identical since PIL images are always encoded
-    assert image_no_download.url == image_with_download.url
+    with pytest.raises(pydantic.ValidationError, match="download"):
+        dspy.Image(sample_pil, download=True)

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -464,6 +464,16 @@ def test_image_repr():
     assert "base64" in str(pil_image)
 
 
+def test_image_constructor_supports_source_and_url_keywords():
+    source = "https://example.com/dog.jpg"
+
+    assert dspy.Image(source=source).url == source
+    assert dspy.Image(url=source).url == source
+
+    with pytest.raises(TypeError, match="both `source` and `url`"):
+        dspy.Image(source, url=source)
+
+
 def test_resource_factories_do_not_warn(tmp_path):
     tmp_file = tmp_path / "test.png"
     tmp_file.write_bytes(b"pngdata")

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -424,7 +424,7 @@ def test_pdf_from_file():
 
     try:
         # Create a dspy.Image from the file
-        pdf_image = dspy.Image.from_file(tmp_file_path)
+        pdf_image = dspy.Image.from_path(tmp_file_path)
 
         # The constructor encodes the file into a data URI we can inspect directly
         assert "data:application/pdf" in pdf_image.url
@@ -475,7 +475,7 @@ def test_image_constructor_supports_source_and_url_keywords():
         dspy.Image(source, url=source)
 
 
-def test_resource_factories_do_not_warn(tmp_path):
+def test_canonical_factories_do_not_warn(tmp_path):
     tmp_file = tmp_path / "test.png"
     tmp_file.write_bytes(b"pngdata")
 
@@ -487,6 +487,14 @@ def test_resource_factories_do_not_warn(tmp_path):
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", DeprecationWarning)
+        dspy.Image.from_path(str(tmp_file))
+
+
+def test_deprecated_factory_aliases_warn(tmp_path):
+    tmp_file = tmp_path / "test.png"
+    tmp_file.write_bytes(b"pngdata")
+
+    with pytest.warns(DeprecationWarning, match="Image.from_file is deprecated"):
         dspy.Image.from_file(str(tmp_file))
 
     sample_pil = PILImage.new("RGB", (10, 10), color="blue")
@@ -532,7 +540,7 @@ def test_deprecated_verify_warns_without_download():
 def test_deprecated_download_does_not_rescue_local_path():
     # The Image(path) hard break holds even with the deprecated download flag.
     with pytest.warns(DeprecationWarning):
-        with pytest.raises(ValueError, match=r"Image\.from_file"):
+        with pytest.raises(ValueError, match=r"Image\.from_path"):
             dspy.Image("/etc/passwd", download=True)
 
 
@@ -543,9 +551,9 @@ def test_pil_image_with_deprecated_download_still_encodes():
     assert image.url.startswith("data:image/")
 
 
-def test_from_file_missing_file():
+def test_from_path_missing_file():
     with pytest.raises(ValueError, match="File not found"):
-        dspy.Image.from_file("/nonexistent/image.png")
+        dspy.Image.from_path("/nonexistent/image.png")
 
 
 def test_unidentifiable_bytes_raise_value_error():

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -465,11 +465,14 @@ def test_image_repr():
     assert "base64" in str(pil_image)
 
 
-def test_image_constructor_supports_source_and_url_keywords():
+def test_image_constructor_supports_positional_source_and_url_keyword():
     source = "https://example.com/dog.jpg"
 
-    assert dspy.Image(source=source).url == source
+    assert dspy.Image(source).url == source
     assert dspy.Image(url=source).url == source
+
+    with pytest.raises(pydantic.ValidationError, match="source"):
+        dspy.Image(source=source)
 
     with pytest.raises(TypeError, match="both `source` and `url`"):
         dspy.Image(source, url=source)

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -503,12 +503,22 @@ def test_deprecated_factory_aliases_warn(tmp_path):
 
 
 def test_invalid_string_format():
-    """Test that invalid string formats raise a ValueError"""
+    """A string that is neither a data URI, a URL, nor an existing local path raises."""
     invalid_string = "this_is_not_a_url_or_file"
 
     # Should raise a ValueError and not pass the string through
     with pytest.raises(ValueError, match="Unrecognized"):
         dspy.Image(invalid_string)
+
+
+def test_positional_local_path_is_deprecated(tmp_path):
+    tmp_file = tmp_path / "photo.png"
+    tmp_file.write_bytes(b"pngdata")
+
+    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
+        image = dspy.Image(str(tmp_file))
+
+    assert image.url.startswith("data:image/png;base64,")
 
 
 def test_deprecated_download_true_downloads(monkeypatch):
@@ -535,13 +545,6 @@ def test_deprecated_verify_warns_without_download():
     with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
         image = dspy.Image(source, verify=False)
     assert image.url == source
-
-
-def test_deprecated_download_does_not_rescue_local_path():
-    # The Image(path) hard break holds even with the deprecated download flag.
-    with pytest.warns(DeprecationWarning):
-        with pytest.raises(ValueError, match=r"Image\.from_path"):
-            dspy.Image("/etc/passwd", download=True)
 
 
 def test_pil_image_with_deprecated_download_still_encodes():

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -503,7 +503,7 @@ def test_deprecated_factory_aliases_warn(tmp_path):
 
 
 def test_invalid_string_format():
-    """A string that is neither a data URI, a URL, nor an existing local path raises."""
+    """A string that is neither a data URI nor a URL raises."""
     invalid_string = "this_is_not_a_url_or_file"
 
     # Should raise a ValueError and not pass the string through
@@ -511,14 +511,15 @@ def test_invalid_string_format():
         dspy.Image(invalid_string)
 
 
-def test_positional_local_path_is_deprecated(tmp_path):
+def test_positional_local_path_hard_breaks(tmp_path, monkeypatch):
+    """Image(path) raises pointing at from_path, and never touches the filesystem to decide."""
     tmp_file = tmp_path / "photo.png"
     tmp_file.write_bytes(b"pngdata")
 
-    with pytest.warns(DeprecationWarning, match="Constructing Image from a local file path is deprecated"):
-        image = dspy.Image(str(tmp_file))
+    monkeypatch.setattr("builtins.open", lambda *a, **k: pytest.fail("Image(path) read the filesystem"))
 
-    assert image.url.startswith("data:image/png;base64,")
+    with pytest.raises(ValueError, match=r"Image\.from_path"):
+        dspy.Image(str(tmp_file))
 
 
 def test_deprecated_download_true_downloads(monkeypatch):

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import tempfile
 import warnings
@@ -502,11 +503,44 @@ def test_invalid_string_format():
         dspy.Image(invalid_string)
 
 
-def test_pil_image_rejects_download_parameter():
-    sample_pil = PILImage.new("RGB", (60, 30), color="red")
+def test_deprecated_download_true_downloads(monkeypatch):
+    response = type("Response", (), {"content": b"pngdata", "headers": {"Content-Type": "image/png"}})()
+    response.raise_for_status = lambda: None
+    monkeypatch.setattr("dspy.adapters.types.image.requests.get", lambda *args, **kwargs: response)
 
-    with pytest.raises(pydantic.ValidationError, match="download"):
-        dspy.Image(sample_pil, download=True)
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image("https://example.com/dog.jpg", download=True)
+
+    assert image.url.startswith("data:image/png;base64,")
+    assert base64.b64decode(image.url.split(",", 1)[1]) == b"pngdata"
+
+
+def test_deprecated_download_false_keeps_reference():
+    source = "https://example.com/dog.jpg"
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image(source, download=False)
+    assert image.url == source
+
+
+def test_deprecated_verify_warns_without_download():
+    source = "https://example.com/dog.jpg"
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image(source, verify=False)
+    assert image.url == source
+
+
+def test_deprecated_download_does_not_rescue_local_path():
+    # The Image(path) hard break holds even with the deprecated download flag.
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(ValueError, match=r"Image\.from_file"):
+            dspy.Image("/etc/passwd", download=True)
+
+
+def test_pil_image_with_deprecated_download_still_encodes():
+    sample_pil = PILImage.new("RGB", (60, 30), color="red")
+    with pytest.warns(DeprecationWarning, match="`download` and `verify`"):
+        image = dspy.Image(sample_pil, download=True)
+    assert image.url.startswith("data:image/")
 
 
 def test_from_file_missing_file():

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -188,7 +188,6 @@ def test_workflow_with_custom_instruction_proposer_and_component_selector():
         Example(
             clock_photo=dspy.Image(
                 "https://upload.wikimedia.org/wikipedia/commons/thumb/c/cf/Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg/500px-Pendulum_clock_by_Jacob_Kock%2C_antique_furniture_photography%2C_IMG_0931_edit.jpg",
-                download=False,
             ),
             hour=8,
             minute=18,
@@ -196,7 +195,6 @@ def test_workflow_with_custom_instruction_proposer_and_component_selector():
         Example(
             clock_photo=dspy.Image(
                 "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Telechron_clock_2H07-Br_Administrator.JPG/960px-Telechron_clock_2H07-Br_Administrator.JPG",
-                download=False,
             ),
             hour=4,
             minute=16,


### PR DESCRIPTION
## Before / after

Before, constructing or parsing a DSPy resource type could interpret a string as a locator and silently read a host file or fetch a remote URL; after, construction and validation do not dereference locator-shaped inputs, while filesystem and network I/O require an explicit `from_path()` / `from_url()` call or the narrowly retained deprecated direct call `Image(url, download=True)`.

## Summary

- **[SECURITY HARDENING]** Make `Image`, `Audio`, and `File` construction and LM-output validation free of implicit DSPy-initiated filesystem and network access.
- **[FIX]** Prevent Pydantic dictionary validation from activating the deprecated `Image(..., download=True)` compatibility shim.
- **[API]** Make `from_path()` the canonical local-read factory and `from_url()` the explicit remote-download factory.
- **[MIGRATION]** Preserve safe positional/in-memory construction and existing helper signatures instead of requiring all values to move to named factories.
- **[BREAKING / DELIBERATE]** Reject implicit local paths and locator-shaped embedded audio/file values without touching the host.

This is the lower-migration-churn alternative to #10069.

## Why this boundary

DSPy adapters parse LM output through Pydantic. Previously, that validation path reused convenience coercion that could call `open()` or `requests.get()`. A value being validated as data could therefore cause host I/O merely because it resembled a path or URL—or, in the image case, because a dictionary contained `download=True`.

This is defense-in-depth hardening, not a claim of a high-severity practical exploit. The reported PoCs require an unusual signature with `Image` / `Audio` / `File` output fields. The useful invariant is: **validation does not dereference locators; host I/O must be requested through an explicit API.**

The deprecated positional `Image(url, download=True)` shim remains for one release because it represents a direct developer-authored request, not coercion of untrusted dictionary data. Pydantic invokes the custom constructor with keyword data, so `download` and `verify` now require a positional source and are rejected from `TypeAdapter`, nested-model, and deserialization paths.

### Python and ecosystem rationale

Python does not prohibit side effects in `__init__`; this PR draws a narrower capability boundary:

- [PEP 20](https://peps.python.org/pep-0020/) says “Explicit is better than implicit.” Calls named `from_path()` and `from_url()` expose host I/O at the call site; bytes, PIL images, arrays, and embedded data remain in-memory transformations.
- Python's [`pathlib` design](https://docs.python.org/3/library/pathlib.html#pure-paths) separates path representation from filesystem operations such as [`Path.open()` and `Path.read_bytes()`](https://docs.python.org/3/library/pathlib.html#reading-and-writing-files). DSPy now similarly separates locator-shaped data from explicit dereferencing.
- Pydantic documents [`TypeAdapter`](https://docs.pydantic.dev/latest/concepts/type_adapter/) as a validation boundary for arbitrary types. DSPy uses this path for LM output, nested models, and deserialization, so it must not grant implicit access to the host.
- Pydantic [discourages custom `BaseModel.__init__` implementations](https://docs.pydantic.dev/latest/concepts/models/#defining-a-custom-init). This alternative retains the existing constructors as a migration constraint, but isolates and tests the security-sensitive compatibility branch rather than treating it as general validation behavior.
- The [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html) treats application-initiated requests to caller-controlled URLs as a security boundary. `from_url()` remains explicit and caller-owned; callers must validate untrusted destinations for their environment.

## Security and I/O contract

| Input | Construction / validation | Explicit operation |
|---|---|---|
| Local image path | rejected without touching the filesystem | `Image.from_path(path)` |
| Local audio path | rejected without touching the filesystem | `Audio.from_path(path)` |
| Local file path | rejected without touching the filesystem | `File.from_path(path)` |
| HTTP(S) image URL | retained as a provider-fetched reference | `Image.from_url(url)` downloads into a data URI |
| HTTP(S) audio URL | rejected as embedded audio data | `Audio.from_url(url)` downloads and embeds it |
| URL-shaped file data | rejected | no `File.from_url()` in this PR |
| Raw bytes / arrays / PIL objects | normalized in memory; no host I/O | existing constructors and factories remain available |
| Validation payload containing `download` / `verify` | rejected without fetching | no validation-time migration by design |
| Direct positional `Image(url, download=True)` | downloads with a deprecation warning | migrate to `Image.from_url(url)` |

`from_url()` is a synchronous, caller-initiated network request. It follows redirects and provides no SSRF protection beyond requiring an HTTP(S) URL. If a URL is derived from untrusted input, the caller owns destination validation or allowlisting.

## Public API after this PR

| Capability | Image | Audio | File |
|---|---|---|---|
| In-memory constructor | `Image(URL_or_data_URI)`, `Image(bytes)`, `Image(PIL_image)` | `Audio(data_URI_or_dict)`, `Audio(bytes, audio_format=...)`, array input with `sampling_rate=` | `File(data_URI_or_dict)`, `File(bytes)` |
| Canonical keyword fields | `Image(url=...)` | `Audio(data=<base64>, audio_format=...)` | `File(file_data=..., file_id=..., filename=...)` |
| Non-fetching remote reference | positional source or keyword `url=` | — | provider `file_id=` only |
| Read local resource | `from_path()` | `from_path()` | `from_path()` |
| Download remote resource | `from_url()` | `from_url()` | — |
| Existing specialized factory | deprecated `from_PIL()` | `from_array()` | `from_bytes()`, `from_file_id()` |

Deprecated APIs retained through 3.3 and scheduled for removal in 3.4:

- `Image.from_file()` → `Image.from_path()`
- `Image.from_PIL()` → `Image(PIL_image)`
- `Audio.from_file()` → `Audio.from_path()`
- `Image(url, download=True)` → `Image.from_url(url)`
- Constructor `download` / `verify` arguments generally → explicit reference construction or `Image.from_url(url, verify=...)`

## Breaking changes in 3.3.0

### Constructors and validation

| Previous call / behavior | New behavior | Migration |
|---|---|---|
| `Image(local_path)` implicitly read a file | rejects without reading | `Image.from_path(path)` |
| `Image(url=local_path)` could be interpreted as a file | rejects without reading | `Image.from_path(path)` |
| Pydantic validation of `{"url": ..., "download": true}` could fetch | rejects without fetching | explicit application code may call `Image.from_url()` |
| `Image(url=..., download=...)` keyword-only construction | rejects because the shim is direct-positional only | use `Image(url=...)` for a reference or `Image.from_url()` to download |
| Direct `Image(url, download=True)` | still downloads, but warns | migrate to `Image.from_url(url)` before 3.4 |
| `Audio(path_or_url)` could be treated as embedded data or loaded | rejects without reading/fetching | `Audio.from_path()` / `Audio.from_url()` |
| `File(path)` could read the filesystem | rejects without reading | `File.from_path()` |
| LM-output parsing of locator-shaped resources | rejects or retains a non-fetching image reference; never dereferences | no implicit-I/O migration by design |

### Factories and helpers

| Previous call / behavior | New behavior | Migration |
|---|---|---|
| `Image.from_url(url)` retained a reference by default | downloads and returns a data URI | use `Image(url)` / `Image(url=url)` for a reference |
| `Image.from_url(url, download=...)` | `download` removed | choose reference construction or `from_url()` explicitly |
| `encode_image(path)` | rejects local paths | `Image.from_path(path)` |
| `encode_image(..., download_images=..., verify=...)` | options removed | `Image.from_url(..., verify=...)` for a fetch |
| `encode_audio(path_or_url)` | rejects locator strings | `Audio.from_path()` / `Audio.from_url()` |
| `encode_file_to_dict(path)` | rejects local paths | `File.from_path(path)` |
| Image/Audio `from_file()` | deprecated alias | `from_path()` |

## Unchanged / intentionally out of scope

- Safe in-memory positional construction remains supported for bytes, PIL images, arrays, data URIs, dictionaries, and existing resource instances where previously accepted.
- Existing `encode_audio(..., format=...)`, `Audio.from_array(..., format=...)`, and positional optional arguments are not renamed or made keyword-only.
- Embedded audio/file payload validation is not tightened beyond the locator/no-host-I/O boundary in this alternative.
- `Image(url="https://...")` remains a non-fetching reference; the downstream model provider may fetch it.
- The custom Pydantic constructors remain temporarily; this PR secures their validation boundary rather than redesigning the entire resource API.
- No async resource-loading API or `File.from_url()` is added.
- DSPy does not implement a universal SSRF allowlist; trust policy remains with the caller explicitly invoking `from_url()`.

## Review guide

1. `dspy/adapters/types/image.py`: non-fetching construction, explicit image loading, and the direct-positional compatibility guard.
2. `dspy/adapters/types/audio.py`: in-memory normalization plus explicit path/URL factories.
3. `dspy/adapters/types/file.py`: in-memory normalization plus explicit path factory.
4. `tests/adapters/test_resource_loading.py`: constructor and `TypeAdapter.validate_python()` host-I/O boundary, exact metadata-endpoint regression, compatibility-shim coverage, and explicit factories.
5. Resource documentation under `docs/docs/api/primitives/` and `docs/docs/diving-deeper/adapters.md`.

## Validation

- `uv run --frozen pytest --deno -q tests/adapters/test_resource_loading.py`
- 30 tests passed locally.
- `test_construction_performs_no_host_io` and `test_validation_performs_no_host_io` forbid `open()` and `requests.get()` for locator-shaped inputs.
- `test_image_validation_rejects_download_without_host_io` covers the exact `download=True` metadata-endpoint payload.
- `test_image_positional_download_compatibility_shim` proves the intentionally retained direct-call migration path still works and warns.
- Full GitHub CI is pending on this draft.

Addresses #10067.
