### PR TITLE
ci: shard primary tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -68,7 +68,7 @@ jobs:
           )
 
   test:
-    name: Run Tests
+    name: "Primary Tests: Clients, Adapters, and Utils"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -97,11 +97,11 @@ jobs:
         run: |
           uv sync --dev -p .venv --extra dev
           uv pip list
-      - name: Run tests with pytest
+      - name: Run clients, adapters, and utils shard
         run: uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/clients tests/adapters tests/utils
 
   remaining_test:
-    name: Run Remaining Tests
+    name: "Primary Tests: All Other Directories"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -130,7 +130,7 @@ jobs:
         run: |
           uv sync --dev -p .venv --extra dev
           uv pip list
-      - name: Run remaining tests with pytest
+      - name: Run all other primary tests shard
         run: >-
           uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/
           --ignore=tests/clients --ignore=tests/adapters --ignore=tests/utils

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,12 +82,6 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-        with:
-          deno-version: v2.7.7
-      - name: Verify Deno installation
-        run: deno --version
       - name: Install uv with caching
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -104,7 +104,7 @@ jobs:
           uv sync --dev -p .venv --extra dev
           uv pip list
       - name: Run tests with pytest
-        run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
+        run: uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/
 
   extra_test:
     name: Run Extra and Deno Tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -105,11 +105,44 @@ jobs:
           uv pip list
       - name: Run tests with pytest
         run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
-      - name: Install optional dependencies
+
+  extra_test:
+    name: Run Extra and Deno Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+      - name: Verify Deno installation
+        run: deno --version
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
-  
+
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -104,12 +104,80 @@ jobs:
           uv sync --dev -p .venv --extra dev
           uv pip list
       - name: Run tests with pytest
-        run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
-      - name: Install optional dependencies
+        run: uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/clients tests/adapters tests/utils
+
+  remaining_test:
+    name: Run Remaining Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
+        run: |
+          uv sync --dev -p .venv --extra dev
+          uv pip list
+      - name: Run remaining tests with pytest
+        run: >-
+          uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/
+          --ignore=tests/clients --ignore=tests/adapters --ignore=tests/utils
+
+  extra_test:
+    name: Run Extra and Deno Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+      - name: Verify Deno installation
+        run: deno --version
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
-  
+
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Split the 1,446-node primary test suite into two deterministic path shards on every supported Python version:

- `Primary Tests: Clients, Adapters, and Utils`: `tests/clients tests/adapters tests/utils`
- `Primary Tests: All Other Directories`: all other tests

Tests, markers, dependencies, Python versions, worker count, distribution strategy, and assertions are unchanged. New tests default to the remainder shard.

## Coverage proof

| Set | Tests |
|---|---:|
| Primary unsharded | 1,446 |
| clients/adapters/utils | 538 |
| remainder | 908 |
| overlap | **0** |
| omitted | **0** |

Both exact shard commands passed. Greptile independently reproduced the partition and execution proof at 5/5 confidence.

## GitHub Actions evidence

Across repeated green runs, the primary critical path fell from a 134.6s unsharded mean to approximately 44.6s after the final Deno cleanup: about **90s / 66.9% faster**.

This does not burn additional aggregate runner time despite adding five checks:

- unsharded primary jobs: 673s aggregate
- sharded primary jobs: 411–429s aggregate
- reduction: approximately **36–39%**

The tradeoff is five additional visible `Primary Tests: All Other Directories (3.x)` checks. Branch protection must include them, or use the stacked aggregate scheduling/gate policy in #10184.

## Validation

- Exact-head normal `Lint, Test, and Build` workflow: green
- Greptile: 5/5
- No production code changes
- No test behavior or coverage changes