### PR TITLE
fix(dspy): reject sync async-tool calls inside running loops

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -172,7 +172,13 @@ class Tool(Type):
 
         if loop is None:
             return asyncio.run(coroutine)
-        return loop.run_until_complete(coroutine)
+
+        coroutine.close()
+        raise ValueError(
+            "You are calling `__call__` on an async tool from within a running event loop, which cannot be "
+            "converted to a sync call, even with `allow_tool_async_sync_conversion` enabled. Please use "
+            "`await tool.acall(...)` instead."
+        )
 
     @with_callbacks
     def __call__(self, **kwargs):

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -408,6 +408,14 @@ def test_async_tool_call_in_sync_mode():
         assert result == "hello 1"
 
 
+@pytest.mark.asyncio
+async def test_async_tool_sync_call_within_running_loop():
+    tool = Tool(async_dummy_function)
+    with dspy.context(allow_tool_async_sync_conversion=True):
+        with pytest.raises(ValueError, match=r".*await tool\.acall.*"):
+            tool(x=1, y="hello")
+
+
 TOOL_CALL_TEST_CASES = [
     ([], {"tool_calls": []}),
     (


### PR DESCRIPTION
## Summary

Ports the Tool running-loop portion of dbreunig/dspy#8 as an independent upstream change.

- reject sync conversion of an async tool when the current thread already runs an event loop
- direct callers to `await tool.acall(...)` instead of surfacing the opaque `run_until_complete` runtime error
- close the already-created coroutine before raising, avoiding an un-awaited-coroutine warning
- preserve async-to-sync conversion when no loop is running

The original PR’s base `Module.aforward` and limiter changes are intentionally separated.

Authored by @dbreunig.

## Test plan

- `pytest tests/adapters/test_tool.py -q` (39 passed)
- focused Ruff check passed
- upstream CI