### PR TITLE
ci: schedule interpreter tests before optional tail

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,7 +141,10 @@ jobs:
       - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
+        run: >-
+          uv run -p .venv pytest tests/primitives/test_python_interpreter.py tests/
+          --ignore=tests/primitives/test_python_interpreter.py
+          -m 'extra or deno' --extra --deno -n auto --dist worksteal
 
   llm_call_test:
     name: Run Tests with Real LM

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -141,10 +141,10 @@ jobs:
       - name: Install dependencies
         run: uv sync -p .venv --extra dev --extra test_extras
       - name: Run extra and deno tests
-        run: >-
-          uv run -p .venv pytest tests/primitives/test_python_interpreter.py tests/
-          --ignore=tests/primitives/test_python_interpreter.py
-          -m 'extra or deno' --extra --deno -n auto --dist worksteal
+        run: |
+          mapfile -t test_files < <(find tests -type f -name 'test_*.py' ! -path 'tests/primitives/test_python_interpreter.py' -print)
+          uv run -p .venv pytest tests/primitives/test_python_interpreter.py "${test_files[@]}" \
+            -m 'extra or deno' --extra --deno -n auto --dist worksteal
 
   llm_call_test:
     name: Run Tests with Real LM


### PR DESCRIPTION
## Benchmark candidate

Collect `tests/primitives/test_python_interpreter.py` first, followed by every other test file, in the existing optional/Deno matrix. Worker count (four), `worksteal`, markers, flags, tests, assertions, dependencies, Python versions, and Deno version are unchanged.

The command discovers the remaining 95 test files and passes each path explicitly. Collection proof against the production marker/flags:

| set | nodes |
|---|---:|
| current `tests/` command | 166 |
| interpreter-first command | 166 |
| unique ordered nodes | 166 |
| overlap difference / omitted / extra | 0 / 0 / 0 |

Why: all seven measured Deno stragglers live in the 72-node interpreter file. With chunk-based `worksteal`, moving that file to the front should start long work earlier instead of exposing it near the job tail, without adding jobs or oversubscribing the four-vCPU runner.

Acceptance bar: normal Actions must reduce the slowest optional job (119s parent reference), then an unchanged repeat and Greptile 5/5. Otherwise close.
