### PR TITLE
fix(dspy): make Refine and BestOfN failures consistent

### DIFF
--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -1,7 +1,10 @@
+import logging
 from typing import Callable
 
 import dspy
 from dspy.predict.predict import Module, Prediction
+
+logger = logging.getLogger(__name__)
 
 
 class BestOfN(Module):
@@ -45,13 +48,15 @@ class BestOfN(Module):
         self.reward_fn = lambda *args: reward_fn(*args)  # to prevent this from becoming a parameter
         self.threshold = threshold
         self.N = N
-        self.fail_count = fail_count or N  # default to N if fail_count is not provided
+        self.fail_count = N if fail_count is None else fail_count
 
     def forward(self, **kwargs):
         lm = self.module.get_lm() or dspy.settings.lm
         start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]
         best_pred, best_trace, best_reward = None, None, -float("inf")
+        last_error = None
+        failures = 0
 
         for idx, rid in enumerate(rollout_ids):
             lm_ = lm.copy(rollout_id=rid, temperature=1.0)
@@ -73,11 +78,14 @@ class BestOfN(Module):
                     break
 
             except Exception as e:
-                print(f"BestOfN: Attempt {idx + 1} failed with rollout id {rid}: {e}")
-                if idx > self.fail_count:
-                    raise e
-                self.fail_count -= 1
+                logger.warning(f"BestOfN: Attempt {idx + 1} failed with rollout id {rid}: {e}")
+                last_error = e
+                failures += 1
+                if failures > self.fail_count:
+                    raise
 
         if best_trace:
             dspy.settings.trace.extend(best_trace)
+        if best_pred is None and last_error is not None:
+            raise last_error
         return best_pred

--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 import textwrap
 from typing import Callable
 
@@ -10,6 +11,8 @@ from dspy.predict.predict import Prediction
 from dspy.signatures import InputField, OutputField, Signature
 
 from .predict import Module
+
+logger = logging.getLogger(__name__)
 
 
 class OfferFeedback(Signature):
@@ -88,7 +91,7 @@ class Refine(Module):
         self.reward_fn = lambda *args: reward_fn(*args)  # to prevent this from becoming a parameter
         self.threshold = threshold
         self.N = N
-        self.fail_count = fail_count or N  # default to N if fail_count is not provided
+        self.fail_count = N if fail_count is None else fail_count
         self.module_code = inspect.getsource(module.__class__)
         try:
             self.reward_fn_code = inspect.getsource(reward_fn)
@@ -100,6 +103,8 @@ class Refine(Module):
         start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]
         best_pred, best_trace, best_reward = None, None, -float("inf")
+        last_error = None
+        failures = 0
         advice = None
         adapter = dspy.settings.adapter or dspy.ChatAdapter()
 
@@ -168,12 +173,15 @@ class Refine(Module):
                 # print(f"Advice for each module: {advice}")
 
             except Exception as e:
-                print(f"Refine: Attempt failed with rollout id {rid}: {e}")
-                if idx > self.fail_count:
-                    raise e
-                self.fail_count -= 1
+                logger.warning(f"Refine: Attempt failed with rollout id {rid}: {e}")
+                last_error = e
+                failures += 1
+                if failures > self.fail_count:
+                    raise
         if best_trace:
             dspy.settings.trace.extend(best_trace)
+        if best_pred is None and last_error is not None:
+            raise last_error
         return best_pred
 
 

--- a/tests/predict/test_best_of_n.py
+++ b/tests/predict/test_best_of_n.py
@@ -78,3 +78,37 @@ def test_refine_module_custom_fail_count():
     assert module_call_count[0] == 2, (
         "Module should have been called exactly 2 times, but was called %d times" % module_call_count[0]
     )
+
+
+def test_best_of_n_total_failure_raises_last_error():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+
+    def always_raise(self, **kwargs):
+        raise ValueError("Deliberately failing")
+
+    predict = DummyModule("question -> answer", always_raise)
+
+    best_of_n = BestOfN(module=predict, N=1, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=1)
+    with pytest.raises(ValueError, match="Deliberately failing"):
+        best_of_n(question="What is the capital of Belgium?")
+    assert best_of_n.fail_count == 1
+
+
+def test_best_of_n_zero_fail_count_raises_first_error():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+    module_call_count = 0
+
+    def always_raise(self, **kwargs):
+        nonlocal module_call_count
+        module_call_count += 1
+        raise ValueError("Deliberately failing")
+
+    predict = DummyModule("question -> answer", always_raise)
+    best_of_n = BestOfN(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=0)
+
+    with pytest.raises(ValueError, match="Deliberately failing"):
+        best_of_n(question="What is the capital of Belgium?")
+
+    assert module_call_count == 1

--- a/tests/predict/test_refine.py
+++ b/tests/predict/test_refine.py
@@ -78,3 +78,37 @@ def test_refine_module_custom_fail_count():
     assert module_call_count[0] == 2, (
         "Module should have been called exactly 2 times, but was called %d times" % module_call_count[0]
     )
+
+
+def test_refine_total_failure_raises_last_error():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+
+    def always_raise(self, **kwargs):
+        raise ValueError("Deliberately failing")
+
+    predict = DummyModule("question -> answer", always_raise)
+
+    refine = Refine(module=predict, N=1, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=1)
+    with pytest.raises(ValueError, match="Deliberately failing"):
+        refine(question="What is the capital of Belgium?")
+    assert refine.fail_count == 1
+
+
+def test_refine_zero_fail_count_raises_first_error():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+    module_call_count = 0
+
+    def always_raise(self, **kwargs):
+        nonlocal module_call_count
+        module_call_count += 1
+        raise ValueError("Deliberately failing")
+
+    predict = DummyModule("question -> answer", always_raise)
+    refine = Refine(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=0)
+
+    with pytest.raises(ValueError, match="Deliberately failing"):
+        refine(question="What is the capital of Belgium?")
+
+    assert module_call_count == 1


### PR DESCRIPTION
## Summary

Ports the Refine/BestOfN portion of dbreunig/dspy#6 as an independent upstream change, with failure-budget fixes from upstream review.

- log failed attempts instead of printing them
- raise the final exception when every attempt fails instead of returning `None`
- treat `fail_count` as a per-call allowance rather than mutating instance state
- preserve an explicit `fail_count=0`
- use a bare re-raise when the failure budget is exceeded

Original implementation authored by @dbreunig; failure-budget corrections were added during upstream review.

## Test plan

- `pytest tests/predict/test_refine.py tests/predict/test_best_of_n.py -q` (10 passed)
- focused Ruff check passed
- upstream CI