### PR TITLE
fix(persist): scrub known LM config from program pickles

### DIFF
--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import cloudpickle
 import orjson
 
-from dspy.utils.saving import get_dependency_versions
+from dspy.utils.saving import dump_program, get_dependency_versions
 
 # NOTE: Note: It's important (temporary decision) to maintain named_parameters that's different in behavior from
 # named_sub_modules for the time being.
@@ -218,7 +218,7 @@ class BaseModule:
                     cloudpickle.register_pickle_by_value(module)
 
                 with open(path / "program.pkl", "wb") as f:
-                    cloudpickle.dump(self, f)
+                    dump_program(self, f)
             except Exception as e:
                 raise RuntimeError(
                     f"Saving failed with error: {e}. Please remove the non-picklable attributes from your DSPy program, "

--- a/dspy/utils/saving.py
+++ b/dspy/utils/saving.py
@@ -1,7 +1,8 @@
+import copyreg
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, BinaryIO
 
 import cloudpickle
 import orjson
@@ -10,6 +11,50 @@ if TYPE_CHECKING:
     from dspy.primitives.module import Module
 
 logger = logging.getLogger(__name__)
+
+UNSAFE_PROGRAM_LM_CONFIG_KEYS = frozenset({"api_key", "api_base", "base_url", "model_list"})
+AUTH_HEADER_NAMES = frozenset({"authorization", "proxy-authorization", "api-key", "x-api-key", "cookie", "set-cookie"})
+
+
+def _sanitize_program_lm_config(config: dict) -> dict:
+    """Remove known unsafe values from DSPy-owned LM configuration."""
+    sanitized = {key: value for key, value in config.items() if key not in UNSAFE_PROGRAM_LM_CONFIG_KEYS}
+    for header_field in ("headers", "extra_headers"):
+        headers = sanitized.get(header_field)
+        if isinstance(headers, dict):
+            sanitized[header_field] = {
+                key: value for key, value in headers.items() if str(key).lower() not in AUTH_HEADER_NAMES
+            }
+    return sanitized
+
+
+def _reduce_program_lm(lm):
+    state = lm.__dict__.copy()
+    state["history"] = []
+    state["kwargs"] = _sanitize_program_lm_config(state.get("kwargs") or {})
+    return copyreg.__newobj__, (type(lm),), state
+
+
+def _reduce_program_predict(predict):
+    state = predict.__getstate__()
+    state["config"] = _sanitize_program_lm_config(state.get("config") or {})
+    return copyreg.__newobj__, (type(predict),), state
+
+
+def dump_program(program: "Module", file: BinaryIO) -> None:
+    """Serialize a program while sanitizing known DSPy-owned LM configuration."""
+    from dspy.clients.lm import LM
+    from dspy.predict.predict import Predict
+
+    class ProgramPickler(cloudpickle.CloudPickler):
+        dispatch_table = cloudpickle.CloudPickler.dispatch_table.new_child(
+            {
+                LM: _reduce_program_lm,
+                Predict: _reduce_program_predict,
+            }
+        )
+
+    ProgramPickler(file).dump(program)
 
 
 def get_dependency_versions():

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -2078,3 +2078,84 @@ def test_lm_responses_does_not_validate_reasoning_temperature_client_side():
     sent = responses.call_args.kwargs
     assert sent["temperature"] == 0.7
     assert sent["reasoning"] == {"effort": "low", "summary": "auto"}
+
+
+def test_program_pickle_scrubs_known_lm_config_and_history(tmp_path):
+    lm = dspy.LM(
+        "openai/gpt-4o-mini",
+        api_key="sk-live-SECRET",
+        base_url="https://private-SECRET.example.com",
+        model_list=[{"api_key": "nested-SECRET"}],
+        cache=False,
+        extra_headers={"Authorization": "Bearer header-SECRET", "X-Route": "blue"},
+    )
+    lm.history.append({"prompt": "PRIVATE-PROMPT"})
+    predict = dspy.Predict(
+        "q -> a",
+        api_key="predict-SECRET",
+        api_base="https://predict-SECRET.example.com",
+        headers={"X-API-Key": "header-SECRET", "X-Route": "green"},
+    )
+    predict.lm = lm
+    predict.save(tmp_path / "program", save_program=True)
+
+    raw = (tmp_path / "program" / "program.pkl").read_bytes()
+    assert b"SECRET" not in raw
+    assert b"PRIVATE-PROMPT" not in raw
+
+    loaded = dspy.load(str(tmp_path / "program"), allow_pickle=True)
+    assert "api_key" not in loaded.lm.kwargs
+    assert "base_url" not in loaded.lm.kwargs
+    assert "model_list" not in loaded.lm.kwargs
+    assert loaded.lm.kwargs["extra_headers"] == {"X-Route": "blue"}
+    assert loaded.lm.history == []
+    assert "api_key" not in loaded.config
+    assert "api_base" not in loaded.config
+    assert loaded.config["headers"] == {"X-Route": "green"}
+
+
+def test_copy_and_deepcopy_keep_lm_credentials_and_history():
+    import copy
+
+    import cloudpickle
+
+    lm = dspy.LM("openai/gpt-4o-mini", api_key="sk-keep", cache=False)
+    lm.history.append("entry")
+
+    deep = copy.deepcopy(lm)
+    assert deep.kwargs["api_key"] == "sk-keep"
+    assert deep.history == ["entry"]
+
+    shallow = lm.copy()
+    assert shallow.kwargs["api_key"] == "sk-keep"
+
+    round_tripped = cloudpickle.loads(cloudpickle.dumps(lm))
+    assert round_tripped.kwargs["api_key"] == "sk-keep"
+    assert round_tripped.history == ["entry"]
+
+
+def test_program_pickle_does_not_sanitize_custom_lm_state(tmp_path):
+    class CustomLM(dspy.BaseLM):
+        def forward(self, prompt=None, messages=None, **kwargs):
+            raise NotImplementedError
+
+    lm = CustomLM("custom/model", api_key="custom-secret")
+    lm.history.append("custom-history")
+    predict = dspy.Predict("q -> a")
+    predict.lm = lm
+    predict.save(tmp_path / "program", save_program=True)
+
+    loaded = dspy.load(str(tmp_path / "program"), allow_pickle=True)
+    assert loaded.lm.kwargs["api_key"] == "custom-secret"
+    assert loaded.lm.history == ["custom-history"]
+
+
+def test_program_pickle_does_not_sanitize_custom_predict_config(tmp_path):
+    class CustomPredict(dspy.Predict):
+        pass
+
+    predict = CustomPredict("q -> a", api_key="custom-secret")
+    predict.save(tmp_path / "program", save_program=True)
+
+    loaded = dspy.load(str(tmp_path / "program"), allow_pickle=True)
+    assert loaded.config["api_key"] == "custom-secret"


### PR DESCRIPTION
## Summary

A deliberately restricted alternative to #10103:

- scrub known DSPy-owned LM configuration (`api_key`, `api_base`, `base_url`, and `model_list`) from whole-program pickle artifacts
- remove known authentication headers from built-in `dspy.LM` and `dspy.Predict` configuration
- clear built-in `dspy.LM` history from program artifacts
- leave custom LM/Predict subclasses and ordinary copy/pickle behavior unchanged

## Design

`save_program=True` uses a per-save cloudpickle dispatch table for exact built-in `dspy.LM` and `dspy.Predict` types. This avoids adding context-sensitive `__getstate__` behavior to `BaseLM` and intentionally does not claim to sanitize arbitrary custom authentication schemes or arbitrary object graphs.

Program pickles remain trusted, potentially sensitive artifacts and must only be loaded from trusted sources.

## Testing

- `uv run --frozen pytest --deno tests/clients/test_lm.py -k 'program_pickle or copy_and_deepcopy_keep' -q`
- `uv run --frozen pytest --deno tests/primitives/test_base_module.py -q`
- `uv run --frozen ruff check dspy/clients/base_lm.py dspy/primitives/base_module.py dspy/utils/saving.py tests/clients/test_lm.py`
- `git diff --check`
