### PR TITLE
fix(deps): cap FastAPI for LiteLLM proxy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "numpy>=1.26.0",
     "litellm>=1.65.8; sys_platform == 'win32' or python_version == '3.14'",
     "litellm[proxy]>=1.65.8; sys_platform != 'win32' and python_version < '3.14'",  # Remove 3.14 condition once uvloop supports
+    "fastapi<0.140.7; sys_platform != 'win32' and python_version < '3.14'",  # Remove once LiteLLM supports newer FastAPI
 ]
 test_extras = [
     "mcp; python_version >= '3.10'",

--- a/uv.lock
+++ b/uv.lock
@@ -789,6 +789,7 @@ anthropic = [
 dev = [
     { name = "build" },
     { name = "datamodel-code-generator" },
+    { name = "fastapi", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "litellm", version = "1.68.0", source = { registry = "https://pypi.org/simple" }, extra = ["proxy"], marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "litellm", version = "1.72.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -843,6 +844,7 @@ requires-dist = [
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
     { name = "diskcache", specifier = ">=5.6.0" },
+    { name = "fastapi", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = "<0.140.7" },
     { name = "gepa", extras = ["dspy"], specifier = "==0.1.1" },
     { name = "json-repair", specifier = ">=0.54.2" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.3.0" },


### PR DESCRIPTION
## Stack

Depends on #10127. Merge #10127 first, then merge this PR.

## Summary

- cap FastAPI below 0.140.7 only in the `dev` extra that installs `litellm[proxy]`
- update `uv.lock` with the new conditional development constraint

## Why

FastAPI removed the internal `get_flat_dependant` helper in 0.140.7. Released LiteLLM proxy versions still import that helper, so a highest-version dependency resolution installs an incompatible combination and the proxy exits during startup. DSPy's proxy-backed tests then time out waiting for it.

This currently breaks both the scheduled `main` dependency-range run and PR dependency-range checks:

- https://github.com/stanfordnlp/dspy/actions/runs/30805776159
- https://github.com/stanfordnlp/dspy/actions/runs/30848933493/job/91804038688

The cap is deliberately limited to the development platforms where DSPy installs `litellm[proxy]`. It does not add FastAPI to ordinary DSPy runtime installations.

With the cap, highest resolution selects FastAPI 0.140.6 and LiteLLM 1.93.0. The LiteLLM downgrade is expected because LiteLLM 1.94+ also requires a Starlette version incompatible with FastAPI 0.140.6.

Upstream fixes are open but not yet released:

- https://github.com/BerriAI/litellm/pull/35139
- https://github.com/BerriAI/litellm/pull/35389

The cap can be removed after LiteLLM ships a compatible release.

Closes #10128.

## Verification

- `uv lock --check --no-config`
- highest-resolution compile for Linux/Python 3.11 resolves `fastapi==0.140.6` and `litellm==1.93.0`
- pre-commit TOML, large-file, and merge-conflict checks pass
