### PR TITLE
ci: defer builds until primary tests release runners

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -267,7 +267,6 @@ jobs:
   build_package:
     name: Build Package
     needs: [test, remaining_test]
-    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -249,6 +249,8 @@ jobs:
 
   build_package:
     name: Build Package
+    needs: [test, remaining_test]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Delay the five short build-matrix jobs until both primary test shard matrices pass. Normal `needs` semantics skip package builds on revisions that already failed either primary shard.

No build command, test command, matrix, check name, assertion, dependency, or coverage changes. Failed primary-test revisions no longer consume five package-build runners.

## Why

Exact timestamps from the all-shards benchmark proved this repository peaks at 20 concurrent Actions jobs. Eager 14–24s builds occupy five slots while 35–140s test jobs queue, extending wall time without making builds finish any earlier relative to the critical path.

Repeated integration proof in #10177:

| composition | workflow wall time |
|---|---:|
| unthrottled all-shards | 160s |
| deferred builds, no lower-yield optional sub-shard | 139s / 131s (**135s mean**) |

In both green runs, all long jobs started within 8s. Builds began after primary shards released runners and still completed before the optional/real-LM critical path. The complete state was 14s / 9.4% faster than the prior 149s clean state and 152s / 53.0% faster than original 287s CI.

This PR isolates only the scheduling dependency from that completed benchmark. Exact-head normal CI and Greptile 5/5 remain required.