### PR TITLE
ci: skip uv cache for real-LM tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -133,6 +133,8 @@ jobs:
           ) &
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
       - name: Create and activate virtual environment
         run: |
           uv venv .venv

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -131,13 +131,8 @@ jobs:
               echo "$?" > "$RUNNER_TEMP/ollama-pull.status"
             fi
           ) &
-      - name: Install uv with caching
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            **/pyproject.toml
-            **/uv.lock
       - name: Create and activate virtual environment
         run: |
           uv venv .venv


### PR DESCRIPTION
## Summary

Disable setup-uv's dependency cache only in the real-LM job. This isolated PR stacks on #10169.

No dependencies, versions, tests, model setup, or assertions change. `uv sync` still installs the exact lockfile environment; only the action cache around uv's download cache is removed.

## Why

The cache is restoring only ~154KB and dependency installation takes 3–5s, but concurrent real-LM measurements repeatedly showed one identical-key restore stall for 75s. Another primary job saw a 185s restore stall. In the real-LM shard runs:

| Job | setup-uv cache | dependency install |
|---|---:|---:|
| sibling A, run 1 | 7s | 4s |
| sibling B, run 1 | **75s** | 4s |
| sibling A, run 2 | normal | normal |
| sibling B, run 2 | **~75s** | normal |

Caching 154KB cannot repay a 75s failure mode. Normal Actions will measure the uncached setup and exact dependency install before this is considered ready.

## Validation

- Workflow YAML/pre-commit passes
- Exact normal Actions pending
