### PR TITLE
fix(adapters): stop re-issuing a completed generation on parse failure

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -19,7 +19,7 @@ from dspy.adapters.utils import (
 from dspy.clients.base_lm import BaseLM
 from dspy.signatures.signature import Signature, SignatureMeta
 from dspy.utils.callback import BaseCallback
-from dspy.utils.exceptions import AdapterParseError, LMError
+from dspy.utils.exceptions import AdapterParseError
 
 logger = logging.getLogger(__name__)
 
@@ -80,16 +80,13 @@ class JSONAdapter(ChatAdapter):
             structured_output_model = _get_structured_outputs_response_format(
                 signature, self.use_native_function_calling
             )
-            lm_kwargs["response_format"] = structured_output_model
-            return super().__call__(lm, lm_kwargs, signature, demos, inputs)
-        except LMError:
-            # Provider/backend failures should propagate; the fallback below is only for local structured-output
-            # setup/schema failures where retrying in JSON mode is appropriate.
-            raise
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
+
+        lm_kwargs["response_format"] = structured_output_model
+        return super().__call__(lm, lm_kwargs, signature, demos, inputs)
 
     async def acall(
         self,
@@ -107,16 +104,13 @@ class JSONAdapter(ChatAdapter):
             structured_output_model = _get_structured_outputs_response_format(
                 signature, self.use_native_function_calling
             )
-            lm_kwargs["response_format"] = structured_output_model
-            return await super().acall(lm, lm_kwargs, signature, demos, inputs)
-        except LMError:
-            # Provider/backend failures should propagate; the fallback below is only for local structured-output
-            # setup/schema failures where retrying in JSON mode is appropriate.
-            raise
         except Exception:
             logger.warning("Failed to use structured output format, falling back to JSON mode.")
             lm_kwargs["response_format"] = {"type": "json_object"}
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
+
+        lm_kwargs["response_format"] = structured_output_model
+        return await super().acall(lm, lm_kwargs, signature, demos, inputs)
 
     def format_field_structure(self, signature: type[Signature]) -> str:
         parts = []


### PR DESCRIPTION
## Context

`JSONAdapter` wraps both the structured-output schema construction and the LM call in a single `try`, so any failure after the request has been sent falls back to JSON mode and re-issues it.

The failure that matters in practice is a response truncated at `max_tokens`. It raises `AdapterParseError`, the fallback discards a generation that already completed, and it runs the call again without the schema, which makes it no more likely to parse than the first attempt was. I hit this on a ~16k-token completion: a truncation warning followed immediately by `Failed to use structured output format, falling back to JSON mode.` One call, two full generations, and it failed anyway.

#9826 narrowed this with `except LMError: raise`, and its comment states the intent:

> Provider/backend failures should propagate; the fallback below is only for local structured-output setup/schema failures where retrying in JSON mode is appropriate.

`AdapterParseError` is not an `LMError`, so it still triggers the retry.

## What changes

Only the schema construction stays inside the `try`, in `__call__` and `acall`. Every failure after the request is sent now propagates, which is what #9826 was after, so enumerating exception types is no longer necessary and `except LMError: raise` is removed.

| situation | before | after |
|---|---|---|
| `_get_structured_outputs_response_format` raises | falls back to `{"type": "json_object"}` | unchanged |
| provider rejects the request (`LMError`) | propagates | unchanged |
| response cannot be parsed | discards the generation and re-issues it | propagates |

Nothing changes for calls that succeed, or for LMs without structured-output support.

`tests/adapters` and `tests/predict` pass (500). `test_in_memory_resource_construction` fails on `main` too, it needs Pillow.
