### PR TITLE
fix(dspy): keep fail_count immutable in BestOfN and Refine

### DIFF
--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -45,13 +45,15 @@ class BestOfN(Module):
         self.reward_fn = lambda *args: reward_fn(*args)  # to prevent this from becoming a parameter
         self.threshold = threshold
         self.N = N
-        self.fail_count = fail_count or N  # default to N if fail_count is not provided
+        self.fail_count = N if fail_count is None else fail_count
 
     def forward(self, **kwargs):
         lm = self.module.get_lm() or dspy.settings.lm
         start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]
         best_pred, best_trace, best_reward = None, None, -float("inf")
+        failures = 0
+        last_exception = None
 
         for idx, rid in enumerate(rollout_ids):
             lm_ = lm.copy(rollout_id=rid, temperature=1.0)
@@ -74,9 +76,13 @@ class BestOfN(Module):
 
             except Exception as e:
                 print(f"BestOfN: Attempt {idx + 1} failed with rollout id {rid}: {e}")
-                if idx > self.fail_count:
-                    raise e
-                self.fail_count -= 1
+                failures += 1
+                last_exception = e
+                if failures > self.fail_count:
+                    raise
+
+        if best_pred is None and last_exception is not None:
+            raise last_exception
 
         if best_trace:
             dspy.settings.trace.extend(best_trace)

--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -88,7 +88,7 @@ class Refine(Module):
         self.reward_fn = lambda *args: reward_fn(*args)  # to prevent this from becoming a parameter
         self.threshold = threshold
         self.N = N
-        self.fail_count = fail_count or N  # default to N if fail_count is not provided
+        self.fail_count = N if fail_count is None else fail_count
         self.module_code = inspect.getsource(module.__class__)
         try:
             self.reward_fn_code = inspect.getsource(reward_fn)
@@ -102,6 +102,8 @@ class Refine(Module):
         best_pred, best_trace, best_reward = None, None, -float("inf")
         advice = None
         adapter = dspy.settings.adapter or dspy.ChatAdapter()
+        failures = 0
+        last_exception = None
 
         for idx, rid in enumerate(rollout_ids):
             lm_ = lm.copy(rollout_id=rid, temperature=1.0)
@@ -169,9 +171,12 @@ class Refine(Module):
 
             except Exception as e:
                 print(f"Refine: Attempt failed with rollout id {rid}: {e}")
-                if idx > self.fail_count:
-                    raise e
-                self.fail_count -= 1
+                failures += 1
+                last_exception = e
+                if failures > self.fail_count:
+                    raise
+        if best_pred is None and last_exception is not None:
+            raise last_exception
         if best_trace:
             dspy.settings.trace.extend(best_trace)
         return best_pred

--- a/tests/predict/test_best_of_n.py
+++ b/tests/predict/test_best_of_n.py
@@ -48,15 +48,58 @@ def test_refine_forward_success_first_attempt():
 def test_refine_module_default_fail_count():
     lm = DummyLM([{"answer": "Brussels"}, {"answer": "City of Brussels"}, {"answer": "Brussels"}])
     dspy.configure(lm=lm)
+    module_call_count = [0]
 
     def always_raise(self, **kwargs):
-        raise ValueError("Deliberately failing")
+        module_call_count[0] += 1
+        raise ValueError(f"Failure {module_call_count[0]}")
 
     predict = DummyModule("question -> answer", always_raise)
 
     best_of_n = BestOfN(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Failure 3"):
         best_of_n(question="What is the capital of Belgium?")
+    with pytest.raises(ValueError, match="Failure 6"):
+        best_of_n(question="What is the capital of Belgium?")
+    assert module_call_count[0] == 6
+    assert best_of_n.fail_count == 3
+
+
+def test_refine_module_zero_fail_count():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+    module_call_count = [0]
+
+    def always_raise(self, **kwargs):
+        module_call_count[0] += 1
+        raise ValueError("Deliberately failing")
+
+    predict = DummyModule("question -> answer", always_raise)
+    best_of_n = BestOfN(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=0)
+
+    with pytest.raises(ValueError, match="Deliberately failing"):
+        best_of_n(question="What is the capital of Belgium?")
+    assert module_call_count[0] == 1
+    assert best_of_n.fail_count == 0
+
+
+def test_refine_module_succeeds_after_allowed_failure():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+    module_call_count = [0]
+
+    def raise_once(self, **kwargs):
+        module_call_count[0] += 1
+        if module_call_count[0] == 1:
+            raise ValueError("Deliberately failing")
+        return self.predictor(**kwargs)
+
+    predict = DummyModule("question -> answer", raise_once)
+    best_of_n = BestOfN(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=1)
+
+    result = best_of_n(question="What is the capital of Belgium?")
+    assert result.answer == "Brussels"
+    assert module_call_count[0] == 2
 
 
 def test_refine_module_custom_fail_count():

--- a/tests/predict/test_refine.py
+++ b/tests/predict/test_refine.py
@@ -48,15 +48,58 @@ def test_refine_forward_success_first_attempt():
 def test_refine_module_default_fail_count():
     lm = DummyLM([{"answer": "Brussels"}, {"answer": "City of Brussels"}, {"answer": "Brussels"}])
     dspy.configure(lm=lm)
+    module_call_count = [0]
 
     def always_raise(self, **kwargs):
-        raise ValueError("Deliberately failing")
+        module_call_count[0] += 1
+        raise ValueError(f"Failure {module_call_count[0]}")
 
     predict = DummyModule("question -> answer", always_raise)
 
     refine = Refine(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Failure 3"):
         refine(question="What is the capital of Belgium?")
+    with pytest.raises(ValueError, match="Failure 6"):
+        refine(question="What is the capital of Belgium?")
+    assert module_call_count[0] == 6
+    assert refine.fail_count == 3
+
+
+def test_refine_module_zero_fail_count():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+    module_call_count = [0]
+
+    def always_raise(self, **kwargs):
+        module_call_count[0] += 1
+        raise ValueError("Deliberately failing")
+
+    predict = DummyModule("question -> answer", always_raise)
+    refine = Refine(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=0)
+
+    with pytest.raises(ValueError, match="Deliberately failing"):
+        refine(question="What is the capital of Belgium?")
+    assert module_call_count[0] == 1
+    assert refine.fail_count == 0
+
+
+def test_refine_module_succeeds_after_allowed_failure():
+    lm = DummyLM([{"answer": "Brussels"}])
+    dspy.configure(lm=lm)
+    module_call_count = [0]
+
+    def raise_once(self, **kwargs):
+        module_call_count[0] += 1
+        if module_call_count[0] == 1:
+            raise ValueError("Deliberately failing")
+        return self.predictor(**kwargs)
+
+    predict = DummyModule("question -> answer", raise_once)
+    refine = Refine(module=predict, N=3, reward_fn=lambda _, __: 1.0, threshold=0.0, fail_count=1)
+
+    result = refine(question="What is the capital of Belgium?")
+    assert result.answer == "Brussels"
+    assert module_call_count[0] == 2
 
 
 def test_refine_module_custom_fail_count():


### PR DESCRIPTION
## Summary

`BestOfN` and `Refine` treat their failure budget as mutable per-instance state, so a long-lived module becomes progressively less tolerant of transient failures, and an explicit `fail_count=0` is silently ignored.

## Root cause

Both constructors use `fail_count or N`, so an explicit `0` is falsy and gets replaced by `N`. Inside `forward`, every caught exception runs `self.fail_count -= 1`, permanently mutating the configuration of a reusable module.

With `N=3`, the default budget, and a module that always raises:

- first call: 3 attempts, and the instance is left with `fail_count=1`
- second, identical call: only 2 attempts

So two identical requests get different retry behavior purely because of an earlier call.

## Fix

- Fall back to `N` only when `fail_count is None`, so `fail_count=0` means "tolerate no failures" as documented.
- Count failures and remember the last exception in local `forward` variables; `self.fail_count` is now read-only after construction.
- Re-raise the last exception once every attempt has failed and no prediction was produced, instead of returning `None`.

The same change is applied to both `BestOfN.forward` and `Refine.forward`.

## Behavior changes

- `fail_count=0` now raises on the first exception instead of being coerced to `N`.
- When the budget is at least `N` and every attempt raises, `forward` re-raises the last exception rather than silently returning `None`.

## Testing

```
uv run pytest tests/predict/test_best_of_n.py tests/predict/test_refine.py
```

Added or extended coverage for both modules:

- two identical invocations get the same number of attempts, and `fail_count` is unchanged afterwards
- `fail_count=0` fails after a single attempt
- one tolerated failure followed by a success returns the prediction
- an all-failing run surfaces the last exception rather than `None`

The existing custom-`fail_count` tests are unchanged and still pass.

## AI assistance

AI assistance was used to draft this patch and its tests. The guiding prompt was: "BestOfN and Refine mutate self.fail_count on every caught exception and treat fail_count=0 as unset; make the configured budget immutable per invocation, honor an explicit 0, re-raise the last exception when all attempts fail, and add regression tests for repeated calls, zero budget, transient failure, and all-failed runs." I reviewed the resulting diff, ran the tests locally, and take responsibility for the change.
