### PR TITLE
ci: prefetch Ollama image during test setup

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -122,6 +122,15 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
+      - name: Prefetch Ollama image
+        run: |
+          (
+            if docker pull ollama/ollama:0.31.2 > "$RUNNER_TEMP/ollama-pull.log" 2>&1; then
+              echo 0 > "$RUNNER_TEMP/ollama-pull.status"
+            else
+              echo "$?" > "$RUNNER_TEMP/ollama-pull.status"
+            fi
+          ) &
       - name: Install uv with caching
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -145,6 +154,14 @@ jobs:
           key: ollama-llama3.2-3b-${{ runner.os }}-ollama0.31.2-v2
       - name: Start Ollama service
         run: |
+          for _ in {1..120}; do
+            [[ -f "$RUNNER_TEMP/ollama-pull.status" ]] && break
+            sleep 1
+          done
+          if [[ ! -f "$RUNNER_TEMP/ollama-pull.status" ]] || [[ "$(cat "$RUNNER_TEMP/ollama-pull.status")" != 0 ]]; then
+            cat "$RUNNER_TEMP/ollama-pull.log"
+            exit 1
+          fi
           mkdir -p ollama-data
           docker run -d --name ollama \
             -p 11434:11434 \


### PR DESCRIPTION
## Summary

Start pulling the pinned Ollama Docker image while the independent Python/uv setup and model-cache restore run. The real-LM tests, model, image, warm-up, and assertions are unchanged.

The service step waits for the pull to finish and propagates a failed/timed-out pull before starting Ollama.

## Why

In a clean pre-change Actions run, the real-LM job spent 39 seconds in `Start Ollama service`, after dependency setup and a 25-second model-cache restore had already completed. These operations are independent. Prefetching should hide most or all of the image-download latency behind setup without reducing coverage.

Pre-change evidence:
- [Run 31188418077](https://github.com/stanfordnlp/dspy/actions/runs/31188418077): real-LM job 170s
- Setup/cache before service: setup-uv + dependency install + model-cache restore
- Start Ollama: 39s
- Real-LM pytest: 86s; all 5 tests passed

I will add exact-head Actions timing and a repeated run before claiming a speedup.

## Validation

- `pre-commit run --files .github/workflows/run_tests.yml`
- `git diff --check`
- Normal GitHub Actions pending
