### PR TITLE
fix(dspy): track completed None results in ParallelExecutor

### DIFF
--- a/dspy/utils/parallelizer.py
+++ b/dspy/utils/parallelizer.py
@@ -15,6 +15,8 @@ from dspy.utils.callback_context import _bind_active_call_id
 
 logger = logging.getLogger(__name__)
 
+_UNSET = object()
+
 
 class ParallelExecutor:
     def __init__(
@@ -73,7 +75,7 @@ class ParallelExecutor:
 
     def _execute_sequential(self, function, data):
         """Execute items sequentially on the main thread."""
-        results = [None] * len(data)
+        results = [_UNSET] * len(data)
 
         pbar = tqdm.tqdm(
             total=len(data),
@@ -101,10 +103,10 @@ class ParallelExecutor:
             logger.warning("Execution cancelled due to errors or interruption.")
             raise Exception("Execution cancelled due to errors or interruption.")
 
-        return results
+        return [None if result is _UNSET else result for result in results]
 
     def _execute_parallel(self, function, data):
-        results = [None] * len(data)
+        results = [_UNSET] * len(data)
         job_cancelled = "cancelled"
 
         # We resubmit at most once per item.
@@ -175,7 +177,7 @@ class ParallelExecutor:
                 )
 
                 def all_done():
-                    return all(r is not None for r in results)
+                    return all(result is not _UNSET for result in results)
 
                 while futures_set and not self.cancel_jobs.is_set():
                     if all_done():
@@ -188,7 +190,7 @@ class ParallelExecutor:
                         except Exception:
                             pass
                         else:
-                            if outcome != job_cancelled and results[index] is None:
+                            if outcome != job_cancelled and results[index] is _UNSET:
                                 self._process_outcome(results, index, outcome)
 
                             self._report_progress(pbar, results, len(data))
@@ -227,7 +229,7 @@ class ParallelExecutor:
             logger.warning("Execution cancelled due to errors or interruption.")
             raise Exception("Execution cancelled due to errors or interruption.")
 
-        return results
+        return [None if result is _UNSET else result for result in results]
 
     def _process_outcome(self, results, idx, outcome):
         """Store a single outcome and track errors."""
@@ -241,12 +243,12 @@ class ParallelExecutor:
     def _report_progress(self, pbar, results, total):
         """Compute metrics and update the progress bar."""
         if self.compare_results:
-            vals = [r[-1] for r in results if r is not None]
+            vals = [result[-1] for result in results if result is not _UNSET and result is not None]
             self._update_progress(pbar, sum(vals), len(vals))
         else:
             self._update_progress(
                 pbar,
-                len([r for r in results if r is not None]),
+                len([result for result in results if result is not _UNSET]),
                 total,
             )
 

--- a/tests/utils/test_parallelizer.py
+++ b/tests/utils/test_parallelizer.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from unittest import mock
 
 import pytest
 
@@ -182,3 +183,15 @@ def test_sequential_compare_results():
     results = executor.execute(task, data)
 
     assert results == [(1, False), (2, False), (3, True), (4, True), (5, True)]
+
+
+@pytest.mark.parametrize("num_threads", [1, 3])
+def test_none_returning_tasks_are_counted_as_complete(num_threads):
+    data = [1, 2, 3, 4, 5]
+    executor = ParallelExecutor(num_threads=num_threads, disable_progress_bar=True)
+
+    with mock.patch.object(executor, "_update_progress") as update_progress:
+        results = executor.execute(lambda _: None, data)
+
+    assert results == [None] * len(data)
+    assert update_progress.call_args == mock.call(mock.ANY, len(data), len(data))


### PR DESCRIPTION
## Summary

Ports the completed-result tracking portion of dbreunig/dspy#4 as an independent upstream change.

- use a private sentinel to distinguish unfinished slots from legitimate `None` results
- count `None`-returning tasks as completed in sequential and threaded progress
- prevent completed `None` slots from being accepted again after straggler resubmission
- preserve the public result contract where failed or unfinished slots are returned as `None`

The original PR’s SIGINT-handler change is intentionally excluded because guarding with `callable()` does not define correct behavior for `SIG_DFL` versus `SIG_IGN`.

Original implementation authored by @dbreunig, with a progress-accounting regression assertion added during upstream review.

## Test plan

- `pytest tests/utils/test_parallelizer.py -q` (14 passed)
- `git diff --check`
- upstream CI

## Lint note

A local whole-file Ruff run found two pre-existing RUF043 findings in `test_parallelizer.py` lines 62 and 147; this PR does not modify those assertions.