### PR TITLE
ci: benchmark load scheduling for optional tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist load
 
   llm_call_test:
     name: Run Tests with Real LM


### PR DESCRIPTION
## Benchmark candidate

Change only the optional/Deno matrix from xdist `worksteal` to dynamic `load` scheduling. Worker count, 166-node selection, flags, tests, assertions, dependencies, Python matrix, and Deno version are unchanged.

Why test this workload separately: seven Deno cases are much slower than the other 159 optional nodes. `load` assigns the next node to each available worker rather than maintaining and stealing from per-worker chunks, which may reduce the measured 119–129s optional straggler without adding Actions jobs. The primary suite previously favored `worksteal`, so this change is deliberately scoped and makes no offline claim.

Acceptance bar: normal Actions must reduce the slowest optional job, not merely the five-job mean, and an unchanged repeat must confirm it. Otherwise close.
