### PR TITLE
fix(dspy): enforce output field constraints when parsing LM responses

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -234,7 +234,7 @@ class ChatAdapter(Adapter):
         for k, v in sections:
             if (k not in fields) and (k in signature.output_fields):
                 try:
-                    fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                    fields[k] = parse_value(v, signature.output_fields[k].annotation, signature.output_fields[k])
                 except Exception as e:
                     raise AdapterParseError(
                         adapter_name="ChatAdapter",

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -187,7 +187,7 @@ class JSONAdapter(ChatAdapter):
         # Attempt to cast each value to type signature.output_fields[k].annotation.
         for k, v in fields.items():
             if k in signature.output_fields:
-                fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                fields[k] = parse_value(v, signature.output_fields[k].annotation, signature.output_fields[k])
 
         if fields.keys() != signature.output_fields.keys():
             raise AdapterParseError(

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -4,7 +4,7 @@ import inspect
 import json
 import types
 from collections.abc import Mapping
-from typing import Any, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
 import json_repair
 import pydantic
@@ -146,9 +146,18 @@ def find_enum_member(enum, identifier):
     raise ValueError(f"{identifier} is not a valid name or value for the enum {enum.__name__}")
 
 
-def parse_value(value, annotation):
+def parse_value(value, annotation, field_info: FieldInfo | None = None):
+    # Constraints declared on a field (`max_length`, `ge`, `pattern`, ...) are stored in
+    # `FieldInfo.metadata`, not in its annotation, so validating against the annotation alone
+    # accepts any LM output that merely has the right type. Re-attach them here when the caller
+    # knows the field, and fall back to the bare annotation when it doesn't.
+    constraints = tuple(field_info.metadata) if field_info is not None else ()
+    target = Annotated[(annotation, *constraints)] if constraints else annotation
+
     if annotation is str:
-        return str(value)
+        # Stringify rather than validate the raw value.
+        text = str(value)
+        return TypeAdapter(target).validate_python(text) if constraints else text
 
     if isinstance(annotation, enum.EnumMeta):
         return find_enum_member(annotation, value)
@@ -173,11 +182,11 @@ def parse_value(value, annotation):
         raise ValueError(f"{value!r} is not one of {allowed!r}")
 
     if not isinstance(value, str):
-        return TypeAdapter(annotation).validate_python(value)
+        return TypeAdapter(target).validate_python(value)
 
     if origin in (Union, types.UnionType) and type(None) in get_args(annotation) and str in get_args(annotation):
         # Handle union annotations, e.g., `str | None`, `Optional[str]`, `Union[str, int, None]`, etc.
-        return TypeAdapter(annotation).validate_python(value)
+        return TypeAdapter(target).validate_python(value)
 
     candidate = json_repair.loads(value)  # json_repair.loads returns "" on failure.
     if candidate == "" and value != "":
@@ -187,12 +196,12 @@ def parse_value(value, annotation):
             candidate = value
 
     try:
-        return TypeAdapter(annotation).validate_python(candidate)
+        return TypeAdapter(target).validate_python(candidate)
     except pydantic.ValidationError as e:
         if _annotation_is_subclass(annotation, DspyType):
             try:
                 # For dspy.Type, try parsing from the original value in case it has a custom parser
-                return TypeAdapter(annotation).validate_python(value)
+                return TypeAdapter(target).validate_python(value)
             except Exception:
                 raise e
         raise

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -154,20 +154,23 @@ def parse_value(value, annotation, field_info: FieldInfo | None = None):
     constraints = tuple(field_info.metadata) if field_info is not None else ()
     target = Annotated[(annotation, *constraints)] if constraints else annotation
 
+    def enforce(resolved):
+        # Branches that resolve a value themselves still have to answer to the field's constraints.
+        return TypeAdapter(target).validate_python(resolved) if constraints else resolved
+
     if annotation is str:
         # Stringify rather than validate the raw value.
-        text = str(value)
-        return TypeAdapter(target).validate_python(text) if constraints else text
+        return enforce(str(value))
 
     if isinstance(annotation, enum.EnumMeta):
-        return find_enum_member(annotation, value)
+        return enforce(find_enum_member(annotation, value))
 
     origin = get_origin(annotation)
 
     if origin is Literal:
         allowed = get_args(annotation)
         if value in allowed:
-            return value
+            return enforce(value)
 
         if isinstance(value, str):
             v = value.strip()
@@ -177,7 +180,7 @@ def parse_value(value, annotation, field_info: FieldInfo | None = None):
                 v = v[1:-1]
 
             if v in allowed:
-                return v
+                return enforce(v)
 
         raise ValueError(f"{value!r} is not one of {allowed!r}")
 

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -107,7 +107,7 @@ class XMLAdapter(ChatAdapter):
         from dspy.adapters.utils import parse_value
 
         try:
-            return parse_value(raw, field_info.annotation)
+            return parse_value(raw, field_info.annotation, field_info)
         except Exception as e:
             from dspy.utils.exceptions import AdapterParseError
 

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -579,7 +579,7 @@ class RLM(Module):
             field = self.signature.output_fields[name]
             annotation = getattr(field, "annotation", str)
             try:
-                parsed_outputs[name] = parse_value(raw_output[name], annotation)
+                parsed_outputs[name] = parse_value(raw_output[name], annotation, field)
             except (ValueError, pydantic.ValidationError) as e:
                 type_errors.append(
                     f"{name}: expected {annotation.__name__ if hasattr(annotation, '__name__') else annotation}, "

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -2,9 +2,11 @@
 
 from typing import Literal, Optional, Union
 
+import pydantic
 import pytest
 from pydantic import BaseModel
 
+import dspy
 from dspy.adapters.utils import parse_value
 
 
@@ -105,3 +107,79 @@ def test_parse_value_json_repair():
     malformed = "not json or literal"
     with pytest.raises(Exception):
         parse_value(malformed, dict)
+
+
+def test_parse_value_enforces_str_constraints_from_field_info():
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(max_length=3)
+
+    field = Sig.output_fields["answer"]
+
+    assert parse_value("ok", field.annotation, field) == "ok"
+    with pytest.raises(pydantic.ValidationError, match="at most 3 characters"):
+        parse_value("toolong", field.annotation, field)
+
+
+def test_parse_value_enforces_numeric_constraints_from_field_info():
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        score: int = dspy.OutputField(ge=1, le=5)
+
+    field = Sig.output_fields["score"]
+
+    assert parse_value("3", field.annotation, field) == 3
+    with pytest.raises(pydantic.ValidationError, match="less than or equal to 5"):
+        parse_value("99", field.annotation, field)
+    with pytest.raises(pydantic.ValidationError, match="greater than or equal to 1"):
+        parse_value("0", field.annotation, field)
+
+
+def test_parse_value_enforces_constraints_on_optional_annotation():
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str | None = dspy.OutputField(max_length=3)
+
+    field = Sig.output_fields["answer"]
+
+    assert parse_value("ok", field.annotation, field) == "ok"
+    with pytest.raises(pydantic.ValidationError, match="at most 3 characters"):
+        parse_value("toolong", field.annotation, field)
+
+
+def test_parse_value_enforces_constraints_on_container_annotation():
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        tags: list[str] = dspy.OutputField(max_length=2)
+
+    field = Sig.output_fields["tags"]
+
+    assert parse_value('["a", "b"]', field.annotation, field) == ["a", "b"]
+    with pytest.raises(pydantic.ValidationError, match="at most 2 items"):
+        parse_value('["a", "b", "c"]', field.annotation, field)
+
+
+def test_parse_value_unconstrained_field_is_unchanged():
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+        count: int = dspy.OutputField()
+
+    answer = Sig.output_fields["answer"]
+    count = Sig.output_fields["count"]
+
+    assert parse_value("anything at all", answer.annotation, answer) == "anything at all"
+    # A digit-only string must stay a string rather than being reinterpreted as an int.
+    assert parse_value("1234", answer.annotation, answer) == "1234"
+    assert parse_value("7", count.annotation, count) == 7
+
+
+def test_parse_value_without_field_info_keeps_previous_behavior():
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(max_length=3)
+
+    field = Sig.output_fields["answer"]
+
+    assert parse_value("toolong", field.annotation) == "toolong"
+    assert parse_value(123, str) == "123"

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -1,5 +1,6 @@
 # ruff: noqa: UP007
 
+import enum
 from typing import Literal, Optional, Union
 
 import pydantic
@@ -183,3 +184,51 @@ def test_parse_value_without_field_info_keeps_previous_behavior():
 
     assert parse_value("toolong", field.annotation) == "toolong"
     assert parse_value(123, str) == "123"
+
+
+def test_parse_value_enforces_constraints_on_literal_annotation():
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: Literal["ok", "okay"] = dspy.OutputField(max_length=3)
+
+    field = Sig.output_fields["answer"]
+
+    assert parse_value("ok", field.annotation, field) == "ok"
+    with pytest.raises(pydantic.ValidationError, match="at most 3 items"):
+        parse_value("okay", field.annotation, field)
+    # The quoted / bracketed forms resolve to the same value and must be checked too.
+    with pytest.raises(pydantic.ValidationError, match="at most 3 items"):
+        parse_value("'okay'", field.annotation, field)
+
+
+def test_parse_value_enforces_constraints_on_enum_annotation():
+    class Choice(str, enum.Enum):
+        OK = "ok"
+        OKAY = "okay"
+
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: Choice = dspy.OutputField(max_length=3)
+
+    field = Sig.output_fields["answer"]
+
+    assert parse_value("ok", field.annotation, field) is Choice.OK
+    with pytest.raises(pydantic.ValidationError, match="at most 3 items"):
+        parse_value("okay", field.annotation, field)
+
+
+def test_parse_value_unconstrained_literal_and_enum_are_unchanged():
+    class Choice(str, enum.Enum):
+        OKAY = "okay"
+
+    class Sig(dspy.Signature):
+        question: str = dspy.InputField()
+        lit: Literal["okay"] = dspy.OutputField()
+        choice: Choice = dspy.OutputField()
+
+    lit = Sig.output_fields["lit"]
+    choice = Sig.output_fields["choice"]
+
+    assert parse_value("okay", lit.annotation, lit) == "okay"
+    assert parse_value("'okay'", lit.annotation, lit) == "okay"
+    assert parse_value("okay", choice.annotation, choice) is Choice.OKAY

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2866,3 +2866,18 @@ def test_provider_tool_calls_preserve_id_and_repair_arguments():
             dspy.ToolCalls.ToolCall(id="call_from_responses", name="search", args={"query": "cats"})
         ]
     )
+
+
+def test_chat_adapter_enforces_output_field_constraints():
+    # The adapter has to hand the whole FieldInfo to `parse_value`; passing the annotation alone
+    # drops `max_length`, and an over-long response parses as valid output.
+    class ConstrainedSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(max_length=3)
+
+    adapter = dspy.ChatAdapter()
+
+    assert adapter.parse(ConstrainedSignature, "[[ ## answer ## ]]\nok") == {"answer": "ok"}
+
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="at most 3 characters"):
+        adapter.parse(ConstrainedSignature, "[[ ## answer ## ]]\ntoolong")

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1699,3 +1699,16 @@ Outputs will be a JSON object with the following fields.
 In adhering to this structure, your objective is:\x20
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+def test_json_adapter_enforces_output_field_constraints():
+    class ConstrainedSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField(max_length=3)
+
+    adapter = dspy.JSONAdapter()
+
+    assert adapter.parse(ConstrainedSignature, '{"answer": "ok"}') == {"answer": "ok"}
+
+    with pytest.raises(pydantic.ValidationError, match="at most 3 characters"):
+        adapter.parse(ConstrainedSignature, '{"answer": "toolong"}')


### PR DESCRIPTION
## Changes Description

Fixes #7925

A signature can declare constraints on an output field, and DSPy already renders them into the prompt; a field declared as `dspy.OutputField(max_length=3)` carries `'constraints': 'maximum length: 3'` and the model is told about it. The response was never checked against them, so DSPy stated a rule and then accepted any violation of it silently

The reason is that constraints are stored in `FieldInfo.metadata` rather than in the annotation, and every adapter validated with `parse_value(value, field.annotation)`. A `TypeAdapter` built from the annotation alone enforces the type and nothing else. On top of that, `parse_value` short-circuits on `if annotation is str: return str(value)`, so a constrained `str` field, which is the case in the issue, skipped validation entirely

`parse_value` now takes the field it is parsing for and re-attaches that field's constraint metadata through `Annotated` before validating. The four call sites (`chat_adapter.py`, `json_adapter.py`, `xml_adapter.py`, `predict/rlm.py`) pass their `FieldInfo`. Fields that declare no constraints are unaffected, and the two-argument form of `parse_value` keeps its previous behaviour for any caller that does not have a `FieldInfo` to hand

```python
class Sig(dspy.Signature):
    question: str = dspy.InputField()
    answer: str = dspy.OutputField(max_length=3)

field = Sig.output_fields["answer"]
parse_value("toolong", field.annotation, field)
# before: 'toolong'
# after:  ValidationError: String should have at most 3 characters
```

The `Annotated` route was chosen over the `__pydantic_validator__.validate_assignment` approach in the issue because it needs no model construction per parse and works on bare annotations. It was checked against `str`, `Optional[str]`, `str | None`, `list[str]`, `dict[str, int]` and `Annotated[Any, Ge(1)]`; all enforce correctly, including the union shapes

Branches that resolve a value themselves rather than handing it to pydantic (the `str` fast path, the enum member, and both literal returns) go through the same enforcement helper, so a `Literal` or str `Enum` field cannot slip a value past a constraint the way it could in the first revision of this PR

Tests cover string length, numeric bounds, an optional annotation, a container annotation, a constrained literal, a constrained str enum, fields with no constraints, the two-argument call, and the adapter call sites in ChatAdapter and JSONAdapter. Ten of them fail without the change to `dspy/adapters/utils.py`

## Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## Warnings

This changes behaviour for existing programs. A program that declares a constraint and receives output violating it used to get that output back; it now raises. That is the point of the fix, and it only affects fields that declare constraints, but it is not backwards compatible for anyone who declared one decoratively and relied on it being ignored. Happy to put it behind an opt-in flag if you would rather it not be on by default

Separately, ChatAdapter falls back to JSONAdapter whenever parsing raises, so a constraint violation costs an extra LM call and the user sees the fallback's error rather than the real one:

```
AdapterParseError: LM response cannot be serialized to a JSON object.
Adapter JSONAdapter failed to parse the LM response.
LM Response: [[ ## answer ## ]]
toolong
```

The real cause, `String should have at most 3 characters`, is swallowed. That fallback masks every ChatAdapter parse failure the same way, so it is not introduced here, but this change does create a new class of failure that runs into it. Whether a validation failure should be retried through another adapter at all felt like a separate question, so it is left alone and the adapter tests call `adapter.parse` directly. Glad to follow up if you want it addressed
