### PR TITLE
ci: run optional pytest partitions concurrently per job

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,7 +141,18 @@ jobs:
       - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+        run: |
+          uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n 2 --dist worksteal \
+            -k 'not (large_list_variable or multiple_large_variables or enable_write_flag or interpreter_security_filesystem_access or read_file_access_control or enable_env_vars_flag or enable_net_flag)' &
+          remaining_pid=$!
+          uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n 2 --dist worksteal \
+            -k 'large_list_variable or multiple_large_variables or enable_write_flag or interpreter_security_filesystem_access or read_file_access_control or enable_env_vars_flag or enable_net_flag' &
+          heavy_pid=$!
+
+          status=0
+          wait "$remaining_pid" || status=$?
+          wait "$heavy_pid" || status=$?
+          exit "$status"
 
   llm_call_test:
     name: Run Tests with Real LM


### PR DESCRIPTION
## Summary

Run the existing complete optional-suite partition inside each Python-version job as two concurrent pytest processes:

- 159 remaining optional/Deno nodes with 2 xdist workers
- 7 heavy Deno nodes with 2 xdist workers

This retains four total xdist workers and does not add GitHub Actions jobs, which matters because the combined benchmark measured a hard 20-job concurrency ceiling.

## Behavior and coverage proof

Collection against the production marker/flags:

| set | nodes |
|---|---:|
| unsplit `extra or deno` | 166 |
| remaining selection | 159 |
| heavy selection | 7 |
| overlap | 0 |
| omitted | 0 |
| extra | 0 |

Both subprocesses are always waited. Any non-zero process status fails the Actions step. No test, marker, assertion, dependency, Python version, or Deno version changes.

## Why this shape

#10172 proved the same 159/7 split reduces the optional critical lane by 24.1–29.2% when represented as ten Actions jobs. #10175 then proved those five additional jobs overflow the repository's 20-runner cap and make the complete workflow slower. This PR tests whether preserving that partition *inside* the existing five jobs captures the load-balancing gain without consuming runner slots.

Normal Actions timing and an unchanged repeat will determine whether this is worth merging; no offline speed claim is used.
