### PR TITLE
test(dspy): reuse LiteLLM server per pytest worker

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,11 @@ from typing import Any
 
 import pytest
 
-from tests.test_utils.server import litellm_test_server, read_litellm_test_server_request_logs  # noqa: F401
+from tests.test_utils.server import (  # noqa: F401
+    _litellm_test_server,
+    litellm_test_server,
+    read_litellm_test_server_request_logs,
+)
 
 SKIP_DEFAULT_FLAGS = ["reliability", "extra", "llm_call", "deno"]
 

--- a/tests/test_utils/server/__init__.py
+++ b/tests/test_utils/server/__init__.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -13,10 +14,18 @@ from tests.test_utils.server.litellm_server import LITELLM_TEST_SERVER_LOG_FILE_
 
 
 @pytest.fixture()
-def litellm_test_server() -> tuple[str, str]:
+def litellm_test_server(_litellm_test_server: tuple[str, str]) -> Iterator[tuple[str, str]]:
+    """Provide the shared LiteLLM server with request logs isolated to this test."""
+    server_url, server_log_file_path = _litellm_test_server
+    open(server_log_file_path, "w").close()
+    yield server_url, server_log_file_path
+
+
+@pytest.fixture(scope="session")
+def _litellm_test_server() -> Iterator[tuple[str, str]]:
     """
-    Start a LiteLLM test server for a DSPy integration test case, and tear down the
-    server when the test case completes.
+    Start one LiteLLM test server per pytest worker and tear it down when the
+    session completes.
     """
     if sys.version_info[:2] == (3, 14):
         pytest.skip("Litellm proxy server is not supported on Python 3.14.")
@@ -36,7 +45,7 @@ def litellm_test_server() -> tuple[str, str]:
         )
 
         try:
-            _wait_for_port(host=host, port=port)
+            _wait_for_port(host=host, port=port, process=process)
         except TimeoutError as e:
             process.terminate()
             raise e
@@ -76,13 +85,15 @@ def _get_random_port():
         return s.getsockname()[1]
 
 
-def _wait_for_port(host, port, timeout=60):
-    start_time = time.time()
-    while time.time() - start_time < timeout:
+def _wait_for_port(host, port, process=None, timeout=60):
+    start_time = time.monotonic()
+    while time.monotonic() - start_time < timeout:
+        if process is not None and process.poll() is not None:
+            raise TimeoutError(f"Server process exited with status {process.returncode} before port {port} was ready.")
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             try:
                 sock.connect((host, port))
                 return True
             except ConnectionRefusedError:
-                time.sleep(0.5)  # Wait briefly before trying again
+                time.sleep(0.05)
     raise TimeoutError(f"Server on port {port} did not become ready within {timeout} seconds.")


### PR DESCRIPTION
## 📝 Changes Description

Start one LiteLLM proxy per pytest worker instead of one process per test. A function-scoped wrapper truncates the request log before each test, preserving per-test request-log isolation.

The readiness loop also polls at 50ms instead of 500ms and fails immediately if the child process exits before opening its port.

### Isolated benchmark

The benchmark includes all 10 fixture consumers:

```bash
python -m pytest -q --durations=15 \
  tests/clients/test_lm.py::test_chat_lms_can_be_queried \
  tests/clients/test_lm.py::test_dspy_cache \
  tests/clients/test_lm.py::test_text_lms_can_be_queried \
  tests/clients/test_lm.py::test_lm_calls_support_callables \
  tests/clients/test_lm.py::test_lm_calls_support_pydantic_models \
  tests/clients/test_lm.py::test_responses_api_tool_calls \
  tests/streaming/test_streaming.py::test_streamify_yields_expected_response_chunks \
  tests/streaming/test_streaming.py::test_streaming_response_yields_expected_response_chunks
```

| | Untouched `main` | This PR |
|---|---:|---:|
| Runtime | 49.47s | 7.96s / 7.24s |
| Proxy startups | 10 | 1 per worker |
| Result | 10 passed | 10 passed |

**41.5–42.2 seconds removed: 83.9–85.4% faster.**

Additional xdist validation:

```bash
python -m pytest -q -n 4 --dist worksteal <same 10 tests>
# 10 passed in 11.02s
```

Each xdist worker owns a separate random port and temporary log path. Tests execute sequentially within each worker, so truncating the worker-local log at function setup preserves isolation.

## ✅ Contributor Checklist

- [x] Pre-commit checks are passing locally
- [x] Title corresponds to the required format
- [x] Commit message follows `{label}(dspy): {message}`
- [x] All fixture consumers pass serially and under xdist

## ⚠️ Warnings

The session fixture assumes consumers finish their requests before test teardown. All current consumers do so; none leave background requests running.