### PR TITLE
ci: shard real-LM tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -139,13 +139,8 @@ jobs:
               echo "$?" > "$RUNNER_TEMP/ollama-pull.status"
             fi
           ) &
-      - name: Install uv with caching
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            **/pyproject.toml
-            **/uv.lock
       - name: Create and activate virtual environment
         run: |
           uv venv .venv

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -111,10 +111,18 @@ jobs:
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
   
   llm_call_test:
-    name: Run Tests with Real LM
+    name: ${{ matrix.job_name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - job_name: Run Tests with Real LM
+            test_expression: stream_listener_chat_adapter or stream_listener_json_adapter or single_module_call_with_usage_tracker
+          - job_name: Run Remaining Tests with Real LM
+            test_expression: not (stream_listener_chat_adapter or stream_listener_json_adapter or single_module_call_with_usage_tracker)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -194,7 +202,9 @@ jobs:
       - name: Set LM environment variable
         run: echo "LM_FOR_TEST=ollama/llama3.2:3b" >> "$GITHUB_ENV"
       - name: Run tests
-        run: uv run -p .venv pytest -m llm_call --llm_call -vv --durations=5 tests/
+        run: >-
+          uv run -p .venv pytest -m llm_call --llm_call -vv --durations=5
+          -k '${{ matrix.test_expression }}' tests/
       - name: Fix permissions for cache
         if: always()
         run: sudo chown -R "$USER":"$USER" ollama-data || true


### PR DESCRIPTION
## Summary

Run the five Ollama-backed tests as two parallel jobs on top of #10169's image-prefetch optimization. This is an isolated stacked PR; once #10169 merges, it can be retargeted to `main` with only this matrix change remaining.

The two jobs use the same Python version, pinned Ollama image/model, model cache, dependencies, warm-up, environment, pytest markers, and assertions. Only the complementary `-k` selections differ.

## Coverage proof

The existing `llm_call` selection contains 24 nodes: five Ollama tests that execute in this job and 19 provider-specific tests that skip without credentials.

| Set | Selected nodes | Ollama tests expected to execute |
|---|---:|---:|
| First LM shard | 3 | 3 |
| Remaining LM shard | 21 | 2 |
| overlap | **0** | **0** |
| omitted | **0** | **0** |

Based on the clean unsharded Actions durations, generated-call time is balanced at roughly 41s versus 28s. With #10169 reducing setup/service overhead, the hypothesis is a real-LM critical path around 85–100s instead of 136–138s.

No timing claim is made until both normal Actions jobs pass and repeat.

## Tradeoff

Adds one runner job and duplicates model-cache restore/Ollama setup to reduce wall-clock latency. The existing `Run Tests with Real LM` context is retained for the first shard; the new `Run Remaining Tests with Real LM` context must also become required before merge.
