### PR TITLE
fix(interpreter): serialize sandbox results with Python json so non-JS-safe values survive

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -666,6 +666,10 @@ class PythonInterpreter:
                 # Check for SUBMIT (encoded as success with "final" field)
                 if "final" in result:
                     return FinalOutput(result["final"])
+                if "output_json" in result:
+                    # Results serialized with Python json inside the sandbox, so
+                    # big ints, nan/inf, and sets survive the JS boundary.
+                    return json.loads(result["output_json"])
                 return result.get("output", None)
 
             # Handle error response

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -28,6 +28,20 @@ class FinalOutput(BaseException):
 if 'SUBMIT' not in dir():
     def SUBMIT(output):
         raise FinalOutput({"output": output})
+
+def _dspy_serialize_result(value):
+    # Serialize the result with Python json so values that are valid Python but
+    # not JS-JSON-safe (ints beyond 2**53, nan/inf, sets) survive the trip back
+    # to the host, which parses with Python json.loads.
+    def _default(o):
+        if isinstance(o, (set, frozenset)):
+            # Match the host-side injection convention: sets become sorted lists.
+            try:
+                return sorted(o)
+            except TypeError:
+                return list(o)
+        raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+    return json.dumps(value, default=_default)
 `;
 
 // Generate a tool wrapper function with typed signature.
@@ -338,8 +352,30 @@ while (true) {
       const capturedStdout = pyodide.runPython("buf_stdout.getvalue()");
 
       // If result is None, output prints; otherwise output the result
-      let output = (result === null || result === undefined) ? capturedStdout : (result.toJs?.() ?? result);
-      console.log(jsonrpcResult({ output }, requestId));
+      if (result === null || result === undefined) {
+        console.log(jsonrpcResult({ output: capturedStdout }, requestId));
+      } else {
+        // Serialize the result on the Python side so values that are valid
+        // Python but not JS-JSON-safe (ints beyond 2**53 become BigInt and make
+        // JSON.stringify throw; sets stringify as {}; nan/inf become null)
+        // survive the trip back to the host intact.
+        let serialized = null;
+        try {
+          pyodide.globals.set("_dspy_last_result", result);
+          serialized = pyodide.runPython("_dspy_serialize_result(_dspy_last_result)");
+        } catch (e) {
+          serialized = null;  // not Python-JSON-serializable; use legacy path below
+        } finally {
+          pyodide.globals.delete("_dspy_last_result");
+        }
+        if (serialized !== null) {
+          console.log(jsonrpcResult({ output_json: serialized }, requestId));
+        } else {
+          const output = result.toJs?.() ?? result;
+          console.log(jsonrpcResult({ output }, requestId));
+        }
+        if (result?.destroy) result.destroy();
+      }
     } catch (error) {
       // We have an error => check if it's a SyntaxError or something else
       // The Python error class name is stored in error.type: https://pyodide.org/en/stable/usage/api/js-api.html#pyodide.ffi.PythonError

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import json
+import math
 import os
 import random
 import threading
@@ -289,6 +290,42 @@ def test_serialize_set_mixed_types(pooled_interpreter):
     result = interpreter.execute("x", variables={"x": {1, "a"}})
     assert isinstance(result, list)
     assert set(result) == {1, "a"}
+
+
+def test_result_big_int_round_trip(pooled_interpreter):
+    """Regression test: ints beyond 2**53 must survive the trip back to the host.
+
+    Pyodide converts them to JS BigInt, which JSON.stringify cannot serialize,
+    so returning one previously crashed the execution outright.
+    """
+    interpreter = pooled_interpreter
+    assert interpreter.execute("2**60 + 1") == 2**60 + 1
+    assert interpreter.execute("x", variables={"x": 10**30}) == 10**30
+    assert interpreter.execute("{'count': 2**60}") == {"count": 2**60}
+
+
+def test_result_set_round_trip(pooled_interpreter):
+    """Regression test: sets computed in the sandbox must not be silently dropped.
+
+    A set result previously became a JS Set, which JSON.stringify serializes as
+    {}. Sets now return as sorted lists, matching the variable-injection
+    convention for sets.
+    """
+    interpreter = pooled_interpreter
+    assert interpreter.execute("{3, 1, 2}") == [1, 2, 3]
+    assert interpreter.execute("{'unique': {2, 1}}") == {"unique": [1, 2]}
+
+
+def test_result_non_finite_floats_round_trip(pooled_interpreter):
+    """Regression test: nan/inf inside results must not be silently nulled.
+
+    Non-finite floats previously became None on the way back to the host because
+    JS JSON.stringify turns NaN and Infinity into null.
+    """
+    interpreter = pooled_interpreter
+    result = interpreter.execute("{'a': [float('nan')], 'b': float('inf')}")
+    assert math.isnan(result["a"][0])
+    assert result["b"] == float("inf")
 
 
 def test_serialize_pydantic_variable(pooled_interpreter):

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -316,6 +316,15 @@ def test_result_set_round_trip(pooled_interpreter):
     assert interpreter.execute("{'unique': {2, 1}}") == {"unique": [1, 2]}
 
 
+def test_result_set_mixed_types_round_trip(pooled_interpreter):
+    """Mixed-type sets can't be sorted, so they return as a list in arbitrary
+    order rather than failing serialization, mirroring the injection fallback."""
+    interpreter = pooled_interpreter
+    result = interpreter.execute("{1, 'a'}")
+    assert isinstance(result, list)
+    assert set(result) == {1, "a"}
+
+
 def test_result_non_finite_floats_round_trip(pooled_interpreter):
     """Regression test: nan/inf inside results must not be silently nulled.
 


### PR DESCRIPTION
Fixes #10140.

## Problem

Sandbox execution results cross back to the host via `result.toJs()` + `JSON.stringify` in `runner.js`. Values that are valid Python but not JS-JSON-safe break on the return leg:

| `execute(...)` | Before | After |
|---|---|---|
| `"2**60"` | **CodeExecutionError (crash)** | `1152921504606846976` |
| `"x", variables={"x": 10**30}` | **CodeExecutionError (crash)** | `10**30` exactly |
| `"{1, 2, 3}"` | `{}` (silent loss) | `[1, 2, 3]` |
| `"{'a': [float('nan')]}"` | `{'a': [None]}` | `{'a': [nan]}` |

The crash is reachable through `ProgramOfThought`: any program whose answer exceeds 2**53 (e.g. `math.factorial(20)`) fails deterministically.

## Fix

Serialize the result **inside Pyodide with Python `json`** and send it through the JSON-RPC channel as a string (`output_json`); the host parses it with Python `json.loads`. This mirrors the existing tool-result path, which already sends host tool return values as `{"value": json.dumps(...), "type": "json"}` for the sandbox to parse — the same pattern, other direction.

- Big ints round-trip exactly (both ends are arbitrary-precision Python).
- `nan`/`inf` survive: Python `json.dumps` emits `NaN`/`Infinity` literals and host-side `json.loads` accepts them.
- Sets serialize as sorted lists, matching the documented variable-injection convention in `_serialize_value` ("Sets become sorted lists ... for JSON compatibility").
- Anything Python `json` cannot serialize falls back to the previous `toJs()` path, so behavior for exotic objects is unchanged.

## Not fixed here (pre-existing, unchanged)

- `bytes` results still come back garbled via the fallback path.
- Scalar integral floats (`42.0`, `-0.0`) still return as `int` — they convert to a JS `Number` before any serializer can see them.
- The `SUBMIT`/`FinalOutput` path does `JSON.parse` on the exception args in JS, so a big int passed to `SUBMIT` is silently rounded rather than crashing. Happy to address that in a follow-up if there's interest.

## Testing

- 3 new regression tests (big ints incl. nested, computed sets incl. nested, nan/inf in results).
- Full deno-marked suite passes: `tests/primitives/test_python_interpreter.py`, `test_code_interpreter.py`, `tests/predict/test_program_of_thought.py`, `test_rlm.py` — 232 passed, 2 skipped (pre-existing "requires actual LM" skips). Baseline verified green on unpatched main before the change.
