### PR TITLE
docs: fix BestofN casing in cheatsheet (BestofN -> BestOfN)

### DIFF
--- a/docs/docs/cheatsheet.md
+++ b/docs/docs/cheatsheet.md
@@ -468,11 +468,11 @@ dspy.configure_cache(
 )
 ```
 
-## DSPy `Refine` and `BestofN`
+## DSPy `Refine` and `BestOfN`
 
->`dspy.Suggest` and `dspy.Assert` are replaced by `dspy.Refine` and `dspy.BestofN` in DSPy 2.6.
+>`dspy.Suggest` and `dspy.Assert` are replaced by `dspy.Refine` and `dspy.BestOfN` in DSPy 2.6.
 
-### BestofN
+### BestOfN
 
 Runs a module up to `N` times with different rollout IDs (bypassing cache) and returns the best prediction, as defined by the `reward_fn`, or the first prediction that passes the `threshold`.
 


### PR DESCRIPTION
The Refine/BestOfN migration section in `docs/docs/cheatsheet.md` refers to `BestofN` (lowercase `o`) in a heading, a migration note (`dspy.BestofN`), and a subheading (lines 471, 473, 475).

The class is `BestOfN` (`dspy/predict/best_of_n.py`, exported in `dspy/predict/__init__.py` and reachable as `dspy.BestOfN`), so `dspy.BestofN` raises `AttributeError`. The runnable example further down the same file (line 485) already uses the correct `dspy.BestOfN`.

This fixes the three misspelled occurrences. Docs-only, no functional change.
