### PR TITLE
ci: benchmark six optional test workers

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n 6 --dist worksteal
 
   llm_call_test:
     name: Run Tests with Real LM


### PR DESCRIPTION
## Benchmark candidate

Use six xdist workers only for the optional/Deno matrix. The 166-node selection, `worksteal` scheduler, tests, assertions, flags, dependencies, Python versions, and Deno version are unchanged.

The default Actions runner exposes four logical CPUs. Eight-worker oversubscription was already rejected as 22% slower on Actions; this tests whether a smaller 1.5× oversubscription can hide Deno subprocess waits without the eight-worker contention penalty.

Acceptance bar: reduce the slowest optional job (parent 119s exact-head reference), then repeat unchanged. Otherwise close. No offline speed claim.
