### PR TITLE
ci: increase workers for extra and Deno tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n 8 --dist worksteal
 
   llm_call_test:
     name: Run Tests with Real LM


### PR DESCRIPTION
## Summary

Use eight pytest workers for the isolated extra/Deno matrix introduced by #10164, instead of the four workers returned by `-n auto` on GitHub-hosted runners.

This stacked PR contains one isolated command-line change. Tests, markers, dependencies, Deno version, distribution strategy, and assertions are unchanged.

## Evidence before Actions

On the same orb checkout with Deno 2.7.7 and the exact optional-suite command:

| Workers | Pytest | Wall clock |
|---:|---:|---:|
| 4 (Actions `auto`) | 65.65s | 68.50s |
| 8 | 48.58s | 52.66s |

Local observed improvement: **15.84s / 23.1% wall clock**, with the same **166 passed** result.

This is only a candidate until normal GitHub Actions confirms it on the actual four-core runner. A previous eight-worker candidate for the *primary* suite was rejected after Actions disproved its local result; this PR specifically measures the Deno-heavy optional suite and will be held to the same standard.

## Validation

- Exact four-worker optional suite: `166 passed`
- Exact eight-worker optional suite: `166 passed`
- `pre-commit run --files .github/workflows/run_tests.yml`
- Normal GitHub Actions pending
