### PR TITLE
fix(dspy): repair ReAct error formatter after parallel merges

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -99,7 +99,7 @@ class ReAct(Module):
             try:
                 pred = self._call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
             except ContextWindowExceededError as err:
-                logger.warning(f"Ending the trajectory: {_fmt_exc(err)}")
+                logger.warning(f"Ending the trajectory: {format_error_for_lm(err, traceback_frames=5)}")
                 break
             except ValueError as err:
                 logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {format_error_for_lm(err, traceback_frames=5)}")
@@ -127,7 +127,7 @@ class ReAct(Module):
             try:
                 pred = await self._async_call_with_potential_trajectory_truncation(self.react, trajectory, **input_args)
             except ContextWindowExceededError as err:
-                logger.warning(f"Ending the trajectory: {_fmt_exc(err)}")
+                logger.warning(f"Ending the trajectory: {format_error_for_lm(err, traceback_frames=5)}")
                 break
             except ValueError as err:
                 logger.warning(f"Ending the trajectory: Agent failed to select a valid tool: {format_error_for_lm(err, traceback_frames=5)}")


### PR DESCRIPTION
## Summary

Repairs the semantic merge conflict between #10132 and #10135.

#10135 removed the private `_fmt_exc` helper in favor of `format_error_for_lm`. #10132 was tested against the earlier base and subsequently introduced two new `_fmt_exc` references. Both PRs merged textually without conflict, leaving the merged `main` with an undefined name.

This changes the two context-window warning paths to use the shared formatter, matching every other ReAct error path.

## Test plan

- `pytest tests/predict/test_react.py::test_context_window_exceeded_after_retries -q` (1 passed)
- confirmed `dspy/predict/react.py` contains no `_fmt_exc` references
- upstream CI

## Follow-up

The original PR checks completed before #10135 changed their base. Requiring PR branches to be current before merge, or retesting overlapping PRs against the latest main, would prevent this class of integration failure.