### PR TITLE
feat(dspy): track LM duration and aggregate response cost

### DIFF
--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -2,6 +2,7 @@ import copy as copy_module
 import datetime
 import importlib
 import inspect
+import time
 import uuid
 import warnings
 from typing import Any, Literal, TextIO
@@ -283,7 +284,7 @@ class BaseLM:
         """Set of supported OpenAI-style parameter names for the model."""
         return set()
 
-    def _process_lm_response(self, response, prompt, messages, **kwargs):
+    def _process_lm_response(self, response, prompt, messages, duration=None, **kwargs):
         merged_kwargs = {**self.kwargs, **kwargs}
 
         if self.model_type == "responses":
@@ -291,8 +292,9 @@ class BaseLM:
         else:
             outputs = self._process_completion(response, merged_kwargs)
 
+        cost = getattr(response, "_hidden_params", {}).get("response_cost")
         if not getattr(response, "cache_hit", False) and settings.usage_tracker:
-            settings.usage_tracker.add_usage(self.model, dict(getattr(response, "usage", {}) or {}))
+            settings.usage_tracker.add_usage(self.model, dict(getattr(response, "usage", {}) or {}), cost=cost)
 
         if settings.disable_history:
             return outputs
@@ -306,7 +308,8 @@ class BaseLM:
             "response": response,
             "outputs": outputs,
             "usage": dict(getattr(response, "usage", {}) or {}),
-            "cost": getattr(response, "_hidden_params", {}).get("response_cost"),
+            "cost": cost,
+            "duration": duration,
             "timestamp": datetime.datetime.now().isoformat(),
             "uuid": str(uuid.uuid4()),
             "model": self.model,
@@ -364,8 +367,12 @@ class BaseLM:
             return self._legacy_call_direct(*items, prompt=prompt, messages=messages, **kwargs)
 
         if forward_contract == "typed_lm":
+            start = time.perf_counter()
             response = self.forward(normalized_request)
-            response = self._finalize_lm_response(normalized_request, self._validate_typed_lm_response(response))
+            duration = time.perf_counter() - start
+            response = self._finalize_lm_response(
+                normalized_request, self._validate_typed_lm_response(response), duration=duration
+            )
         else:
             response = self._legacy_forward_as_lm_response(normalized_request)
         if return_typed_response:
@@ -397,8 +404,12 @@ class BaseLM:
             return await self._legacy_acall_direct(*items, prompt=prompt, messages=messages, **kwargs)
 
         if forward_contract == "typed_lm":
+            start = time.perf_counter()
             response = await self.aforward(normalized_request)
-            response = self._finalize_lm_response(normalized_request, self._validate_typed_lm_response(response))
+            duration = time.perf_counter() - start
+            response = self._finalize_lm_response(
+                normalized_request, self._validate_typed_lm_response(response), duration=duration
+            )
         else:
             response = await self._legacy_aforward_as_lm_response(normalized_request)
         if return_typed_response:
@@ -438,13 +449,15 @@ class BaseLM:
     ) -> list[dict[str, Any] | str]:
         """Execute the pre-typed synchronous call path and return legacy outputs."""
         prompt = self._legacy_prompt_from_items(items, prompt=prompt)
+        start = time.perf_counter()
         response = self.forward(prompt=prompt, messages=messages, **kwargs)
+        duration = time.perf_counter() - start
         if isinstance(response, LMResponse):
             raise TypeError(
                 f"{type(self).__name__}.forward() returned dspy.LMResponse on the legacy direct path. "
                 "Set forward_contract='typed_lm' or pass an LMRequest/use dspy.context(experimental=True)."
             )
-        return self._process_lm_response(response, prompt, messages, **kwargs)
+        return self._process_lm_response(response, prompt, messages, duration=duration, **kwargs)
 
     async def _legacy_acall_direct(
         self,
@@ -455,13 +468,15 @@ class BaseLM:
     ) -> list[dict[str, Any] | str]:
         """Execute the pre-typed asynchronous call path and return legacy outputs."""
         prompt = self._legacy_prompt_from_items(items, prompt=prompt)
+        start = time.perf_counter()
         response = await self.aforward(prompt=prompt, messages=messages, **kwargs)
+        duration = time.perf_counter() - start
         if isinstance(response, LMResponse):
             raise TypeError(
                 f"{type(self).__name__}.aforward() returned dspy.LMResponse on the legacy direct path. "
                 "Set forward_contract='typed_lm' or pass an LMRequest/use dspy.context(experimental=True)."
             )
-        return self._process_lm_response(response, prompt, messages, **kwargs)
+        return self._process_lm_response(response, prompt, messages, duration=duration, **kwargs)
 
     def _legacy_prompt_from_items(self, items: tuple[Any, ...], *, prompt: str | None) -> str | None:
         """Validate and extract the one positional prompt accepted by legacy calls."""
@@ -514,14 +529,16 @@ class BaseLM:
         prompt = self._prompt_from_lm_request(request)
         if prompt is not None:
             messages = None
+        start = time.perf_counter()
         response = self.forward(prompt=prompt, messages=messages, **data)
+        duration = time.perf_counter() - start
         typed_response = self._validate_legacy_lm_response(response, stacklevel=4)
         if typed_response is not None:
-            return self._finalize_lm_response(request, typed_response)
+            return self._finalize_lm_response(request, typed_response, duration=duration)
         with settings.context(disable_history=True, usage_tracker=None):
             outputs = self._process_lm_response(response, prompt, messages, **data)
         lm_response = self._legacy_outputs_to_lm_response(outputs, request=request, provider_response=response)
-        return self._finalize_lm_response(request, lm_response)
+        return self._finalize_lm_response(request, lm_response, duration=duration)
 
     async def _legacy_aforward_as_lm_response(self, request: LMRequest) -> LMResponse:
         """Async variant of `_legacy_forward_as_lm_response()`."""
@@ -530,14 +547,16 @@ class BaseLM:
         prompt = self._prompt_from_lm_request(request)
         if prompt is not None:
             messages = None
+        start = time.perf_counter()
         response = await self.aforward(prompt=prompt, messages=messages, **data)
+        duration = time.perf_counter() - start
         typed_response = self._validate_legacy_lm_response(response, stacklevel=4)
         if typed_response is not None:
-            return self._finalize_lm_response(request, typed_response)
+            return self._finalize_lm_response(request, typed_response, duration=duration)
         with settings.context(disable_history=True, usage_tracker=None):
             outputs = self._process_lm_response(response, prompt, messages, **data)
         lm_response = self._legacy_outputs_to_lm_response(outputs, request=request, provider_response=response)
-        return self._finalize_lm_response(request, lm_response)
+        return self._finalize_lm_response(request, lm_response, duration=duration)
 
     def _legacy_outputs_to_lm_response(
         self,
@@ -585,17 +604,18 @@ class BaseLM:
         part = message.parts[0]
         return part.text if getattr(part, "type", None) == "text" else None
 
-    def _finalize_lm_response(self, request: LMRequest, response: LMResponse) -> LMResponse:
+    def _finalize_lm_response(
+        self, request: LMRequest, response: LMResponse, duration: float | None = None
+    ) -> LMResponse:
         """Record usage and typed history for a normalized LM response."""
         if not getattr(response, "cache_hit", False) and settings.usage_tracker:
-            usage = response.usage_as_dict()
-            if usage:
-                settings.usage_tracker.add_usage(self.model, usage)
+            settings.usage_tracker.add_usage(self.model, response.usage_as_dict(), cost=response.cost)
 
         if not settings.disable_history:
             entry = LMHistoryEntry(
                 request=request,
                 response=response,
+                duration=duration,
                 timestamp=datetime.datetime.now().isoformat(),
                 uuid=str(uuid.uuid4()),
                 model_type=getattr(self, "model_type", None),

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -930,6 +930,8 @@ class LMHistoryEntry(BaseModel, Mapping[str, Any]):
 
     Store the canonical request and response, then derive legacy convenience
     fields such as `outputs`, `usage`, `messages`, and `kwargs` on demand.
+    `duration` is elapsed wall-clock time spent in the provider-facing LM call;
+    it does not include request preparation or response post-processing.
     Because this class implements `Mapping`, existing history code can keep
     using `entry["messages"]`, `entry.get("prompt")`, `entry.items()`, and
     `dict(entry)`.
@@ -937,6 +939,7 @@ class LMHistoryEntry(BaseModel, Mapping[str, Any]):
 
     request: LMRequest
     response: LMResponse
+    duration: float | None = None
     timestamp: str
     uuid: str
     model_type: str | None = None

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -51,9 +51,11 @@ def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO
         messages = item["messages"] or [{"role": "user", "content": item["prompt"]}]
         outputs = item["outputs"]
         timestamp = item.get("timestamp", "Unknown time")
+        duration = item.get("duration")
+        header = f"[{timestamp}]" if duration is None else f"[{timestamp}] ({duration:.3f}s)"
 
         print("\n\n\n", file=out)
-        print(_blue(f"[{timestamp}]", use_colors=use_colors), file=out)
+        print(_blue(header, use_colors=use_colors), file=out)
 
         for msg in messages:
             print(_red(f"{msg['role'].capitalize()} message:", use_colors=use_colors), file=out)

--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -1,5 +1,7 @@
 """Usage tracking utilities for DSPy."""
 
+import copy
+import threading
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, Generator
@@ -21,6 +23,17 @@ class UsageTracker:
         #     ],
         # }
         self.usage_data = defaultdict(list)
+        # Map of LM name to accumulated response cost, e.g. {"openai/gpt-4o-mini": 0.0021}.
+        self.total_cost_by_model = defaultdict(float)
+        self._lock = threading.Lock()
+
+    def __deepcopy__(self, memo):
+        copied = type(self)()
+        memo[id(self)] = copied
+        with self._lock:
+            copied.usage_data = copy.deepcopy(self.usage_data, memo)
+            copied.total_cost_by_model = copy.deepcopy(self.total_cost_by_model, memo)
+        return copied
 
     def _flatten_usage_entry(self, usage_entry: dict[str, Any]) -> dict[str, Any]:
         result = {}
@@ -49,20 +62,33 @@ class UsageTracker:
                 result[k] = (current_v or 0) + (v or 0)
         return result
 
-    def add_usage(self, lm: str, usage_entry: dict[str, Any]) -> None:
-        """Add a usage entry to the tracker."""
-        if len(usage_entry) > 0:
-            self.usage_data[lm].append(self._flatten_usage_entry(usage_entry))
+    def add_usage(self, lm: str, usage_entry: dict[str, Any], cost: float | None = None) -> None:
+        """Add a usage entry, and optionally its response cost, to the tracker."""
+        flattened_usage = self._flatten_usage_entry(usage_entry) if usage_entry else None
+        normalized_cost = float(cost) if cost is not None else None
+        with self._lock:
+            if flattened_usage is not None:
+                self.usage_data[lm].append(flattened_usage)
+            if normalized_cost is not None:
+                self.total_cost_by_model[lm] += normalized_cost
 
     def get_total_tokens(self) -> dict[str, dict[str, Any]]:
         """Calculate total tokens from all tracked usage."""
+        with self._lock:
+            usage_data = copy.deepcopy(self.usage_data)
+
         total_usage_by_lm = {}
-        for lm, usage_entries in self.usage_data.items():
+        for lm, usage_entries in usage_data.items():
             total_usage = {}
             for usage_entry in usage_entries:
                 total_usage = self._merge_usage_entries(total_usage, usage_entry)
             total_usage_by_lm[lm] = total_usage
         return total_usage_by_lm
+
+    def get_total_cost(self) -> float:
+        """Calculate the total cost from all tracked usage, 0.0 when no costs were reported."""
+        with self._lock:
+            return sum(self.total_cost_by_model.values(), 0.0)
 
 
 @contextmanager

--- a/tests/clients/test_inspect_global_history.py
+++ b/tests/clients/test_inspect_global_history.py
@@ -92,6 +92,22 @@ def test_inspect_history_renders_output_tool_calls_without_text():
     assert 'search: {"query": "dogs"}' in text
 
 
+def test_inspect_history_renders_duration():
+    out = StringIO()
+    history = [
+        {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "outputs": ["Hello"],
+            "timestamp": "now",
+            "duration": 0.25,
+        }
+    ]
+
+    pretty_print_history(history, n=1, file=out)
+
+    assert "[now] (0.250s)" in out.getvalue()
+
+
 def test_inspect_history_with_n(capsys):
     """Test that inspect_history works with n
     Random failures in this test most likely mean you are printing messages somewhere

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -621,6 +621,7 @@ def test_base_lm_legacy_bridge_records_typed_history_and_usage_once():
     assert len(lm.history) == 1
     assert lm.history[0].request == request
     assert lm.history[0].response == response
+    assert lm.history[0].duration > 0
     total_usage = usage_tracker.get_total_tokens()["custom-model"]
     assert total_usage["prompt_tokens"] == 1
     assert total_usage["completion_tokens"] == 2
@@ -1081,6 +1082,8 @@ async def test_async_lm_call():
 
         assert result == ["answer"]
         mock_acompletion.assert_called_once()
+        assert isinstance(lm.history[-1]["duration"], float)
+        assert lm.history[-1]["duration"] > 0
 
 
 @pytest.mark.asyncio
@@ -1119,6 +1122,40 @@ async def test_async_lm_call_with_cache(tmp_path):
         assert mock_alitellm_completion.call_count == 2
 
     dspy.cache = original_cache
+
+
+def test_lm_history_records_duration():
+    lm = dspy.LM(model="openai/gpt-4o-mini", cache=False)
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = ModelResponse(
+            choices=[Choices(message=Message(content="test answer"))],
+            model="openai/gpt-4o-mini",
+        )
+        lm("query")
+
+    assert isinstance(lm.history[-1]["duration"], float)
+    assert lm.history[-1]["duration"] > 0
+
+
+def test_lm_cost_flows_into_usage_tracker():
+    mock_response = ModelResponse(
+        choices=[Choices(message=Message(content="answer"))],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        model="openai/gpt-4o-mini",
+    )
+    mock_response._hidden_params = {"response_cost": 0.25}
+
+    with mock.patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = mock_response
+
+        lm = dspy.LM(model="openai/gpt-4o-mini", cache=False)
+        with track_usage() as tracker:
+            lm("query")
+            lm("query")
+
+    assert lm.history[-1]["cost"] == 0.25
+    assert tracker.total_cost_by_model["openai/gpt-4o-mini"] == pytest.approx(0.5)
+    assert tracker.get_total_cost() == pytest.approx(0.5)
 
 
 def test_lm_history_size_limit():

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -1,5 +1,8 @@
+import copy
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
+import pytest
 from pydantic import BaseModel
 
 import dspy
@@ -27,6 +30,72 @@ def test_add_usage_entry():
     tracker.add_usage("gpt-4o-mini", usage_entry)
     assert len(tracker.usage_data["gpt-4o-mini"]) == 1
     assert tracker.usage_data["gpt-4o-mini"][0] == usage_entry
+
+
+def test_add_usage_with_cost():
+    """Test accumulating response costs across calls and models."""
+    tracker = UsageTracker()
+
+    tracker.add_usage("gpt-4o-mini", {"prompt_tokens": 10, "completion_tokens": 5}, cost=0.001)
+    tracker.add_usage("gpt-4o-mini", {"prompt_tokens": 20, "completion_tokens": 10}, cost=0.002)
+    tracker.add_usage("gpt-3.5-turbo", {"prompt_tokens": 5, "completion_tokens": 5}, cost=0.0005)
+
+    assert tracker.total_cost_by_model["gpt-4o-mini"] == pytest.approx(0.003)
+    assert tracker.total_cost_by_model["gpt-3.5-turbo"] == pytest.approx(0.0005)
+    assert tracker.get_total_cost() == pytest.approx(0.0035)
+
+
+def test_add_usage_with_none_cost():
+    """None costs are not accumulated, and the total defaults to 0.0."""
+    tracker = UsageTracker()
+
+    assert tracker.get_total_cost() == 0.0
+
+    tracker.add_usage("gpt-4o-mini", {"prompt_tokens": 10, "completion_tokens": 5})
+    tracker.add_usage("gpt-4o-mini", {"prompt_tokens": 20, "completion_tokens": 10}, cost=None)
+
+    assert len(tracker.usage_data["gpt-4o-mini"]) == 2
+    assert len(tracker.total_cost_by_model) == 0
+    assert tracker.get_total_cost() == 0.0
+
+
+def test_add_usage_cost_without_usage_entry():
+    """Cost is tracked even when the provider reports no token usage."""
+    tracker = UsageTracker()
+
+    tracker.add_usage("gpt-4o-mini", {}, cost=0.01)
+
+    assert len(tracker.usage_data) == 0
+    assert tracker.get_total_cost() == pytest.approx(0.01)
+
+
+def test_usage_and_cost_updates_are_thread_safe():
+    tracker = UsageTracker()
+    update_count = 1_000
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        list(
+            executor.map(
+                lambda _: tracker.add_usage("model", {"total_tokens": 1}, cost=0.01),
+                range(update_count),
+            )
+        )
+
+    assert tracker.get_total_tokens()["model"]["total_tokens"] == update_count
+    assert tracker.get_total_cost() == pytest.approx(update_count * 0.01)
+
+
+def test_usage_tracker_can_be_deep_copied():
+    tracker = UsageTracker()
+    tracker.add_usage("model", {"total_tokens": 1}, cost=0.01)
+
+    copied = copy.deepcopy(tracker)
+    copied.add_usage("model", {"total_tokens": 2}, cost=0.02)
+
+    assert tracker.get_total_tokens()["model"]["total_tokens"] == 1
+    assert tracker.get_total_cost() == pytest.approx(0.01)
+    assert copied.get_total_tokens()["model"]["total_tokens"] == 3
+    assert copied.get_total_cost() == pytest.approx(0.03)
 
 
 def test_get_total_tokens():


### PR DESCRIPTION
## Summary

Ports dbreunig/dspy#9 with concurrency and contract fixes from upstream review.

- record provider-facing sync and async call duration in LM history
- display duration in `inspect_history`
- aggregate provider-reported response costs in `UsageTracker`
- retain cache-hit exclusion for cost and token accounting
- track cost even when a provider omits token usage
- make usage and cost reads/writes thread-safe while preserving `UsageTracker` deepcopy isolation
- normalize reported numeric costs to `float`

`duration` measures elapsed time in the provider-facing `forward`/`aforward` call, not request preparation, adapter parsing, or post-processing. Costs are provider estimates attributed to the configured DSPy model key, matching existing token attribution.

Original implementation authored by @dbreunig; synchronization, deepcopy support, concurrency tests, and contract documentation were added during upstream review.

## Test plan

- `pytest tests/utils/test_usage_tracker.py tests/clients/test_inspect_global_history.py -q` (19 passed, 1 skipped)
- `pytest tests/clients/test_lm.py -q` (89 passed)
- `pytest tests/core/test_types.py -q` (26 passed)
- focused Ruff check passed
- upstream CI