### PR TITLE
fix(callback): keep with_callbacks wrappers picklable

### DIFF
--- a/dspy/utils/callback.py
+++ b/dspy/utils/callback.py
@@ -5,7 +5,9 @@ import uuid
 from typing import Any, Callable
 
 import dspy
-from dspy.utils.callback_context import ACTIVE_CALL_ID
+
+# Re-exported for backwards compatibility; the wrappers below import it lazily instead.
+from dspy.utils.callback_context import ACTIVE_CALL_ID  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
@@ -297,6 +299,10 @@ def with_callbacks(fn):
 
             _execute_start_callbacks(instance, fn, call_id, callbacks, args, kwargs)
 
+            # Imported here, not at module level, so cloudpickle does not capture the ContextVar
+            # by value when serializing a decorated class.
+            from dspy.utils.callback_context import ACTIVE_CALL_ID
+
             # Active ID must be set right before the function is called, not before calling the callbacks.
             parent_call_id = ACTIVE_CALL_ID.get()
             ACTIVE_CALL_ID.set(call_id)
@@ -326,6 +332,10 @@ def with_callbacks(fn):
             call_id = uuid.uuid4().hex
 
             _execute_start_callbacks(instance, fn, call_id, callbacks, args, kwargs)
+
+            # Imported here, not at module level, so cloudpickle does not capture the ContextVar
+            # by value when serializing a decorated class.
+            from dspy.utils.callback_context import ACTIVE_CALL_ID
 
             # Active ID must be set right before the function is called, not before calling the callbacks.
             parent_call_id = ACTIVE_CALL_ID.get()

--- a/tests/callback/test_callback.py
+++ b/tests/callback/test_callback.py
@@ -1,5 +1,6 @@
 import time
 
+import cloudpickle
 import pytest
 
 import dspy
@@ -73,6 +74,16 @@ def test_bind_active_call_id_restores_context_after_exception():
 
     assert observed_call_ids == ["parent-call"]
     assert ACTIVE_CALL_ID.get() is None
+
+
+def test_with_callbacks_wrapper_is_picklable():
+    # The wrappers must not capture ACTIVE_CALL_ID by value, otherwise cloudpickle cannot
+    # serialize any class whose methods they decorate, e.g. every Adapter subclass.
+    async def async_fn(self):
+        return None
+
+    cloudpickle.dumps(with_callbacks(lambda self: None))
+    cloudpickle.dumps(with_callbacks(async_fn))
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_settings.py
+++ b/tests/utils/test_settings.py
@@ -262,3 +262,42 @@ def callback(x):
         # Only need to clean up sys.path
         if str(tmp_path) in sys.path:
             sys.path.remove(str(tmp_path))
+
+
+def test_settings_save_with_custom_adapter_subclass(tmp_path):
+    custom_module_path = tmp_path / "custom_adapter.py"
+    with open(custom_module_path, "w") as f:
+        f.write(
+            """
+from dspy.adapters.chat_adapter import ChatAdapter
+
+
+class MyAdapter(ChatAdapter):
+    pass
+"""
+        )
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        import custom_adapter
+
+        dspy.configure(adapter=custom_adapter.MyAdapter())
+
+        settings_path = tmp_path / "settings.pkl"
+        dspy.settings.save(settings_path, modules_to_serialize=[custom_adapter])
+
+        # Remove the custom module again to simulate it not being available at load time
+        sys.modules.pop("custom_adapter", None)
+        sys.path.remove(str(tmp_path))
+        del custom_adapter
+
+        dspy.configure(adapter=None)
+
+        loaded_settings = dspy.load_settings(settings_path, allow_pickle=True)
+        dspy.settings.configure(**loaded_settings)
+
+        assert type(dspy.settings.adapter).__name__ == "MyAdapter"
+
+    finally:
+        if str(tmp_path) in sys.path:
+            sys.path.remove(str(tmp_path))


### PR DESCRIPTION
Fixes #10123

The `with_callbacks` wrappers referenced `ACTIVE_CALL_ID` as a module global, so
cloudpickle pulled the ContextVar in when serializing a decorated class by value.
Importing it inside the wrappers makes it a local, so it is never captured. The
module-level import stays as a re-export.

Adds a unit test that the wrappers pickle, and an end-to-end test that
`settings.save(..., modules_to_serialize=[...])` round-trips a custom Adapter
subclass with the source module removed.

AI-assisted: Claude Code was used to reproduce the bug, write the failing tests,
and draft the fix. I reviewed and verified every line, ran the affected suites
against a clean-main baseline, and confirmed the issue's reproduction end to end.