### PR TITLE
fix(dspy): root CodeInterpreterError under DSPyError

### DIFF
--- a/dspy/primitives/code_interpreter.py
+++ b/dspy/primitives/code_interpreter.py
@@ -9,11 +9,13 @@ code-executing modules to work with different interpreter implementations:
 
 from typing import Any, Callable, Protocol, runtime_checkable
 
+from dspy.utils.exceptions import DSPyError
+
 # Types that can be used directly in Python function signatures for SUBMIT()
 SIMPLE_TYPES = (str, int, float, bool, list, dict, type(None))
 
 
-class CodeInterpreterError(RuntimeError):
+class CodeInterpreterError(DSPyError, RuntimeError):
     """Base class for errors reported by a code interpreter.
 
     A bare instance indicates a failure that submitted code cannot repair, such

--- a/tests/primitives/test_code_interpreter.py
+++ b/tests/primitives/test_code_interpreter.py
@@ -1,0 +1,21 @@
+import dspy
+from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreterError
+
+
+def test_code_interpreter_error_is_dspy_error():
+    error = CodeInterpreterError("boom")
+    assert isinstance(error, dspy.DSPyError)
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "boom"
+    assert error.args == ("boom",)
+
+    try:
+        raise error
+    except RuntimeError as caught:
+        assert caught is error
+
+
+def test_code_execution_error_is_dspy_error():
+    error = CodeExecutionError("boom")
+    assert isinstance(error, dspy.DSPyError)
+    assert isinstance(error, CodeInterpreterError)


### PR DESCRIPTION
## Summary

Ports the code-interpreter portion of dbreunig/dspy#6 as an independent upstream change.

- make `CodeInterpreterError` a `DSPyError`
- retain `RuntimeError` compatibility through multiple inheritance
- apply the taxonomy to `CodeExecutionError` transitively
- verify message, args, and existing `except RuntimeError` behavior

Original implementation authored by @dbreunig, with compatibility assertions added during upstream review.

## Test plan

- `pytest tests/primitives/test_code_interpreter.py -q` (2 passed)
- focused Ruff check passed
- upstream CI