### PR TITLE
ci: use eight workers for pytest

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -104,7 +104,10 @@ jobs:
           uv sync --dev -p .venv --extra dev
           uv pip list
       - name: Run tests with pytest
-        run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
+        # The suite spends substantial time waiting on subprocesses, servers,
+        # and deliberate synchronization, so two workers per CI CPU reduce
+        # the critical path without changing test selection or behavior.
+        run: uv run -p .venv pytest -vv -n 8 --dist worksteal tests/
       - name: Install optional dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests


### PR DESCRIPTION
## Summary

Run the primary pytest suite with eight xdist workers instead of `auto` (four workers on the current GitHub-hosted runner).

This suite is substantially wait- and I/O-bound: subprocess startup, LiteLLM server startup, filesystem work, and synchronization waits leave four workers idle enough that a conservative 2x oversubscription shortens the matrix critical path. Test selection, ordering strategy, markers, and assertions are unchanged. The extra/Deno suite remains on `auto` because it has a different resource profile.

## CI-equivalent benchmark

All measurements constrained the process to four CPUs and used the workflow's `--dist worksteal` mode. Outcomes were unchanged: 1,192 passed, 417 skipped, 2 xfailed.

Three parent-revision runs:

| Workers | Pytest times | Mean |
|---|---|---:|
| 4 | 103.53s, 113.49s, 111.05s | 109.36s |
| 8 | 77.35s, 86.46s, 86.06s | 83.29s |

Mean reduction: **26.07s / 23.8%**.

A direct paired run on current `main` measured **106.33s → 84.85s** (20.2%). A reverse-order eight-worker run measured 82.65s, ruling out the speedup being solely a warm-cache artifact.

For comparison, single exploratory runs with six and twelve workers took 86.59s and 79.76s. Eight is the smallest worker count that consistently captures most of the benefit, limiting memory pressure on the 16 GB Actions runner.

## Validation

- `pre-commit run --files .github/workflows/run_tests.yml`
- Repeated four-CPU full-suite runs shown above
- Normal PR CI will provide the real five-version Actions matrix measurement