### PR TITLE
Add timeout to Audio.from_url so it doesn't hang forever

### DIFF
--- a/dspy/adapters/types/audio.py
+++ b/dspy/adapters/types/audio.py
@@ -80,7 +80,7 @@ class Audio(Type):
         return encode_audio(values)
 
     @classmethod
-    def from_url(cls, url: str, verify: bool = True) -> "Audio":
+    def from_url(cls, url: str, verify: bool = True, timeout: float = 30.0) -> "Audio":
         """
         Download an audio file from URL and encode it as base64.
 
@@ -93,11 +93,13 @@ class Audio(Type):
         Args:
             url: The URL of the audio to download.
             verify: Whether to verify SSL certificates. Set to False for self-signed certs.
+            timeout: Timeout in seconds for the request. Prevents hanging on a slow or
+                unresponsive server. Pass ``None`` to wait indefinitely.
         """
         parsed_url = urlparse(url)
         if parsed_url.scheme not in ("http", "https") or not parsed_url.netloc:
             raise ValueError(f"Audio.from_url requires an HTTP(S) URL, received: {url}")
-        response = requests.get(url, verify=verify)
+        response = requests.get(url, verify=verify, timeout=timeout)
         response.raise_for_status()
         mime_type = response.headers.get("Content-Type", "audio/wav")
         if not mime_type.startswith("audio/"):

--- a/tests/adapters/test_audio.py
+++ b/tests/adapters/test_audio.py
@@ -1,6 +1,9 @@
-import pytest
+from unittest import mock
 
-from dspy.adapters.types.audio import _normalize_audio_format
+import pytest
+import requests
+
+from dspy.adapters.types.audio import Audio, _normalize_audio_format
 
 
 @pytest.mark.parametrize(
@@ -30,3 +33,34 @@ def test_normalize_audio_format(input_format, expected_format):
     This single test covers the logic for from_url, from_file, and encode_audio.
     """
     assert _normalize_audio_format(input_format) == expected_format
+
+
+def test_from_url_passes_default_timeout():
+    """from_url should pass a timeout to requests.get so it can't hang forever."""
+    response = mock.Mock()
+    response.headers = {"Content-Type": "audio/wav"}
+    response.content = b"fake-audio-bytes"
+
+    with mock.patch("dspy.adapters.types.audio.requests.get", return_value=response) as mock_get:
+        Audio.from_url("https://example.com/sound.wav")
+
+    assert mock_get.call_args.kwargs["timeout"] == 30.0
+
+
+def test_from_url_uses_custom_timeout():
+    """A caller-provided timeout should be forwarded to requests.get."""
+    response = mock.Mock()
+    response.headers = {"Content-Type": "audio/wav"}
+    response.content = b"fake-audio-bytes"
+
+    with mock.patch("dspy.adapters.types.audio.requests.get", return_value=response) as mock_get:
+        Audio.from_url("https://example.com/sound.wav", timeout=5.0)
+
+    assert mock_get.call_args.kwargs["timeout"] == 5.0
+
+
+def test_from_url_propagates_timeout_error():
+    """If the request times out, the error should surface instead of hanging."""
+    with mock.patch("dspy.adapters.types.audio.requests.get", side_effect=requests.exceptions.Timeout):
+        with pytest.raises(requests.exceptions.Timeout):
+            Audio.from_url("https://example.com/sound.wav")


### PR DESCRIPTION
requests.get had no timeout, so a slow or unresponsive server could make from_url hang indefinitely. Added a timeout parameter (default 30s) and passed it through to requests.get. Passing timeout=None keeps the old behaviour. Added tests for the default, a custom value, and that a timeout error is raised instead of hanging.

Part of #9993