### PR TITLE
fix(propose): include every dynamic signature in get_dspy_source_code

### DIFF
--- a/dspy/propose/utils.py
+++ b/dspy/propose/utils.py
@@ -172,13 +172,14 @@ def get_dspy_source_code(module):
             except TypeError:
                 continue
             if isinstance(item, Parameter):
-                if hasattr(item, "signature") and item.signature is not None and item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig" not in completed_set:
+                if hasattr(item, "signature") and item.signature is not None:
                     try:
-                        header.append(inspect.getsource(item.signature))
-                        print(inspect.getsource(item.signature))
+                        signature_code = inspect.getsource(item.signature)
                     except (TypeError, OSError):
-                        header.append(str(item.signature))
-                    completed_set.add(item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig")
+                        signature_code = str(item.signature)
+                    if signature_code not in completed_set:
+                        header.append(signature_code)
+                        completed_set.add(signature_code)
             if isinstance(item, dspy.Module):
                 code = get_dspy_source_code(item).strip()
                 if code not in completed_set:

--- a/tests/propose/test_source_code_utils.py
+++ b/tests/propose/test_source_code_utils.py
@@ -1,0 +1,60 @@
+import dspy
+from dspy.propose.utils import get_dspy_source_code
+
+
+def test_get_dspy_source_code_includes_all_dynamic_signatures():
+    qa_signature = dspy.Signature("question -> answer")
+    summary_signature = dspy.Signature("text -> summary")
+
+    class TwoDynamicSignatures(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.qa = dspy.Predict(qa_signature)
+            self.summarize = dspy.Predict(summary_signature)
+
+    code = get_dspy_source_code(TwoDynamicSignatures())
+    header = code.split("class TwoDynamicSignatures")[0]
+
+    # Both dynamic signatures must be present, even though both are keyed as
+    # "StringSignature" and share the same __name__.
+    assert "question -> answer" in header
+    assert "text -> summary" in header
+
+
+def test_get_dspy_source_code_deduplicates_shared_signature():
+    qa_signature = dspy.Signature("question -> answer")
+
+    class SharedSignature(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.first = dspy.Predict(qa_signature)
+            self.second = dspy.Predict(qa_signature)
+
+    code = get_dspy_source_code(SharedSignature())
+    assert code.count("question -> answer") == 1
+
+
+def test_get_dspy_source_code_does_not_print_signatures(capsys):
+    class Predictor(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predict = dspy.Predict("question -> answer")
+
+    get_dspy_source_code(Predictor())
+    assert capsys.readouterr().out == ""
+
+
+def test_get_dspy_source_code_handles_none_parent_namespace():
+    # On Python 3.14, pydantic leaves __pydantic_parent_namespace__ as None for
+    # dynamically created signatures (see #9937). The dedup key must not
+    # subscript it.
+    qa_signature = dspy.Signature("question -> answer")
+    qa_signature.__pydantic_parent_namespace__ = None
+
+    class NoneNamespaceSignature(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predict = dspy.Predict(qa_signature)
+
+    code = get_dspy_source_code(NoneNamespaceSignature())
+    assert "question -> answer" in code


### PR DESCRIPTION
## Summary

`get_dspy_source_code` deduplicated dynamic signatures using a key that is the literal string `"Signature"` for every dynamic signature, so only the first one was included and later predictors' signatures were silently dropped. This PR dedups by the actual signature source/representation (the same pattern already used for nested modules), removes a leftover debug `print()`, and also avoids the Python 3.14 crash when the namespace attribute is `None`.

Fixes #10100; also addresses the crash reported in #9937.

Note: existing PRs #10112 and #10113 overlap with parts of this change. This implementation adds regression coverage neither PR has, including the `None`-namespace case.

## Validation

- 4 new regression tests pass
- `pytest tests/propose tests/teleprompt`: 85 passed
- `ruff` clean on changed files
