### PR TITLE
fix: deduplicate signatures by content in get_dspy_source_code (fixes silent drop of dynamic signatures)

### DIFF
--- a/dspy/propose/utils.py
+++ b/dspy/propose/utils.py
@@ -173,6 +173,9 @@ def get_dspy_source_code(module):
                 continue
             if isinstance(item, Parameter):
                 if hasattr(item, "signature") and item.signature is not None:
+                    # Which branch runs is determined by the signature's origin (source availability),
+                    # not by call order, so a given signature always yields the same sig_source here
+                    # and can't be emitted twice under two different representations.
                     try:
                         sig_source = inspect.getsource(item.signature)
                     except (TypeError, OSError):

--- a/dspy/propose/utils.py
+++ b/dspy/propose/utils.py
@@ -172,13 +172,14 @@ def get_dspy_source_code(module):
             except TypeError:
                 continue
             if isinstance(item, Parameter):
-                if hasattr(item, "signature") and item.signature is not None and item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig" not in completed_set:
+                if hasattr(item, "signature") and item.signature is not None:
                     try:
-                        header.append(inspect.getsource(item.signature))
-                        print(inspect.getsource(item.signature))
+                        sig_source = inspect.getsource(item.signature)
                     except (TypeError, OSError):
-                        header.append(str(item.signature))
-                    completed_set.add(item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig")
+                        sig_source = str(item.signature)
+                    if sig_source not in completed_set:
+                        header.append(sig_source)
+                        completed_set.add(sig_source)
             if isinstance(item, dspy.Module):
                 code = get_dspy_source_code(item).strip()
                 if code not in completed_set:


### PR DESCRIPTION
## Bug

`get_dspy_source_code` (`dspy/propose/utils.py`) only includes the **first** dynamic signature when a program has multiple — every subsequent one is silently dropped from `program_code_string`. This means MIPROv2's `grounded_proposer` is passed a truncated view of the program and any predictor after the first is invisible to the optimizer.

Fixes #10100.

## Root cause

The deduplication key is:

```python
item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig"
```

For any signature built dynamically (`dspy.Signature("q -> a")`, `ChainOfThought`, `.prepend`, `.with_instructions`, …), Pydantic captures `SignatureMeta.__new__`'s own local variable `signature_name`, whose value is always the string literal `"Signature"`. Every dynamic signature therefore maps to the same key `"Signature_sig"`, so only the first one passes the `not in completed_set` guard.

```python
import dspy
from dspy.propose.utils import get_dspy_source_code

QA  = dspy.Signature("question -> answer")
SUM = dspy.Signature("text -> summary")

class TwoDynamic(dspy.Module):
    def __init__(self):
        super().__init__()
        self.qa = dspy.Predict(QA)
        self.summarize = dspy.Predict(SUM)

code = get_dspy_source_code(TwoDynamic())
header = code.split("class TwoDynamic")[0]
print("-> answer  in header:", "-> answer"  in header)   # True
print("-> summary in header:", "-> summary" in header)   # False  ← BUG
```

## Fix

Use the signature's actual source/string representation as the deduplication key — already the approach used four lines below for `dspy.Module` items:

```python
# Before
if hasattr(item, "signature") and item.signature is not None and item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig" not in completed_set:
    try:
        header.append(inspect.getsource(item.signature))
        print(inspect.getsource(item.signature))          # leftover debug print
    except (TypeError, OSError):
        header.append(str(item.signature))
    completed_set.add(item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig")

# After
if hasattr(item, "signature") and item.signature is not None:
    try:
        sig_source = inspect.getsource(item.signature)
    except (TypeError, OSError):
        sig_source = str(item.signature)
    if sig_source not in completed_set:
        header.append(sig_source)
        completed_set.add(sig_source)
```

Also removes the debug `print()` that was logging signature source to stdout on every `get_dspy_source_code` call.