### PR TITLE
feat(callbacks): expose optimizer compile events

### DIFF
--- a/docs/docs/tutorials/observability/index.md
+++ b/docs/docs/tutorials/observability/index.md
@@ -205,6 +205,7 @@ Sometimes, you may want to implement a custom logging solution. For instance, yo
 |`on_adapter_parse_start` / `on_adapter_parse_end`| Triggered when a `dspy.Adapter` subclass postprocess the output text from an LM. |
 |`on_tool_start` / `on_tool_end` | Triggered when a `dspy.Tool` subclass is invoked. |
 |`on_evaluate_start` / `on_evaluate_end` | Triggered when a `dspy.Evaluate` instance is invoked. |
+|`on_compile_start` / `on_compile_end` | Triggered when a DSPy optimizer's `compile()` method is invoked. |
 
 Here's an example of custom callback that logs the intermediate steps of a ReAct agent:
 

--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -1,11 +1,17 @@
 from typing import Any
 
 from dspy.primitives import Example, Module
+from dspy.utils.callback import with_callbacks
 
 
 class Teleprompter:
     def __init__(self):
         pass
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if "compile" in cls.__dict__:
+            cls.compile = with_callbacks(cls.compile)
 
     def compile(self, student: Module, *, trainset: list[Example], teacher: Module | None = None, valset: list[Example] | None = None, **kwargs) -> Module:
         """

--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -1,7 +1,27 @@
+import contextvars
+import functools
 from typing import Any
 
 from dspy.primitives import Example, Module
 from dspy.utils.callback import with_callbacks
+
+_ACTIVE_OPTIMIZERS = contextvars.ContextVar("active_optimizers", default=())
+
+
+def _with_compile_callbacks(fn):
+    callback_fn = with_callbacks(fn)
+
+    @functools.wraps(fn)
+    def wrapper(instance, *args, **kwargs):
+        if id(instance) in _ACTIVE_OPTIMIZERS.get():
+            return fn(instance, *args, **kwargs)
+        token = _ACTIVE_OPTIMIZERS.set((*_ACTIVE_OPTIMIZERS.get(), id(instance)))
+        try:
+            return callback_fn(instance, *args, **kwargs)
+        finally:
+            _ACTIVE_OPTIMIZERS.reset(token)
+
+    return wrapper
 
 
 class Teleprompter:
@@ -11,7 +31,7 @@ class Teleprompter:
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         if "compile" in cls.__dict__:
-            cls.compile = with_callbacks(cls.compile)
+            cls.compile = _with_compile_callbacks(cls.compile)
 
     def compile(self, student: Module, *, trainset: list[Example], teacher: Module | None = None, valset: list[Example] | None = None, **kwargs) -> Module:
         """

--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 from typing import Any
 
 import dspy.utils.callback_context as callback_context
@@ -8,6 +9,20 @@ from dspy.utils.callback import with_callbacks
 
 def _with_compile_callbacks(fn):
     callback_fn = with_callbacks(fn)
+
+    if inspect.iscoroutinefunction(fn):
+        @functools.wraps(fn)
+        async def async_wrapper(instance, *args, **kwargs):
+            active_optimizers = callback_context._ACTIVE_OPTIMIZERS.get()
+            if id(instance) in active_optimizers:
+                return await fn(instance, *args, **kwargs)
+            token = callback_context._ACTIVE_OPTIMIZERS.set((*active_optimizers, id(instance)))
+            try:
+                return await callback_fn(instance, *args, **kwargs)
+            finally:
+                callback_context._ACTIVE_OPTIMIZERS.reset(token)
+
+        return async_wrapper
 
     @functools.wraps(fn)
     def wrapper(instance, *args, **kwargs):

--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -1,10 +1,20 @@
+import asyncio
 import functools
 import inspect
+import threading
 from typing import Any
 
 import dspy.utils.callback_context as callback_context
 from dspy.primitives import Example, Module
 from dspy.utils.callback import with_callbacks
+
+
+def _compile_invocation_key(instance):
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        task = None
+    return id(instance), threading.get_ident(), id(task) if task is not None else None
 
 
 def _with_compile_callbacks(fn):
@@ -13,27 +23,29 @@ def _with_compile_callbacks(fn):
     if inspect.iscoroutinefunction(fn):
         @functools.wraps(fn)
         async def async_wrapper(instance, *args, **kwargs):
-            active_optimizers = callback_context._ACTIVE_OPTIMIZERS.get()
-            if id(instance) in active_optimizers:
+            active_compiles = callback_context._ACTIVE_COMPILES.get()
+            invocation_key = _compile_invocation_key(instance)
+            if invocation_key in active_compiles:
                 return await fn(instance, *args, **kwargs)
-            token = callback_context._ACTIVE_OPTIMIZERS.set((*active_optimizers, id(instance)))
+            token = callback_context._ACTIVE_COMPILES.set((*active_compiles, invocation_key))
             try:
                 return await callback_fn(instance, *args, **kwargs)
             finally:
-                callback_context._ACTIVE_OPTIMIZERS.reset(token)
+                callback_context._ACTIVE_COMPILES.reset(token)
 
         return async_wrapper
 
     @functools.wraps(fn)
     def wrapper(instance, *args, **kwargs):
-        active_optimizers = callback_context._ACTIVE_OPTIMIZERS.get()
-        if id(instance) in active_optimizers:
+        active_compiles = callback_context._ACTIVE_COMPILES.get()
+        invocation_key = _compile_invocation_key(instance)
+        if invocation_key in active_compiles:
             return fn(instance, *args, **kwargs)
-        token = callback_context._ACTIVE_OPTIMIZERS.set((*active_optimizers, id(instance)))
+        token = callback_context._ACTIVE_COMPILES.set((*active_compiles, invocation_key))
         try:
             return callback_fn(instance, *args, **kwargs)
         finally:
-            callback_context._ACTIVE_OPTIMIZERS.reset(token)
+            callback_context._ACTIVE_COMPILES.reset(token)
 
     return wrapper
 
@@ -44,6 +56,8 @@ class Teleprompter:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
+        # Cover conventional class-body overrides while preserving inherited wrapped methods.
+        # Replacing compile after class creation is not a supported instrumentation path.
         if "compile" in cls.__dict__:
             cls.compile = _with_compile_callbacks(cls.compile)
 

--- a/dspy/teleprompt/teleprompt.py
+++ b/dspy/teleprompt/teleprompt.py
@@ -1,11 +1,9 @@
-import contextvars
 import functools
 from typing import Any
 
+import dspy.utils.callback_context as callback_context
 from dspy.primitives import Example, Module
 from dspy.utils.callback import with_callbacks
-
-_ACTIVE_OPTIMIZERS = contextvars.ContextVar("active_optimizers", default=())
 
 
 def _with_compile_callbacks(fn):
@@ -13,13 +11,14 @@ def _with_compile_callbacks(fn):
 
     @functools.wraps(fn)
     def wrapper(instance, *args, **kwargs):
-        if id(instance) in _ACTIVE_OPTIMIZERS.get():
+        active_optimizers = callback_context._ACTIVE_OPTIMIZERS.get()
+        if id(instance) in active_optimizers:
             return fn(instance, *args, **kwargs)
-        token = _ACTIVE_OPTIMIZERS.set((*_ACTIVE_OPTIMIZERS.get(), id(instance)))
+        token = callback_context._ACTIVE_OPTIMIZERS.set((*active_optimizers, id(instance)))
         try:
             return callback_fn(instance, *args, **kwargs)
         finally:
-            _ACTIVE_OPTIMIZERS.reset(token)
+            callback_context._ACTIVE_OPTIMIZERS.reset(token)
 
     return wrapper
 

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -285,6 +285,12 @@ class BaseCallback:
     def on_interpreter_shutdown_end(self, call_id: str, outputs: Any | None, exception: Exception | None = None):
         pass
 
+    def on_optimizer_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        pass
+
+    def on_optimizer_end(self, call_id: str, outputs: Any | None, exception: Exception | None = None):
+        pass
+
 
 def with_callbacks(fn):
     """Decorator to add callback functionality to instance methods."""
@@ -381,12 +387,16 @@ def with_callbacks(fn):
 
 def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -> Callable:
     """Selects the appropriate on_start handler of the callback based on the instance and function name."""
+    from dspy.teleprompt.teleprompt import Teleprompter
+
     if isinstance(instance, dspy.BaseLM):
         return callback.on_lm_start
     elif isinstance(instance, dspy.Evaluate):
         return callback.on_evaluate_start
     elif isinstance(instance, dspy.CodeInterpreter):
         return getattr(callback, f"on_interpreter_{_INTERPRETER_OPERATIONS[fn.__name__]}_start")
+    elif isinstance(instance, Teleprompter):
+        return callback.on_optimizer_start
 
     if isinstance(instance, dspy.Adapter):
         if fn.__name__ == "format":
@@ -405,12 +415,16 @@ def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -
 
 def _get_on_end_handler(callback: BaseCallback, instance: Any, fn: Callable) -> Callable:
     """Selects the appropriate on_end handler of the callback based on the instance and function name."""
+    from dspy.teleprompt.teleprompt import Teleprompter
+
     if isinstance(instance, dspy.BaseLM):
         return callback.on_lm_end
     elif isinstance(instance, dspy.Evaluate):
         return callback.on_evaluate_end
     elif isinstance(instance, dspy.CodeInterpreter):
         return getattr(callback, f"on_interpreter_{_INTERPRETER_OPERATIONS[fn.__name__]}_end")
+    elif isinstance(instance, Teleprompter):
+        return callback.on_optimizer_end
 
     if isinstance(instance, (dspy.Adapter)):
         if fn.__name__ == "format":

--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -285,10 +285,24 @@ class BaseCallback:
     def on_interpreter_shutdown_end(self, call_id: str, outputs: Any | None, exception: Exception | None = None):
         pass
 
-    def on_optimizer_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+    def on_compile_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        """A handler triggered when an optimizer's compile method is called.
+
+        Args:
+            call_id: A unique identifier for the compile call. Can be used to connect start/end handlers.
+            instance: The optimizer instance.
+            inputs: The inputs to the optimizer's compile method as key-value pairs.
+        """
         pass
 
-    def on_optimizer_end(self, call_id: str, outputs: Any | None, exception: Exception | None = None):
+    def on_compile_end(self, call_id: str, outputs: Any | None, exception: Exception | None = None):
+        """A handler triggered after an optimizer's compile method is called.
+
+        Args:
+            call_id: A unique identifier for the compile call. Can be used to connect start/end handlers.
+            outputs: The compiled program, or None if compilation failed.
+            exception: The exception raised during compilation, if any.
+        """
         pass
 
 
@@ -396,7 +410,7 @@ def _get_on_start_handler(callback: BaseCallback, instance: Any, fn: Callable) -
     elif isinstance(instance, dspy.CodeInterpreter):
         return getattr(callback, f"on_interpreter_{_INTERPRETER_OPERATIONS[fn.__name__]}_start")
     elif isinstance(instance, Teleprompter):
-        return callback.on_optimizer_start
+        return callback.on_compile_start
 
     if isinstance(instance, dspy.Adapter):
         if fn.__name__ == "format":
@@ -424,7 +438,7 @@ def _get_on_end_handler(callback: BaseCallback, instance: Any, fn: Callable) -> 
     elif isinstance(instance, dspy.CodeInterpreter):
         return getattr(callback, f"on_interpreter_{_INTERPRETER_OPERATIONS[fn.__name__]}_end")
     elif isinstance(instance, Teleprompter):
-        return callback.on_optimizer_end
+        return callback.on_compile_end
 
     if isinstance(instance, (dspy.Adapter)):
         if fn.__name__ == "format":

--- a/dspy/utils/callback_context.py
+++ b/dspy/utils/callback_context.py
@@ -3,7 +3,7 @@ from contextvars import ContextVar
 from typing import Callable
 
 ACTIVE_CALL_ID = ContextVar("active_call_id", default=None)
-_ACTIVE_OPTIMIZERS = ContextVar("active_optimizers", default=())
+_ACTIVE_COMPILES = ContextVar("active_compiles", default=())
 
 
 def _bind_active_call_id(fn: Callable) -> Callable:

--- a/dspy/utils/callback_context.py
+++ b/dspy/utils/callback_context.py
@@ -3,6 +3,7 @@ from contextvars import ContextVar
 from typing import Callable
 
 ACTIVE_CALL_ID = ContextVar("active_call_id", default=None)
+_ACTIVE_OPTIMIZERS = ContextVar("active_optimizers", default=())
 
 
 def _bind_active_call_id(fn: Callable) -> Callable:

--- a/tests/callback/test_optimizer_callback.py
+++ b/tests/callback/test_optimizer_callback.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import Mock, patch
 
 import cloudpickle
@@ -199,6 +200,37 @@ async def test_async_override_calling_super_emits_one_compile_callback_pair():
     assert start["instance"] is optimizer
     assert start["parent_call_id"] is None
     assert end["call_id"] == start["call_id"]
+
+
+@pytest.mark.asyncio
+async def test_same_instance_compile_in_child_task_emits_nested_callback_pair():
+    class Optimizer(Teleprompter):
+        async def compile(self, student, *, trainset, child=False):
+            if not child:
+                return await asyncio.create_task(self.compile(student, trainset=trainset, child=True))
+            return student
+
+    callback = RecordingCallback()
+    optimizer = Optimizer()
+    student = dspy.Module()
+
+    with dspy.context(callbacks=[callback]):
+        assert await optimizer.compile(student, trainset=[]) is student
+
+    outer_start, child_start, child_end, outer_end = callback.events
+    assert [event["handler"] for event in callback.events] == [
+        "compile_start",
+        "compile_start",
+        "compile_end",
+        "compile_end",
+    ]
+    assert outer_start["instance"] is child_start["instance"] is optimizer
+    assert outer_start["parent_call_id"] is None
+    assert child_start["parent_call_id"] == outer_start["call_id"]
+    assert child_end["call_id"] == child_start["call_id"]
+    assert child_end["parent_call_id"] == outer_start["call_id"]
+    assert outer_end["call_id"] == outer_start["call_id"]
+    assert outer_end["parent_call_id"] is None
 
 
 def test_compile_callback_wrapper_round_trips_through_cloudpickle():

--- a/tests/callback/test_optimizer_callback.py
+++ b/tests/callback/test_optimizer_callback.py
@@ -1,0 +1,188 @@
+import pytest
+
+import dspy
+from dspy.teleprompt.teleprompt import Teleprompter
+from dspy.teleprompt.vanilla import LabeledFewShot
+from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
+
+
+class RecordingCallback(BaseCallback):
+    def __init__(self):
+        self.events = []
+
+    def on_optimizer_start(self, call_id, instance, inputs):
+        self.events.append({
+            "handler": "optimizer_start",
+            "call_id": call_id,
+            "parent_call_id": ACTIVE_CALL_ID.get(),
+            "instance": instance,
+            "inputs": inputs,
+        })
+
+    def on_optimizer_end(self, call_id, outputs, exception):
+        self.events.append({
+            "handler": "optimizer_end",
+            "call_id": call_id,
+            "parent_call_id": ACTIVE_CALL_ID.get(),
+            "outputs": outputs,
+            "exception": exception,
+        })
+
+    def on_module_start(self, call_id, instance, inputs):
+        self.events.append({
+            "handler": "module_start",
+            "call_id": call_id,
+            "parent_call_id": ACTIVE_CALL_ID.get(),
+            "instance": instance,
+            "inputs": inputs,
+        })
+
+    def on_module_end(self, call_id, outputs, exception):
+        self.events.append({
+            "handler": "module_end",
+            "call_id": call_id,
+            "parent_call_id": ACTIVE_CALL_ID.get(),
+            "outputs": outputs,
+            "exception": exception,
+        })
+
+
+def events_for(callback, handler):
+    return [event for event in callback.events if event["handler"] == handler]
+
+
+def test_optimizer_callbacks_report_bound_inputs_output_and_call_id():
+    class Optimizer(Teleprompter):
+        def compile(self, student, *, trainset, teacher=None):
+            return student
+
+    callback = RecordingCallback()
+    optimizer = Optimizer()
+    student = dspy.Module()
+    trainset = [dspy.Example(question="test").with_inputs("question")]
+
+    with dspy.context(callbacks=[callback]):
+        result = optimizer.compile(student, trainset=trainset)
+
+    start, end = callback.events
+    assert start["handler"] == "optimizer_start"
+    assert start["instance"] is optimizer
+    assert start["inputs"] == {"student": student, "trainset": trainset, "teacher": None}
+    assert start["parent_call_id"] is None
+    assert end["handler"] == "optimizer_end"
+    assert end["call_id"] == start["call_id"]
+    assert end["outputs"] is result is student
+    assert end["exception"] is None
+
+
+def test_optimizer_callback_reports_and_propagates_same_exception():
+    expected_error = ValueError("compile failed")
+
+    class FailingOptimizer(Teleprompter):
+        def __init__(self):
+            self.should_fail = True
+
+        def compile(self, student, *, trainset):
+            if self.should_fail:
+                self.should_fail = False
+                raise expected_error
+            return student
+
+    callback = RecordingCallback()
+    optimizer = FailingOptimizer()
+    student = dspy.Module()
+
+    with dspy.context(callbacks=[callback]):
+        with pytest.raises(ValueError) as exc_info:
+            optimizer.compile(student, trainset=[])
+        assert optimizer.compile(student, trainset=[]) is student
+
+    first_start, first_end, second_start, second_end = callback.events
+    assert first_end["call_id"] == first_start["call_id"]
+    assert first_end["outputs"] is None
+    assert first_end["exception"] is expected_error
+    assert exc_info.value is expected_error
+    assert second_end["call_id"] == second_start["call_id"]
+    assert second_end["outputs"] is student
+    assert second_end["exception"] is None
+
+
+def test_nested_optimizer_and_module_callbacks_preserve_hierarchy():
+    class Student(dspy.Module):
+        def forward(self, value):
+            return dspy.Prediction(value=value)
+
+    class InnerOptimizer(Teleprompter):
+        def compile(self, student, *, trainset):
+            student(value=trainset[0])
+            return student
+
+    class OuterOptimizer(Teleprompter):
+        def compile(self, student, *, trainset, optimizer):
+            return optimizer.compile(student, trainset=trainset)
+
+    callback = RecordingCallback()
+    outer = OuterOptimizer()
+    inner = InnerOptimizer()
+    student = Student()
+
+    with dspy.context(callbacks=[callback]):
+        assert outer.compile(student, trainset=["value"], optimizer=inner) is student
+
+    assert [event["handler"] for event in callback.events] == [
+        "optimizer_start",
+        "optimizer_start",
+        "module_start",
+        "module_end",
+        "optimizer_end",
+        "optimizer_end",
+    ]
+    outer_start, inner_start, module_start, module_end, inner_end, outer_end = callback.events
+    assert inner_start["parent_call_id"] == outer_start["call_id"]
+    assert module_start["parent_call_id"] == inner_start["call_id"]
+    assert module_end["parent_call_id"] == inner_start["call_id"]
+    assert inner_end["parent_call_id"] == outer_start["call_id"]
+    assert outer_end["parent_call_id"] is None
+    assert len({outer_start["call_id"], inner_start["call_id"], module_start["call_id"]}) == 3
+
+
+def test_inherited_compile_is_not_wrapped_twice_and_override_is_wrapped_once():
+    class BaseOptimizer(Teleprompter):
+        def compile(self, student, *, trainset):
+            return student
+
+    class InheritedOptimizer(BaseOptimizer):
+        pass
+
+    class OverridingOptimizer(BaseOptimizer):
+        def compile(self, student, *, trainset):
+            return super().compile(student, trainset=trainset)
+
+    callback = RecordingCallback()
+    student = dspy.Module()
+
+    with dspy.context(callbacks=[callback]):
+        InheritedOptimizer().compile(student, trainset=[])
+        OverridingOptimizer().compile(student, trainset=[])
+
+    starts = events_for(callback, "optimizer_start")
+    ends = events_for(callback, "optimizer_end")
+    assert len(starts) == len(ends) == 2
+    assert isinstance(starts[0]["instance"], InheritedOptimizer)
+    assert isinstance(starts[1]["instance"], OverridingOptimizer)
+    assert starts[1]["parent_call_id"] is None
+
+
+def test_existing_optimizer_compile_is_instrumented():
+    callback = RecordingCallback()
+    optimizer = LabeledFewShot(k=0)
+    student = dspy.Module()
+
+    with dspy.context(callbacks=[callback]):
+        compiled = optimizer.compile(student, trainset=[])
+
+    start, end = callback.events
+    assert start["instance"] is optimizer
+    assert start["inputs"] == {"student": student, "trainset": [], "sample": True}
+    assert end["outputs"] is compiled
+    assert end["exception"] is None

--- a/tests/callback/test_optimizer_callback.py
+++ b/tests/callback/test_optimizer_callback.py
@@ -1,9 +1,13 @@
+from unittest.mock import Mock, patch
+
 import pytest
 
 import dspy
+from dspy.teleprompt.bettertogether import BetterTogether
 from dspy.teleprompt.teleprompt import Teleprompter
 from dspy.teleprompt.vanilla import LabeledFewShot
 from dspy.utils.callback import ACTIVE_CALL_ID, BaseCallback
+from dspy.utils.dummies import DummyLM
 
 
 class RecordingCallback(BaseCallback):
@@ -186,3 +190,44 @@ def test_existing_optimizer_compile_is_instrumented():
     assert start["inputs"] == {"student": student, "trainset": [], "sample": True}
     assert end["outputs"] is compiled
     assert end["exception"] is None
+
+
+def test_bettertogether_nests_child_optimizer_callback():
+    class Student(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predictor = dspy.Predict("question -> answer")
+
+        def forward(self, question):
+            return self.predictor(question=question)
+
+    class ChildOptimizer(Teleprompter):
+        def compile(self, student, *, trainset):
+            return student
+
+    callback = RecordingCallback()
+    child = ChildOptimizer()
+    optimizer = BetterTogether(metric=lambda example, prediction, trace=None: 1.0, child=child)
+    student = Student()
+    student.set_lm(DummyLM([{"answer": "answer"}]))
+    trainset = [dspy.Example(question="question", answer="answer").with_inputs("question")]
+
+    with (
+        patch("dspy.teleprompt.bettertogether.eval_candidate_program", return_value=Mock(score=1.0)),
+        patch("dspy.teleprompt.bettertogether.launch_lms"),
+        patch("dspy.teleprompt.bettertogether.kill_lms"),
+        dspy.context(callbacks=[callback]),
+    ):
+        optimizer.compile(student, trainset=trainset, valset=trainset, strategy="child")
+
+    starts = events_for(callback, "optimizer_start")
+    ends = events_for(callback, "optimizer_end")
+    assert len(starts) == len(ends) == 2
+    assert starts[0]["instance"] is optimizer
+    assert starts[0]["parent_call_id"] is None
+    assert starts[1]["instance"] is child
+    assert starts[1]["parent_call_id"] == starts[0]["call_id"]
+    assert ends[0]["call_id"] == starts[1]["call_id"]
+    assert ends[0]["parent_call_id"] == starts[0]["call_id"]
+    assert ends[1]["call_id"] == starts[0]["call_id"]
+    assert ends[1]["parent_call_id"] is None

--- a/tests/callback/test_optimizer_callback.py
+++ b/tests/callback/test_optimizer_callback.py
@@ -231,3 +231,47 @@ def test_bettertogether_nests_child_optimizer_callback():
     assert ends[0]["parent_call_id"] == starts[0]["call_id"]
     assert ends[1]["call_id"] == starts[0]["call_id"]
     assert ends[1]["parent_call_id"] is None
+
+
+def test_bettertogether_reports_child_failure_but_completes_outer_run():
+    expected_error = RuntimeError("child compile failed")
+
+    class Student(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predictor = dspy.Predict("question -> answer")
+
+        def forward(self, question):
+            return self.predictor(question=question)
+
+    class FailingChildOptimizer(Teleprompter):
+        def compile(self, student, *, trainset):
+            raise expected_error
+
+    callback = RecordingCallback()
+    child = FailingChildOptimizer()
+    optimizer = BetterTogether(metric=lambda example, prediction, trace=None: 1.0, child=child)
+    student = Student()
+    student.set_lm(DummyLM([{"answer": "answer"}]))
+    trainset = [dspy.Example(question="question", answer="answer").with_inputs("question")]
+
+    with (
+        patch("dspy.teleprompt.bettertogether.eval_candidate_program", return_value=Mock(score=1.0)),
+        patch("dspy.teleprompt.bettertogether.launch_lms"),
+        patch("dspy.teleprompt.bettertogether.kill_lms"),
+        dspy.context(callbacks=[callback]),
+    ):
+        compiled = optimizer.compile(student, trainset=trainset, valset=trainset, strategy="child")
+
+    starts = events_for(callback, "optimizer_start")
+    ends = events_for(callback, "optimizer_end")
+    assert len(starts) == len(ends) == 2
+    assert starts[1]["instance"] is child
+    assert starts[1]["parent_call_id"] == starts[0]["call_id"]
+    assert ends[0]["call_id"] == starts[1]["call_id"]
+    assert ends[0]["outputs"] is None
+    assert ends[0]["exception"] is expected_error
+    assert ends[1]["call_id"] == starts[0]["call_id"]
+    assert ends[1]["outputs"] is compiled
+    assert ends[1]["exception"] is None
+    assert compiled.flag_compilation_error_occurred is True

--- a/tests/callback/test_optimizer_callback.py
+++ b/tests/callback/test_optimizer_callback.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock, patch
 
+import cloudpickle
 import pytest
 
 import dspy
@@ -175,6 +176,23 @@ def test_inherited_compile_is_not_wrapped_twice_and_override_is_wrapped_once():
     assert isinstance(starts[0]["instance"], InheritedOptimizer)
     assert isinstance(starts[1]["instance"], OverridingOptimizer)
     assert starts[1]["parent_call_id"] is None
+
+
+def test_optimizer_callback_wrapper_round_trips_through_cloudpickle():
+    class Optimizer(Teleprompter):
+        def compile(self, student, *, trainset):
+            return student
+
+    optimizer = cloudpickle.loads(cloudpickle.dumps(Optimizer))()
+    callback = RecordingCallback()
+    student = dspy.Module()
+
+    with dspy.context(callbacks=[callback]):
+        assert optimizer.compile(student, trainset=[]) is student
+
+    start, end = callback.events
+    assert start["instance"] is optimizer
+    assert end["call_id"] == start["call_id"]
 
 
 def test_existing_optimizer_compile_is_instrumented():

--- a/tests/callback/test_optimizer_callback.py
+++ b/tests/callback/test_optimizer_callback.py
@@ -178,6 +178,29 @@ def test_inherited_compile_is_not_wrapped_twice_and_override_is_wrapped_once():
     assert starts[1]["parent_call_id"] is None
 
 
+@pytest.mark.asyncio
+async def test_async_override_calling_super_emits_one_optimizer_callback_pair():
+    class BaseOptimizer(Teleprompter):
+        async def compile(self, student, *, trainset):
+            return student
+
+    class OverridingOptimizer(BaseOptimizer):
+        async def compile(self, student, *, trainset):
+            return await super().compile(student, trainset=trainset)
+
+    callback = RecordingCallback()
+    optimizer = OverridingOptimizer()
+    student = dspy.Module()
+
+    with dspy.context(callbacks=[callback]):
+        assert await optimizer.compile(student, trainset=[]) is student
+
+    start, end = callback.events
+    assert start["instance"] is optimizer
+    assert start["parent_call_id"] is None
+    assert end["call_id"] == start["call_id"]
+
+
 def test_optimizer_callback_wrapper_round_trips_through_cloudpickle():
     class Optimizer(Teleprompter):
         def compile(self, student, *, trainset):

--- a/tests/callback/test_optimizer_callback.py
+++ b/tests/callback/test_optimizer_callback.py
@@ -15,18 +15,18 @@ class RecordingCallback(BaseCallback):
     def __init__(self):
         self.events = []
 
-    def on_optimizer_start(self, call_id, instance, inputs):
+    def on_compile_start(self, call_id, instance, inputs):
         self.events.append({
-            "handler": "optimizer_start",
+            "handler": "compile_start",
             "call_id": call_id,
             "parent_call_id": ACTIVE_CALL_ID.get(),
             "instance": instance,
             "inputs": inputs,
         })
 
-    def on_optimizer_end(self, call_id, outputs, exception):
+    def on_compile_end(self, call_id, outputs, exception):
         self.events.append({
-            "handler": "optimizer_end",
+            "handler": "compile_end",
             "call_id": call_id,
             "parent_call_id": ACTIVE_CALL_ID.get(),
             "outputs": outputs,
@@ -56,7 +56,7 @@ def events_for(callback, handler):
     return [event for event in callback.events if event["handler"] == handler]
 
 
-def test_optimizer_callbacks_report_bound_inputs_output_and_call_id():
+def test_compile_callbacks_report_bound_inputs_output_and_call_id():
     class Optimizer(Teleprompter):
         def compile(self, student, *, trainset, teacher=None):
             return student
@@ -70,17 +70,17 @@ def test_optimizer_callbacks_report_bound_inputs_output_and_call_id():
         result = optimizer.compile(student, trainset=trainset)
 
     start, end = callback.events
-    assert start["handler"] == "optimizer_start"
+    assert start["handler"] == "compile_start"
     assert start["instance"] is optimizer
     assert start["inputs"] == {"student": student, "trainset": trainset, "teacher": None}
     assert start["parent_call_id"] is None
-    assert end["handler"] == "optimizer_end"
+    assert end["handler"] == "compile_end"
     assert end["call_id"] == start["call_id"]
     assert end["outputs"] is result is student
     assert end["exception"] is None
 
 
-def test_optimizer_callback_reports_and_propagates_same_exception():
+def test_compile_callback_reports_and_propagates_same_exception():
     expected_error = ValueError("compile failed")
 
     class FailingOptimizer(Teleprompter):
@@ -135,12 +135,12 @@ def test_nested_optimizer_and_module_callbacks_preserve_hierarchy():
         assert outer.compile(student, trainset=["value"], optimizer=inner) is student
 
     assert [event["handler"] for event in callback.events] == [
-        "optimizer_start",
-        "optimizer_start",
+        "compile_start",
+        "compile_start",
         "module_start",
         "module_end",
-        "optimizer_end",
-        "optimizer_end",
+        "compile_end",
+        "compile_end",
     ]
     outer_start, inner_start, module_start, module_end, inner_end, outer_end = callback.events
     assert inner_start["parent_call_id"] == outer_start["call_id"]
@@ -170,8 +170,8 @@ def test_inherited_compile_is_not_wrapped_twice_and_override_is_wrapped_once():
         InheritedOptimizer().compile(student, trainset=[])
         OverridingOptimizer().compile(student, trainset=[])
 
-    starts = events_for(callback, "optimizer_start")
-    ends = events_for(callback, "optimizer_end")
+    starts = events_for(callback, "compile_start")
+    ends = events_for(callback, "compile_end")
     assert len(starts) == len(ends) == 2
     assert isinstance(starts[0]["instance"], InheritedOptimizer)
     assert isinstance(starts[1]["instance"], OverridingOptimizer)
@@ -179,7 +179,7 @@ def test_inherited_compile_is_not_wrapped_twice_and_override_is_wrapped_once():
 
 
 @pytest.mark.asyncio
-async def test_async_override_calling_super_emits_one_optimizer_callback_pair():
+async def test_async_override_calling_super_emits_one_compile_callback_pair():
     class BaseOptimizer(Teleprompter):
         async def compile(self, student, *, trainset):
             return student
@@ -201,7 +201,7 @@ async def test_async_override_calling_super_emits_one_optimizer_callback_pair():
     assert end["call_id"] == start["call_id"]
 
 
-def test_optimizer_callback_wrapper_round_trips_through_cloudpickle():
+def test_compile_callback_wrapper_round_trips_through_cloudpickle():
     class Optimizer(Teleprompter):
         def compile(self, student, *, trainset):
             return student
@@ -233,7 +233,7 @@ def test_existing_optimizer_compile_is_instrumented():
     assert end["exception"] is None
 
 
-def test_bettertogether_nests_child_optimizer_callback():
+def test_bettertogether_nests_child_compile_callback():
     class Student(dspy.Module):
         def __init__(self):
             super().__init__()
@@ -261,8 +261,8 @@ def test_bettertogether_nests_child_optimizer_callback():
     ):
         optimizer.compile(student, trainset=trainset, valset=trainset, strategy="child")
 
-    starts = events_for(callback, "optimizer_start")
-    ends = events_for(callback, "optimizer_end")
+    starts = events_for(callback, "compile_start")
+    ends = events_for(callback, "compile_end")
     assert len(starts) == len(ends) == 2
     assert starts[0]["instance"] is optimizer
     assert starts[0]["parent_call_id"] is None
@@ -304,8 +304,8 @@ def test_bettertogether_reports_child_failure_but_completes_outer_run():
     ):
         compiled = optimizer.compile(student, trainset=trainset, valset=trainset, strategy="child")
 
-    starts = events_for(callback, "optimizer_start")
-    ends = events_for(callback, "optimizer_end")
+    starts = events_for(callback, "compile_start")
+    ends = events_for(callback, "compile_end")
     assert len(starts) == len(ends) == 2
     assert starts[1]["instance"] is child
     assert starts[1]["parent_call_id"] == starts[0]["call_id"]


### PR DESCRIPTION
## Summary

This PR adds the missing compile-run callback envelope for DSPy optimizers:

- `on_compile_start(call_id, instance, inputs)`
- `on_compile_end(call_id, outputs, exception)`

These methods follow the same start/end contract already used by Module, LM, Evaluate, Tool, Adapter, and CodeInterpreter callbacks. No tracing backend, exporter, storage layer, or optimizer-specific event model is added to DSPy.

## Public boundary and semantics

| Instrumented boundary | Start callback | End callback | Emission semantics |
|---|---|---|---|
| A concrete `Teleprompter.compile()` run | `on_compile_start` | `on_compile_end` | One pair per logical synchronous or asynchronous compile run |

The start callback receives:

- an opaque `call_id` used to pair events and establish lineage;
- the concrete optimizer `instance`;
- the bound `compile()` inputs.

The matching end callback receives the same `call_id`, the compiled program as `outputs` (or `None` on failure), and the original `exception` when compilation fails.

An override delegating to `super().compile()` on the **same optimizer instance** remains one logical callback pair. A call to a **different optimizer instance** emits a nested pair with its own `call_id`.

The API is named for the observed operation rather than `on_optimizer_start/end`: it brackets one `compile()` invocation, not optimizer construction or a longer-lived optimizer lifecycle. The `instance` argument still identifies the concrete optimizer.

### Why `compile()` is the boundary

`compile()` is the only public lifecycle shared by every current concrete optimizer. The current tree contains 16 concrete optimizer implementations, and all 16 are covered by this mechanism—including implementations added after the callback code was written.

Optimizers do not share a truthful `propose`, `evaluate`, `select`, candidate object, phase model, or event ordering. For example, MIPRO uses Optuna trials, RandomSearch uses seeds, SIMBA mutates program pools, BootstrapFewShot collects accepted traces, BetterTogether composes optimizers, and fine-tuning optimizers create provider jobs. Adding those concepts to the common callback API would encode a workflow that does not exist.

Accordingly, this PR intentionally excludes candidate, trial, phase, score, and instance-local optimizer callback APIs.

## Implementation

Concrete `Teleprompter.compile()` overrides are wrapped centrally through `Teleprompter.__init_subclass__`, following DSPy's existing adapter wrapping pattern. This avoids editing every optimizer and automatically covers future subclasses.

- The `cls.__dict__` check avoids wrapping inherited `compile()` methods again.
- A context-local same-instance guard suppresses duplicate spans when an override calls `super().compile()` in the same thread/task.
- The guard includes the execution thread and asyncio task, so a same-instance compile launched in a child task remains a distinct nested run even though child tasks inherit `ContextVar` values.
- Distinct optimizer instances remain independently nested through the existing `ACTIVE_CALL_ID` lineage.
- Guard state is reset in `finally`, including after failures.
- Sync and async overrides are both supported.
- Runtime context is accessed through the importable callback-context module so custom optimizer wrappers remain cloudpickle-serializable.

Production changes are limited to:

- 54 lines in `dspy/teleprompt/teleprompt.py`;
- 28 lines in callback API/routing and public method documentation;
- one callback-context variable.

No concrete optimizer implementation is modified.

The class hook covers conventional class-body `compile` overrides. Replacing `compile` after class creation, or supplying it solely through an earlier foreign mixin, is not a supported instrumentation path. A future optimizer API consolidation can replace this compatibility hook with a stable public `compile()` template around a protected implementation method.

## Where this fits

Before this PR, DSPy could trace work performed *inside* optimization but could not represent the optimizer run that owned it:

```text
Optimizer.compile
└── child Optimizer.compile
    └── Evaluate
        └── Module
            └── LM / Tool / CodeInterpreter
```

The existing `with_callbacks` dispatcher and `ACTIVE_CALL_ID` context already provide paired events, parentage, callback failure isolation, scoped/global callback configuration, and worker-thread propagation. This PR enters that existing hierarchy at `compile()` rather than creating a second observability system.

## Real tracing integration

A real OpenTelemetry SDK consumer was implemented as a `BaseCallback`. It creates optimizer, Evaluate, and Module spans, uses `ACTIVE_CALL_ID` to connect parents, records evaluation scores, and marks failed optimizer spans with OTel error status.

The integration executed the real `BootstrapFewShotWithRandomSearch` implementation with its real `LabeledFewShot` child, two real `Evaluate` calls, and four real program calls—without optimizer mocks:

```text
optimizer.BootstrapFewShotWithRandomSearch  OK
├── evaluate.Evaluate                       OK  score=100.0
│   ├── module.ExactProgram                 OK
│   └── module.ExactProgram                 OK
├── optimizer.LabeledFewShot                OK
└── evaluate.Evaluate                       OK  score=100.0
    ├── module.ExactProgram                 OK
    └── module.ExactProgram                 OK
```

An invalid RandomSearch restriction produced an `ERROR` optimizer span containing the original exception. A standalone real `LabeledFewShot.compile()` produced one successful optimizer span.

The consumer deliberately exported only optimizer type, argument names, collection sizes, explicit callback metadata, score, and exception status—not raw programs or datasets. `inputs` can contain large or sensitive objects, so serialization/redaction policy belongs in the integration rather than DSPy core.

Third-party MLflow, Langfuse, or other tracing adapters must explicitly implement the two new compile callback methods; this PR provides the backend-neutral events but does not claim those external integrations are already updated.

## Metadata scope

Consumers can currently derive:

- optimizer type and bound run inputs;
- compiled output or exact failure;
- optimizer/child call lineage;
- existing `Evaluate.callback_metadata` values and final `EvaluationResult` scores.

Built-in optimizers do **not** yet consistently attach candidate identities to `Evaluate.callback_metadata`. Candidate attribution is separate follow-up work, not part of this API. It should reuse existing Evaluate spans where possible rather than duplicate scores through a new universal candidate callback.

## Behavioral coverage

Focused tests cover:

- bound compile inputs, returned program identity, and paired call IDs;
- exact exception identity and successful reuse after failure;
- nested optimizer → optimizer → module lineage;
- inherited compile methods without duplicate wrapping;
- overriding sync and async compile methods that call `super().compile()` without duplicate same-instance spans;
- same-instance compiles launched in inherited asyncio child tasks emitting distinct nested spans;
- existing concrete optimizer instrumentation through `LabeledFewShot`;
- actual BetterTogether strategy execution nesting its configured child optimizer;
- BetterTogether child failure recovery: failed child span plus successful recovered outer run;
- custom optimizer cloudpickle round trips with callbacks intact.

The inheritance coverage specifically protects real super-delegating optimizers such as `InferRules` and `SignatureOptimizer`.

## Verification

```bash
uv run --frozen ruff check \
  dspy/utils/callback.py \
  dspy/utils/callback_context.py \
  dspy/teleprompt/teleprompt.py \
  tests/callback/test_optimizer_callback.py

uv run --frozen pytest -q tests/callback/test_optimizer_callback.py
```

Current focused result: **10 passed**, Ruff clean. The GitHub test/build matrix runs on Python 3.10–3.14.

## Cross-component hierarchy validation

A separate `BaseCallback`-compatible recorder captured a real optimizer run containing a DSPy module, Deno interpreter, sandbox-to-host tool call, and LM call. Assertions verified every parent ID and terminal status before rendering this report:

![Optimizer, interpreter, and LM callback hierarchy captured from a real Deno execution](https://ampcode.com/user-content/artifacts/ffa52080038257d3865046aa30422868b7b7c0ebbda2fc86988344574156c03d-file.png)

Validated hierarchy:

- optimizer compile → module;
- module → interpreter execute;
- interpreter execute → process startup and host tool call;
- host tool call → LM call;
- module → interpreter shutdown.

An intentional host-tool failure was also validated through the full stack: tool, execute, module, and optimizer spans were marked failed with their correct exception representations, while startup and shutdown remained successful and correctly nested.

## Contributor checklist

- [x] Pre-commit checks pass
- [x] Title follows the required format
- [x] Commit messages follow the required format
