### PR TITLE
Add code interpreter execution instructions

### DIFF
--- a/docs/docs/api/modules/RLM.md
+++ b/docs/docs/api/modules/RLM.md
@@ -111,7 +111,7 @@ $20,000,000
 | `verbose` | `bool` | `False` | Log detailed execution info |
 | `tools` | `list[Union[Callable, dspy.Tool]]` | `None` | Additional tool functions callable from interpreter code |
 | `sub_lm` | `dspy.LM` | `None` | LM for sub-queries. Defaults to `dspy.settings.lm`. Use a cheaper model here. |
-| `interpreter_factory` | `Callable[[], CodeInterpreter]` | `PythonInterpreter` | Creates one interpreter per invocation. RLM shuts down each returned interpreter. |
+| `interpreter_factory` | `Callable[[], CodeInterpreter]` | `PythonInterpreter` | Creates one interpreter per invocation. RLM shuts down each returned interpreter. May expose an optional `execution_instructions` string for the action prompt. |
 
 ## Built-in Tools
 
@@ -200,6 +200,11 @@ rlm = dspy.RLM(
 ```
 
 RLM creates and shuts down one interpreter from this factory per invocation. It adds invocation-scoped tools to the returned interpreter's mutable `tools` dictionary, so remote sandboxes need a `CodeInterpreter` adapter that supports that protocol. To reuse a caller-owned interpreter, pass it as the first positional argument when calling the module: `rlm(interpreter, context=data, query=query)`. RLM updates its tools and output metadata but does not shut down or restore it. Reuse is supported only for sequential calls to the same RLM instance; use the factory path for concurrency.
+
+If the factory exposes an `execution_instructions` string, RLM adds it to the action predictor's task instructions,
+which DSPy adapters place in the system prompt. Optimizers such as GEPA may therefore adapt the execution guidance
+along with the rest of the action policy. Factory classes and configured callable provider objects can expose this
+metadata; anonymous factories without it continue to use the generic action prompt.
 
 ### Custom Sandbox-Serializable Inputs
 

--- a/docs/docs/api/tools/PythonInterpreter.md
+++ b/docs/docs/api/tools/PythonInterpreter.md
@@ -23,6 +23,15 @@ DSPy disables ambient `deno.json`, lockfile, `package.json`, and local `node_mod
 runner. A `package.json` in the current directory or an ancestor therefore cannot redirect the sandbox's pinned
 Pyodide dependency. No `DENO_NO_PACKAGE_JSON` environment variable is required.
 
+## Execution Instructions
+
+`PythonInterpreter.execution_instructions` describes stable constraints of its Pyodide execution environment. It
+is class metadata, so code-generating modules can inspect it without starting Deno or allocating an interpreter.
+`RLM` includes these instructions in its action prompt, which adapters render in the model's system prompt.
+
+Custom interpreter factories may expose their own `execution_instructions` string. This metadata is optional; a
+factory without it remains valid and uses RLM's generic action prompt.
+
 <!-- START_API_REF -->
 ::: dspy.PythonInterpreter
     handler: python

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -56,7 +56,7 @@ ACTION_INSTRUCTIONS_TEMPLATE = """You are tasked with producing the following ou
 {output_fields}
 
 You have access to a Python REPL environment. Write Python code and it will be executed. You will see the output, then write more code based on what you learned. This is an iterative process.
-
+{interpreter_rules}
 Available:
 - Variables: {inputs} (your input data)
 - `llm_query(prompt)` - query a sub-LLM (~500K char capacity) for semantic analysis
@@ -162,7 +162,8 @@ class RLM(Module):
                    Allows using a different (e.g., cheaper) model for sub-queries.
             interpreter_factory: Zero-argument callable that creates an interpreter for each forward pass. The
                 callable may be invoked concurrently, and DSPy shuts down each interpreter it returns. RLM updates
-                the returned interpreter's mutable ``tools`` dictionary before execution.
+                the returned interpreter's mutable ``tools`` dictionary before execution. The callable may expose
+                an ``execution_instructions`` string describing its runtime for the action prompt.
         """
         super().__init__()
         _validate_interpreter_factory(interpreter_factory)
@@ -351,10 +352,15 @@ class RLM(Module):
         # Format tool documentation for user-provided tools
         tool_docs = self._format_tool_docs(self._user_tools)
 
+        execution_instructions = getattr(self._interpreter_factory, "execution_instructions", "")
+        if not isinstance(execution_instructions, str):
+            raise TypeError("interpreter_factory.execution_instructions must be a string")
+        interpreter_rules = f"\nExecution environment:\n{execution_instructions}\n" if execution_instructions else ""
+
         action_sig = (
             dspy.Signature({}, task_instructions + ACTION_INSTRUCTIONS_TEMPLATE.format(
                 inputs=inputs_str, final_output_names=final_output_names, output_fields=output_fields,
-                max_llm_calls=self.max_llm_calls,
+                max_llm_calls=self.max_llm_calls, interpreter_rules=interpreter_rules,
             ) + tool_docs)
             .append("variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str)
             .append("repl_history", dspy.InputField(desc="Previous REPL code executions and their outputs"), type_=REPLHistory)

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -45,7 +45,6 @@ from dspy.utils.annotation import experimental
 from dspy.utils.exceptions import format_error_for_lm
 
 if TYPE_CHECKING:
-
     from dspy.signatures.signature import Signature
 
 logger = logging.getLogger(__name__)
@@ -63,7 +62,8 @@ Available:
 - `llm_query_batched(prompts)` - query multiple prompts concurrently (much faster for multiple queries)
 - `print()` - ALWAYS print to see results
 - `SUBMIT({final_output_names})` - submit final output when done
-- Standard libraries: re, json, collections, math, etc.
+
+The Python facilities and restrictions of this REPL are described in `execution_instructions`.
 
 IMPORTANT: This is ITERATIVE. Each code block you write will execute, you'll see the output, then you decide what to do next. Do NOT try to solve everything in one step.
 
@@ -96,7 +96,7 @@ def _strip_code_fences(code: str) -> str:
 
     # Find the first opening fence (skip any text before it)
     fence_start = code.find("```")
-    lang_line, separator, remainder = code[fence_start + 3:].partition("\n")
+    lang_line, separator, remainder = code[fence_start + 3 :].partition("\n")
     if not separator:
         return code
 
@@ -276,9 +276,7 @@ class RLM(Module):
         def _query_lm(prompt: str) -> str:
             target_lm = lm if lm is not None else dspy.settings.lm
             if target_lm is None:
-                raise dspy.LMNotConfiguredError(
-                    "No LM configured. Use dspy.configure(lm=...) or pass sub_lm to RLM."
-                )
+                raise dspy.LMNotConfiguredError("No LM configured. Use dspy.configure(lm=...) or pass sub_lm to RLM.")
             response = target_lm(prompt)
             if isinstance(response, dspy.LMResponse):
                 text = response.text
@@ -340,10 +338,7 @@ class RLM(Module):
         # Simple names for SUBMIT() examples
         final_output_names = ", ".join(self.signature.output_fields.keys())
 
-        output_fields = "\n".join(
-            f"- {translate_field_type(n, f)}"
-            for n, f in self.signature.output_fields.items()
-        )
+        output_fields = "\n".join(f"- {translate_field_type(n, f)}" for n, f in self.signature.output_fields.items())
 
         # Include original signature instructions (docstring) if present
         task_instructions = f"{self.signature.instructions}\n\n" if self.signature.instructions else ""
@@ -352,15 +347,45 @@ class RLM(Module):
         tool_docs = self._format_tool_docs(self._user_tools)
 
         action_sig = (
-            dspy.Signature({}, task_instructions + ACTION_INSTRUCTIONS_TEMPLATE.format(
-                inputs=inputs_str, final_output_names=final_output_names, output_fields=output_fields,
-                max_llm_calls=self.max_llm_calls,
-            ) + tool_docs)
-            .append("variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str)
-            .append("repl_history", dspy.InputField(desc="Previous REPL code executions and their outputs"), type_=REPLHistory)
-            .append("iteration", dspy.InputField(desc="Current iteration number (1-indexed) out of max_iters"), type_=str)
-            .append("reasoning", dspy.OutputField(desc="Think step-by-step: what do you know? What remains? Plan your next action."), type_=str)
-            .append("code", dspy.OutputField(desc="Python code to execute. Use markdown code block format: ```python\\n<code>\\n```"), type_=str)
+            dspy.Signature(
+                {},
+                task_instructions
+                + ACTION_INSTRUCTIONS_TEMPLATE.format(
+                    inputs=inputs_str,
+                    final_output_names=final_output_names,
+                    output_fields=output_fields,
+                    max_llm_calls=self.max_llm_calls,
+                )
+                + tool_docs,
+            )
+            .append(
+                "execution_instructions",
+                dspy.InputField(desc="Stable instructions and restrictions for the configured code interpreter"),
+                type_=str,
+            )
+            .append(
+                "variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str
+            )
+            .append(
+                "repl_history",
+                dspy.InputField(desc="Previous REPL code executions and their outputs"),
+                type_=REPLHistory,
+            )
+            .append(
+                "iteration", dspy.InputField(desc="Current iteration number (1-indexed) out of max_iters"), type_=str
+            )
+            .append(
+                "reasoning",
+                dspy.OutputField(desc="Think step-by-step: what do you know? What remains? Plan your next action."),
+                type_=str,
+            )
+            .append(
+                "code",
+                dspy.OutputField(
+                    desc="Python code to execute. Use markdown code block format: ```python\\n<code>\\n```"
+                ),
+                type_=str,
+            )
         )
 
         # Extract signature: includes the original signature's output fields and task instructions.
@@ -371,15 +396,21 @@ class RLM(Module):
         # Prepend original task instructions to extract instructions so the LLM knows what task to extract for
         extended_task_instructions = ""
         if task_instructions:
-            extended_task_instructions = "The trajectory was generated with the following objective: \n" + task_instructions + "\n"
+            extended_task_instructions = (
+                "The trajectory was generated with the following objective: \n" + task_instructions + "\n"
+            )
         full_extract_instructions = extended_task_instructions + extract_instructions
 
         extract_sig = dspy.Signature(
             {**self.signature.output_fields},
             full_extract_instructions,
         )
-        extract_sig = extract_sig.prepend("repl_history", dspy.InputField(desc="Your REPL interactions so far"), type_=REPLHistory)
-        extract_sig = extract_sig.prepend("variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str)
+        extract_sig = extract_sig.prepend(
+            "repl_history", dspy.InputField(desc="Your REPL interactions so far"), type_=REPLHistory
+        )
+        extract_sig = extract_sig.prepend(
+            "variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str
+        )
 
         return action_sig, extract_sig
 
@@ -433,7 +464,9 @@ class RLM(Module):
             raise ValueError(f"Missing required inputs: {sorted(missing)}")
 
     def _prepare_serializable_vars(
-        self, input_args: dict[str, Any], repl: CodeInterpreter,
+        self,
+        input_args: dict[str, Any],
+        repl: CodeInterpreter,
     ) -> dict[str, Any]:
         """Inject SandboxSerializable values into the interpreter.
 
@@ -460,10 +493,12 @@ class RLM(Module):
                 except UnicodeDecodeError:
                     encoded_var_name = f"{raw_var_name}_base64"
                     payload_vars[encoded_var_name] = base64.b64encode(payload).decode("ascii")
-                    code_lines.extend([
-                        "import base64",
-                        f"{raw_var_name} = base64.b64decode({encoded_var_name})",
-                    ])
+                    code_lines.extend(
+                        [
+                            "import base64",
+                            f"{raw_var_name} = base64.b64decode({encoded_var_name})",
+                        ]
+                    )
             else:
                 payload_vars[raw_var_name] = str(payload)
 
@@ -481,9 +516,11 @@ class RLM(Module):
     def _make_interpreter_tool(self, tool: Tool) -> Callable:
         """Preserve function metadata while routing execution through Tool."""
         if inspect.iscoroutinefunction(tool.func) or inspect.iscoroutinefunction(getattr(tool.func, "__call__", None)):
+
             async def invoke(**kwargs):
                 return await tool.acall(**kwargs)
         else:
+
             def invoke(**kwargs):
                 return tool(**kwargs)
 
@@ -566,12 +603,18 @@ class RLM(Module):
 
         # Validate raw_output is a dict
         if not isinstance(raw_output, dict):
-            return None, f"[Error] FINAL returned {type(raw_output).__name__}, expected dict with fields: {output_field_names}"
+            return (
+                None,
+                f"[Error] FINAL returned {type(raw_output).__name__}, expected dict with fields: {output_field_names}",
+            )
 
         # Validate all required output fields are present
         missing = set(output_field_names) - set(raw_output.keys())
         if missing:
-            return None, f"[Error] Missing output fields: {sorted(missing)}. Use SUBMIT({', '.join(output_field_names)})"
+            return (
+                None,
+                f"[Error] Missing output fields: {sorted(missing)}. Use SUBMIT({', '.join(output_field_names)})",
+            )
 
         # Parse and validate each output field
         parsed_outputs = {}
@@ -626,9 +669,7 @@ class RLM(Module):
             if error:
                 return history.append(reasoning=pred.reasoning, code=code, output=error)
 
-            final_history = history.append(
-                reasoning=pred.reasoning, code=code, output=f"FINAL: {parsed_outputs}"
-            )
+            final_history = history.append(reasoning=pred.reasoning, code=code, output=f"FINAL: {parsed_outputs}")
             return Prediction(
                 **parsed_outputs,
                 trajectory=[e.model_dump() for e in final_history],
@@ -666,18 +707,19 @@ class RLM(Module):
         iteration: int,
         input_args: dict[str, Any],
         output_field_names: list[str],
+        execution_instructions: str,
     ) -> Prediction | REPLHistory:
         """Execute one iteration. Returns Prediction if done, else updated REPLHistory."""
         variables_info = [variable.format() for variable in variables]
         action = self.generate_action(
+            execution_instructions=execution_instructions,
             variables_info=variables_info,
             repl_history=history,
             iteration=f"{iteration + 1}/{self.max_iters}",
         )
         if self.verbose:
             logger.info(
-                f"RLM iteration {iteration + 1}/{self.max_iters}\n"
-                f"Reasoning: {action.reasoning}\nCode:\n{action.code}"
+                f"RLM iteration {iteration + 1}/{self.max_iters}\nReasoning: {action.reasoning}\nCode:\n{action.code}"
             )
 
         try:
@@ -716,12 +758,17 @@ class RLM(Module):
         variables = self._build_variables(**input_args)
 
         with self._interpreter_context(execution_tools, interpreter) as repl:
+            execution_instructions = getattr(repl, "execution_instructions", "")
+            if not isinstance(execution_instructions, str):
+                raise TypeError(
+                    f"interpreter.execution_instructions must be a string, not {type(execution_instructions).__name__}."
+                )
             regular_args = self._prepare_serializable_vars(input_args, repl)
             history: REPLHistory = REPLHistory(max_output_chars=self.max_output_chars)
 
             for iteration in range(self.max_iters):
                 result: Prediction | REPLHistory = self._execute_iteration(
-                    repl, variables, history, iteration, regular_args, output_field_names
+                    repl, variables, history, iteration, regular_args, output_field_names, execution_instructions
                 )
                 if isinstance(result, Prediction):
                     return result
@@ -759,18 +806,19 @@ class RLM(Module):
         iteration: int,
         input_args: dict[str, Any],
         output_field_names: list[str],
+        execution_instructions: str,
     ) -> Prediction | REPLHistory:
         """Async version: Execute one iteration."""
         variables_info = [variable.format() for variable in variables]
         pred = await self.generate_action.acall(
+            execution_instructions=execution_instructions,
             variables_info=variables_info,
             repl_history=history,
             iteration=f"{iteration + 1}/{self.max_iters}",
         )
         if self.verbose:
             logger.info(
-                f"RLM iteration {iteration + 1}/{self.max_iters}\n"
-                f"Reasoning: {pred.reasoning}\nCode:\n{pred.code}"
+                f"RLM iteration {iteration + 1}/{self.max_iters}\nReasoning: {pred.reasoning}\nCode:\n{pred.code}"
             )
 
         try:
@@ -805,12 +853,17 @@ class RLM(Module):
         variables = self._build_variables(**input_args)
 
         with self._interpreter_context(execution_tools, interpreter) as repl:
+            execution_instructions = getattr(repl, "execution_instructions", "")
+            if not isinstance(execution_instructions, str):
+                raise TypeError(
+                    f"interpreter.execution_instructions must be a string, not {type(execution_instructions).__name__}."
+                )
             regular_args = self._prepare_serializable_vars(input_args, repl)
             history = REPLHistory(max_output_chars=self.max_output_chars)
 
             for iteration in range(self.max_iters):
                 result = await self._aexecute_iteration(
-                    repl, variables, history, iteration, regular_args, output_field_names
+                    repl, variables, history, iteration, regular_args, output_field_names, execution_instructions
                 )
                 if isinstance(result, Prediction):
                     return result

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -182,6 +182,32 @@ class RLM(Module):
         self.generate_action = dspy.Predict(action_sig)
         self.extract = dspy.Predict(extract_sig)
 
+    def load_state(self, state: dict[str, Any], *, allow_unsafe_lm_state: bool = False) -> None:
+        """Load state, upgrading action demos saved before execution instructions were added."""
+        action_state = state.get("generate_action")
+        if action_state:
+            current_fields = self.generate_action.signature.dump_state()["fields"]
+            saved_fields = action_state.get("signature", {}).get("fields", [])
+            legacy_action_state = len(saved_fields) + 1 == len(current_fields) and saved_fields == current_fields[1:]
+            if legacy_action_state:
+                state = dict(state)
+                action_state = dict(action_state)
+                state["generate_action"] = action_state
+
+                signature_state = dict(action_state["signature"])
+                signature_state["fields"] = [current_fields[0], *saved_fields]
+                action_state["signature"] = signature_state
+
+                legacy_fields = set(self.generate_action.signature.fields) - {"execution_instructions"}
+                action_state["demos"] = [
+                    {**demo, "execution_instructions": ""}
+                    if "execution_instructions" not in demo and legacy_fields.issubset(demo)
+                    else demo
+                    for demo in action_state.get("demos", [])
+                ]
+
+        super().load_state(state, allow_unsafe_lm_state=allow_unsafe_lm_state)
+
     # =========================================================================
     # Tool Creation and Validation
     # =========================================================================

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -45,6 +45,7 @@ from dspy.utils.annotation import experimental
 from dspy.utils.exceptions import format_error_for_lm
 
 if TYPE_CHECKING:
+
     from dspy.signatures.signature import Signature
 
 logger = logging.getLogger(__name__)
@@ -96,7 +97,7 @@ def _strip_code_fences(code: str) -> str:
 
     # Find the first opening fence (skip any text before it)
     fence_start = code.find("```")
-    lang_line, separator, remainder = code[fence_start + 3 :].partition("\n")
+    lang_line, separator, remainder = code[fence_start + 3:].partition("\n")
     if not separator:
         return code
 
@@ -276,7 +277,9 @@ class RLM(Module):
         def _query_lm(prompt: str) -> str:
             target_lm = lm if lm is not None else dspy.settings.lm
             if target_lm is None:
-                raise dspy.LMNotConfiguredError("No LM configured. Use dspy.configure(lm=...) or pass sub_lm to RLM.")
+                raise dspy.LMNotConfiguredError(
+                    "No LM configured. Use dspy.configure(lm=...) or pass sub_lm to RLM."
+                )
             response = target_lm(prompt)
             if isinstance(response, dspy.LMResponse):
                 text = response.text
@@ -338,7 +341,10 @@ class RLM(Module):
         # Simple names for SUBMIT() examples
         final_output_names = ", ".join(self.signature.output_fields.keys())
 
-        output_fields = "\n".join(f"- {translate_field_type(n, f)}" for n, f in self.signature.output_fields.items())
+        output_fields = "\n".join(
+            f"- {translate_field_type(n, f)}"
+            for n, f in self.signature.output_fields.items()
+        )
 
         # Include original signature instructions (docstring) if present
         task_instructions = f"{self.signature.instructions}\n\n" if self.signature.instructions else ""
@@ -347,45 +353,16 @@ class RLM(Module):
         tool_docs = self._format_tool_docs(self._user_tools)
 
         action_sig = (
-            dspy.Signature(
-                {},
-                task_instructions
-                + ACTION_INSTRUCTIONS_TEMPLATE.format(
-                    inputs=inputs_str,
-                    final_output_names=final_output_names,
-                    output_fields=output_fields,
-                    max_llm_calls=self.max_llm_calls,
-                )
-                + tool_docs,
-            )
-            .append(
-                "execution_instructions",
-                dspy.InputField(desc="Stable instructions and restrictions for the configured code interpreter"),
-                type_=str,
-            )
-            .append(
-                "variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str
-            )
-            .append(
-                "repl_history",
-                dspy.InputField(desc="Previous REPL code executions and their outputs"),
-                type_=REPLHistory,
-            )
-            .append(
-                "iteration", dspy.InputField(desc="Current iteration number (1-indexed) out of max_iters"), type_=str
-            )
-            .append(
-                "reasoning",
-                dspy.OutputField(desc="Think step-by-step: what do you know? What remains? Plan your next action."),
-                type_=str,
-            )
-            .append(
-                "code",
-                dspy.OutputField(
-                    desc="Python code to execute. Use markdown code block format: ```python\\n<code>\\n```"
-                ),
-                type_=str,
-            )
+            dspy.Signature({}, task_instructions + ACTION_INSTRUCTIONS_TEMPLATE.format(
+                inputs=inputs_str, final_output_names=final_output_names, output_fields=output_fields,
+                max_llm_calls=self.max_llm_calls,
+            ) + tool_docs)
+            .append("execution_instructions", dspy.InputField(desc="Stable instructions and restrictions for the configured code interpreter"), type_=str)
+            .append("variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str)
+            .append("repl_history", dspy.InputField(desc="Previous REPL code executions and their outputs"), type_=REPLHistory)
+            .append("iteration", dspy.InputField(desc="Current iteration number (1-indexed) out of max_iters"), type_=str)
+            .append("reasoning", dspy.OutputField(desc="Think step-by-step: what do you know? What remains? Plan your next action."), type_=str)
+            .append("code", dspy.OutputField(desc="Python code to execute. Use markdown code block format: ```python\\n<code>\\n```"), type_=str)
         )
 
         # Extract signature: includes the original signature's output fields and task instructions.
@@ -396,21 +373,15 @@ class RLM(Module):
         # Prepend original task instructions to extract instructions so the LLM knows what task to extract for
         extended_task_instructions = ""
         if task_instructions:
-            extended_task_instructions = (
-                "The trajectory was generated with the following objective: \n" + task_instructions + "\n"
-            )
+            extended_task_instructions = "The trajectory was generated with the following objective: \n" + task_instructions + "\n"
         full_extract_instructions = extended_task_instructions + extract_instructions
 
         extract_sig = dspy.Signature(
             {**self.signature.output_fields},
             full_extract_instructions,
         )
-        extract_sig = extract_sig.prepend(
-            "repl_history", dspy.InputField(desc="Your REPL interactions so far"), type_=REPLHistory
-        )
-        extract_sig = extract_sig.prepend(
-            "variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str
-        )
+        extract_sig = extract_sig.prepend("repl_history", dspy.InputField(desc="Your REPL interactions so far"), type_=REPLHistory)
+        extract_sig = extract_sig.prepend("variables_info", dspy.InputField(desc="Metadata about the variables available in the REPL"), type_=str)
 
         return action_sig, extract_sig
 
@@ -464,9 +435,7 @@ class RLM(Module):
             raise ValueError(f"Missing required inputs: {sorted(missing)}")
 
     def _prepare_serializable_vars(
-        self,
-        input_args: dict[str, Any],
-        repl: CodeInterpreter,
+        self, input_args: dict[str, Any], repl: CodeInterpreter,
     ) -> dict[str, Any]:
         """Inject SandboxSerializable values into the interpreter.
 
@@ -493,12 +462,10 @@ class RLM(Module):
                 except UnicodeDecodeError:
                     encoded_var_name = f"{raw_var_name}_base64"
                     payload_vars[encoded_var_name] = base64.b64encode(payload).decode("ascii")
-                    code_lines.extend(
-                        [
-                            "import base64",
-                            f"{raw_var_name} = base64.b64decode({encoded_var_name})",
-                        ]
-                    )
+                    code_lines.extend([
+                        "import base64",
+                        f"{raw_var_name} = base64.b64decode({encoded_var_name})",
+                    ])
             else:
                 payload_vars[raw_var_name] = str(payload)
 
@@ -516,11 +483,9 @@ class RLM(Module):
     def _make_interpreter_tool(self, tool: Tool) -> Callable:
         """Preserve function metadata while routing execution through Tool."""
         if inspect.iscoroutinefunction(tool.func) or inspect.iscoroutinefunction(getattr(tool.func, "__call__", None)):
-
             async def invoke(**kwargs):
                 return await tool.acall(**kwargs)
         else:
-
             def invoke(**kwargs):
                 return tool(**kwargs)
 
@@ -603,18 +568,12 @@ class RLM(Module):
 
         # Validate raw_output is a dict
         if not isinstance(raw_output, dict):
-            return (
-                None,
-                f"[Error] FINAL returned {type(raw_output).__name__}, expected dict with fields: {output_field_names}",
-            )
+            return None, f"[Error] FINAL returned {type(raw_output).__name__}, expected dict with fields: {output_field_names}"
 
         # Validate all required output fields are present
         missing = set(output_field_names) - set(raw_output.keys())
         if missing:
-            return (
-                None,
-                f"[Error] Missing output fields: {sorted(missing)}. Use SUBMIT({', '.join(output_field_names)})",
-            )
+            return None, f"[Error] Missing output fields: {sorted(missing)}. Use SUBMIT({', '.join(output_field_names)})"
 
         # Parse and validate each output field
         parsed_outputs = {}
@@ -669,7 +628,9 @@ class RLM(Module):
             if error:
                 return history.append(reasoning=pred.reasoning, code=code, output=error)
 
-            final_history = history.append(reasoning=pred.reasoning, code=code, output=f"FINAL: {parsed_outputs}")
+            final_history = history.append(
+                reasoning=pred.reasoning, code=code, output=f"FINAL: {parsed_outputs}"
+            )
             return Prediction(
                 **parsed_outputs,
                 trajectory=[e.model_dump() for e in final_history],
@@ -719,7 +680,8 @@ class RLM(Module):
         )
         if self.verbose:
             logger.info(
-                f"RLM iteration {iteration + 1}/{self.max_iters}\nReasoning: {action.reasoning}\nCode:\n{action.code}"
+                f"RLM iteration {iteration + 1}/{self.max_iters}\n"
+                f"Reasoning: {action.reasoning}\nCode:\n{action.code}"
             )
 
         try:
@@ -818,7 +780,8 @@ class RLM(Module):
         )
         if self.verbose:
             logger.info(
-                f"RLM iteration {iteration + 1}/{self.max_iters}\nReasoning: {pred.reasoning}\nCode:\n{pred.code}"
+                f"RLM iteration {iteration + 1}/{self.max_iters}\n"
+                f"Reasoning: {pred.reasoning}\nCode:\n{pred.code}"
             )
 
         try:

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -343,6 +343,11 @@ class PythonInterpreter:
         self._pending_large_vars = {}
         self._session_ended = False
 
+    execution_instructions = (
+        "Python runs in Pyodide/WebAssembly. State persists across executions, but subprocesses and native "
+        "extensions are unavailable. Host filesystem, environment, and network access require explicit permission."
+    )
+
     def _check_session_active(self) -> None:
         if self._session_ended:
             raise CodeInterpreterError(

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -202,38 +202,7 @@ class PythonInterpreter:
         self._tools_registered = False
         # TODO later on add enable_run (--allow-run) by proxying subprocess.run through Deno.run() to fix 'emscripten does not support processes' error
 
-        if deno_command:
-            self.deno_command = list(deno_command)
-        else:
-            args = ["deno", "run"]
-
-            # Also allow reading Deno's cache directory so Pyodide can load its files
-            deno_dir = self._get_deno_dir()
-            raw_read_paths = [
-                self._get_runner_path(),
-                *([deno_dir] if deno_dir else []),
-                *self.enable_read_paths,
-                *self.enable_write_paths,
-            ]
-            allowed_read_paths = [_canonicalize_path(p) for p in raw_read_paths]
-            args.append(f"--allow-read={','.join(allowed_read_paths)}")
-
-            self._env_arg = ""
-            if self.enable_env_vars:
-                user_vars = [str(v).strip() for v in self.enable_env_vars]
-                args.append("--allow-env=" + ",".join(user_vars))
-                self._env_arg = ",".join(user_vars)
-            if self.enable_network_access:
-                args.append(f"--allow-net={','.join(str(x) for x in self.enable_network_access)}")
-            if self.enable_write_paths:
-                args.append(f"--allow-write={','.join(_canonicalize_path(x) for x in self.enable_write_paths)}")
-
-            args.append(_canonicalize_path(self._get_runner_path()))
-
-            # For runner.js to load in env vars
-            if self._env_arg:
-                args.append(self._env_arg)
-            self.deno_command = args
+        self._deno_command = list(deno_command) if deno_command else None
 
         self.deno_process = None
         self._mounted_files = False
@@ -241,6 +210,54 @@ class PythonInterpreter:
         self._owner_thread: int | None = None
         self._pending_large_vars = {}
         self._session_ended = False
+
+    @property
+    def execution_instructions(self) -> str:
+        """Describe stable constraints of the Deno/Pyodide execution environment."""
+        return (
+            "Code runs as Python in Pyodide inside a Deno-hosted WebAssembly environment. "
+            "State, imports, functions, and variables persist across executions in this session. "
+            "Pure-Python and Pyodide-compatible packages may be available; ordinary CPython native "
+            "extensions and subprocesses are unavailable. Host filesystem, environment, and network "
+            "access are unavailable unless explicitly enabled. Use the provided host tools for "
+            "capabilities not available in the sandbox."
+        )
+
+    @property
+    def deno_command(self) -> list[str]:
+        """Return the Deno command, resolving the cache directory lazily."""
+        if self._deno_command is None:
+            self._deno_command = self._build_deno_command()
+        return self._deno_command
+
+    def _build_deno_command(self) -> list[str]:
+        args = ["deno", "run"]
+
+        # Also allow reading Deno's cache directory so Pyodide can load its files.
+        deno_dir = self._get_deno_dir()
+        raw_read_paths = [
+            self._get_runner_path(),
+            *([deno_dir] if deno_dir else []),
+            *self.enable_read_paths,
+            *self.enable_write_paths,
+        ]
+        allowed_read_paths = [_canonicalize_path(p) for p in raw_read_paths]
+        args.append(f"--allow-read={','.join(allowed_read_paths)}")
+
+        env_arg = ""
+        if self.enable_env_vars:
+            user_vars = [str(v).strip() for v in self.enable_env_vars]
+            args.append("--allow-env=" + ",".join(user_vars))
+            env_arg = ",".join(user_vars)
+        if self.enable_network_access:
+            args.append(f"--allow-net={','.join(str(x) for x in self.enable_network_access)}")
+        if self.enable_write_paths:
+            args.append(f"--allow-write={','.join(_canonicalize_path(x) for x in self.enable_write_paths)}")
+
+        args.append(_canonicalize_path(self._get_runner_path()))
+        if env_arg:
+            args.append(env_arg)
+        return args
 
     def _check_session_active(self) -> None:
         if self._session_ended:
@@ -292,12 +309,7 @@ class PythonInterpreter:
             return os.environ["DENO_DIR"]
 
         try:
-            result = subprocess.run(
-                ["deno", "info", "--json"],
-                capture_output=True,
-                text=True,
-                check=False
-            )
+            result = subprocess.run(["deno", "info", "--json"], capture_output=True, text=True, check=False)
             if result.returncode == 0:
                 info = json.loads(result.stdout)
                 return info.get("denoDir")
@@ -372,10 +384,7 @@ class PythonInterpreter:
         if self.tools:
             tools_info = []
             for name, fn in self.tools.items():
-                tools_info.append({
-                    "name": name,
-                    "parameters": self._extract_parameters(fn)
-                })
+                tools_info.append({"name": name, "parameters": self._extract_parameters(fn)})
             params["tools"] = tools_info
 
         if self.output_fields:
@@ -404,10 +413,14 @@ class PythonInterpreter:
                 result = _await_in_sync(result)
             result = _make_jsonable(result)
             if result is None or isinstance(result, str):
-                response = _jsonrpc_result({"value": str(result) if result is not None else "", "type": "string"}, request_id)
+                response = _jsonrpc_result(
+                    {"value": str(result) if result is not None else "", "type": "string"}, request_id
+                )
             else:
                 try:
-                    response = _jsonrpc_result({"value": json.dumps(result, allow_nan=False), "type": "json"}, request_id)
+                    response = _jsonrpc_result(
+                        {"value": json.dumps(result, allow_nan=False), "type": "json"}, request_id
+                    )
                 except (TypeError, ValueError):
                     response = _jsonrpc_result({"value": str(result), "type": "string"}, request_id)
         except Exception as e:
@@ -437,7 +450,7 @@ class PythonInterpreter:
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="UTF-8",
-                env=os.environ.copy()
+                env=os.environ.copy(),
             )
         except FileNotFoundError as e:
             install_instructions = (
@@ -591,10 +604,7 @@ class PythonInterpreter:
             items = ", ".join(self._serialize_value(item) for item in value)
             return f"[{items}]"
         elif isinstance(value, dict):
-            items = ", ".join(
-                f"{self._serialize_value(k)}: {self._serialize_value(v)}"
-                for k, v in value.items()
-            )
+            items = ", ".join(f"{self._serialize_value(k)}: {self._serialize_value(v)}" for k, v in value.items())
             return f"{{{items}}}"
         elif isinstance(value, set):
             # Sets become sorted lists (or unsorted if mixed types) for JSON compatibility

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -309,7 +309,12 @@ class PythonInterpreter:
             return os.environ["DENO_DIR"]
 
         try:
-            result = subprocess.run(["deno", "info", "--json"], capture_output=True, text=True, check=False)
+            result = subprocess.run(
+                ["deno", "info", "--json"],
+                capture_output=True,
+                text=True,
+                check=False
+            )
             if result.returncode == 0:
                 info = json.loads(result.stdout)
                 return info.get("denoDir")
@@ -384,7 +389,10 @@ class PythonInterpreter:
         if self.tools:
             tools_info = []
             for name, fn in self.tools.items():
-                tools_info.append({"name": name, "parameters": self._extract_parameters(fn)})
+                tools_info.append({
+                    "name": name,
+                    "parameters": self._extract_parameters(fn)
+                })
             params["tools"] = tools_info
 
         if self.output_fields:
@@ -413,14 +421,10 @@ class PythonInterpreter:
                 result = _await_in_sync(result)
             result = _make_jsonable(result)
             if result is None or isinstance(result, str):
-                response = _jsonrpc_result(
-                    {"value": str(result) if result is not None else "", "type": "string"}, request_id
-                )
+                response = _jsonrpc_result({"value": str(result) if result is not None else "", "type": "string"}, request_id)
             else:
                 try:
-                    response = _jsonrpc_result(
-                        {"value": json.dumps(result, allow_nan=False), "type": "json"}, request_id
-                    )
+                    response = _jsonrpc_result({"value": json.dumps(result, allow_nan=False), "type": "json"}, request_id)
                 except (TypeError, ValueError):
                     response = _jsonrpc_result({"value": str(result), "type": "string"}, request_id)
         except Exception as e:
@@ -450,7 +454,7 @@ class PythonInterpreter:
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="UTF-8",
-                env=os.environ.copy(),
+                env=os.environ.copy()
             )
         except FileNotFoundError as e:
             install_instructions = (
@@ -604,7 +608,10 @@ class PythonInterpreter:
             items = ", ".join(self._serialize_value(item) for item in value)
             return f"[{items}]"
         elif isinstance(value, dict):
-            items = ", ".join(f"{self._serialize_value(k)}: {self._serialize_value(v)}" for k, v in value.items())
+            items = ", ".join(
+                f"{self._serialize_value(k)}: {self._serialize_value(v)}"
+                for k, v in value.items()
+            )
             return f"{{{items}}}"
         elif isinstance(value, set):
             # Sets become sorted lists (or unsorted if mixed types) for JSON compatibility

--- a/tests/predict/snapshots/rlm_python_interpreter_lm_request.json
+++ b/tests/predict/snapshots/rlm_python_interpreter_lm_request.json
@@ -1,0 +1,48 @@
+{
+  "model": "snapshot-model",
+  "messages": [
+    {
+      "role": "system",
+      "parts": [
+        {
+          "type": "text",
+          "metadata": {},
+          "text": "Your input fields are:\n1. `variables_info` (str): Metadata about the variables available in the REPL\n2. `repl_history` (REPLHistory): Previous REPL code executions and their outputs\n3. `iteration` (str): Current iteration number (1-indexed) out of max_iters\nYour output fields are:\n1. `reasoning` (str): Think step-by-step: what do you know? What remains? Plan your next action.\n2. `code` (str): Python code to execute. Use markdown code block format: ```python\\n<code>\\n```\nAll interactions will be structured in the following way, with the appropriate values filled in.\n\n[[ ## variables_info ## ]]\n{variables_info}\n\n[[ ## repl_history ## ]]\n{repl_history}\n\n[[ ## iteration ## ]]\n{iteration}\n\n[[ ## reasoning ## ]]\n{reasoning}\n\n[[ ## code ## ]]\n{code}\n\n[[ ## completed ## ]]\nIn adhering to this structure, your objective is: \n        Given the fields `query`, produce the fields `answer`.\n        \n        You are tasked with producing the following outputs given the inputs `query`:\n        - {answer}\n        \n        You have access to a Python REPL environment. Write Python code and it will be executed. You will see the output, then write more code based on what you learned. This is an iterative process.\n        \n        Execution environment:\n        Python runs in Pyodide/WebAssembly. State persists across executions, but subprocesses and native extensions are unavailable. Host filesystem, environment, and network access require explicit permission.\n        \n        Available:\n        - Variables: `query` (your input data)\n        - `llm_query(prompt)` - query a sub-LLM (~500K char capacity) for semantic analysis\n        - `llm_query_batched(prompts)` - query multiple prompts concurrently (much faster for multiple queries)\n        - `print()` - ALWAYS print to see results\n        - `SUBMIT(answer)` - submit final output when done\n        - Standard libraries: re, json, collections, math, etc.\n        \n        IMPORTANT: This is ITERATIVE. Each code block you write will execute, you'll see the output, then you decide what to do next. Do NOT try to solve everything in one step.\n        \n        1. EXPLORE FIRST - Look at your data before processing it. Print samples, check types/lengths, understand the structure.\n        2. ITERATE - Write small code snippets, observe outputs, then decide next steps. State persists between iterations.\n        3. VERIFY BEFORE SUBMITTING - If results seem wrong (zeros, empty, unexpected), reconsider your approach.\n        4. USE llm_query FOR SEMANTICS - String matching finds WHERE things are; llm_query understands WHAT things mean.\n        5. MINIMIZE RETYPING (INPUTS & OUTPUTS) - When values are long, precise, or error-prone (IDs, numbers, code, quotes), re-access them via variables and parse/compute in code instead of retyping. Use small, targeted prints to sanity-check, but avoid manual copying when variables can carry the exact value.\n        6. SUBMIT ONLY AFTER SEEING OUTPUTS - SUBMIT ends the current run immediately. If you need to inspect printed output, run it in one step, review the result, then call SUBMIT in a later step.\n        \n        You have max 50 sub-LLM calls. When done, call SUBMIT() with your output."
+        }
+      ],
+      "name": null,
+      "metadata": {}
+    },
+    {
+      "role": "user",
+      "parts": [
+        {
+          "type": "text",
+          "metadata": {},
+          "text": "[[ ## variables_info ## ]]\n«query: str»\n\n[[ ## repl_history ## ]]\nYou have not interacted with the REPL environment yet.\n\n[[ ## iteration ## ]]\n1/20\n\nRespond with the corresponding output fields, starting with the field `[[ ## reasoning ## ]]`, then `[[ ## code ## ]]`, and then ending with the marker for `[[ ## completed ## ]]`."
+        }
+      ],
+      "name": null,
+      "metadata": {}
+    }
+  ],
+  "tools": [],
+  "config": {
+    "temperature": 0.0,
+    "max_tokens": 1000,
+    "top_p": null,
+    "stop": null,
+    "n": null,
+    "logprobs": null,
+    "response_format": null,
+    "reasoning": null,
+    "tool_choice": null,
+    "cache": {
+      "enabled": false,
+      "rollout_id": null
+    },
+    "prompt_cache": null,
+    "extensions": {}
+  },
+  "metadata": {}
+}

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -8,9 +8,11 @@ Test organization:
 
 import base64
 from contextlib import contextmanager
+from pathlib import Path
 
 import pytest
 
+import dspy
 from dspy.adapters.types.tool import Tool
 from dspy.predict.rlm import RLM, _strip_code_fences
 from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreterError, FinalOutput
@@ -426,6 +428,46 @@ class TestRLMInitialization:
 
 
 class TestRLMInterpreterLifecycle:
+    def test_execution_instructions_are_part_of_action_prompt(self):
+        class Factory(MockInterpreterFactory):
+            execution_instructions = "Use this runtime."
+
+        signature = RLM("query -> answer", interpreter_factory=Factory()).generate_action.signature
+        optimized = signature.with_instructions("Optimized instructions")
+
+        assert "Use this runtime." in signature.instructions
+        assert optimized.instructions == "Optimized instructions"
+
+    def test_python_interpreter_lm_request_bytes(self):
+        class StopLMCall(BaseException):
+            pass
+
+        class CapturingLM(dspy.BaseLM):
+            forward_contract = "typed_lm"
+
+            def __init__(self):
+                super().__init__("snapshot-model", temperature=0.0, max_tokens=1000, cache=False)
+                self.request = None
+
+            def forward(self, request):
+                self.request = request
+                raise StopLMCall
+
+        lm = CapturingLM()
+        rlm = RLM("query -> answer", interpreter_factory=PythonInterpreter)
+
+        with pytest.raises(StopLMCall), dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+            rlm.generate_action(
+                variables_info=["query: str"],
+                repl_history=REPLHistory(),
+                iteration="1/20",
+            )
+
+        request = lm.request.model_dump_json(indent=2).encode()
+        snapshot = Path(__file__).with_name("snapshots") / "rlm_python_interpreter_lm_request.json"
+
+        assert request == snapshot.read_bytes().removesuffix(b"\n")
+
     def test_interpreter_remains_available_as_signature_input(self):
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "CPython"})])
         rlm = RLM("interpreter -> answer", max_iters=1, interpreter_factory=factory)

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -7,6 +7,7 @@ Test organization:
 """
 
 import base64
+import json
 from contextlib import contextmanager
 
 import pytest
@@ -243,6 +244,41 @@ class TestRLMInitialization:
         assert rlm.max_llm_calls == 100
         assert rlm.sub_lm is mock_lm
         assert rlm._interpreter_factory is MockInterpreter
+
+    def test_load_migrates_legacy_action_demos(self, tmp_path):
+        import dspy
+
+        rlm = RLM("context -> answer", interpreter_factory=MockInterpreter)
+        rlm.generate_action.demos = [
+            {
+                "variables_info": "context: str",
+                "repl_history": REPLHistory(),
+                "iteration": "1/20",
+                "reasoning": "Inspect the context.",
+                "code": "```python\nprint(context)\n```",
+            }
+        ]
+        path = tmp_path / "legacy_rlm.json"
+        rlm.save(path)
+
+        state = json.loads(path.read_text())
+        action_state = state["generate_action"]
+        action_state["signature"]["fields"].pop(0)  # execution_instructions did not exist
+        path.write_text(json.dumps(state))
+
+        loaded = RLM("context -> answer", interpreter_factory=MockInterpreter)
+        loaded.load(path)
+
+        demo = loaded.generate_action.demos[0]
+        assert demo["execution_instructions"] == ""
+        assert (
+            loaded.generate_action.signature.fields["variables_info"].json_schema_extra["prefix"]
+            == "Variables Info:"
+        )
+        messages = dspy.ChatAdapter().format_demos(loaded.generate_action.signature, loaded.generate_action.demos)
+        assert not any(
+            "though some input or output fields are not supplied" in message["content"] for message in messages
+        )
 
     def test_forward_validates_required_inputs(self):
         """Test that forward() raises ValueError for missing required inputs."""

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -36,6 +36,7 @@ def make_mock_predictor(responses: list[dict], async_mode: bool = False):
     class MockPredictor:
         def __init__(self):
             self.idx = 0
+            self.calls = []
 
         def _next_response(self):
             result = responses[self.idx % len(responses)]
@@ -43,9 +44,11 @@ def make_mock_predictor(responses: list[dict], async_mode: bool = False):
             return Prediction(**result)
 
         def __call__(self, **kwargs):
+            self.calls.append(kwargs)
             return self._next_response()
 
         async def acall(self, **kwargs):
+            self.calls.append(kwargs)
             return self._next_response()
 
     return MockPredictor()
@@ -76,6 +79,7 @@ def add_tool(a: int = 0, b: int = 0) -> str:
 def multiply_tool(a: int = 0, b: int = 0) -> str:
     """Multiply two numbers."""
     return str(a * b)
+
 
 # ============================================================================
 # Unit Tests: MockInterpreter
@@ -143,6 +147,7 @@ class TestRLMInitialization:
 
     def test_custom_tools(self):
         """Test RLM with custom tools."""
+
         def custom_tool(x: str = "") -> str:
             return x.upper()
 
@@ -153,6 +158,7 @@ class TestRLMInitialization:
     @pytest.mark.parametrize("tool_name", ["invalid-name", "123start"])
     def test_tool_validation_invalid_identifier(self, tool_name):
         """Test RLM rejects tool names that aren't valid Python identifiers."""
+
         def my_tool() -> str:
             return "result"
 
@@ -171,6 +177,7 @@ class TestRLMInitialization:
     @pytest.mark.parametrize("tool_name", ["llm_query", "llm_query_batched", "SUBMIT", "print"])
     def test_tool_validation_reserved_names(self, tool_name):
         """Test RLM rejects tool names that conflict with built-in functions."""
+
         def my_tool() -> str:
             return "result"
 
@@ -186,6 +193,7 @@ class TestRLMInitialization:
 
     def test_tools_dict_rejected(self):
         """Test RLM rejects dict format for tools with helpful error."""
+
         def my_tool() -> str:
             return "result"
 
@@ -311,6 +319,7 @@ class TestRLMInitialization:
 
         with pytest.raises(TypeError, match="Sub-LM response must contain text, got NoneType"):
             tools["llm_query"]("test prompt")
+
     @pytest.mark.parametrize("unexpected_name", ["SUBMIT", "lookup", "tools"])
     def test_forward_rejects_undeclared_inputs_before_interpreter_execution(self, unexpected_name):
         def lookup() -> str:
@@ -318,11 +327,15 @@ class TestRLMInitialization:
 
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "done"})])
         rlm = RLM("context -> answer", tools=[lookup], interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+            ]
+        )
 
-        with pytest.raises(ValueError, match=f"Unexpected inputs not declared in the signature: \\['{unexpected_name}'\\]"):
+        with pytest.raises(
+            ValueError, match=f"Unexpected inputs not declared in the signature: \\['{unexpected_name}'\\]"
+        ):
             rlm(context="some context", **{unexpected_name: "shadowed value"})
 
         assert factory.instances == []
@@ -426,12 +439,63 @@ class TestRLMInitialization:
 
 
 class TestRLMInterpreterLifecycle:
+    def test_execution_instructions_are_read_before_start_and_passed_to_action(self):
+        events = []
+
+        class InstructedInterpreter(MockInterpreter):
+            @property
+            def execution_instructions(self):
+                events.append("instructions")
+                return "Use this restricted runtime."
+
+            def start(self):
+                events.append("start")
+
+        interpreter = InstructedInterpreter(responses=[FinalOutput({"answer": "42"})])
+        rlm = RLM("query -> answer", max_iters=1)
+        predictor = make_mock_predictor([{"reasoning": "Return answer", "code": "SUBMIT('42')"}])
+        rlm.generate_action = predictor
+
+        result = rlm(interpreter, query="test")
+
+        assert result.answer == "42"
+        assert events == ["instructions", "start"]
+        assert predictor.calls[0]["execution_instructions"] == "Use this restricted runtime."
+
+    @pytest.mark.asyncio
+    async def test_async_execution_passes_execution_instructions(self):
+        class InstructedInterpreter(MockInterpreter):
+            execution_instructions = "Async runtime instructions."
+
+        interpreter = InstructedInterpreter(responses=[FinalOutput({"answer": "42"})])
+        rlm = RLM("query -> answer", max_iters=1)
+        predictor = make_mock_predictor([{"reasoning": "Return answer", "code": "SUBMIT('42')"}])
+        rlm.generate_action = predictor
+
+        result = await rlm.acall(interpreter, query="test")
+
+        assert result.answer == "42"
+        assert predictor.calls[0]["execution_instructions"] == "Async runtime instructions."
+
+    def test_legacy_interpreter_uses_empty_execution_instructions(self):
+        interpreter = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
+        rlm = RLM("query -> answer", max_iters=1)
+        predictor = make_mock_predictor([{"reasoning": "Return answer", "code": "SUBMIT('42')"}])
+        rlm.generate_action = predictor
+
+        result = rlm(interpreter, query="test")
+
+        assert result.answer == "42"
+        assert predictor.calls[0]["execution_instructions"] == ""
+
     def test_interpreter_remains_available_as_signature_input(self):
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "CPython"})])
         rlm = RLM("interpreter -> answer", max_iters=1, interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return input", "code": "SUBMIT(interpreter)"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return input", "code": "SUBMIT(interpreter)"},
+            ]
+        )
 
         result = rlm(interpreter="CPython")
 
@@ -442,9 +506,11 @@ class TestRLMInterpreterLifecycle:
     async def test_factory_creates_and_shuts_down_one_interpreter_per_call(self):
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=1, interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
+            ]
+        )
 
         sync_result = rlm(query="sync")
         async_result = await rlm.acall(query="async")
@@ -467,9 +533,11 @@ class TestRLMInterpreterLifecycle:
             ]
         )
         rlm = RLM("query -> answer", max_iters=1, interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return answer", "code": "SUBMIT(answer)"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return answer", "code": "SUBMIT(answer)"},
+            ]
+        )
 
         try:
             sync_result = rlm(interpreter, query="sync")
@@ -557,6 +625,11 @@ class TestRLMFormatting:
         action_sig = rlm.generate_action.signature
         assert "iteration" in action_sig.input_fields
 
+    def test_action_signature_has_execution_instructions_field(self):
+        rlm = RLM("context -> answer")
+
+        assert "execution_instructions" in rlm.generate_action.signature.input_fields
+
     def test_format_output(self):
         """Test output formatting."""
         rlm = RLM("context -> answer")
@@ -598,10 +671,7 @@ class TestRLMFormatting:
     def test_build_variables_multiple(self):
         """Test building multiple variables."""
         rlm = RLM("context, query -> answer")
-        variables = rlm._build_variables(
-            context="Hello world",
-            query="What is this?"
-        )
+        variables = rlm._build_variables(context="Hello world", query="What is this?")
         assert len(variables) == 2
         formatted = "\n\n".join(v.format() for v in variables)
         assert "Variable: `context`" in formatted
@@ -720,6 +790,7 @@ class TestREPLTypes:
 
         class QASig(dspy.Signature):
             """Answer questions."""
+
             context: str = dspy.InputField(desc="Background information")
             question: str = dspy.InputField(desc="The question to answer")
             answer: str = dspy.OutputField()
@@ -742,9 +813,11 @@ class TestRLMCallMethod:
         """Test that __call__ is an alias for forward()."""
         mock = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
+            ]
+        )
 
         result = rlm(mock, query="What is the answer?")
         assert result.answer == "42"
@@ -755,21 +828,27 @@ class TestRLMMaxIterationsFallback:
 
     def test_max_iters_triggers_extract(self):
         """Test that reaching max_iters uses extract fallback."""
-        mock = MockInterpreter(responses=[
-            "exploring...",
-            "still exploring...",
-            "more exploring...",
-        ])
+        mock = MockInterpreter(
+            responses=[
+                "exploring...",
+                "still exploring...",
+                "more exploring...",
+            ]
+        )
         rlm = RLM("query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Explore 1", "code": "print('exploring')"},
-            {"reasoning": "Explore 2", "code": "print('exploring')"},
-            {"reasoning": "Explore 3", "code": "print('exploring')"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Explore 1", "code": "print('exploring')"},
+                {"reasoning": "Explore 2", "code": "print('exploring')"},
+                {"reasoning": "Explore 3", "code": "print('exploring')"},
+            ]
+        )
         # Mock the extract predictor to return a value
-        rlm.extract = make_mock_predictor([
-            {"answer": "extracted_answer"},
-        ])
+        rlm.extract = make_mock_predictor(
+            [
+                {"answer": "extracted_answer"},
+            ]
+        )
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "extracted_answer"
@@ -781,33 +860,42 @@ class TestRLMToolExceptions:
 
     def test_tool_exception_returns_error_in_output(self):
         """Test that tool exceptions are caught and returned as errors."""
+
         def failing_tool() -> str:
             raise RuntimeError("Tool failed!")
 
-        mock = MockInterpreter(responses=[
-            CodeExecutionError("RuntimeError: Tool failed!"),
-            FinalOutput({"answer": "recovered"}),
-        ])
+        mock = MockInterpreter(
+            responses=[
+                CodeExecutionError("RuntimeError: Tool failed!"),
+                FinalOutput({"answer": "recovered"}),
+            ]
+        )
         rlm = RLM("query -> answer", max_iters=5, tools=[failing_tool])
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Call tool", "code": "failing_tool()"},
-            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Call tool", "code": "failing_tool()"},
+                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+            ]
+        )
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
 
     def test_runtime_error_history_uses_stripped_code(self):
         """Runtime execution failures should preserve stripped code in history."""
-        mock = MockInterpreter(responses=[
-            CodeExecutionError("NameError: name 'x' is not defined"),
-            FinalOutput({"answer": "recovered"}),
-        ])
+        mock = MockInterpreter(
+            responses=[
+                CodeExecutionError("NameError: name 'x' is not defined"),
+                FinalOutput({"answer": "recovered"}),
+            ]
+        )
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Will fail", "code": "```python\nprint(x)\n```"},
-            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Will fail", "code": "```python\nprint(x)\n```"},
+                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+            ]
+        )
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
@@ -816,15 +904,19 @@ class TestRLMToolExceptions:
 
     def test_syntax_error_from_execute_is_recoverable(self):
         """SyntaxError from interpreter.execute should be surfaced as an iteration error."""
-        mock = MockInterpreter(responses=[
-            SyntaxError("invalid syntax"),
-            FinalOutput({"answer": "recovered"}),
-        ])
+        mock = MockInterpreter(
+            responses=[
+                SyntaxError("invalid syntax"),
+                FinalOutput({"answer": "recovered"}),
+            ]
+        )
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Bad code", "code": "```python\ndef incomplete(\n```"},
-            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Bad code", "code": "```python\ndef incomplete(\n```"},
+                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+            ]
+        )
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
@@ -832,14 +924,18 @@ class TestRLMToolExceptions:
 
     def test_syntax_error_from_strip_code_fences_is_recoverable(self):
         """SyntaxError raised by _strip_code_fences (e.g. non-Python fence tag) should be recoverable."""
-        mock = MockInterpreter(responses=[
-            FinalOutput({"answer": "recovered"}),
-        ])
+        mock = MockInterpreter(
+            responses=[
+                FinalOutput({"answer": "recovered"}),
+            ]
+        )
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Wrong language", "code": "```bash\nls -la\n```"},
-            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Wrong language", "code": "```bash\nls -la\n```"},
+                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+            ]
+        )
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
@@ -847,6 +943,7 @@ class TestRLMToolExceptions:
 
     def test_interpreter_failure_propagates(self):
         """Process and protocol failures must not fall through to LM extraction."""
+
         def fail_generated_code(code, variables):
             if code == "pass":
                 return ""
@@ -854,9 +951,11 @@ class TestRLMToolExceptions:
 
         mock = MockInterpreter(execute_fn=fail_generated_code)
         rlm = RLM("query -> answer", max_iters=1)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Try code", "code": "print('test')"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Try code", "code": "print('test')"},
+            ]
+        )
         rlm.extract = make_mock_predictor([{"answer": "hallucinated"}])
 
         with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
@@ -865,6 +964,7 @@ class TestRLMToolExceptions:
     @pytest.mark.asyncio
     async def test_interpreter_failure_propagates_async(self):
         """Async process and protocol failures must not fall through to LM extraction."""
+
         def fail_generated_code(code, variables):
             if code == "pass":
                 return ""
@@ -872,9 +972,11 @@ class TestRLMToolExceptions:
 
         mock = MockInterpreter(execute_fn=fail_generated_code)
         rlm = RLM("query -> answer", max_iters=1)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Try code", "code": "print('test')"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Try code", "code": "print('test')"},
+            ]
+        )
         rlm.extract = make_mock_predictor([{"answer": "hallucinated"}])
 
         with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
@@ -961,38 +1063,29 @@ class TestPythonInterpreter:
     def test_variable_injection(self, pooled_interpreter):
         """Test variable injection."""
         interp = pooled_interpreter
-        result = interp.execute(
-            "print(x + y)",
-            variables={"x": 10, "y": 5}
-        )
+        result = interp.execute("print(x + y)", variables={"x": 10, "y": 5})
         assert "15" in result
 
     def test_variable_injection_with_none_values(self, pooled_interpreter):
         """Test variable injection with None values in dicts/lists (JSON null -> Python None)."""
         interp = pooled_interpreter
         # Test None in dict
-        result = interp.execute(
-            "print(data['key'] is None)",
-            variables={"data": {"key": None, "other": "value"}}
-        )
+        result = interp.execute("print(data['key'] is None)", variables={"data": {"key": None, "other": "value"}})
         assert "True" in result
 
         # Test None in list
-        result = interp.execute(
-            "print(items[1] is None)",
-            variables={"items": [1, None, 3]}
-        )
+        result = interp.execute("print(items[1] is None)", variables={"items": [1, None, 3]})
         assert "True" in result
 
         # Test nested None
         result = interp.execute(
-            "print(nested['inner']['value'] is None)",
-            variables={"nested": {"inner": {"value": None}}}
+            "print(nested['inner']['value'] is None)", variables={"nested": {"inner": {"value": None}}}
         )
         assert "True" in result
 
     def test_tool_call_kwargs(self, configure_pooled_interpreter):
         """Test tool call with keyword arguments."""
+
         def echo(message: str = "") -> str:
             return f"Echo: {message}"
 
@@ -1002,6 +1095,7 @@ class TestPythonInterpreter:
 
     def test_tool_call_positional(self, configure_pooled_interpreter):
         """Test tool call with positional arguments."""
+
         def greet(name: str) -> str:
             return f"Hello: {name}"
 
@@ -1011,6 +1105,7 @@ class TestPythonInterpreter:
 
     def test_multiple_tools(self, configure_pooled_interpreter):
         """Test multiple tools."""
+
         def add(a: int = 0, b: int = 0) -> str:
             return str(a + b)
 
@@ -1028,6 +1123,7 @@ print(f"Sum: {sum_result}, Product: {prod_result}")
 
     def test_tool_returns_list(self, configure_pooled_interpreter):
         """Test tool that returns a list (like llm_query_batched)."""
+
         def batch_process(items: list | None = None) -> list:
             items = items or []
             return [f"processed_{item}" for item in items]
@@ -1046,6 +1142,7 @@ print(f"All: {results}")
 
     def test_tool_returns_dict(self, configure_pooled_interpreter):
         """Test tool that returns a dict."""
+
         def get_info() -> dict:
             return {"name": "test", "count": 42}
 
@@ -1120,9 +1217,11 @@ class TestRLMAsyncMock:
     async def test_aforward_rejects_undeclared_inputs_before_interpreter_execution(self):
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "done"})])
         rlm = RLM("context -> answer", interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+            ]
+        )
 
         with pytest.raises(ValueError, match="Unexpected inputs not declared in the signature: \\['SUBMIT'\\]"):
             await rlm.acall(context="some context", SUBMIT="shadowed value")
@@ -1134,9 +1233,11 @@ class TestRLMAsyncMock:
         """Test aforward() returns Prediction with expected output (MockInterpreter)."""
         mock = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
+            ]
+        )
 
         result = await rlm.aforward(mock, query="What is the answer?")
         assert result.answer == "42"
@@ -1146,9 +1247,11 @@ class TestRLMAsyncMock:
         """Test aforward() returns int when signature expects int (MockInterpreter)."""
         mock = MockInterpreter(responses=[FinalOutput({"count": 42})])
         rlm = RLM("query -> count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return count", "code": "SUBMIT(42)"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return count", "code": "SUBMIT(42)"},
+            ]
+        )
 
         result = await rlm.aforward(mock, query="count items")
         assert result.count == 42
@@ -1157,15 +1260,19 @@ class TestRLMAsyncMock:
     @pytest.mark.asyncio
     async def test_aforward_multi_iteration_mock(self):
         """Test aforward() handles multiple iterations before SUBMIT (MockInterpreter)."""
-        mock = MockInterpreter(responses=[
-            "explored data",
-            FinalOutput({"answer": "done"}),
-        ])
+        mock = MockInterpreter(
+            responses=[
+                "explored data",
+                FinalOutput({"answer": "done"}),
+            ]
+        )
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Explore first", "code": "print('exploring')"},
-            {"reasoning": "Now finish", "code": 'SUBMIT("done")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Explore first", "code": "print('exploring')"},
+                {"reasoning": "Now finish", "code": 'SUBMIT("done")'},
+            ]
+        )
 
         result = await rlm.aforward(mock, query="test")
         assert result.answer == "done"
@@ -1174,35 +1281,44 @@ class TestRLMAsyncMock:
 class TestRLMTypeCoercionMock:
     """Unit tests for RLM type coercion using MockInterpreter (no Deno required)."""
 
-    @pytest.mark.parametrize("output_field,output_type,final_value,code,expected", [
-        ("count", "int", 42, "SUBMIT(42)", 42),
-        ("score", "float", 3.14, "SUBMIT(3.14)", 3.14),
-        ("valid", "bool", True, "SUBMIT(True)", True),
-        ("numbers", "list[int]", [1, 2, 3], "SUBMIT([1, 2, 3])", [1, 2, 3]),
-        ("answer", "Literal['yes', 'no']", "yes", 'SUBMIT("yes")', "yes"),
-    ])
+    @pytest.mark.parametrize(
+        "output_field,output_type,final_value,code,expected",
+        [
+            ("count", "int", 42, "SUBMIT(42)", 42),
+            ("score", "float", 3.14, "SUBMIT(3.14)", 3.14),
+            ("valid", "bool", True, "SUBMIT(True)", True),
+            ("numbers", "list[int]", [1, 2, 3], "SUBMIT([1, 2, 3])", [1, 2, 3]),
+            ("answer", "Literal['yes', 'no']", "yes", 'SUBMIT("yes")', "yes"),
+        ],
+    )
     def test_type_coercion(self, output_field, output_type, final_value, code, expected):
         """Test RLM type coercion for various types (MockInterpreter)."""
         mock = MockInterpreter(responses=[FinalOutput({output_field: final_value})])
         rlm = RLM(f"query -> {output_field}: {output_type}", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return value", "code": code},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return value", "code": code},
+            ]
+        )
 
         result = rlm.forward(mock, query="test")
         assert getattr(result, output_field) == expected
 
     def test_type_error_retries(self):
         """Test RLM retries when type validation fails (MockInterpreter)."""
-        mock = MockInterpreter(responses=[
-            FinalOutput({"answer": "maybe"}),  # Invalid for Literal
-            FinalOutput({"answer": "yes"}),    # Valid
-        ])
+        mock = MockInterpreter(
+            responses=[
+                FinalOutput({"answer": "maybe"}),  # Invalid for Literal
+                FinalOutput({"answer": "yes"}),  # Valid
+            ]
+        )
         rlm = RLM("query -> answer: Literal['yes', 'no']", max_iters=5)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Try maybe", "code": 'SUBMIT("maybe")'},
-            {"reasoning": "Try yes", "code": 'SUBMIT("yes")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Try maybe", "code": 'SUBMIT("maybe")'},
+                {"reasoning": "Try yes", "code": 'SUBMIT("yes")'},
+            ]
+        )
 
         result = rlm.forward(mock, query="is it yes?")
         assert result.answer == "yes"
@@ -1221,20 +1337,25 @@ class TestRLMTypeCoercion:
     typed output_fields for SUBMIT based on the signature.
     """
 
-    @pytest.mark.parametrize("output_field,output_type,code,expected,expected_type", [
-        ("count", "int", "SUBMIT(42)", 42, int),
-        ("score", "float", "SUBMIT(3.14)", 3.14, float),
-        ("valid", "bool", "SUBMIT(True)", True, bool),
-        ("numbers", "list[int]", "SUBMIT([1, 2, 3])", [1, 2, 3], list),
-        ("data", "dict[str, str]", 'SUBMIT({"key": "value"})', {"key": "value"}, dict),
-        ("answer", "Literal['yes', 'no']", 'SUBMIT("yes")', "yes", str),
-    ])
+    @pytest.mark.parametrize(
+        "output_field,output_type,code,expected,expected_type",
+        [
+            ("count", "int", "SUBMIT(42)", 42, int),
+            ("score", "float", "SUBMIT(3.14)", 3.14, float),
+            ("valid", "bool", "SUBMIT(True)", True, bool),
+            ("numbers", "list[int]", "SUBMIT([1, 2, 3])", [1, 2, 3], list),
+            ("data", "dict[str, str]", 'SUBMIT({"key": "value"})', {"key": "value"}, dict),
+            ("answer", "Literal['yes', 'no']", 'SUBMIT("yes")', "yes", str),
+        ],
+    )
     def test_type_coercion(self, output_field, output_type, code, expected, expected_type, pooled_interpreter):
         """Test RLM type coercion for various types with PythonInterpreter."""
         rlm = RLM(f"query -> {output_field}: {output_type}", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return value", "code": code},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return value", "code": code},
+            ]
+        )
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert getattr(result, output_field) == expected
@@ -1243,9 +1364,11 @@ class TestRLMTypeCoercion:
     def test_submit_extracts_typed_value(self, pooled_interpreter):
         """Test RLM SUBMIT correctly extracts typed value."""
         rlm = RLM("query -> count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Compute and return", "code": "result = 42\nSUBMIT(result)"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Compute and return", "code": "result = 42\nSUBMIT(result)"},
+            ]
+        )
 
         result = rlm.forward(pooled_interpreter, query="count items")
         assert result.count == 42
@@ -1267,9 +1390,11 @@ class TestRLMMultipleOutputs:
     def test_multi_output_final_kwargs(self, pooled_interpreter):
         """SUBMIT(field1=val1, field2=val2) with keyword args."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return both outputs", "code": 'SUBMIT(name="alice", count=5)'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return both outputs", "code": 'SUBMIT(name="alice", count=5)'},
+            ]
+        )
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "alice"
@@ -1279,9 +1404,11 @@ class TestRLMMultipleOutputs:
     def test_multi_output_final_positional(self, pooled_interpreter):
         """SUBMIT(val1, val2) with positional args mapped to field order."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return both outputs positionally", "code": 'SUBMIT("bob", 10)'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return both outputs positionally", "code": 'SUBMIT("bob", 10)'},
+            ]
+        )
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "bob"
@@ -1290,9 +1417,11 @@ class TestRLMMultipleOutputs:
     def test_multi_output_three_fields(self, pooled_interpreter):
         """Signature with 3+ output fields of different types."""
         rlm = RLM("query -> name: str, age: int, active: bool", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return all three", "code": 'SUBMIT(name="carol", age=30, active=True)'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return all three", "code": 'SUBMIT(name="carol", age=30, active=True)'},
+            ]
+        )
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "carol"
@@ -1302,10 +1431,12 @@ class TestRLMMultipleOutputs:
     def test_multi_output_final_missing_field_errors(self, pooled_interpreter):
         """SUBMIT() with missing field should return error in output."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Missing count field", "code": 'SUBMIT(name="alice")'},
-            {"reasoning": "Now provide both", "code": 'SUBMIT(name="alice", count=5)'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Missing count field", "code": 'SUBMIT(name="alice")'},
+                {"reasoning": "Now provide both", "code": 'SUBMIT(name="alice", count=5)'},
+            ]
+        )
 
         # RLM should retry after getting error for missing field
         result = rlm.forward(pooled_interpreter, query="test")
@@ -1315,9 +1446,11 @@ class TestRLMMultipleOutputs:
     def test_multi_output_submit_vars(self, pooled_interpreter):
         """SUBMIT can pass variables directly for multiple outputs."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Use SUBMIT", "code": 'n = "dave"\nc = 15\nSUBMIT(n, c)'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Use SUBMIT", "code": 'n = "dave"\nc = 15\nSUBMIT(n, c)'},
+            ]
+        )
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "dave"
@@ -1326,9 +1459,11 @@ class TestRLMMultipleOutputs:
     def test_multi_output_type_coercion(self, pooled_interpreter):
         """Each output field is coerced to its declared type."""
         rlm = RLM("query -> count: int, ratio: float, flag: bool", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Return mixed types", "code": "SUBMIT(count=42, ratio=3.14, flag=True)"},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Return mixed types", "code": "SUBMIT(count=42, ratio=3.14, flag=True)"},
+            ]
+        )
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.count == 42
@@ -1354,9 +1489,11 @@ class TestRLMWithDummyLM:
 
     def test_simple_computation_e2e(self, pooled_interpreter):
         """Test full RLM pipeline: DummyLM -> RLM -> PythonInterpreter -> result."""
-        with dummy_lm_context([
-            {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
-        ]):
+        with dummy_lm_context(
+            [
+                {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
+            ]
+        ):
             rlm = RLM("query -> answer: int", max_iters=3)
             result = rlm.forward(pooled_interpreter, query="What is 2 + 3?")
 
@@ -1365,10 +1502,12 @@ class TestRLMWithDummyLM:
 
     def test_multi_turn_computation_e2e(self, pooled_interpreter):
         """Test RLM with multiple turns before SUBMIT."""
-        with dummy_lm_context([
-            {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
-            {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
-        ]):
+        with dummy_lm_context(
+            [
+                {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
+                {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
+            ]
+        ):
             rlm = RLM("query -> answer: int", max_iters=5)
             result = rlm.forward(pooled_interpreter, query="Double ten")
 
@@ -1377,9 +1516,11 @@ class TestRLMWithDummyLM:
 
     def test_with_input_variables_e2e(self, pooled_interpreter):
         """Test RLM with input variables passed to sandbox."""
-        with dummy_lm_context([
-            {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
-        ]):
+        with dummy_lm_context(
+            [
+                {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
+            ]
+        ):
             rlm = RLM("numbers: list[int] -> total: int", max_iters=3)
             result = rlm.forward(pooled_interpreter, numbers=[1, 2, 3, 4, 5])
 
@@ -1387,12 +1528,15 @@ class TestRLMWithDummyLM:
 
     def test_with_tool_e2e(self, pooled_interpreter):
         """Test RLM calling a host-side tool through the sandbox."""
+
         def lookup(key: str) -> str:
             return {"apple": "red", "banana": "yellow"}.get(key, "unknown")
 
-        with dummy_lm_context([
-            {"reasoning": "Look up the color of apple", "code": 'color = lookup(key="apple")\nSUBMIT(color)'},
-        ]):
+        with dummy_lm_context(
+            [
+                {"reasoning": "Look up the color of apple", "code": 'color = lookup(key="apple")\nSUBMIT(color)'},
+            ]
+        ):
             rlm = RLM("fruit -> color: str", max_iters=3, tools=[lookup])
             result = rlm.forward(pooled_interpreter, fruit="apple")
 
@@ -1430,12 +1574,14 @@ class TestRLMWithDummyLM:
         assert execution_tool.__name__ == score.__name__
         assert inspect.signature(execution_tool) == inspect.signature(score)
 
-        with dummy_lm_context([
-            {
-                "reasoning": "Call the tool",
-                "code": 'result = score_payload({"value": 3})\nSUBMIT(result)',
-            },
-        ]):
+        with dummy_lm_context(
+            [
+                {
+                    "reasoning": "Call the tool",
+                    "code": 'result = score_payload({"value": 3})\nSUBMIT(result)',
+                },
+            ]
+        ):
             with dspy.context(callbacks=[Recorder()]):
                 result = rlm.forward(pooled_interpreter, query="test")
 
@@ -1449,9 +1595,11 @@ class TestRLMWithDummyLM:
     @pytest.mark.asyncio
     async def test_aforward_simple_computation_e2e(self):
         """Test aforward() full pipeline: DummyLM -> RLM -> PythonInterpreter -> result."""
-        with dummy_lm_context([
-            {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
-        ]):
+        with dummy_lm_context(
+            [
+                {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
+            ]
+        ):
             rlm = RLM("query -> answer: int", max_iters=3)
             result = await rlm.aforward(query="What is 2 + 3?")
 
@@ -1461,10 +1609,12 @@ class TestRLMWithDummyLM:
     @pytest.mark.asyncio
     async def test_aforward_multi_turn_e2e(self):
         """Test aforward() with multiple turns before SUBMIT."""
-        with dummy_lm_context([
-            {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
-            {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
-        ]):
+        with dummy_lm_context(
+            [
+                {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
+                {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
+            ]
+        ):
             rlm = RLM("query -> answer: int", max_iters=5)
             result = await rlm.aforward(query="Double ten")
 
@@ -1474,9 +1624,11 @@ class TestRLMWithDummyLM:
     @pytest.mark.asyncio
     async def test_aforward_with_input_variables_e2e(self):
         """Test aforward() with input variables passed to sandbox."""
-        with dummy_lm_context([
-            {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
-        ]):
+        with dummy_lm_context(
+            [
+                {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
+            ]
+        ):
             rlm = RLM("numbers: list[int] -> total: int", max_iters=3)
             result = await rlm.aforward(numbers=[1, 2, 3, 4, 5])
 
@@ -1495,24 +1647,23 @@ class TestRLMIntegration:
     def test_simple_computation(self):
         """Test RLM on simple computation."""
         import dspy
+
         dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
 
         rlm = RLM("context, query -> answer", max_iters=5)
-        result = rlm(
-            context={"numbers": [1, 2, 3, 4, 5]},
-            query="What is the sum of the numbers?"
-        )
+        result = rlm(context={"numbers": [1, 2, 3, 4, 5]}, query="What is the sum of the numbers?")
         assert "15" in result.answer
 
     def test_with_llm_query(self):
         """Test RLM using the llm_query tool."""
         import dspy
+
         dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
 
         rlm = RLM("context, query -> answer", max_iters=5)
         result = rlm(
             context="The quick brown fox jumps over the lazy dog.",
-            query="Use llm_query to describe what animal is mentioned as lazy."
+            query="Use llm_query to describe what animal is mentioned as lazy.",
         )
         assert "dog" in result.answer.lower()
 
@@ -1671,14 +1822,18 @@ class TestPrepareSerializableVars:
 
     def test_forward_with_serializable(self):
         """Full forward() pass with a SandboxSerializable input."""
-        mock = MockInterpreter(responses=[
-            "",  # setup execution for _prepare_serializable_vars
-            FinalOutput({"answer": "done"}),
-        ])
+        mock = MockInterpreter(
+            responses=[
+                "",  # setup execution for _prepare_serializable_vars
+                FinalOutput({"answer": "done"}),
+            ]
+        )
         rlm = RLM("data, query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor([
-            {"reasoning": "Done", "code": 'SUBMIT("done")'},
-        ])
+        rlm.generate_action = make_mock_predictor(
+            [
+                {"reasoning": "Done", "code": 'SUBMIT("done")'},
+            ]
+        )
 
         stub = _StubSerializable("test_payload")
         result = rlm.forward(mock, data=stub, query="test")

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -80,7 +80,6 @@ def multiply_tool(a: int = 0, b: int = 0) -> str:
     """Multiply two numbers."""
     return str(a * b)
 
-
 # ============================================================================
 # Unit Tests: MockInterpreter
 # ============================================================================
@@ -147,7 +146,6 @@ class TestRLMInitialization:
 
     def test_custom_tools(self):
         """Test RLM with custom tools."""
-
         def custom_tool(x: str = "") -> str:
             return x.upper()
 
@@ -158,7 +156,6 @@ class TestRLMInitialization:
     @pytest.mark.parametrize("tool_name", ["invalid-name", "123start"])
     def test_tool_validation_invalid_identifier(self, tool_name):
         """Test RLM rejects tool names that aren't valid Python identifiers."""
-
         def my_tool() -> str:
             return "result"
 
@@ -177,7 +174,6 @@ class TestRLMInitialization:
     @pytest.mark.parametrize("tool_name", ["llm_query", "llm_query_batched", "SUBMIT", "print"])
     def test_tool_validation_reserved_names(self, tool_name):
         """Test RLM rejects tool names that conflict with built-in functions."""
-
         def my_tool() -> str:
             return "result"
 
@@ -193,7 +189,6 @@ class TestRLMInitialization:
 
     def test_tools_dict_rejected(self):
         """Test RLM rejects dict format for tools with helpful error."""
-
         def my_tool() -> str:
             return "result"
 
@@ -319,7 +314,6 @@ class TestRLMInitialization:
 
         with pytest.raises(TypeError, match="Sub-LM response must contain text, got NoneType"):
             tools["llm_query"]("test prompt")
-
     @pytest.mark.parametrize("unexpected_name", ["SUBMIT", "lookup", "tools"])
     def test_forward_rejects_undeclared_inputs_before_interpreter_execution(self, unexpected_name):
         def lookup() -> str:
@@ -327,15 +321,11 @@ class TestRLMInitialization:
 
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "done"})])
         rlm = RLM("context -> answer", tools=[lookup], interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+        ])
 
-        with pytest.raises(
-            ValueError, match=f"Unexpected inputs not declared in the signature: \\['{unexpected_name}'\\]"
-        ):
+        with pytest.raises(ValueError, match=f"Unexpected inputs not declared in the signature: \\['{unexpected_name}'\\]"):
             rlm(context="some context", **{unexpected_name: "shadowed value"})
 
         assert factory.instances == []
@@ -491,11 +481,9 @@ class TestRLMInterpreterLifecycle:
     def test_interpreter_remains_available_as_signature_input(self):
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "CPython"})])
         rlm = RLM("interpreter -> answer", max_iters=1, interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return input", "code": "SUBMIT(interpreter)"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return input", "code": "SUBMIT(interpreter)"},
+        ])
 
         result = rlm(interpreter="CPython")
 
@@ -506,11 +494,9 @@ class TestRLMInterpreterLifecycle:
     async def test_factory_creates_and_shuts_down_one_interpreter_per_call(self):
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=1, interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
+        ])
 
         sync_result = rlm(query="sync")
         async_result = await rlm.acall(query="async")
@@ -533,11 +519,9 @@ class TestRLMInterpreterLifecycle:
             ]
         )
         rlm = RLM("query -> answer", max_iters=1, interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return answer", "code": "SUBMIT(answer)"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": "SUBMIT(answer)"},
+        ])
 
         try:
             sync_result = rlm(interpreter, query="sync")
@@ -671,7 +655,10 @@ class TestRLMFormatting:
     def test_build_variables_multiple(self):
         """Test building multiple variables."""
         rlm = RLM("context, query -> answer")
-        variables = rlm._build_variables(context="Hello world", query="What is this?")
+        variables = rlm._build_variables(
+            context="Hello world",
+            query="What is this?"
+        )
         assert len(variables) == 2
         formatted = "\n\n".join(v.format() for v in variables)
         assert "Variable: `context`" in formatted
@@ -790,7 +777,6 @@ class TestREPLTypes:
 
         class QASig(dspy.Signature):
             """Answer questions."""
-
             context: str = dspy.InputField(desc="Background information")
             question: str = dspy.InputField(desc="The question to answer")
             answer: str = dspy.OutputField()
@@ -813,11 +799,9 @@ class TestRLMCallMethod:
         """Test that __call__ is an alias for forward()."""
         mock = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
+        ])
 
         result = rlm(mock, query="What is the answer?")
         assert result.answer == "42"
@@ -828,27 +812,21 @@ class TestRLMMaxIterationsFallback:
 
     def test_max_iters_triggers_extract(self):
         """Test that reaching max_iters uses extract fallback."""
-        mock = MockInterpreter(
-            responses=[
-                "exploring...",
-                "still exploring...",
-                "more exploring...",
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            "exploring...",
+            "still exploring...",
+            "more exploring...",
+        ])
         rlm = RLM("query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Explore 1", "code": "print('exploring')"},
-                {"reasoning": "Explore 2", "code": "print('exploring')"},
-                {"reasoning": "Explore 3", "code": "print('exploring')"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Explore 1", "code": "print('exploring')"},
+            {"reasoning": "Explore 2", "code": "print('exploring')"},
+            {"reasoning": "Explore 3", "code": "print('exploring')"},
+        ])
         # Mock the extract predictor to return a value
-        rlm.extract = make_mock_predictor(
-            [
-                {"answer": "extracted_answer"},
-            ]
-        )
+        rlm.extract = make_mock_predictor([
+            {"answer": "extracted_answer"},
+        ])
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "extracted_answer"
@@ -860,42 +838,33 @@ class TestRLMToolExceptions:
 
     def test_tool_exception_returns_error_in_output(self):
         """Test that tool exceptions are caught and returned as errors."""
-
         def failing_tool() -> str:
             raise RuntimeError("Tool failed!")
 
-        mock = MockInterpreter(
-            responses=[
-                CodeExecutionError("RuntimeError: Tool failed!"),
-                FinalOutput({"answer": "recovered"}),
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            CodeExecutionError("RuntimeError: Tool failed!"),
+            FinalOutput({"answer": "recovered"}),
+        ])
         rlm = RLM("query -> answer", max_iters=5, tools=[failing_tool])
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Call tool", "code": "failing_tool()"},
-                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Call tool", "code": "failing_tool()"},
+            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+        ])
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
 
     def test_runtime_error_history_uses_stripped_code(self):
         """Runtime execution failures should preserve stripped code in history."""
-        mock = MockInterpreter(
-            responses=[
-                CodeExecutionError("NameError: name 'x' is not defined"),
-                FinalOutput({"answer": "recovered"}),
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            CodeExecutionError("NameError: name 'x' is not defined"),
+            FinalOutput({"answer": "recovered"}),
+        ])
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Will fail", "code": "```python\nprint(x)\n```"},
-                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Will fail", "code": "```python\nprint(x)\n```"},
+            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+        ])
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
@@ -904,19 +873,15 @@ class TestRLMToolExceptions:
 
     def test_syntax_error_from_execute_is_recoverable(self):
         """SyntaxError from interpreter.execute should be surfaced as an iteration error."""
-        mock = MockInterpreter(
-            responses=[
-                SyntaxError("invalid syntax"),
-                FinalOutput({"answer": "recovered"}),
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            SyntaxError("invalid syntax"),
+            FinalOutput({"answer": "recovered"}),
+        ])
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Bad code", "code": "```python\ndef incomplete(\n```"},
-                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Bad code", "code": "```python\ndef incomplete(\n```"},
+            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+        ])
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
@@ -924,18 +889,14 @@ class TestRLMToolExceptions:
 
     def test_syntax_error_from_strip_code_fences_is_recoverable(self):
         """SyntaxError raised by _strip_code_fences (e.g. non-Python fence tag) should be recoverable."""
-        mock = MockInterpreter(
-            responses=[
-                FinalOutput({"answer": "recovered"}),
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            FinalOutput({"answer": "recovered"}),
+        ])
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Wrong language", "code": "```bash\nls -la\n```"},
-                {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Wrong language", "code": "```bash\nls -la\n```"},
+            {"reasoning": "Recover", "code": 'SUBMIT("recovered")'},
+        ])
 
         result = rlm.forward(mock, query="test")
         assert result.answer == "recovered"
@@ -943,7 +904,6 @@ class TestRLMToolExceptions:
 
     def test_interpreter_failure_propagates(self):
         """Process and protocol failures must not fall through to LM extraction."""
-
         def fail_generated_code(code, variables):
             if code == "pass":
                 return ""
@@ -951,11 +911,9 @@ class TestRLMToolExceptions:
 
         mock = MockInterpreter(execute_fn=fail_generated_code)
         rlm = RLM("query -> answer", max_iters=1)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Try code", "code": "print('test')"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Try code", "code": "print('test')"},
+        ])
         rlm.extract = make_mock_predictor([{"answer": "hallucinated"}])
 
         with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
@@ -964,7 +922,6 @@ class TestRLMToolExceptions:
     @pytest.mark.asyncio
     async def test_interpreter_failure_propagates_async(self):
         """Async process and protocol failures must not fall through to LM extraction."""
-
         def fail_generated_code(code, variables):
             if code == "pass":
                 return ""
@@ -972,11 +929,9 @@ class TestRLMToolExceptions:
 
         mock = MockInterpreter(execute_fn=fail_generated_code)
         rlm = RLM("query -> answer", max_iters=1)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Try code", "code": "print('test')"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Try code", "code": "print('test')"},
+        ])
         rlm.extract = make_mock_predictor([{"answer": "hallucinated"}])
 
         with pytest.raises(CodeInterpreterError, match="protocol corrupt"):
@@ -1063,29 +1018,38 @@ class TestPythonInterpreter:
     def test_variable_injection(self, pooled_interpreter):
         """Test variable injection."""
         interp = pooled_interpreter
-        result = interp.execute("print(x + y)", variables={"x": 10, "y": 5})
+        result = interp.execute(
+            "print(x + y)",
+            variables={"x": 10, "y": 5}
+        )
         assert "15" in result
 
     def test_variable_injection_with_none_values(self, pooled_interpreter):
         """Test variable injection with None values in dicts/lists (JSON null -> Python None)."""
         interp = pooled_interpreter
         # Test None in dict
-        result = interp.execute("print(data['key'] is None)", variables={"data": {"key": None, "other": "value"}})
+        result = interp.execute(
+            "print(data['key'] is None)",
+            variables={"data": {"key": None, "other": "value"}}
+        )
         assert "True" in result
 
         # Test None in list
-        result = interp.execute("print(items[1] is None)", variables={"items": [1, None, 3]})
+        result = interp.execute(
+            "print(items[1] is None)",
+            variables={"items": [1, None, 3]}
+        )
         assert "True" in result
 
         # Test nested None
         result = interp.execute(
-            "print(nested['inner']['value'] is None)", variables={"nested": {"inner": {"value": None}}}
+            "print(nested['inner']['value'] is None)",
+            variables={"nested": {"inner": {"value": None}}}
         )
         assert "True" in result
 
     def test_tool_call_kwargs(self, configure_pooled_interpreter):
         """Test tool call with keyword arguments."""
-
         def echo(message: str = "") -> str:
             return f"Echo: {message}"
 
@@ -1095,7 +1059,6 @@ class TestPythonInterpreter:
 
     def test_tool_call_positional(self, configure_pooled_interpreter):
         """Test tool call with positional arguments."""
-
         def greet(name: str) -> str:
             return f"Hello: {name}"
 
@@ -1105,7 +1068,6 @@ class TestPythonInterpreter:
 
     def test_multiple_tools(self, configure_pooled_interpreter):
         """Test multiple tools."""
-
         def add(a: int = 0, b: int = 0) -> str:
             return str(a + b)
 
@@ -1123,7 +1085,6 @@ print(f"Sum: {sum_result}, Product: {prod_result}")
 
     def test_tool_returns_list(self, configure_pooled_interpreter):
         """Test tool that returns a list (like llm_query_batched)."""
-
         def batch_process(items: list | None = None) -> list:
             items = items or []
             return [f"processed_{item}" for item in items]
@@ -1142,7 +1103,6 @@ print(f"All: {results}")
 
     def test_tool_returns_dict(self, configure_pooled_interpreter):
         """Test tool that returns a dict."""
-
         def get_info() -> dict:
             return {"name": "test", "count": 42}
 
@@ -1217,11 +1177,9 @@ class TestRLMAsyncMock:
     async def test_aforward_rejects_undeclared_inputs_before_interpreter_execution(self):
         factory = MockInterpreterFactory(responses=[FinalOutput({"answer": "done"})])
         rlm = RLM("context -> answer", interpreter_factory=factory)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("done")'},
+        ])
 
         with pytest.raises(ValueError, match="Unexpected inputs not declared in the signature: \\['SUBMIT'\\]"):
             await rlm.acall(context="some context", SUBMIT="shadowed value")
@@ -1233,11 +1191,9 @@ class TestRLMAsyncMock:
         """Test aforward() returns Prediction with expected output (MockInterpreter)."""
         mock = MockInterpreter(responses=[FinalOutput({"answer": "42"})])
         rlm = RLM("query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return answer", "code": 'SUBMIT("42")'},
+        ])
 
         result = await rlm.aforward(mock, query="What is the answer?")
         assert result.answer == "42"
@@ -1247,11 +1203,9 @@ class TestRLMAsyncMock:
         """Test aforward() returns int when signature expects int (MockInterpreter)."""
         mock = MockInterpreter(responses=[FinalOutput({"count": 42})])
         rlm = RLM("query -> count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return count", "code": "SUBMIT(42)"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return count", "code": "SUBMIT(42)"},
+        ])
 
         result = await rlm.aforward(mock, query="count items")
         assert result.count == 42
@@ -1260,19 +1214,15 @@ class TestRLMAsyncMock:
     @pytest.mark.asyncio
     async def test_aforward_multi_iteration_mock(self):
         """Test aforward() handles multiple iterations before SUBMIT (MockInterpreter)."""
-        mock = MockInterpreter(
-            responses=[
-                "explored data",
-                FinalOutput({"answer": "done"}),
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            "explored data",
+            FinalOutput({"answer": "done"}),
+        ])
         rlm = RLM("query -> answer", max_iters=5)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Explore first", "code": "print('exploring')"},
-                {"reasoning": "Now finish", "code": 'SUBMIT("done")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Explore first", "code": "print('exploring')"},
+            {"reasoning": "Now finish", "code": 'SUBMIT("done")'},
+        ])
 
         result = await rlm.aforward(mock, query="test")
         assert result.answer == "done"
@@ -1281,44 +1231,35 @@ class TestRLMAsyncMock:
 class TestRLMTypeCoercionMock:
     """Unit tests for RLM type coercion using MockInterpreter (no Deno required)."""
 
-    @pytest.mark.parametrize(
-        "output_field,output_type,final_value,code,expected",
-        [
-            ("count", "int", 42, "SUBMIT(42)", 42),
-            ("score", "float", 3.14, "SUBMIT(3.14)", 3.14),
-            ("valid", "bool", True, "SUBMIT(True)", True),
-            ("numbers", "list[int]", [1, 2, 3], "SUBMIT([1, 2, 3])", [1, 2, 3]),
-            ("answer", "Literal['yes', 'no']", "yes", 'SUBMIT("yes")', "yes"),
-        ],
-    )
+    @pytest.mark.parametrize("output_field,output_type,final_value,code,expected", [
+        ("count", "int", 42, "SUBMIT(42)", 42),
+        ("score", "float", 3.14, "SUBMIT(3.14)", 3.14),
+        ("valid", "bool", True, "SUBMIT(True)", True),
+        ("numbers", "list[int]", [1, 2, 3], "SUBMIT([1, 2, 3])", [1, 2, 3]),
+        ("answer", "Literal['yes', 'no']", "yes", 'SUBMIT("yes")', "yes"),
+    ])
     def test_type_coercion(self, output_field, output_type, final_value, code, expected):
         """Test RLM type coercion for various types (MockInterpreter)."""
         mock = MockInterpreter(responses=[FinalOutput({output_field: final_value})])
         rlm = RLM(f"query -> {output_field}: {output_type}", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return value", "code": code},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return value", "code": code},
+        ])
 
         result = rlm.forward(mock, query="test")
         assert getattr(result, output_field) == expected
 
     def test_type_error_retries(self):
         """Test RLM retries when type validation fails (MockInterpreter)."""
-        mock = MockInterpreter(
-            responses=[
-                FinalOutput({"answer": "maybe"}),  # Invalid for Literal
-                FinalOutput({"answer": "yes"}),  # Valid
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            FinalOutput({"answer": "maybe"}),  # Invalid for Literal
+            FinalOutput({"answer": "yes"}),    # Valid
+        ])
         rlm = RLM("query -> answer: Literal['yes', 'no']", max_iters=5)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Try maybe", "code": 'SUBMIT("maybe")'},
-                {"reasoning": "Try yes", "code": 'SUBMIT("yes")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Try maybe", "code": 'SUBMIT("maybe")'},
+            {"reasoning": "Try yes", "code": 'SUBMIT("yes")'},
+        ])
 
         result = rlm.forward(mock, query="is it yes?")
         assert result.answer == "yes"
@@ -1337,25 +1278,20 @@ class TestRLMTypeCoercion:
     typed output_fields for SUBMIT based on the signature.
     """
 
-    @pytest.mark.parametrize(
-        "output_field,output_type,code,expected,expected_type",
-        [
-            ("count", "int", "SUBMIT(42)", 42, int),
-            ("score", "float", "SUBMIT(3.14)", 3.14, float),
-            ("valid", "bool", "SUBMIT(True)", True, bool),
-            ("numbers", "list[int]", "SUBMIT([1, 2, 3])", [1, 2, 3], list),
-            ("data", "dict[str, str]", 'SUBMIT({"key": "value"})', {"key": "value"}, dict),
-            ("answer", "Literal['yes', 'no']", 'SUBMIT("yes")', "yes", str),
-        ],
-    )
+    @pytest.mark.parametrize("output_field,output_type,code,expected,expected_type", [
+        ("count", "int", "SUBMIT(42)", 42, int),
+        ("score", "float", "SUBMIT(3.14)", 3.14, float),
+        ("valid", "bool", "SUBMIT(True)", True, bool),
+        ("numbers", "list[int]", "SUBMIT([1, 2, 3])", [1, 2, 3], list),
+        ("data", "dict[str, str]", 'SUBMIT({"key": "value"})', {"key": "value"}, dict),
+        ("answer", "Literal['yes', 'no']", 'SUBMIT("yes")', "yes", str),
+    ])
     def test_type_coercion(self, output_field, output_type, code, expected, expected_type, pooled_interpreter):
         """Test RLM type coercion for various types with PythonInterpreter."""
         rlm = RLM(f"query -> {output_field}: {output_type}", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return value", "code": code},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return value", "code": code},
+        ])
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert getattr(result, output_field) == expected
@@ -1364,11 +1300,9 @@ class TestRLMTypeCoercion:
     def test_submit_extracts_typed_value(self, pooled_interpreter):
         """Test RLM SUBMIT correctly extracts typed value."""
         rlm = RLM("query -> count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Compute and return", "code": "result = 42\nSUBMIT(result)"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Compute and return", "code": "result = 42\nSUBMIT(result)"},
+        ])
 
         result = rlm.forward(pooled_interpreter, query="count items")
         assert result.count == 42
@@ -1390,11 +1324,9 @@ class TestRLMMultipleOutputs:
     def test_multi_output_final_kwargs(self, pooled_interpreter):
         """SUBMIT(field1=val1, field2=val2) with keyword args."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return both outputs", "code": 'SUBMIT(name="alice", count=5)'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return both outputs", "code": 'SUBMIT(name="alice", count=5)'},
+        ])
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "alice"
@@ -1404,11 +1336,9 @@ class TestRLMMultipleOutputs:
     def test_multi_output_final_positional(self, pooled_interpreter):
         """SUBMIT(val1, val2) with positional args mapped to field order."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return both outputs positionally", "code": 'SUBMIT("bob", 10)'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return both outputs positionally", "code": 'SUBMIT("bob", 10)'},
+        ])
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "bob"
@@ -1417,11 +1347,9 @@ class TestRLMMultipleOutputs:
     def test_multi_output_three_fields(self, pooled_interpreter):
         """Signature with 3+ output fields of different types."""
         rlm = RLM("query -> name: str, age: int, active: bool", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return all three", "code": 'SUBMIT(name="carol", age=30, active=True)'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return all three", "code": 'SUBMIT(name="carol", age=30, active=True)'},
+        ])
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "carol"
@@ -1431,12 +1359,10 @@ class TestRLMMultipleOutputs:
     def test_multi_output_final_missing_field_errors(self, pooled_interpreter):
         """SUBMIT() with missing field should return error in output."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Missing count field", "code": 'SUBMIT(name="alice")'},
-                {"reasoning": "Now provide both", "code": 'SUBMIT(name="alice", count=5)'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Missing count field", "code": 'SUBMIT(name="alice")'},
+            {"reasoning": "Now provide both", "code": 'SUBMIT(name="alice", count=5)'},
+        ])
 
         # RLM should retry after getting error for missing field
         result = rlm.forward(pooled_interpreter, query="test")
@@ -1446,11 +1372,9 @@ class TestRLMMultipleOutputs:
     def test_multi_output_submit_vars(self, pooled_interpreter):
         """SUBMIT can pass variables directly for multiple outputs."""
         rlm = RLM("query -> name: str, count: int", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Use SUBMIT", "code": 'n = "dave"\nc = 15\nSUBMIT(n, c)'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Use SUBMIT", "code": 'n = "dave"\nc = 15\nSUBMIT(n, c)'},
+        ])
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.name == "dave"
@@ -1459,11 +1383,9 @@ class TestRLMMultipleOutputs:
     def test_multi_output_type_coercion(self, pooled_interpreter):
         """Each output field is coerced to its declared type."""
         rlm = RLM("query -> count: int, ratio: float, flag: bool", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Return mixed types", "code": "SUBMIT(count=42, ratio=3.14, flag=True)"},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Return mixed types", "code": "SUBMIT(count=42, ratio=3.14, flag=True)"},
+        ])
 
         result = rlm.forward(pooled_interpreter, query="test")
         assert result.count == 42
@@ -1489,11 +1411,9 @@ class TestRLMWithDummyLM:
 
     def test_simple_computation_e2e(self, pooled_interpreter):
         """Test full RLM pipeline: DummyLM -> RLM -> PythonInterpreter -> result."""
-        with dummy_lm_context(
-            [
-                {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
-            ]
-        ):
+        with dummy_lm_context([
+            {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
+        ]):
             rlm = RLM("query -> answer: int", max_iters=3)
             result = rlm.forward(pooled_interpreter, query="What is 2 + 3?")
 
@@ -1502,12 +1422,10 @@ class TestRLMWithDummyLM:
 
     def test_multi_turn_computation_e2e(self, pooled_interpreter):
         """Test RLM with multiple turns before SUBMIT."""
-        with dummy_lm_context(
-            [
-                {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
-                {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
-            ]
-        ):
+        with dummy_lm_context([
+            {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
+            {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
+        ]):
             rlm = RLM("query -> answer: int", max_iters=5)
             result = rlm.forward(pooled_interpreter, query="Double ten")
 
@@ -1516,11 +1434,9 @@ class TestRLMWithDummyLM:
 
     def test_with_input_variables_e2e(self, pooled_interpreter):
         """Test RLM with input variables passed to sandbox."""
-        with dummy_lm_context(
-            [
-                {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
-            ]
-        ):
+        with dummy_lm_context([
+            {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
+        ]):
             rlm = RLM("numbers: list[int] -> total: int", max_iters=3)
             result = rlm.forward(pooled_interpreter, numbers=[1, 2, 3, 4, 5])
 
@@ -1528,15 +1444,12 @@ class TestRLMWithDummyLM:
 
     def test_with_tool_e2e(self, pooled_interpreter):
         """Test RLM calling a host-side tool through the sandbox."""
-
         def lookup(key: str) -> str:
             return {"apple": "red", "banana": "yellow"}.get(key, "unknown")
 
-        with dummy_lm_context(
-            [
-                {"reasoning": "Look up the color of apple", "code": 'color = lookup(key="apple")\nSUBMIT(color)'},
-            ]
-        ):
+        with dummy_lm_context([
+            {"reasoning": "Look up the color of apple", "code": 'color = lookup(key="apple")\nSUBMIT(color)'},
+        ]):
             rlm = RLM("fruit -> color: str", max_iters=3, tools=[lookup])
             result = rlm.forward(pooled_interpreter, fruit="apple")
 
@@ -1574,14 +1487,12 @@ class TestRLMWithDummyLM:
         assert execution_tool.__name__ == score.__name__
         assert inspect.signature(execution_tool) == inspect.signature(score)
 
-        with dummy_lm_context(
-            [
-                {
-                    "reasoning": "Call the tool",
-                    "code": 'result = score_payload({"value": 3})\nSUBMIT(result)',
-                },
-            ]
-        ):
+        with dummy_lm_context([
+            {
+                "reasoning": "Call the tool",
+                "code": 'result = score_payload({"value": 3})\nSUBMIT(result)',
+            },
+        ]):
             with dspy.context(callbacks=[Recorder()]):
                 result = rlm.forward(pooled_interpreter, query="test")
 
@@ -1595,11 +1506,9 @@ class TestRLMWithDummyLM:
     @pytest.mark.asyncio
     async def test_aforward_simple_computation_e2e(self):
         """Test aforward() full pipeline: DummyLM -> RLM -> PythonInterpreter -> result."""
-        with dummy_lm_context(
-            [
-                {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
-            ]
-        ):
+        with dummy_lm_context([
+            {"reasoning": "I need to compute 2 + 3", "code": "result = 2 + 3\nSUBMIT(result)"},
+        ]):
             rlm = RLM("query -> answer: int", max_iters=3)
             result = await rlm.aforward(query="What is 2 + 3?")
 
@@ -1609,12 +1518,10 @@ class TestRLMWithDummyLM:
     @pytest.mark.asyncio
     async def test_aforward_multi_turn_e2e(self):
         """Test aforward() with multiple turns before SUBMIT."""
-        with dummy_lm_context(
-            [
-                {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
-                {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
-            ]
-        ):
+        with dummy_lm_context([
+            {"reasoning": "First explore the data", "code": "x = 10\nprint(f'x = {x}')"},
+            {"reasoning": "Now compute and return", "code": "y = x * 2\nSUBMIT(y)"},
+        ]):
             rlm = RLM("query -> answer: int", max_iters=5)
             result = await rlm.aforward(query="Double ten")
 
@@ -1624,11 +1531,9 @@ class TestRLMWithDummyLM:
     @pytest.mark.asyncio
     async def test_aforward_with_input_variables_e2e(self):
         """Test aforward() with input variables passed to sandbox."""
-        with dummy_lm_context(
-            [
-                {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
-            ]
-        ):
+        with dummy_lm_context([
+            {"reasoning": "Sum the numbers in the list", "code": "SUBMIT(sum(numbers))"},
+        ]):
             rlm = RLM("numbers: list[int] -> total: int", max_iters=3)
             result = await rlm.aforward(numbers=[1, 2, 3, 4, 5])
 
@@ -1647,23 +1552,24 @@ class TestRLMIntegration:
     def test_simple_computation(self):
         """Test RLM on simple computation."""
         import dspy
-
         dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
 
         rlm = RLM("context, query -> answer", max_iters=5)
-        result = rlm(context={"numbers": [1, 2, 3, 4, 5]}, query="What is the sum of the numbers?")
+        result = rlm(
+            context={"numbers": [1, 2, 3, 4, 5]},
+            query="What is the sum of the numbers?"
+        )
         assert "15" in result.answer
 
     def test_with_llm_query(self):
         """Test RLM using the llm_query tool."""
         import dspy
-
         dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
 
         rlm = RLM("context, query -> answer", max_iters=5)
         result = rlm(
             context="The quick brown fox jumps over the lazy dog.",
-            query="Use llm_query to describe what animal is mentioned as lazy.",
+            query="Use llm_query to describe what animal is mentioned as lazy."
         )
         assert "dog" in result.answer.lower()
 
@@ -1822,18 +1728,14 @@ class TestPrepareSerializableVars:
 
     def test_forward_with_serializable(self):
         """Full forward() pass with a SandboxSerializable input."""
-        mock = MockInterpreter(
-            responses=[
-                "",  # setup execution for _prepare_serializable_vars
-                FinalOutput({"answer": "done"}),
-            ]
-        )
+        mock = MockInterpreter(responses=[
+            "",  # setup execution for _prepare_serializable_vars
+            FinalOutput({"answer": "done"}),
+        ])
         rlm = RLM("data, query -> answer", max_iters=3)
-        rlm.generate_action = make_mock_predictor(
-            [
-                {"reasoning": "Done", "code": 'SUBMIT("done")'},
-            ]
-        )
+        rlm.generate_action = make_mock_predictor([
+            {"reasoning": "Done", "code": 'SUBMIT("done")'},
+        ])
 
         stub = _StubSerializable("test_payload")
         result = rlm.forward(mock, data=stub, query="test")

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -1623,3 +1623,10 @@ def test_base_exceptions_do_not_desync_interpreter():
             with pytest.raises(CodeExecutionError, match=error_type):
                 interpreter.execute(code)
             assert interpreter.execute("print('still alive')") == "still alive\n"
+
+
+def test_execution_instructions_are_class_metadata():
+    interpreter = PythonInterpreter(deno_command=["deno", "run"])
+
+    assert interpreter.execution_instructions == PythonInterpreter.execution_instructions
+    assert "Pyodide" in interpreter.execution_instructions

--- a/tests/primitives/test_python_interpreter_config.py
+++ b/tests/primitives/test_python_interpreter_config.py
@@ -1,0 +1,48 @@
+import subprocess
+
+import pytest
+
+from dspy.primitives.code_interpreter import CodeInterpreter
+from dspy.primitives.python_interpreter import PythonInterpreter
+from tests.mock_interpreter import MockInterpreter
+
+
+def test_execution_instructions_are_read_only():
+    interpreter = PythonInterpreter(deno_command=["deno", "run"])
+
+    assert isinstance(interpreter.execution_instructions, str)
+    assert interpreter.execution_instructions
+    with pytest.raises(AttributeError):
+        interpreter.execution_instructions = "replacement"
+
+
+def test_construct_and_read_execution_instructions_does_not_invoke_deno(monkeypatch):
+    PythonInterpreter._get_deno_dir.cache_clear()
+
+    def fail(*args, **kwargs):
+        raise AssertionError("constructing the interpreter or reading instructions invoked Deno")
+
+    monkeypatch.setattr(subprocess, "run", fail)
+    monkeypatch.setattr(subprocess, "Popen", fail)
+
+    interpreter = PythonInterpreter()
+
+    assert interpreter.execution_instructions == interpreter.execution_instructions
+    assert interpreter.deno_process is None
+
+
+def test_execution_instructions_describe_stable_constraints_without_host_paths(tmp_path):
+    secret_path = tmp_path / "distinctive-host-path"
+    interpreter = PythonInterpreter(enable_read_paths=[secret_path])
+    instructions = interpreter.execution_instructions
+
+    assert "Pyodide" in instructions
+    assert "WebAssembly" in instructions
+    assert "persist" in instructions
+    assert "subprocesses are unavailable" in instructions
+    assert "network access are unavailable unless explicitly enabled" in instructions
+    assert str(secret_path) not in instructions
+
+
+def test_legacy_interpreter_still_satisfies_runtime_protocol():
+    assert isinstance(MockInterpreter(), CodeInterpreter)


### PR DESCRIPTION
## Summary

- expose stable `PythonInterpreter.execution_instructions` as class-level runtime metadata
- insert optional factory/provider execution guidance into RLM's normal action instructions, rendered by adapters in the system message
- intentionally let `Signature.with_instructions` and optimizers such as GEPA adapt or replace that guidance with the rest of the action policy
- document the capability and lock the complete PythonInterpreter RLM `LMRequest` with a byte-exact golden snapshot

Factories without `execution_instructions` remain valid and use the generic action prompt.

## Stack

Depends on #10208, which is merged into `main`.

## Size

Production diff: **+14/-3** (`rlm.py` +9/-3; `python_interpreter.py` +5). The remaining diff is documentation and focused tests, including the complete-request golden snapshot.

## Validation

- the golden test invokes the real `RLM.generate_action` → adapter → typed `BaseLM` boundary and snapshots the complete `LMRequest`: model, full system and user messages, tools, generation/cache config, and metadata
- byte comparison covers deterministic first-iteration variables, empty REPL history, and iteration data in addition to the interpreter guidance
- RLM unit suite: **106 passed, 39 skipped**
- RLM + PythonInterpreter with real Deno on the equivalent production patch: **255 passed, 2 skipped**
- absent metadata and explicit empty metadata produce identical generic prompts; non-string metadata fails clearly
- candidate-only Ruff and `git diff --check` are clean

## Independent adversarial review

- **Verdict:** APPROVE / no candidate-introduced code or design findings on exact SHA `e3a4f4d5af850a92337743fbb9f988af8a43ff8c` against exact `main` base `a5ac92dcb4056f435d34366fa6096041f75e01a4`
- **Receipt:** https://ampcode.com/threads/T-01a010ce-107b-706d-b7ef-81ed1e4baab5
- Review independently executed the real request path, confirmed all five `LMRequest` top-level fields are serialized, and mutation-tested user-only iteration, model, and config sensitivity.

## Current CI caveat

All code, Ruff, docs, build, Python 3.10–3.14, Extra+Deno, real-LM, Greptile, and zizmor checks pass. Workflow lint failed before linting because GitHub returned HTTP 500 while actionlint was being downloaded; rerun that job before merge.