### PR TITLE
fix(dspy): keep interpreter synced after base exceptions

### DIFF
--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -131,10 +131,12 @@ const jsonrpcError = (code, message, id, data = null) => {
   return JSON.stringify({ jsonrpc: "2.0", error: err, id });
 };
 
-// Global handler to prevent uncaught promise rejections from crashing Deno
-// These can occur during async Python <-> JS interop
+// Prevent promise rejections from async Python <-> JS interop from crashing Deno.
 globalThis.addEventListener("unhandledrejection", (event) => {
   event.preventDefault();
+  // Pyodide reports these as unhandled before runPythonAsync rejects into the execute
+  // handler, which will respond with the request ID. Do not emit a duplicate id:null error.
+  if (event.reason?.type === "SystemExit" || event.reason?.type === "KeyboardInterrupt") return;
   console.log(jsonrpcError(JSONRPC_APP_ERRORS.RuntimeError, `Unhandled async error: ${event.reason?.message || event.reason}`, null));
 });
 

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -19,6 +19,9 @@ sys.stdout, sys.stderr = buf_stdout, buf_stderr
 def last_exception_args():
     return json.dumps(sys.last_exc.args) if sys.last_exc else None
 
+def last_exception_ends_execution():
+    return isinstance(sys.last_exc, (SystemExit, KeyboardInterrupt))
+
 class FinalOutput(BaseException):
     # Control-flow exception to signal completion (like StopIteration)
     pass
@@ -136,7 +139,7 @@ globalThis.addEventListener("unhandledrejection", (event) => {
   event.preventDefault();
   // Pyodide reports these as unhandled before runPythonAsync rejects into the execute
   // handler, which will respond with the request ID. Do not emit a duplicate id:null error.
-  if (event.reason?.type === "SystemExit" || event.reason?.type === "KeyboardInterrupt") return;
+  if (event.reason?.name === "PythonError" && pyodide.runPython("last_exception_ends_execution()")) return;
   console.log(jsonrpcError(JSONRPC_APP_ERRORS.RuntimeError, `Unhandled async error: ${event.reason?.message || event.reason}`, null));
 });
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -115,6 +115,8 @@ def test_base_exceptions_do_not_desync_interpreter():
         for code, error_type in [
             ("import sys\nsys.exit(0)", "SystemExit"),
             ("raise KeyboardInterrupt()", "KeyboardInterrupt"),
+            ("class ExitSignal(SystemExit): pass\nraise ExitSignal(0)", "ExitSignal"),
+            ("class InterruptSignal(KeyboardInterrupt): pass\nraise InterruptSignal()", "InterruptSignal"),
         ]:
             with pytest.raises(CodeExecutionError, match=error_type):
                 interpreter.execute(code)

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -110,6 +110,17 @@ def test_exception_args(pooled_interpreter):
         interpreter.execute(code)
 
 
+def test_base_exceptions_do_not_desync_interpreter():
+    with PythonInterpreter() as interpreter:
+        for code, error_type in [
+            ("import sys\nsys.exit(0)", "SystemExit"),
+            ("raise KeyboardInterrupt()", "KeyboardInterrupt"),
+        ]:
+            with pytest.raises(CodeExecutionError, match=error_type):
+                interpreter.execute(code)
+            assert interpreter.execute("print('still alive')") == "still alive\n"
+
+
 def test_generated_exception_name_cannot_spoof_interpreter_failure(pooled_interpreter):
     interpreter = pooled_interpreter
     with pytest.raises(CodeExecutionError, match="CodeInterpreterError"):


### PR DESCRIPTION
## 📝 Changes Description

This PR prevents `SystemExit`, `KeyboardInterrupt`, and their subclasses from desynchronizing a `PythonInterpreter` session.

Pyodide reports these exceptions through the global `unhandledrejection` handler before `runPythonAsync` reaches the request-local `catch`. The global handler consequently emitted an `id: null` JSON-RPC error followed by the correctly identified response, leaving the second response queued for the next execution. The runner now asks Python whether the current exception inherits from either control-flow exception, suppresses that duplicate global event, and lets the request-local handler produce the sole response.

A regression test verifies that the built-in exceptions and custom subclasses surface as `CodeExecutionError` and that subsequent execution succeeds in the same interpreter.

Closes #10165.

## 🧪 Validation

- Reported deterministic repro and subclass regression pass on Deno 2.6.9 and 2.7.7.
- `python -m pytest tests/primitives/test_python_interpreter.py --deno -q` on Deno 2.7.7: 73 passed.
- `pre-commit run --files dspy/primitives/runner.js tests/primitives/test_python_interpreter.py`: passed.

## ✅ Contributor Checklist

- [x] Pre-commit checks are passing locally
- [x] PR title follows the required format
- [x] Commit messages follow the required format `{label}(dspy): {message}`

## ⚠️ Warnings

None.