### PR TITLE
fix(dspy): tighten ChatAdapter JSON fallback

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -16,7 +16,7 @@ from dspy.adapters.utils import (
 from dspy.clients.base_lm import BaseLM
 from dspy.signatures.signature import Signature
 from dspy.utils.callback import BaseCallback
-from dspy.utils.exceptions import AdapterParseError, LMError
+from dspy.utils.exceptions import AdapterParseError
 
 field_header_pattern = re.compile(r"\[\[ ## (\w+) ## \]\]")
 
@@ -52,7 +52,7 @@ class ChatAdapter(Adapter):
             use_native_function_calling: Whether to enable native function calling capabilities.
             native_response_types: List of output field types handled by native LM features.
             use_json_adapter_fallback: Whether to automatically fallback to JSONAdapter if the ChatAdapter fails.
-                If True, when an error occurs (except ContextWindowExceededError), the adapter will retry using
+                If True, when the LM response cannot be parsed (`AdapterParseError`), the adapter will retry using
                 JSONAdapter. Defaults to True.
             parallel_tool_calls: Whether to request provider-side parallel tool-call generation when native function
                 calling is active. If None, the adapter does not set the provider option.
@@ -83,15 +83,18 @@ class ChatAdapter(Adapter):
     ) -> list[dict[str, Any]]:
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
-        except Exception as e:
+        except AdapterParseError as e:
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 
-            if isinstance(e, LMError) or isinstance(self, JSONAdapter) or not self.use_json_adapter_fallback:
-                # On LM errors, already using JSONAdapter, or use_json_adapter_fallback is False, we don't want to
-                # retry with a different adapter. Raise the original error instead of the fallback error.
+            if isinstance(self, JSONAdapter) or not self.use_json_adapter_fallback:
+                # If already using JSONAdapter, or use_json_adapter_fallback is False, we don't want to retry with a
+                # different adapter. Raise the original error instead of the fallback error.
                 raise
-            return self._make_json_adapter_fallback()(lm, lm_kwargs, signature, demos, inputs)
+            try:
+                return self._make_json_adapter_fallback()(lm, lm_kwargs, signature, demos, inputs)
+            except Exception as fallback_error:
+                raise fallback_error from e
 
     async def acall(
         self,
@@ -103,15 +106,18 @@ class ChatAdapter(Adapter):
     ) -> list[dict[str, Any]]:
         try:
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
-        except Exception as e:
+        except AdapterParseError as e:
             # fallback to JSONAdapter
             from dspy.adapters.json_adapter import JSONAdapter
 
-            if isinstance(e, LMError) or isinstance(self, JSONAdapter) or not self.use_json_adapter_fallback:
-                # On LM errors, already using JSONAdapter, or use_json_adapter_fallback is False, we don't want to
-                # retry with a different adapter. Raise the original error instead of the fallback error.
+            if isinstance(self, JSONAdapter) or not self.use_json_adapter_fallback:
+                # If already using JSONAdapter, or use_json_adapter_fallback is False, we don't want to retry with a
+                # different adapter. Raise the original error instead of the fallback error.
                 raise
-            return await self._make_json_adapter_fallback().acall(lm, lm_kwargs, signature, demos, inputs)
+            try:
+                return await self._make_json_adapter_fallback().acall(lm, lm_kwargs, signature, demos, inputs)
+            except Exception as fallback_error:
+                raise fallback_error from e
 
     def format_field_description(self, signature: type[Signature]) -> str:
         return (

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -73,7 +73,7 @@ class JSONAdapter(ChatAdapter):
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().__call__)
-        if result:
+        if result is not None:
             return result
 
         try:
@@ -100,7 +100,7 @@ class JSONAdapter(ChatAdapter):
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         result = self._json_adapter_call_common(lm, lm_kwargs, signature, demos, inputs, super().acall)
-        if result:
+        if result is not None:
             return await result
 
         try:

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2866,3 +2866,85 @@ def test_provider_tool_calls_preserve_id_and_repair_arguments():
             dspy.ToolCalls.ToolCall(id="call_from_responses", name="search", args={"query": "cats"})
         ]
     )
+
+
+def test_chat_adapter_non_parse_error_does_not_trigger_fallback():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="[[ ## answer ## ]]\nParis\n\n[[ ## completed ## ]]"))],
+            model="openai/gpt-4o-mini",
+        )
+        lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+        with mock.patch.object(dspy.ChatAdapter, "parse", side_effect=RuntimeError("bug in parse")):
+            with mock.patch("dspy.adapters.json_adapter.JSONAdapter.__call__") as mock_json_adapter_call:
+                with pytest.raises(RuntimeError, match="bug in parse"):
+                    adapter(lm, {}, signature, [], {"question": "What is the capital of France?"})
+
+        mock_json_adapter_call.assert_not_called()
+        assert mock_completion.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_adapter_non_parse_error_does_not_trigger_fallback_async():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+
+    with mock.patch("litellm.acompletion") as mock_acompletion:
+        mock_acompletion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="[[ ## answer ## ]]\nParis\n\n[[ ## completed ## ]]"))],
+            model="openai/gpt-4o-mini",
+        )
+        lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+        with mock.patch.object(dspy.ChatAdapter, "parse", side_effect=RuntimeError("bug in parse")):
+            with mock.patch("dspy.adapters.json_adapter.JSONAdapter.acall") as mock_json_adapter_acall:
+                with pytest.raises(RuntimeError, match="bug in parse"):
+                    await adapter.acall(lm, {}, signature, [], {"question": "What is the capital of France?"})
+
+        mock_json_adapter_acall.assert_not_called()
+        assert mock_acompletion.call_count == 1
+
+
+def test_chat_adapter_fallback_failure_chains_original_error():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="nonsense"))],
+            model="openai/gpt-4o-mini",
+        )
+        lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+        with pytest.raises(dspy.utils.exceptions.AdapterParseError) as exc_info:
+            adapter(lm, {}, signature, [], {"question": "What is the capital of France?"})
+
+    assert exc_info.value.adapter_name == "JSONAdapter"
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, dspy.utils.exceptions.AdapterParseError)
+    assert cause.adapter_name == "ChatAdapter"
+
+
+@pytest.mark.asyncio
+async def test_chat_adapter_fallback_failure_chains_original_error_async():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.ChatAdapter()
+
+    with mock.patch("litellm.acompletion") as mock_acompletion:
+        mock_acompletion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="nonsense"))],
+            model="openai/gpt-4o-mini",
+        )
+        lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+        with pytest.raises(dspy.utils.exceptions.AdapterParseError) as exc_info:
+            await adapter.acall(lm, {}, signature, [], {"question": "What is the capital of France?"})
+
+    assert exc_info.value.adapter_name == "JSONAdapter"
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, dspy.utils.exceptions.AdapterParseError)
+    assert cause.adapter_name == "ChatAdapter"

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1699,3 +1699,33 @@ Outputs will be a JSON object with the following fields.
 In adhering to this structure, your objective is:\x20
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message
+
+
+def test_json_adapter_returns_empty_completions_from_common_call_path():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.JSONAdapter()
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+    with mock.patch("litellm.completion") as mock_completion:
+        with mock.patch.object(dspy.JSONAdapter, "_json_adapter_call_common", return_value=[]):
+            result = adapter(lm, {}, signature, [], {"question": "Dummy question!"})
+
+    assert result == []
+    mock_completion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_json_adapter_returns_empty_completions_from_common_call_path_async():
+    signature = dspy.make_signature("question->answer")
+    adapter = dspy.JSONAdapter()
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+
+    async def empty_completions():
+        return []
+
+    with mock.patch("litellm.acompletion") as mock_acompletion:
+        with mock.patch.object(dspy.JSONAdapter, "_json_adapter_call_common", return_value=empty_completions()):
+            result = await adapter.acall(lm, {}, signature, [], {"question": "Dummy question!"})
+
+    assert result == []
+    mock_acompletion.assert_not_called()


### PR DESCRIPTION
## Summary

Ports dbreunig/dspy#5 to upstream.

- retry through `JSONAdapter` only for `AdapterParseError`
- preserve the original parse failure as the fallback error cause
- distinguish an empty completions result from an unavailable structured-output path
- avoid masking programming and callback errors with a second LM call

Authored by @dbreunig.

## Test plan

- focused sync and async ChatAdapter fallback tests
- empty-completions consistency tests
- upstream CI