### PR TITLE
ci: benchmark optional test shards on split suite

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -104,12 +104,88 @@ jobs:
           uv sync --dev -p .venv --extra dev
           uv pip list
       - name: Run tests with pytest
-        run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
-      - name: Install optional dependencies
+        run: uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/
+
+  extra_test:
+    name: Run Extra and Deno Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+      - name: Verify Deno installation
+        run: deno --version
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
-  
+        run: >-
+          uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+          -k 'not (large_list_variable or multiple_large_variables or enable_write_flag or
+          interpreter_security_filesystem_access or read_file_access_control or enable_env_vars_flag or enable_net_flag)'
+
+  heavy_deno_test:
+    name: Run Heavy Deno Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+      - name: Verify Deno installation
+        run: deno --version
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
+        run: uv sync -p .venv --extra dev --extra test_extras
+      - name: Run heavy Deno tests
+        run: >-
+          uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+          -k 'large_list_variable or multiple_large_variables or enable_write_flag or
+          interpreter_security_filesystem_access or read_file_access_control or enable_env_vars_flag or enable_net_flag'
+
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Temporary CI benchmark — draft until #10164 merges

This measures optional-suite sharding on top of #10164's still-open split-suite workflow and current optimized `main`. Once #10164 lands, its overlapping diff drops out and this becomes an isolated optional-sharding PR; the combined workflow must then be rerun before readiness.

## Candidate

The 166-test optional lane has one severe xdist straggler: seven Deno tests account for about 60s of 132s aggregate test time, including a single 22s 100MB-list roundtrip. Run those seven tests in their own parallel job while the other 159 optional tests run unchanged in the existing job.

Tests, markers, dependencies, Deno version, Python versions, worker count, distribution strategy, payload sizes, and assertions are unchanged. The two `-k` expressions are exact complements; future tests default to the 159-test remainder side.

## Coverage proof

| Set | Tests |
|---|---:|
| Optional unsharded | 166 |
| Heavy Deno shard | 7 |
| Optional remainder | 159 |
| overlap | **0** |
| omitted | **0** |

Both exact shard commands passed locally with Deno 2.7.7:

- heavy shard: 7 passed, 43.07s wall
- remainder: 159 passed, 29.52s wall
- unsharded: 166 passed, 59.51s wall

Local critical-path improvement: **16.44s / 27.6%**. Normal Actions is the deciding measurement.

## Tradeoff

Adds five runner jobs to lower wall-clock latency. If retained, branch protection must require the five new `Run Heavy Deno Tests` contexts in addition to the existing optional checks.
