### PR TITLE
docs: clarify DSPy programming model and direction

### DIFF
--- a/docs/docs/getting-started/class-based-signatures.md
+++ b/docs/docs/getting-started/class-based-signatures.md
@@ -50,9 +50,9 @@ In adhering to this structure, your objective is:
     Write a classical haiku given the provided inputs.
 ```
 
-Signature docstrings and field descriptions are optional, but they are handy levers when field names don’t provide sufficient context for a task. However, resist the urge to restate what the signature already says or write prescriptive tutorials. Expansive rules, watch-outs, and guidance are what optimizers are for (more on that later). 
+Signature docstrings and field descriptions are optional, but they are handy when field names don’t provide enough context. State requirements that are genuinely part of the task, but resist restating the signature or adding model-specific coaxing such as prompting tricks and long tutorials. Optimizers can adapt instructions to a model and learn from the long tail; they should not have to guess requirements you already know.
 
-Though it’s worth noting: field descriptions are not touched by the optimizers, so mind your naming. A poorly chosen field name can’t be adjusted by optimizers.
+Field descriptions are not changed by optimizers, so name and describe the contract carefully. A poorly chosen field name cannot be optimized away.
 
 ## Tightening signature fields with richer types
 

--- a/docs/docs/getting-started/first-program.md
+++ b/docs/docs/getting-started/first-program.md
@@ -11,7 +11,9 @@ result = haiku_generator(subject="computer science")
 print(result.haiku)
 ```
 
-The first line specifies our `Signature`. Signature is a core concept in DSPy, and it’s how we define our task. Similar to function signatures in programming, a DSPy Signature describes the inputs a function accepts and the outputs it returns. 
+The first line specifies our `Signature`. A DSPy Signature defines the boundary of a task, much like a function signature describes the inputs a function accepts and the outputs it returns.
+
+The difference is that the implementation inside this boundary can use language-model judgment. We deliberately isolate that fuzzy transformation here; the surrounding Python remains normal, exact software. A signature does not discover our intent—we still choose and name the contract.
 
 The simplest way to define a DSPy Signature is with a string of the form `"inputs -> outputs"`. In our case, we want to provide a `subject` and get back a `haiku`.
 

--- a/docs/docs/getting-started/metrics.md
+++ b/docs/docs/getting-started/metrics.md
@@ -2,11 +2,13 @@
 
 ## Why optimizers need metrics
 
-Before DSPy can improve our program automatically, we need to tell it what “better” means. That starts with a metric and a baseline evaluation. In this section we’ll see why optimization beats hand-tuning, design a quantifiable metric for our haiku task, and run a baseline score so we have something to beat.
+Before DSPy can improve our program automatically, we need to tell it what “better” means. That starts with a metric and a baseline evaluation. In this section we’ll design a quantifiable metric for our haiku task and run a baseline score so we have something to beat.
 
-So far we’ve written DSPy programs by hand. Our signatures and instructions are only as good as what we type, with no examples to learn from. The quality of our haikus depends on the base knowledge a given model has about locations and writing haikus.
+This is the third form of intent in a DSPy program. Python expresses exact structure, signatures describe fuzzy transformations, and examples plus metrics describe success across real cases. Metrics are especially useful for requirements that vary across a distribution or are easier to judge than to enumerate.
 
-*Optimizers* close that gap. An optimizer is an algorithm that improves your program automatically, and [DSPy ships several](../diving-deeper/choosing-an-optimizer.md). Some select small input/output pairs (few-shot examples) to include in the prompt as demonstrations. Others rewrite the natural-language instructions in your signatures. A few go further and fine-tune the underlying model. What they share is a loop: run your program many times, keep the version that scores best.
+They are not a substitute for saying what we know. So far we’ve written DSPy programs by hand, and if every haiku must have three lines, we should state or enforce that requirement directly. Evaluation and optimization help us measure the result, adapt it to a model, and handle the long tail.
+
+*Optimizers* close that gap. An optimizer is an algorithm that improves your program automatically, and [DSPy ships several](../diving-deeper/choosing-an-optimizer.md). Some select small input/output pairs as demonstrations. Others rewrite natural-language instructions. Some fine-tune the underlying model, and newer optimizers can use reinforcement learning. What they share is a contract: take a program and a way to judge it, then produce a better program.
 
 To decide what “better” means, an optimizer needs a *metric*: a Python function that scores a single prediction.
 

--- a/docs/docs/getting-started/program-dont-prompt.md
+++ b/docs/docs/getting-started/program-dont-prompt.md
@@ -1,23 +1,49 @@
 # Program, don’t prompt
 
-DSPy is a declarative way to build with LLMs. 
+A capable language model is not yet a system. A system has behavior we can repeat, inspect, change, evaluate, and improve. **DSPy is a Python framework for building those systems.**
 
-We describe our tasks as structured inputs and outputs. Often, we compose multiple tasks into multi-step programs and agents where each piece stays independently inspectable, swappable, and tunable. DSPy handles prompt construction, context management, and optimization that tunes each step to improve the whole program.
+You do not need to become a prompt engineer—or an ML expert—to begin. Start by describing one useful transformation as named inputs and outputs. DSPy turns that declaration into the messages a model needs. As the application grows, ordinary Python gives it structure, and examples and metrics tell DSPy what to improve.
 
-When a step needs to act on the world (to search, fetch, or compute), we give it tools as plain Python functions. Functions also serve as metrics: you define one to grade the output, and DSPy generates a better program accordingly. The optimizer tunes the prompt for any model you pick, so a small, cheap model can often match or beat a hand-prompted frontier one..
+The goal is intelligence you can program, not an oracle you prompt and hope.
 
-DSPy helps us program LLMs, rather than prompting them, creating modular, maintainable and optimizable AI software.
+## Express intent where it fits
 
-## What we’ll learn today
+Most AI systems need three forms of intent:
 
-In this tutorial we’ll build a haiku-writing program that starts with four lines of Python and grows into a tool-using, prompt-optimized agent. Along the way we’ll touch each of DSPy’s core components. We’ll learn:
+1. **Python for what must happen exactly.** Use normal functions, branches, loops, permissions, and state for the parts that should behave like normal software.
+2. **Signatures for what requires judgment.** Describe a fuzzy transformation with typed, meaningful inputs and outputs—for example, `customer_message -> intent, urgency`.
+3. **Examples and metrics for what good looks like.** Use data, checks, or judgments to capture variation and the difficult cases that are easier to recognize than enumerate.
 
-- How to install DSPy, configure a **language model** and write a simple DSPy program.  
-- What a **Signature** is, and why DSPy uses signatures instead of hand-written prompt strings.  
-- What a **Module** is, how `Predict`, `ChainOfThought`, and `ReAct` differ, and when to reach for each.  
-- How to compose a custom `dspy.Module` that decomposes a task into named, independent stages.  
-- How to write **metrics** and use **optimizers** to compile better versions of our program.  
-- How to save optimized programs and reload them.
+You rarely need all three at first. A four-line program with one signature is a good start. Add explicit control flow when the workflow needs it. Add data and optimization once you can say how to distinguish better results from worse ones.
+
+This division matters. If a rule must always hold, write it in Python or a type instead of asking the model to remember it. If a task genuinely needs interpretation, isolate that ambiguity in a signature instead of hard-coding a brittle approximation. If you already know a requirement, state it; optimization is for adapting to models and handling varied edge cases, not for guessing intent you could have expressed directly.
+
+## A small programming model
+
+DSPy keeps the task you mean separate from the techniques used to perform it:
+
+- A **Signature** declares the transformation: its named, typed inputs and outputs.
+- A **Module** chooses an inference strategy. The same signature can run with `Predict`, `ChainOfThought`, `ReAct`, or a module you compose in plain Python.
+- A **metric** scores behavior against your objective.
+- An **optimizer** uses that feedback to compile a better version of the whole program—by improving instructions, selecting demonstrations, tuning weights, or using newer methods as they emerge.
+
+That separation makes each piece independently inspectable, swappable, and tunable. A better model, inference strategy, or optimizer should improve your system without forcing you to rewrite what the system means.
+
+DSPy handles prompt construction, structured parsing, context management, and optimization. You keep ownership of the intent and the software around it.
+
+## What we’ll build
+
+In this tutorial, we’ll start with a four-line haiku writer and grow it into a tool-using, optimized program. Along the way we’ll learn:
+
+- how to install DSPy, configure a **language model**, and write a simple program;
+- how **Signatures** express tasks without model-specific prompt strings;
+- how `Predict`, `ChainOfThought`, and `ReAct` provide different **Module** strategies for the same task;
+- how to compose a custom module with normal Python control flow;
+- how tools connect a program to search, retrieval, and computation;
+- how **metrics** express success and **optimizers** compile better programs;
+- how to inspect, save, and reload the resulting program.
+
+These ideas also guide [what belongs in DSPy and where the project is going](../roadmap.md).
 
 ---
 

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -1,127 +1,77 @@
----
-draft: true
----
+# DSPy's direction
 
-!!! warning "This document is from Aug 2024. Since then, DSPy 2.5 and 2.6 were released, DSPy has grown considerably, and 3.0 is approaching! Content below is highly outdated."
+DSPy exists to make intelligence **programmable**.
 
+Models will keep improving. That is good news, but a capable model is not yet a system. People build systems so behavior can be repeated, inspected, changed, reused, evaluated, and improved. DSPy provides the programming model for doing that with language models.
 
+This page is both a direction and a filter. We use the principles below to decide what belongs in DSPy's core, what belongs in an integration or application, and what we should research next.
 
-# Roadmap Sketch: DSPy 2.5+
+## The design promise
 
-It’s been a year since DSPy evolved out of Demonstrate–Search–Predict (DSP), whose research started at Stanford NLP all the way back in February 2022. Thanks to 200 wonderful contributors, DSPy has introduced tens of thousands of people to building modular LM programs and optimizing their prompts and weights automatically. In this time, DSPy has grown to 160,000 monthly downloads and 16,000 stars on GitHub, becoming synonymous with prompt optimization in many circles and inspiring at least a half-dozen cool new libraries.
+A DSPy program should let you express intent in the form that fits it best:
 
-This document is an initial sketch of DSPy’s public roadmap for the next few weeks and months, as we work on DSPy 2.5 and plan for DSPy 3.0. Suggestions and open-source contributors are more than welcome: just open an issue or submit a pull request regarding the roadmap.
+1. **Python for structure.** Use ordinary code for control flow, state, constraints, and operations that must happen exactly.
+2. **Signatures for judgment.** Use typed, named inputs and outputs for transformations where natural-language understanding is useful and some ambiguity is intentional.
+3. **Examples and metrics for feedback.** Use data, checks, and judgments to show what success means across real cases, especially the long tail.
 
+You do not need all three on day one. A useful program may start with one signature. Add Python structure when the workflow demands it, and add evaluation or optimization when you can describe what better means.
 
+DSPy keeps these forms separate but composable:
 
-## Technical Objectives
+- A **Signature** says what transformation you want.
+- A **Module** chooses how to perform it at inference time.
+- An **optimizer** uses feedback to improve the program as a whole.
 
-The thesis of DSPy is that for LMs to be useful, we have to shift from ad-hoc prompting to new notions of programming LMs. Instead of relying on LMs gaining much more general or more compositional capabilities, we need to enable developers to iteratively explore their problems and build modular software that invokes LMs for well-scoped tasks. We need to enable that through modules and optimizers that isolate how they decompose their problems and describe their system's objectives from how their LMs are invoked or fine-tuned to maximize their objectives. DSPy's goal has been to develop (and to build the community and shared infrastructure for the collective development of) the abstractions, programming patterns, and optimizers toward this thesis.
+This separation is the core of DSPy. The signature should not need to change when you replace `Predict` with `ReAct`, switch model providers, or adopt a better optimizer.
 
-To a first approximation, DSPy’s current user-facing language has the minimum number of appropriate abstractions that address the goals above: declarative signatures, define-by-run modules, and optimizers that can be composed quite powerfully. But there are several things we need to do better to realize our goals. The upcoming DSPy releases will have the following objectives.
+## Keep structure in Python and judgment in signatures
 
-1. Polishing the core functionality.
-2. Developing more accurate, lower-cost optimizers.
-3. Building end-to-end tutorials from DSPy’s ML workflow to deployment.
-4. Shifting towards more interactive optimization & tracking.
+DSPy is plain Python on purpose. Branches, loops, retries, permissions, and calls to normal software should remain real code. When a step requires fuzzy interpretation or generation, isolate that ambiguity in a well-named signature. In programming-language terms, this is an imperative shell with declarative leaves.
 
+This gives programs deliberate joints: each fuzzy transformation has an interface, each stage can be inspected independently, and the surrounding system remains understandable with normal programming tools. DSPy should complement Python rather than replace it with a new graph language.
 
+Signatures do not discover product intent for you. They are where **you** state it. Put requirements you already know in the signature, types, or surrounding code. Use examples, metrics, and optimizers to handle variation, model-specific behavior, and cases that are difficult to enumerate—not to avoid specifying known requirements.
 
-## Team & Organization
+## Stable programs, improving implementations
 
-DSPy is fairly unusual in its technical objectives, contributors, and audience. Though DSPy takes inspiration from PyTorch, a library for building and optimizing DNNs, there is one major difference: PyTorch was introduced well after DNNs were mature ML concepts, but DSPy seeks to establish and advance core LM Programs research: the framework is propelled by constant academic research from programming abstractions (like the original **Demonstrate–Search–Predict** concepts, DSPy **Signatures**, or **LM Assertions**) to NLP systems (like **STORM**, **PATH**, and **IReRa**) to prompt optimizers (like **MIPRO**) and RL (like **BetterTogether**), among many other related directions.
+DSPy separates a relatively stable, human-facing program from the techniques used to execute and optimize it.
 
-This research all composes into a concrete, practical library, thanks to dozens of industry contributors, many of whom are deploying apps in production using DSPy. Because of this, DSPy reaches not only of grad students and ML engineers, but also many non-ML engineers, from early adopter SWEs to hobbyists exploring new ways of using LMs. The following team, with help from many folks in the OSS community, is working towards the objectives in this Roadmap.
+Inference strategies and optimization algorithms should improve—and eventually be replaced—as models improve. A program written against DSPy's core abstractions should benefit without being redesigned around every new prompting trick, model API, or training method.
 
-**Project Lead:** Omar Khattab (Stanford & Databricks)
+Although prompt optimization is an important technique, it is not the boundary of DSPy. An optimizer may synthesize instructions, select demonstrations, tune weights, use reinforcement learning, or apply methods that have not been invented yet. The durable contract is: **take a program plus a way to judge it, and produce a better program**.
 
-**Project Mentors:** Chris Potts (Stanford), Matei Zaharia (UC Berkeley & Databricks), Heather Miller (CMU & Two Sigma)
+## What belongs in DSPy
 
-**Core Library:** Arnav Singhvi (Databricks & Stanford), Herumb Shandilya (Stanford), Hanna Moazam (Databricks), Sri Vardhamanan (Dashworks), Cyrus Nouroozi (Zenbase), Amir Mehr (Zenbase), Kyle Caverly (Modular), with special thanks to Keshav Santhanam (Stanford), Thomas Ahle (Normal Computing), Connor Shorten (Weaviate)
+A feature is a strong candidate for DSPy's core when it does one or more of the following while preserving the design promise:
 
-**Prompt Optimization:** Krista Opsahl-Ong (Stanford), Michael Ryan (Stanford), Josh Purtell (Basis), with special thanks to Eric Zhang (Stanford)
+- makes signatures, modules, tools, metrics, or optimizers compose more naturally;
+- improves portability across models, providers, and modalities;
+- helps isolate and inspect fuzzy LM behavior inside a larger program;
+- lets a new inference or learning strategy work across many existing programs;
+- makes evaluation, optimization, saving, loading, or deployment reliable end to end;
+- removes incidental prompt or provider machinery from user code;
+- stays approachable for a Python user who is not an ML specialist.
 
-**Finetuning & RL:** Dilara Soylu (Stanford), Isaac Miller (Anyscale), Karel D'Oosterlinck (Ghent), with special thanks to Paridhi Masehswari (Stanford)
+A feature probably belongs outside the core when it:
 
-**PL Abstractions:** Shangyin Tan (UC Berkeley), Manish Shetty (UC Berkeley), Peter Zhong (CMU)
+- encodes one application's workflow rather than a reusable programming primitive;
+- exposes a temporary prompting trick as a permanent user-facing abstraction;
+- duplicates Python control flow with a DSPy-specific graph or orchestration language;
+- couples task intent to one model, provider, agent architecture, or optimizer;
+- hides behavior in a way that makes stages harder to inspect, evaluate, or replace;
+- adds convenience at the cost of weakening composition or creating a second way to express the same idea.
 
-**Applications:** Jasper Xian (Waterloo), Saron Samuel (Stanford), Alberto Mancarella (Stanford), Faraz Khoubsirat (Waterloo), Saiful Haq (IIT-B), Ashutosh Sharma (UIUC)
+Such work can still be valuable. It may fit better as a tool, adapter, integration, recipe, external package, or application built with DSPy.
 
+## Roadmap priorities
 
+We prioritize work that closes the gap between a user's stated intent and the best systems current models can deliver:
 
-## 1) Polishing the core functionality.
+1. **Make the small core excellent.** Keep signatures, modules, adapters, tools, metrics, and program state predictable, typed, composable, and easy to debug.
+2. **Improve whole-program optimization.** Advance prompt, demonstration, weight, and reinforcement-learning optimizers while reducing their data, compute, and expert-tuning requirements.
+3. **Support richer inference without changing intent.** Let programs adopt agents, tools, multimodal models, long-context strategies, and future techniques behind stable signatures.
+4. **Complete the path to production.** Make evaluation, observability, async execution, streaming, versioned artifacts, deployment, and monitoring first-class parts of the workflow.
+5. **Teach the programming model clearly.** Help software developers and domain experts build strong systems without first becoming prompt engineers or ML researchers.
+6. **Grow an open research ecosystem.** Make new modules and optimizers reusable so advances from researchers, model builders, and practitioners can benefit the same programs.
 
-Over the next month, polishing is the main objective and likely the one to have the highest ROI on the experience of the average user. Conceptually, DSPy has an extremely small core. It’s nothing but (1) LMs, (2) Signatures & Modules, (3) Optimizers, and (4) Assertions. These concepts and their implementations evolved organically over the past couple of years. We are working now to consolidate what we’ve learned and refactor internally so that things “just work” out of the box for new users, who may not know all the tips-and-tricks just yet.
-
-More concretely:
-
-1. We want to increase the quality of zero-shot, off-the-shelf DSPy programs, i.e. those not yet compiled on custom data.
-2. Wherever possible, DSPy should delegate lower-level internal complexity (like managing LMs and structured generation) to emerging lower-level libraries. When required, we may fork smaller libraries out of DSPy to support infrastructure pieces as their own projects.
-3. DSPy should internally be more modular and we need higher compatibility between internal components. Specifically, we need more deeper and more native investment in (i) typed multi-field constraints, (ii) assertions, (iii) observability and experimental tracking, (iv) deployment of artifacts and related concerns like streaming and async, and (v) fine-tuning and serving open models.
-
-
-### On LMs
-
-As of DSPy 2.4, the library has approximately 20,000 lines of code and roughly another 10,000 lines of code for tests, examples, and documentation. Some of these are clearly necessary (e.g., DSPy optimizers) but others exist only because the LM space lacks the building blocks we need under the hood. Luckily, for LM interfaces, a very strong library now exists: LiteLLM, a library that unifies interfaces to various LM and embedding providers. We expect to reduce around 6000 LoCs of support for custom LMs and retrieval models by shifting a lot of that to LiteLLM.
-
-Objectives in this space include improved caching, saving/loading of LMs, support for streaming and async LM requests. Work here is currently led by Hanna Moazam and Sri Vardhamanan, building on a foundation by Cyrus Nouroozi, Amir Mehr, Kyle Caverly, and others.
-
-
-### On Signatures & Modules
-
-Traditionally, LMs offer text-in-text-out interfaces. Toward modular programming, DSPy introduced signatures for the first time (as DSP Templates in Jan 2023) as a way to structure the inputs and outputs of LM interactions. Standard prompts conflate interface (“what should the LM do?”) with implementation (“how do we tell it to do that?”). DSPy signatures isolate the former so we can infer and learn the latter from data — in the context of a bigger program. Today in the LM landscape, notions of "structured outputs" have evolved dramatically, thanks to constrained decoding and other improvements, and have become mainstream. What may be called "structured inputs" remains is yet to become mainstream outside of DSPy, but is as crucial.
-
-Objectives in this space include refining the abstractions and implementations first-class notion of LM Adapters in DSPy, as translators that sits between signatures and LM interfaces. While Optimizers adjust prompts through interactions with a user-supplied metric and data, Adapters are more concerned with building up interactions with LMs to account for, e.g. (i) non-plaintext LM interfaces like chat APIs, structured outputs, function calling, and multi-modal APIs, (ii) languages beyond English or other forms of higher-level specialization. This has been explored in DSPy on and off in various forms, but we have started working on more fundamental approaches to this problem that will offer tangible improvements to most use-cases. Work here is currently led by Omar Khattab.
-
-
-### On Finetuning & Serving
-
-In February 2023, DSPy introduced the notion of compiling to optimize the weights of an LM program. (To understand just how long ago that was in AI terms, this was before the Alpaca training project at Stanford had even started and a month before the first GPT-4 was released.) Since then, we have shown in October 2023 and, much more expansively, in July 2024, that the fine-tuning flavor of DSPy can deliver large gains for small LMs, especially when composed with prompt optimization.
-
-Overall, though, most DSPy users in practice explore prompt optimization and not weight optimization and most of our examples do the same. The primary reason for a lot of this is infrastructure. Fine-tuning in the DSPy flavor is more than just training a model: ultimately, we need to bootstrap training data for several different modules in a program, train multiple models and handle model selection, and then load and plug in those models into the program's modules. Doing this robustly at the level of abstraction DSPy offers requires a level of resource management that is not generally supported by external existing tools. Major efforts in this regard are currently led by Dilara Soylu and Isaac Miller.
-
-
-### On Optimizers & Assertions
-
-This is a naturally major direction in the course of polishing. We will share more thoughts here after making more progress on the three angles above.
-
-
-
-## 2) Developing more accurate, lower-cost optimizers.
-
-A very large fraction of the research in DSPy focuses on optimizing the prompts and the weights of LM programs. In December 2022, we introduced the algorithm and abstractions behind BootstrapFewShot (as Demonstrate in DSP) and several of its variants. In February 2023, we introduced the core version of what later became BootstrapFinetune. In August 2023, we introduced new variations of both of these. In December 2023, we introduced the first couple of instruction optimizers into DSPy, CA-OPRO and early versions of MIPRO. These were again upgraded in March 2024. Fast forward to June and July 2024, we released MIPROv2 for prompt optimization and BetterTogether for fine-tuning the weights of LM programs.
-
-We have been working towards a number of stronger optimizers. While we cannot share the internal details of research on new optimizers yet, we can outline the goals. A DSPy optimizer can be characterized via three angles:
-
-1. Quality: How much quality can it deliver from various LMs? How effective does it need the zero-shot program to be in order to work well?
-2. Cost: How many labeled (and unlabeled) inputs does it need? How many invocations of the program does it need? How expensive is the resulting optimized program at inference time?
-3. Robustness: How well can it generalize to different unseen data points or distributions? How sensitive is it to mistakes of the metric or labels?
-
-Over the next six months, our goal is to dramatically improve each angle of these _when the other two are held constant_.  Concretely, there are three directions here.
-
-- Benchmarking: A key prerequisite here is work on benchmarking. On the team, Michael Ryan and Shangyin Tan are leading these efforts. More soon.
-
-- Quality: The goal here is optimizers that extract, on average, 20% more on representative tasks than MIPROv2 and BetterTogether, under the usual conditions — like a few hundred inputs with labels and a good metric starting from a decent zero-shot program. Various efforts here are led by Dilara Soylu, Michael Ryan, Josh Purtell, Krista Opsahl-Ong, and Isaac Miller.
-
-- Efficiency: The goal here is optimizers that match the current best scores from MIPROv2 and BetterTogether but under 1-2 challenges like: (i) starting from only 10-20 inputs with labels, (ii) starting with a weak zero-shot program that scores 0%, (iii) where significant misalignment exists between train/validation and test, or (iii) where the user supplies no metric but provides a very small number of output judgments.
-
-
-
-## 3) Building end-to-end tutorials from DSPy’s ML workflow to deployment.
-
-Using DSPy well for solving a new task is just doing good machine learning with LMs, but teaching this is hard. On the one hand, it's an iterative process: you make some initial choices, which will be sub-optimal, and then you refine them incrementally. It's highly exploratory: it's often the case that no one knows yet how to best solve a problem in a DSPy-esque way. One the other hand, DSPy offers many emerging lessons from several years of building LM systems, in which the design space, the data regime, and many other factors are new both to ML experts and to the very large fraction of users that have no ML experience.
-
-Though current docs do address [a bunch of this](learn/index.md) in isolated ways, one thing we've learned is that we should separate teaching the core DSPy language (which is ultimately pretty small) from teaching the emerging ML workflow that works well in a DSPy-esque setting. As a natural extension of this, we need to place more emphasis on steps prior and after to the explicit coding in DSPy, from data collection to deployment that serves and monitors the optimized DSPy program in practice. This is just starting but efforts will be ramping up led by Omar Khattab, Isaac Miller, and Herumb Shandilya.
-
-
-## 4) Shifting towards more interactive optimization & tracking.
-
-Right now, a DSPy user has a few ways to observe and tweak the process of optimization. They can study the prompts before, during, and after optimization methods like `inspect_history`, built-in logging, and/or the metadata returned by optimizers. Similarly, they can rely on `program.save` and `program.load` to potentially adjust the optimized prompts by hand. Alternatively, they can use one of the many powerful observability integrations — like from Phoenix Arize, LangWatch, or Weights & Biases Weave — to observe _in real time_ the process of optimization (e.g., scores, stack traces, successful & failed traces, and candidate prompts). DSPy encourages iterative engineering by adjusting the program, data, or metrics across optimization runs. For example, some optimizers allow “checkpointing” — e.g., if you optimize with BootstrapFewShotWithRandomSearch for 10 iterations then increase to 15 iterations, the first 10 will be loaded from cache.
-
-While these can accomplish a lot of goals, there are two limitations that future versions of DSPy will seek to address.
-
-1. In general, DSPy’s (i) observability, (ii) experimental tracking, (iii) cost management, and (iii) deployment of programs should become first-class concerns via integration with tools like MLFlow. We will share more plans addressing this for DSPy 2.6 in the next 1-2 months.
-
-2. DSPy 3.0 will introduce new optimizers that prioritize ad-hoc, human-in-the-loop feedback. This is perhaps the only substantial paradigm shift we see as necessary in the foreseeable future in DSPy. It involves various research questions at the level of the abstractions, UI/HCI, and ML, so it is a longer-term goal that we will share more about in the next 3-4 month.
-
-
+We expect the algorithms under these priorities to change. We intend the programming model above to remain recognizable.

--- a/docs/docs/stylesheets/home.css
+++ b/docs/docs/stylesheets/home.css
@@ -399,6 +399,60 @@
     opacity: 0.6;
 }
 
+/* ===== PROGRAMMING MODEL ===== */
+.hp-thesis { padding: 64px 0; }
+.hp-thesis-header {
+    display: grid;
+    grid-template-columns: 1.3fr 0.7fr;
+    gap: 64px;
+    align-items: end;
+}
+.hp-thesis-header .hp-section-label { margin-bottom: 18px; }
+.hp-thesis-header > p {
+    color: var(--hp-fg-2);
+    font-size: 17px;
+    line-height: 1.55;
+    margin: 0;
+}
+.hp-intent-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    margin-top: 42px;
+    border: 1px solid var(--hp-line);
+}
+.hp-intent-item { padding: 28px; }
+.hp-intent-item + .hp-intent-item { border-left: 1px solid var(--hp-line); }
+.hp-intent-num {
+    font-family: var(--hp-mono);
+    color: var(--hp-accent);
+    font-size: 11px;
+    letter-spacing: 1px;
+    margin-bottom: 24px;
+}
+.dspy-home .hp-intent-item h3 {
+    color: var(--hp-fg);
+    font-size: 18px;
+    margin: 0 0 10px;
+}
+.hp-intent-item p { color: var(--hp-fg-2); line-height: 1.55; margin: 0; }
+.hp-thesis-foot {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    padding-top: 20px;
+    color: var(--hp-fg-3);
+    font-family: var(--hp-mono);
+    font-size: 12px;
+}
+.dspy-home .hp-thesis-foot a,
+.md-typeset .hp-thesis-foot a {
+    color: var(--hp-fg) !important;
+    text-decoration: none !important;
+    border-bottom: 1px dotted var(--hp-fg-3);
+    white-space: nowrap;
+}
+.dspy-home .hp-thesis-foot a:hover { color: var(--hp-accent) !important; }
+
 /* ===== FEATURES (THREE PRIMITIVES) ===== */
 .hp-features { padding: 64px 0; }
 .hp-features-grid {
@@ -774,6 +828,11 @@
     .hp-hero-meta { gap: 16px; padding-top: 16px; }
     .hp-stats-grid { grid-template-columns: repeat(3, 1fr); }
     .hp-stat-production { display: none; }
+    .hp-thesis { padding: 40px 0; }
+    .hp-thesis-header { grid-template-columns: 1fr; gap: 20px; }
+    .hp-intent-grid { grid-template-columns: 1fr; margin-top: 28px; }
+    .hp-intent-item + .hp-intent-item { border-left: none; border-top: 1px solid var(--hp-line); }
+    .hp-thesis-foot { flex-direction: column; }
     .hp-features { padding: 40px 0; }
     .hp-features .hp-section-title { margin-bottom: 0; }
     .hp-features-grid {
@@ -816,6 +875,10 @@
     .hp-stat { padding: 16px 24px 10px; }
     .hp-stat + .hp-stat { border-left: none; border-top: 1px solid var(--hp-line); }
     .hp-stat-num { font-size: 28px; }
+    .hp-thesis { padding: 48px 0; }
+    .hp-thesis-header > p { font-size: 15px; }
+    .hp-intent-item { padding: 22px; }
+    .hp-thesis-foot a { white-space: normal; }
     .hp-features { padding: 48px 0; }
     .hp-features-grid { margin-top: 40px; }
     .hp-section-title { font-size: 24px; }

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,6 +10,7 @@ docs_dir: "docs/"
 
 nav:
     - Overview: index.md
+    - Direction: roadmap.md
     - Getting Started:
         - Program, don't prompt: getting-started/program-dont-prompt.md
         - Setting up DSPy: getting-started/installation.md
@@ -321,13 +322,14 @@ plugins:
             "getting_started/12_where_to_go_next.md":   "getting-started/where-to-go-next.md"
     - llmstxt:
         markdown_description: >
-          DSPy is the framework for programming—rather than prompting—language models.
-          DSPy unifies techniques for prompting, fine-tuning, reasoning, tool use, and evaluation of LMs.
-          It provides a systematic approach to building AI applications through composable modules, 
-          optimization techniques, and evaluation frameworks.
+          DSPy is the framework for building programmable AI systems, rather than relying on ad-hoc prompts.
+          It combines ordinary Python control flow, declarative typed signatures, and feedback from examples
+          and metrics. DSPy unifies prompting, fine-tuning, reasoning, tool use, and evaluation through
+          composable modules and whole-program optimization.
         sections:
           Get Started:
             - index.md: DSPy overview and quick start guide
+            - roadmap.md: DSPy's design promise, scope criteria, and roadmap
           Getting Started:
             - getting-started/**.md
           Diving Deeper:

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -27,9 +27,9 @@
         </h1>
 
         <p class="hp-hero-sub">
-          DSPy is a Python framework for building AI systems. Express your
-          tasks as structured signatures, not prompts, to produce
-          maintainable, modular, and optimizable programs.
+          DSPy is a Python framework for building AI systems. Keep exact behavior
+          in code, express judgment as typed signatures, and use feedback to
+          improve the whole program.
         </p>
 
         <div class="hp-hero-actions">
@@ -118,6 +118,47 @@
     </div>
   </section>
 
+  <!-- ===== PROGRAMMABLE INTELLIGENCE ===== -->
+  <section class="hp-section hp-thesis">
+    <div class="hp-container">
+      <div class="hp-thesis-header">
+        <div>
+          <div class="hp-section-label"><span class="hp-rule"></span> THE PROGRAMMING MODEL</div>
+          <h2 class="hp-section-title">
+            Models provide intelligence. <span class="hp-hl">You specify the system.</span>
+          </h2>
+        </div>
+        <p>
+          A model call is not yet software. DSPy gives you three familiar ways
+          to express intent&mdash;and lets each one do the job it does best.
+        </p>
+      </div>
+
+      <div class="hp-intent-grid">
+        <div class="hp-intent-item">
+          <div class="hp-intent-num">01</div>
+          <h3>Code for what must be exact</h3>
+          <p>Use ordinary Python for control flow, state, constraints, and operations that must happen.</p>
+        </div>
+        <div class="hp-intent-item">
+          <div class="hp-intent-num">02</div>
+          <h3>Signatures for judgment</h3>
+          <p>Give fuzzy transformations clear, typed boundaries without tying them to one model or prompting trick.</p>
+        </div>
+        <div class="hp-intent-item">
+          <div class="hp-intent-num">03</div>
+          <h3>Feedback for hard cases</h3>
+          <p>Use examples and metrics to show what better means, then let optimizers adapt the program.</p>
+        </div>
+      </div>
+
+      <div class="hp-thesis-foot">
+        <span>Start with one signature. Add structure and optimization only when your system needs them.</span>
+        <a href="{{ 'roadmap/' | url }}">Read DSPy&rsquo;s design promise &amp; roadmap &rarr;</a>
+      </div>
+    </div>
+  </section>
+
   <!-- ===== THREE PRIMITIVES ===== -->
   <section class="hp-section hp-features">
     <div class="hp-container">
@@ -174,8 +215,8 @@
           <h3>Optimizers</h3>
           <div class="hp-feature-tagline">Compile your program against a metric.</div>
           <p>
-            Give DSPy examples and a scoring function. It tunes your
-            prompts automatically until quality converges.
+            Give DSPy examples and a scoring function. It can improve
+            instructions, demonstrations, or model weights against your goal.
           </p>
           <div class="hp-feature-cta">
             <a href="{{ 'getting-started/gepa-optimization/' | url }}" class="hp-cta-link">Try Optimizers &rarr;</a>


### PR DESCRIPTION
## Summary

- make DSPy's programmable-intelligence thesis prominent on the homepage and at the start of Getting Started
- explain the three complementary forms of intent: Python structure, signatures for judgment, and examples/metrics for feedback
- clarify the separation between signatures, inference-time modules, and whole-program optimization
- replace the outdated draft roadmap with a living design promise, explicit criteria for what belongs in DSPy's core, and current roadmap priorities
- keep the framing approachable: users can start with one signature and add structure or optimization only when needed

## Validation

- `cd docs && mkdocs build`
- `git diff --check`

The repository-wide pre-push matrix also ran; all five Python versions hit the same unrelated `test_multi_thread_evaluate_call_cancelled` failure, with 1396 other tests passing per supported version.
