### PR TITLE
fix(interpreter): pass SUBMIT payloads through as Python-serialized json

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -663,7 +663,11 @@ class PythonInterpreter:
                 if not isinstance(result, dict):
                     self._raise_terminal_error(f"Malformed execution result: {msg}")
                 self._sync_files()
-                # Check for SUBMIT (encoded as success with "final" field)
+                # Check for SUBMIT (encoded as success with "final_json" or "final")
+                if "final_json" in result:
+                    # Payload serialized with Python json inside the sandbox, so
+                    # big ints and nan/inf survive the JS boundary.
+                    return FinalOutput(json.loads(result["final_json"]))
                 if "final" in result:
                     return FinalOutput(result["final"])
                 return result.get("output", None)

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -19,6 +19,27 @@ sys.stdout, sys.stderr = buf_stdout, buf_stderr
 def last_exception_args():
     return json.dumps(sys.last_exc.args) if sys.last_exc else None
 
+def final_output_json():
+    # Serialize the FinalOutput payload with Python json and hand the string
+    # through JSON-RPC untouched, so values that are valid Python but not
+    # JS-JSON-safe survive: ints beyond 2**53 would be silently rounded by
+    # JSON.parse in JS, and nan/inf (emitted as bare NaN/Infinity by Python
+    # json) would make JSON.parse throw. The host parses with Python
+    # json.loads, which accepts both.
+    if not (sys.last_exc and sys.last_exc.args):
+        return None
+    def _default(o):
+        if isinstance(o, (set, frozenset)):
+            try:
+                return sorted(o)
+            except TypeError:
+                return list(o)
+        raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
+    try:
+        return json.dumps(sys.last_exc.args[0], default=_default)
+    except TypeError:
+        return None
+
 class FinalOutput(BaseException):
     # Control-flow exception to signal completion (like StopIteration)
     pass
@@ -349,6 +370,15 @@ while (true) {
 
       // Handle FinalOutput as a success result, not an error
       if (errorType === "FinalOutput") {
+        // Serialize the payload on the Python side and pass the JSON text
+        // through untouched; JSON.parse here would round ints beyond 2**53
+        // and throw on the NaN/Infinity literals Python json emits.
+        const finalOutputJson = pyodide.globals.get("final_output_json");
+        const serialized = finalOutputJson();
+        if (serialized !== null && serialized !== undefined) {
+          console.log(jsonrpcResult({ final_json: serialized }, requestId));
+          continue;
+        }
         const last_exception_args = pyodide.globals.get("last_exception_args");
         const errorArgs = JSON.parse(last_exception_args()) || [];
         const answer = errorArgs[0] || null;

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -37,7 +37,8 @@ def final_output_json():
         raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
     try:
         return json.dumps(sys.last_exc.args[0], default=_default)
-    except TypeError:
+    except (TypeError, ValueError):
+        # TypeError: unsupported type; ValueError: circular reference.
         return None
 
 class FinalOutput(BaseException):
@@ -379,10 +380,19 @@ while (true) {
           console.log(jsonrpcResult({ final_json: serialized }, requestId));
           continue;
         }
-        const last_exception_args = pyodide.globals.get("last_exception_args");
-        const errorArgs = JSON.parse(last_exception_args()) || [];
-        const answer = errorArgs[0] || null;
-        console.log(jsonrpcResult({ final: answer }, requestId));
+        // The legacy path also serializes with Python json (in
+        // last_exception_args), so a payload the serializer rejected can throw
+        // again here. Surface that as a structured error instead of letting it
+        // escape as an unhandled rejection that kills the session.
+        try {
+          const last_exception_args = pyodide.globals.get("last_exception_args");
+          const errorArgs = JSON.parse(last_exception_args()) || [];
+          const answer = errorArgs[0] || null;
+          console.log(jsonrpcResult({ final: answer }, requestId));
+        } catch (e) {
+          const message = `SUBMIT payload is not JSON-serializable: ${e.message || e}`;
+          console.log(jsonrpcError(JSONRPC_APP_ERRORS.ValueError, message, requestId, { type: "ValueError", args: [message] }));
+        }
         continue;
       }
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -1,6 +1,7 @@
 import asyncio
 import dataclasses
 import json
+import math
 import os
 import random
 import threading
@@ -130,6 +131,35 @@ def test_submit_with_list(pooled_interpreter):
     assert isinstance(result, FinalOutput)
     # SUBMIT now always returns a dict with "output" key for single-output default
     assert result.output == {"output": ["The result is", token]}
+
+
+def test_submit_big_int_round_trip(pooled_interpreter):
+    """Regression test: SUBMIT payloads with ints beyond 2**53 must not be rounded.
+
+    The payload previously crossed the boundary through JS JSON.parse, which
+    represents all numbers as float64, silently corrupting larger ints.
+    """
+    interpreter = pooled_interpreter
+    result = interpreter.execute("SUBMIT(2**60 + 1)")
+    assert isinstance(result, FinalOutput)
+    assert result.output == {"output": 2**60 + 1}
+
+
+def test_submit_non_finite_floats(pooled_interpreter):
+    """Regression test: SUBMIT with nan/inf must not crash execution.
+
+    Python json serializes the payload with bare NaN/Infinity literals, which
+    JS JSON.parse rejects, so SUBMIT(float("nan")) previously raised
+    CodeExecutionError instead of returning the value.
+    """
+    interpreter = pooled_interpreter
+    result = interpreter.execute("SUBMIT(float('nan'))")
+    assert isinstance(result, FinalOutput)
+    assert math.isnan(result.output["output"])
+
+    result = interpreter.execute("SUBMIT({'value': float('inf')})")
+    assert isinstance(result, FinalOutput)
+    assert result.output["output"] == {"value": float("inf")}
 
 
 def test_enable_env_vars_flag():

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -175,6 +175,19 @@ def test_submit_set_round_trip(pooled_interpreter):
     assert result.output == {"output": [1, 2, 3]}
 
 
+def test_submit_circular_payload_raises_cleanly(pooled_interpreter):
+    """Regression test: a circular SUBMIT payload must raise a structured error.
+
+    json.dumps raises ValueError on circular references, which previously
+    escaped as an unhandled async rejection and terminated the Deno session.
+    """
+    interpreter = pooled_interpreter
+    with pytest.raises(CodeExecutionError, match="not JSON-serializable"):
+        interpreter.execute("x = []\nx.append(x)\nSUBMIT(x)")
+    # The session must survive the failed SUBMIT.
+    assert interpreter.execute("1 + 1") == 2
+
+
 def test_enable_env_vars_flag():
     os.environ["FOO_TEST_ENV"] = "test_value"
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -162,6 +162,19 @@ def test_submit_non_finite_floats(pooled_interpreter):
     assert result.output["output"] == {"value": float("inf")}
 
 
+def test_submit_set_round_trip(pooled_interpreter):
+    """Regression test: SUBMIT with a set must not crash, and must follow the
+    same set-to-sorted-list convention as variable injection.
+
+    The payload was previously serialized with a plain json.dumps, which raises
+    TypeError on sets, crashing the execution.
+    """
+    interpreter = pooled_interpreter
+    result = interpreter.execute("SUBMIT({3, 1, 2})")
+    assert isinstance(result, FinalOutput)
+    assert result.output == {"output": [1, 2, 3]}
+
+
 def test_enable_env_vars_flag():
     os.environ["FOO_TEST_ENV"] = "test_value"
 


### PR DESCRIPTION
Fixes #10143.

## Problem

`SUBMIT()` payloads cross the sandbox boundary through JS `JSON.parse` in the `FinalOutput` handler in `runner.js`, then get re-serialized for the host. Failure modes:

| `execute(...)` | Before | After |
|---|---|---|
| `"SUBMIT(2**60 + 1)"` | `{'output': 1152921504606847000}` — **silently off by 23** | exact |
| `"SUBMIT(float('nan'))"` | **CodeExecutionError (crash)** | `{'output': nan}` |
| `"SUBMIT({'value': float('inf')})"` | **CodeExecutionError (crash)** | `{'output': {'value': inf}}` |
| `"SUBMIT({3, 1, 2})"` | **CodeExecutionError (crash)** | `{'output': [1, 2, 3]}` |
| `"SUBMIT(x)"` where `x` is circular | **unhandled rejection, Deno session terminated** | structured `CodeExecutionError`, session survives |

Rounding: `JSON.parse` represents all numbers as float64. Crashes: the payload is serialized by `last_exception_args()` with a plain `json.dumps`, which emits bare `NaN`/`Infinity` literals that JS `JSON.parse` rejects, and raises `TypeError` outright on sets.

This is the SUBMIT leg of the boundary issue fixed for expression results in #10141 — reachable through `ProgramOfThought`, where SUBMIT carries the final answer.

## Fix

Same pattern as #10141: a `final_output_json()` helper serializes the payload inside Pyodide with Python `json`, the resulting string passes through JSON-RPC untouched, and the host parses it with Python `json.loads` (exact big ints, accepts `NaN`/`Infinity`). Payloads Python `json` cannot serialize (`TypeError` for unsupported types, `ValueError` for circular references) fall back to the previous `JSON.parse` path; if that path also fails to serialize — it runs the same Python `json.dumps` inside `last_exception_args()` — the failure is emitted as a structured JSON-RPC `ValueError` instead of escaping as an unhandled rejection that kills the Deno session. Previously a circular `SUBMIT` payload terminated the session outright (on main as well); it now raises a clean `CodeExecutionError` and the session remains usable.

## Type conventions

Deliberately identical to #10141 and to the host-side `_serialize_value` injection convention: sets serialize as sorted lists (unsorted list fallback for mixed types), tuples as lists — covered by `test_submit_set_round_trip`. The serializer's `_default` handler is intentionally duplicated from #10141 rather than shared, so the two PRs stay independent (based on main, either can land first). Happy to unify the two helpers in whichever branch lands second — it will need a rebase over the other at that point anyway.

## Testing

- 4 new regression tests (big-int payload exactness; nan and nested inf payloads returning instead of crashing; set payloads following the injection convention; circular payloads raising a structured error with the session surviving).
- Full deno-marked suite green: `test_python_interpreter.py`, `test_code_interpreter.py`, `test_program_of_thought.py`, `test_rlm.py` — 233 passed, 2 pre-existing "requires actual LM" skips.
