### PR TITLE
feat(dspy): add Module.aforward fallback for sync modules

### DIFF
--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -128,6 +128,16 @@ class Module(BaseModule, metaclass=ProgramMeta):
 
             return await self.aforward(*args, **kwargs)
 
+    async def aforward(self, *args, **kwargs):
+        """Run a sync-only module's ``forward`` method in a worker thread.
+
+        Subclasses with native async logic should override this method.
+        """
+        from dspy.utils.asyncify import asyncify
+
+        forward = object.__getattribute__(self, "forward")
+        return await asyncify(forward)(*args, **kwargs)
+
     def named_predictors(self):
         """Return all named Predict modules in this module.
 

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -169,6 +169,38 @@ def test_complex_module_set_attribute_by_name():
     assert root.sub_module.nested_tuple[1][1].test_attrib is True
 
 
+@pytest.mark.asyncio
+async def test_acall_falls_back_to_sync_forward():
+    class SyncOnly(dspy.Module):
+        def forward(self, x):
+            return x * 2
+
+    assert await SyncOnly().acall(x=3) == 6
+
+
+@pytest.mark.asyncio
+async def test_acall_fallback_sees_context_overrides():
+    class ReadsLM(dspy.Module):
+        def forward(self):
+            return dspy.settings.lm
+
+    lm = DummyLM([{"answer": "n/a"}])
+    with dspy.context(lm=lm):
+        assert await ReadsLM().acall() is lm
+
+
+@pytest.mark.asyncio
+async def test_acall_prefers_defined_aforward():
+    class Both(dspy.Module):
+        def forward(self, x):
+            return "sync"
+
+        async def aforward(self, x):
+            return "async"
+
+    assert await Both().acall(x=1) == "async"
+
+
 class DuplicateModule(Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
## Summary

Ports the base `Module.aforward` portion of dbreunig/dspy#8 as an independent upstream change.

- make `await module.acall(...)` work for modules that only implement sync `forward`
- run sync fallback work through `dspy.asyncify` so settings context reaches the worker thread
- preserve native `aforward` overrides
- bypass the direct-`forward` warning internally without broadening its stack-name exemption

The original PR’s event-loop limiter redesign and Tool diagnostic are intentionally separated.

Original implementation authored by @dbreunig; the internal forward lookup was tightened during upstream review.

## Test plan

- `pytest tests/primitives/test_module.py -q` (19 passed)
- focused Ruff check passed
- upstream CI