### PR TITLE
ci: benchmark all shards within runner capacity

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -133,6 +133,8 @@ jobs:
           ) &
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
       - name: Create and activate virtual environment
         run: |
           uv venv .venv

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -139,13 +139,8 @@ jobs:
               echo "$?" > "$RUNNER_TEMP/ollama-pull.status"
             fi
           ) &
-      - name: Install uv with caching
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            **/pyproject.toml
-            **/uv.lock
       - name: Create and activate virtual environment
         run: |
           uv venv .venv

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -111,10 +111,18 @@ jobs:
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
   
   llm_call_test:
-    name: Run Tests with Real LM
+    name: ${{ matrix.job_name }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - job_name: Run Tests with Real LM
+            test_expression: stream_listener_chat_adapter or stream_listener_json_adapter or single_module_call_with_usage_tracker
+          - job_name: Run Remaining Tests with Real LM
+            test_expression: not (stream_listener_chat_adapter or stream_listener_json_adapter or single_module_call_with_usage_tracker)
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -194,7 +202,9 @@ jobs:
       - name: Set LM environment variable
         run: echo "LM_FOR_TEST=ollama/llama3.2:3b" >> "$GITHUB_ENV"
       - name: Run tests
-        run: uv run -p .venv pytest -m llm_call --llm_call -vv --durations=5 tests/
+        run: >-
+          uv run -p .venv pytest -m llm_call --llm_call -vv --durations=5
+          -k '${{ matrix.test_expression }}' tests/
       - name: Fix permissions for cache
         if: always()
         run: sudo chown -R "$USER":"$USER" ollama-data || true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -131,13 +131,8 @@ jobs:
               echo "$?" > "$RUNNER_TEMP/ollama-pull.status"
             fi
           ) &
-      - name: Install uv with caching
+      - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: |
-            **/pyproject.toml
-            **/uv.lock
       - name: Create and activate virtual environment
         run: |
           uv venv .venv

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -73,6 +73,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      max-parallel: 3
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
@@ -106,6 +107,7 @@ jobs:
     permissions:
       contents: read
     strategy:
+      max-parallel: 3
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
@@ -316,6 +318,8 @@ jobs:
 
   build_package:
     name: Build Package
+    needs: [test, remaining_test]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -122,6 +122,15 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
+      - name: Prefetch Ollama image
+        run: |
+          (
+            if docker pull ollama/ollama:0.31.2 > "$RUNNER_TEMP/ollama-pull.log" 2>&1; then
+              echo 0 > "$RUNNER_TEMP/ollama-pull.status"
+            else
+              echo "$?" > "$RUNNER_TEMP/ollama-pull.status"
+            fi
+          ) &
       - name: Install uv with caching
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -145,6 +154,14 @@ jobs:
           key: ollama-llama3.2-3b-${{ runner.os }}-ollama0.31.2-v2
       - name: Start Ollama service
         run: |
+          for _ in {1..120}; do
+            [[ -f "$RUNNER_TEMP/ollama-pull.status" ]] && break
+            sleep 1
+          done
+          if [[ ! -f "$RUNNER_TEMP/ollama-pull.status" ]] || [[ "$(cat "$RUNNER_TEMP/ollama-pull.status")" != 0 ]]; then
+            cat "$RUNNER_TEMP/ollama-pull.log"
+            exit 1
+          fi
           mkdir -p ollama-data
           docker run -d --name ollama \
             -p 11434:11434 \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,12 +82,6 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-        with:
-          deno-version: v2.7.7
-      - name: Verify Deno installation
-        run: deno --version
       - name: Install uv with caching
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -104,12 +104,88 @@ jobs:
           uv sync --dev -p .venv --extra dev
           uv pip list
       - name: Run tests with pytest
-        run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
-      - name: Install optional dependencies
+        run: uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/
+
+  extra_test:
+    name: Run Extra and Deno Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+      - name: Verify Deno installation
+        run: deno --version
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
-  
+        run: >-
+          uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+          -k 'not (large_list_variable or multiple_large_variables or enable_write_flag or
+          interpreter_security_filesystem_access or read_file_access_control or enable_env_vars_flag or enable_net_flag)'
+
+  heavy_deno_test:
+    name: Run Heavy Deno Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+      - name: Verify Deno installation
+        run: deno --version
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
+        run: uv sync -p .venv --extra dev --extra test_extras
+      - name: Run heavy Deno tests
+        run: >-
+          uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+          -k 'large_list_variable or multiple_large_variables or enable_write_flag or
+          interpreter_security_filesystem_access or read_file_access_control or enable_env_vars_flag or enable_net_flag'
+
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -104,12 +104,80 @@ jobs:
           uv sync --dev -p .venv --extra dev
           uv pip list
       - name: Run tests with pytest
-        run: uv run -p .venv pytest -vv -n auto --dist worksteal tests/
-      - name: Install optional dependencies
+        run: uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/clients tests/adapters tests/utils
+
+  remaining_test:
+    name: Run Remaining Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
+        run: |
+          uv sync --dev -p .venv --extra dev
+          uv pip list
+      - name: Run remaining tests with pytest
+        run: >-
+          uv run -p .venv pytest -vv -m 'not extra and not deno' -n auto --dist worksteal tests/
+          --ignore=tests/clients --ignore=tests/adapters --ignore=tests/utils
+
+  extra_test:
+    name: Run Extra and Deno Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Deno
+        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
+        with:
+          deno-version: v2.7.7
+      - name: Verify Deno installation
+        run: deno --version
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create and activate virtual environment
+        run: |
+          uv venv .venv
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
+      - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
-  
+
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Benchmark only — do not merge

This follow-up reconciles the successful isolated optional shards (#10172) with the measured 20-job Actions concurrency cap:

- primary shard matrices: `max-parallel: 3` each = 6 runnable primary jobs
- optional shard matrices: 10 runnable jobs
- real-LM shards: 2 runnable jobs
- workflow lint + Ruff: 2 runnable jobs
- **startup total: exactly 20**
- builds wait for both primary matrices, still run after failures via `if: ${{ !cancelled() }}`

The four throttled primary entries should enter as 35–45s jobs release slots. Prior runs put the slowest primary shard at 61s, so the second wave should finish near or below the ~100–110s optional/real-LM lanes. Builds then take 15–24s.

Compared with:

- #10175 all shards unthrottled: 160s because jobs queued unpredictably
- #10177 no optional sub-shard: repeated 131–139s / 135s mean

This run determines whether explicit capacity scheduling can retain all isolated lane gains. Every test partition is unchanged from the twice-green #10175 composition. **Do not merge this integration branch.**
