### PR TITLE
fix: cap FastAPI for LiteLLM proxy compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ dev = [
     "datamodel_code_generator>=0.26.3",
     "build>=1.0.3",
     "numpy>=1.26.0",
+    # LiteLLM proxy imports an internal FastAPI helper removed in 0.140.7.
+    "fastapi<0.140.7; sys_platform != 'win32' and python_version < '3.14'",
     "litellm>=1.65.8; sys_platform == 'win32' or python_version == '3.14'",
     "litellm[proxy]>=1.65.8; sys_platform != 'win32' and python_version < '3.14'",  # Remove 3.14 condition once uvloop supports
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -789,6 +789,7 @@ anthropic = [
 dev = [
     { name = "build" },
     { name = "datamodel-code-generator" },
+    { name = "fastapi", marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "litellm", version = "1.68.0", source = { registry = "https://pypi.org/simple" }, extra = ["proxy"], marker = "python_full_version < '3.14' and sys_platform != 'win32'" },
     { name = "litellm", version = "1.72.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' or sys_platform == 'win32'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -843,6 +844,7 @@ requires-dist = [
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
     { name = "diskcache", specifier = ">=5.6.0" },
+    { name = "fastapi", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = "<0.140.7" },
     { name = "gepa", extras = ["dspy"], specifier = "==0.1.1" },
     { name = "json-repair", specifier = ">=0.54.2" },
     { name = "langchain-core", marker = "extra == 'langchain'", specifier = ">=0.3.0" },


### PR DESCRIPTION
## Summary

The DSPy dev extra installs litellm[proxy], whose current dependency range can resolve FastAPI to a release where LiteLLM imports a removed internal helper. Pin FastAPI below 0.140.7 only for the Linux/Python less-than-3.14 development proxy environment, and regenerate the lockfile.

This leaves normal DSPy runtime dependencies and Windows/Python 3.14 paths unchanged.

## Validation

- uv lock --check

Fixes #10128