### PR TITLE
test(dspy): use memory-only cache by default

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import copy
 import os
 from collections.abc import Iterator
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -18,12 +17,12 @@ def _close_cache(cache: Any) -> None:
 
 
 @pytest.fixture(autouse=True)
-def clear_settings(tmp_path: Path) -> Iterator[None]:
+def clear_settings() -> Iterator[None]:
     """Ensure each test gets fresh DSPy settings and an isolated cache."""
     import dspy
 
     original_cache = dspy.cache
-    dspy.configure_cache(disk_cache_dir=tmp_path / ".dspy_cache")
+    dspy.configure_cache(enable_disk_cache=False, enable_memory_cache=True, disk_cache_dir=None)
     try:
         yield
     finally:


### PR DESCRIPTION
## 📝 Changes Description

Use a fresh memory-only DSPy cache in the global per-test isolation fixture instead of creating and closing a temporary 16-shard `FanoutCache` for every test.

This preserves per-test cache isolation and within-test cache hits. Tests that exercise disk persistence already explicitly configure their own `tmp_path`-backed disk caches.

### Isolated benchmark

Same checkout, Python environment, and serial command on both branches:

```bash
python -m pytest -q --durations=20
```

| | Untouched `main` | This PR |
|---|---:|---:|
| Pytest runtime | 266.35s | 112.74s |
| Result | 1,192 passed / 417 skipped / 2 xfailed | 1,192 passed / 417 skipped / 2 xfailed |

**153.61 seconds removed: 57.7% faster, or 2.36x throughput.** An earlier untouched baseline measured 242.89s, so even against that lower baseline this change removes 130.15s (53.6%).

### Why behavior is preserved

- A new cache object is still created for every test.
- Memory caching remains enabled, so repeated requests within a test still hit cache.
- The original global cache is still restored during teardown.
- DSPy settings are still reset from `DEFAULT_CONFIG`.
- Dedicated cache, LM cache, embedding cache, and disk-serialization tests explicitly enable isolated disk caches when disk behavior is under test.

## ✅ Contributor Checklist

- [x] Pre-commit checks are passing locally
- [x] Title corresponds to the required format
- [x] Commit message follows `{label}(dspy): {message}`
- [x] Complete serial suite passes with unchanged outcomes

## ⚠️ Warnings

No production code changes. This intentionally changes only the default storage tier used by the test isolation fixture; disk behavior remains covered by explicit disk-cache tests.