### PR TITLE
Support MCP SDK v2 without changing tool result semantics

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -133,6 +133,34 @@ jobs:
       - name: Run extra and deno tests
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
 
+  mcp_v2_test:
+    name: Run MCP v2 Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create environment
+        run: uv venv .venv
+      - name: Install dependencies with MCP v2
+        run: |
+          uv sync -p .venv --extra dev
+          uv pip install -p .venv "mcp==2.0.0"
+      - name: Run MCP tests
+        run: uv run --frozen --no-sync -p .venv pytest tests/utils/test_mcp.py -m extra --extra
+
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -143,6 +143,34 @@ jobs:
       - name: Run extra and deno tests
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
 
+  mcp_v2_test:
+    name: Run MCP v2 Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+      - name: Install uv with caching
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            **/pyproject.toml
+            **/uv.lock
+      - name: Create environment
+        run: uv venv .venv
+      - name: Install dependencies with MCP v2
+        run: |
+          uv sync -p .venv --extra dev
+          uv pip install -p .venv "mcp==2.0.0"
+      - name: Run MCP tests
+        run: uv run --frozen --no-sync -p .venv pytest tests/utils/test_mcp.py -m extra --extra
+
   llm_call_test:
     name: Run Tests with Real LM
     runs-on: ubuntu-latest

--- a/docs/docs/diving-deeper/tools-react-and-mcp.md
+++ b/docs/docs/diving-deeper/tools-react-and-mcp.md
@@ -107,7 +107,7 @@ Constructor helper. Builds a `ToolCalls` from a list of `{"name", "args"}` dicts
 ### MCP bridge
 
 **`dspy.utils.mcp.convert_mcp_tool(session, tool)`** → `Tool`
-Builds a `Tool` whose `func` is an `async def` closure: it awaits `session.call_tool(tool.name, arguments=kwargs)` and unpacks the result. The unpacker pulls text from any `TextContent` entries (returning a single string when there’s one, a list otherwise) and returns non-text entries as-is. An `isError=True` response raises `RuntimeError`. The MCP tool’s `inputSchema` is mapped to DSPy’s `args`/`arg_types`/`arg_desc` via `convert_input_schema_to_tool_args`.
+Builds a `Tool` whose `func` is an `async def` closure: it awaits `session.call_tool(tool.name, arguments=kwargs)` and unpacks the result. The bridge supports the camelCase fields in mcp SDK v1 and their snake_case replacements in v2. An error result raises `RuntimeError`; structured content is returned exactly as sent; otherwise text and non-text content retain their existing behavior. The tool’s input schema is mapped to DSPy’s `args`/`arg_types`/`arg_desc` via `convert_input_schema_to_tool_args`, and a missing description falls back to its title.
 
 **`dspy.utils.mcp.convert_input_schema_to_tool_args(schema)`** → `(args, arg_types, arg_desc)`
 Walks an MCP-style JSON schema and produces the three dicts a `Tool` needs. Resolves `$defs`, picks up `description` fields as `arg_desc`, and translates JSON-schema types to Python types via a `_TYPE_MAPPING` table. Exported in case callers want to write their own bridge against a non-MCP protocol with similar JSON-schema arguments.

--- a/docs/docs/diving-deeper/tools-react-and-mcp.md
+++ b/docs/docs/diving-deeper/tools-react-and-mcp.md
@@ -107,7 +107,7 @@ Constructor helper. Builds a `ToolCalls` from a list of `{"name", "args"}` dicts
 ### MCP bridge
 
 **`dspy.utils.mcp.convert_mcp_tool(session, tool)`** → `Tool`
-Builds a `Tool` whose `func` is an `async def` closure: it awaits `session.call_tool(tool.name, arguments=kwargs)` and unpacks the result. The unpacker pulls text from any `TextContent` entries (returning a single string when there’s one, a list otherwise) and returns non-text entries as-is. An `isError=True` response raises `RuntimeError`. The MCP tool’s `inputSchema` is mapped to DSPy’s `args`/`arg_types`/`arg_desc` via `convert_input_schema_to_tool_args`.
+Builds a `Tool` whose `func` is an `async def` closure: it awaits `session.call_tool(tool.name, arguments=kwargs)` and unpacks the result. The bridge supports the camelCase fields in mcp SDK v1 and their snake_case replacements in v2. An error result raises `RuntimeError`; text and non-text content retain their existing behavior. The tool’s input schema is mapped to DSPy’s `args`/`arg_types`/`arg_desc` via `convert_input_schema_to_tool_args`.
 
 **`dspy.utils.mcp.convert_input_schema_to_tool_args(schema)`** → `(args, arg_types, arg_desc)`
 Walks an MCP-style JSON schema and produces the three dicts a `Tool` needs. Resolves `$defs`, picks up `description` fields as `arg_desc`, and translates JSON-schema types to Python types via a `_TYPE_MAPPING` table. Exported in case callers want to write their own bridge against a non-MCP protocol with similar JSON-schema arguments.

--- a/docs/docs/learn/programming/mcp.md
+++ b/docs/docs/learn/programming/mcp.md
@@ -22,13 +22,28 @@ MCP enables you to:
 - **Share tools across stacks** - Use the same tools across different frameworks.
 - **Simplify integration** - Convert MCP tools to DSPy tools with one line.
 
-DSPy does not handle MCP server connections directly. You can use client interfaces of the `mcp` library to establish the connection and pass `mcp.ClientSession` to `dspy.Tool.from_mcp_tool` in order to convert mcp tools into DSPy tools.
+DSPy does not handle MCP server connections directly. Use a client interface from the `mcp` library, then pass the client or session to `dspy.Tool.from_mcp_tool`. DSPy supports both major versions of the `mcp` Python SDK.
 
 ## Using MCP with DSPy
 
 ### 1. HTTP Server (Remote)
 
-For remote MCP servers over HTTP, use the streamable HTTP transport:
+With `mcp` SDK v2, use the high-level `Client` for a remote server:
+
+```python
+import asyncio
+import dspy
+from mcp.client import Client
+
+async def main():
+    async with Client("http://localhost:8000/mcp") as client:
+        response = await client.list_tools()
+        dspy_tools = [dspy.Tool.from_mcp_tool(client, tool) for tool in response.tools]
+
+asyncio.run(main())
+```
+
+With SDK v1, use the streamable HTTP transport and a `ClientSession`:
 
 ```python
 import asyncio
@@ -69,7 +84,7 @@ asyncio.run(main())
 
 ### 2. Stdio Server (Local Process)
 
-The most common way to use MCP is with a local server process communicating via stdio:
+The most common way to use MCP is with a local server process communicating via stdio. This example works with both SDK versions:
 
 ```python
 import asyncio

--- a/docs/docs/learn/programming/mcp.md
+++ b/docs/docs/learn/programming/mcp.md
@@ -22,13 +22,28 @@ MCP enables you to:
 - **Share tools across stacks** - Use the same tools across different frameworks.
 - **Simplify integration** - Convert MCP tools to DSPy tools with one line.
 
-DSPy does not handle MCP server connections directly. You can use client interfaces of the `mcp` library to establish the connection and pass `mcp.ClientSession` to `dspy.Tool.from_mcp_tool` in order to convert mcp tools into DSPy tools.
+DSPy does not handle MCP server connections directly. Use a client interface from the `mcp` library, then pass the client or session to `dspy.Tool.from_mcp_tool`. DSPy supports both major versions of the `mcp` Python SDK.
 
 ## Using MCP with DSPy
 
 ### 1. HTTP Server (Remote)
 
-For remote MCP servers over HTTP, use the streamable HTTP transport:
+With `mcp` SDK v2, use the high-level `Client` for a remote server:
+
+```python
+import asyncio
+import dspy
+from mcp.client import Client
+
+async def main():
+    async with Client("http://localhost:8000/mcp") as client:
+        response = await client.list_tools()
+        dspy_tools = [dspy.Tool.from_mcp_tool(client, tool) for tool in response.tools]
+
+asyncio.run(main())
+```
+
+With SDK v1, use the streamable HTTP transport and a `ClientSession`:
 
 ```python
 import asyncio
@@ -69,7 +84,7 @@ asyncio.run(main())
 
 ### 2. Stdio Server (Local Process)
 
-The most common way to use MCP is with a local server process communicating via stdio:
+The most common way to use MCP is with a local server process communicating via stdio. This example works with both SDK versions:
 
 ```python
 import asyncio
@@ -142,6 +157,10 @@ dspy_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
 # Use it like any DSPy tool
 result = await dspy_tool.acall(param1="value", param2=123)
 ```
+
+### Structured results
+
+When an MCP result includes structured content, DSPy returns it exactly as sent instead of returning its text rendering. Official SDK servers represent non-object typed returns in a single-field object, so a tool annotated `-> int` returns `{"result": 3}`. A tool returning a Pydantic model returns a plain dict. Tools without structured content keep the existing text behavior.
 
 ## Learn More
 

--- a/docs/docs/tutorials/mcp/index.md
+++ b/docs/docs/tutorials/mcp/index.md
@@ -46,11 +46,15 @@ it:
 import random
 import string
 
-from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel
 
+try:
+    from mcp.server.fastmcp import FastMCP as MCPServer  # SDK v1
+except ImportError:
+    from mcp.server import MCPServer  # SDK v2
+
 # Create an MCP server
-mcp = FastMCP("Airline Agent")
+mcp = MCPServer("Airline Agent")
 
 
 class Date(BaseModel):
@@ -220,10 +224,10 @@ if __name__ == "__main__":
 
 Before we start the server, let's take a look at the code.
 
-We first create a `FastMCP` instance, which is a utility that helps quickly build an MCP server:
+We first create a server instance, using the class name provided by the installed SDK version:
 
 ```python
-mcp = FastMCP("Airline Agent")
+mcp = MCPServer("Airline Agent")
 ```
 
 Then we define our data structures, which in a real-world application would be the database schema, e.g.:

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -1,6 +1,6 @@
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, Protocol, get_origin, get_type_hints
 
 import json_repair
 import pydantic
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
     from langchain.tools import BaseTool
 
 _TYPE_MAPPING = {"string": str, "integer": int, "number": float, "boolean": bool, "array": list, "object": dict}
+
+
+class _MCPToolClient(Protocol):
+    async def call_tool(self, name: str, arguments: dict[str, Any] | None = None) -> Any: ...
 
 
 class Tool(Type):
@@ -200,12 +204,12 @@ class Tool(Type):
             return result
 
     @classmethod
-    def from_mcp_tool(cls, session: "mcp.ClientSession", tool: "mcp.types.Tool") -> "Tool":
+    def from_mcp_tool(cls, session: _MCPToolClient, tool: "mcp.types.Tool") -> "Tool":
         """
-        Build a DSPy tool from an MCP tool and a ClientSession.
+        Build a DSPy tool from an MCP tool and a compatible MCP client.
 
         Args:
-            session: The MCP session to use.
+            session: An MCP client or session with an async ``call_tool`` method.
             tool: The MCP tool to convert.
 
         Returns:

--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -1,9 +1,17 @@
 from typing import TYPE_CHECKING, Any
 
-from dspy.adapters.types.tool import Tool, convert_input_schema_to_tool_args
+from dspy.adapters.types.tool import Tool, _MCPToolClient, convert_input_schema_to_tool_args
 
 if TYPE_CHECKING:
     import mcp
+
+
+def _get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) -> Any:
+    """Read a field whose Python name changed between mcp SDK v1 and v2."""
+    for name in (snake_name, camel_name):
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return default
 
 
 def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> str | list[Any]:
@@ -21,23 +29,27 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if len(text_contents) == 1:
         tool_content = tool_content[0]
 
-    if call_tool_result.isError:
+    if _get_field(call_tool_result, "is_error", "isError", default=False):
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
 
     return tool_content or non_text_contents
 
 
-def convert_mcp_tool(session: "mcp.ClientSession", tool: "mcp.types.Tool") -> Tool:
+def convert_mcp_tool(session: _MCPToolClient, tool: "mcp.types.Tool") -> Tool:
     """Build a DSPy tool from an MCP tool.
 
+    Both mcp SDK v1's ``ClientSession`` and v2's high-level ``Client`` satisfy
+    the client interface used by this bridge.
+
     Args:
-        session: The MCP session to use.
+        session: An MCP client or session with an async ``call_tool`` method.
         tool: The MCP tool to convert.
 
     Returns:
         A dspy Tool object.
     """
-    args, arg_types, arg_desc = convert_input_schema_to_tool_args(tool.inputSchema)
+    input_schema = _get_field(tool, "input_schema", "inputSchema", default={})
+    args, arg_types, arg_desc = convert_input_schema_to_tool_args(input_schema)
 
     # Convert the MCP tool and Session to a single async method
     async def func(*args, **kwargs):

--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -1,12 +1,29 @@
 from typing import TYPE_CHECKING, Any
 
-from dspy.adapters.types.tool import Tool, convert_input_schema_to_tool_args
+from dspy.adapters.types.tool import Tool, _MCPToolClient, convert_input_schema_to_tool_args
 
 if TYPE_CHECKING:
     import mcp
 
 
-def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> str | list[Any]:
+def _get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) -> Any:
+    """Read a field whose Python name changed between mcp SDK v1 and v2."""
+    for name in (snake_name, camel_name):
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return default
+
+
+def _field_is_set(obj: Any, snake_name: str, camel_name: str) -> bool:
+    fields_set = getattr(obj, "model_fields_set", None)
+    if fields_set is None:
+        fields_set = getattr(obj, "__fields_set__", None)
+    if fields_set is not None:
+        return snake_name in fields_set or camel_name in fields_set
+    return hasattr(obj, snake_name) or hasattr(obj, camel_name)
+
+
+def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> Any:
     from mcp.types import TextContent
 
     text_contents: list[TextContent] = []
@@ -21,27 +38,35 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if len(text_contents) == 1:
         tool_content = tool_content[0]
 
-    if call_tool_result.isError:
+    if _get_field(call_tool_result, "is_error", "isError", default=False):
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
+
+    if _field_is_set(call_tool_result, "structured_content", "structuredContent"):
+        return _get_field(call_tool_result, "structured_content", "structuredContent")
 
     return tool_content or non_text_contents
 
 
-def convert_mcp_tool(session: "mcp.ClientSession", tool: "mcp.types.Tool") -> Tool:
+def convert_mcp_tool(session: _MCPToolClient, tool: "mcp.types.Tool") -> Tool:
     """Build a DSPy tool from an MCP tool.
 
+    Both mcp SDK v1's ``ClientSession`` and v2's high-level ``Client`` satisfy
+    the client interface used by this bridge.
+
     Args:
-        session: The MCP session to use.
+        session: An MCP client or session with an async ``call_tool`` method.
         tool: The MCP tool to convert.
 
     Returns:
         A dspy Tool object.
     """
-    args, arg_types, arg_desc = convert_input_schema_to_tool_args(tool.inputSchema)
+    input_schema = _get_field(tool, "input_schema", "inputSchema", default={})
+    args, arg_types, arg_desc = convert_input_schema_to_tool_args(input_schema)
+    desc = tool.description or getattr(tool, "title", None)
 
     # Convert the MCP tool and Session to a single async method
     async def func(*args, **kwargs):
         result = await session.call_tool(tool.name, arguments=kwargs)
         return _convert_mcp_tool_result(result)
 
-    return Tool(func=func, name=tool.name, desc=tool.description, args=args, arg_types=arg_types, arg_desc=arg_desc)
+    return Tool(func=func, name=tool.name, desc=desc, args=args, arg_types=arg_types, arg_desc=arg_desc)

--- a/tests/utils/resources/mcp_server.py
+++ b/tests/utils/resources/mcp_server.py
@@ -1,7 +1,11 @@
-from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel
 
-mcp = FastMCP("test")
+try:
+    from mcp.server.fastmcp import FastMCP as MCPServer
+except ImportError:
+    from mcp.server import MCPServer
+
+mcp = MCPServer("test")
 
 
 class Profile(BaseModel):

--- a/tests/utils/resources/mcp_server.py
+++ b/tests/utils/resources/mcp_server.py
@@ -1,7 +1,11 @@
-from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel
 
-mcp = FastMCP("test")
+try:
+    from mcp.server.fastmcp import FastMCP as MCPServer
+except ImportError:
+    from mcp.server import MCPServer
+
+mcp = MCPServer("test")
 
 
 class Profile(BaseModel):
@@ -42,6 +46,22 @@ def get_account_name(account: Account):
 def current_datetime() -> str:
     """Get the current datetime"""
     return "2025-07-23T09:10:10.0+00:00"
+
+
+@mcp.tool()
+def get_profile() -> Profile:
+    """Get a user profile as structured output"""
+    return Profile(name="Ann", age=30)
+
+
+class SingleFieldResult(BaseModel):
+    result: int
+
+
+@mcp.tool()
+def genuine_single_field() -> SingleFieldResult:
+    """Return an object whose only field is named result"""
+    return SingleFieldResult(result=42)
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -1,12 +1,62 @@
 import asyncio
 import importlib
+import sys
+from importlib.metadata import version
+from types import SimpleNamespace
 
 import pytest
 
-from dspy.utils.mcp import convert_mcp_tool
+from dspy import Tool
+from dspy.utils.mcp import _convert_mcp_tool_result, convert_mcp_tool
 
 if importlib.util.find_spec("mcp") is None:
     pytest.skip(reason="mcp is not installed", allow_module_level=True)
+
+
+def make_call_tool_result(field_style, texts=(), is_error=False):
+    from mcp.types import TextContent
+
+    fields = {
+        "content": [TextContent(type="text", text=text) for text in texts],
+        "structured_content" if field_style == "snake" else "structuredContent": {"result": "ignored"},
+        "is_error" if field_style == "snake" else "isError": is_error,
+    }
+    return SimpleNamespace(**fields)
+
+
+@pytest.mark.extra
+def test_convert_mcp_tool_result_supports_both_field_styles_without_changing_results():
+    assert _convert_mcp_tool_result(make_call_tool_result("camel", texts=["hi"])) == "hi"
+    assert _convert_mcp_tool_result(make_call_tool_result("snake", texts=["a", "b"])) == ["a", "b"]
+
+
+@pytest.mark.extra
+@pytest.mark.parametrize("field_style", ["camel", "snake"])
+def test_error_result_raises(field_style):
+    result = make_call_tool_result(field_style, texts=["boom"], is_error=True)
+    with pytest.raises(RuntimeError, match="Failed to call a MCP tool: boom"):
+        _convert_mcp_tool_result(result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.extra
+async def test_convert_mcp_tool_with_v2_client():
+    if int(version("mcp").split(".")[0]) < 2:
+        pytest.skip("The high-level MCP client is available in SDK v2")
+
+    from mcp.client import Client
+    from mcp.server import MCPServer
+
+    server = MCPServer("test")
+
+    @server.tool()
+    def increment(value: int) -> int:
+        return value + 1
+
+    async with Client(server) as client:
+        response = await client.list_tools()
+        increment_tool = Tool.from_mcp_tool(client, response.tools[0])
+        assert await increment_tool.acall(value=1) == "2"
 
 
 @pytest.mark.asyncio
@@ -14,8 +64,9 @@ if importlib.util.find_spec("mcp") is None:
 async def test_convert_mcp_tool():
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
+
     server_params = StdioServerParameters(
-        command="python",
+        command=sys.executable,
         args=["tests/utils/resources/mcp_server.py"],
         env=None,
     )
@@ -28,7 +79,10 @@ async def test_convert_mcp_tool():
             add_tool = convert_mcp_tool(session, response.tools[0])
             assert add_tool.name == "add"
             assert add_tool.desc == "Add two numbers"
-            assert add_tool.args == {"a": {"title": "A", "type": "integer"}, "b": {"title": "B", "type": "integer"}}
+            assert add_tool.args == {
+                "a": {"title": "A", "type": "integer"},
+                "b": {"title": "B", "type": "integer"},
+            }
             assert add_tool.arg_types == {"a": int, "b": int}
             assert add_tool.arg_desc == {
                 "a": "No description provided. (Required)",
@@ -49,9 +103,7 @@ async def test_convert_mcp_tool():
             error_tool = convert_mcp_tool(session, response.tools[2])
             assert error_tool.name == "wrong_tool"
             assert error_tool.desc == "This tool raises an error"
-            with pytest.raises(
-                RuntimeError, match="Failed to call a MCP tool: Error executing tool wrong_tool: error!"
-            ):
+            with pytest.raises(RuntimeError, match="error!"):
                 await error_tool.acall()
 
             # Check nested Pydantic arg

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -1,12 +1,126 @@
 import asyncio
 import importlib
+import json
+import sys
+from importlib.metadata import version
+from types import SimpleNamespace
 
 import pytest
 
-from dspy.utils.mcp import convert_mcp_tool
+from dspy.utils.mcp import _convert_mcp_tool_result, _get_field, convert_mcp_tool
 
 if importlib.util.find_spec("mcp") is None:
     pytest.skip(reason="mcp is not installed", allow_module_level=True)
+
+_UNSET = object()
+
+
+def make_call_tool_result(field_style, texts=(), structured=_UNSET, is_error=False):
+    from mcp.types import TextContent
+
+    fields = {"content": [TextContent(type="text", text=text) for text in texts]}
+    if field_style == "snake":
+        fields["is_error"] = is_error
+        if structured is not _UNSET:
+            fields["structured_content"] = structured
+    else:
+        fields["isError"] = is_error
+        if structured is not _UNSET:
+            fields["structuredContent"] = structured
+    return SimpleNamespace(**fields)
+
+
+def expected_result(tool, structured, text):
+    if _get_field(tool, "output_schema", "outputSchema"):
+        return structured
+    return text
+
+
+@pytest.mark.extra
+def test_convert_mcp_tool_result_supports_both_field_styles():
+    assert _convert_mcp_tool_result(make_call_tool_result("camel", texts=["hi"])) == "hi"
+    assert _convert_mcp_tool_result(make_call_tool_result("snake", texts=["a", "b"])) == ["a", "b"]
+
+
+@pytest.mark.extra
+@pytest.mark.parametrize("field_style", ["camel", "snake"])
+def test_structured_content_is_preferred_without_unwrapping(field_style):
+    result = make_call_tool_result(field_style, texts=["3"], structured={"result": 3})
+    assert _convert_mcp_tool_result(result) == {"result": 3}
+
+    result = make_call_tool_result(field_style, structured={"result": []})
+    assert _convert_mcp_tool_result(result) == {"result": []}
+
+    result = make_call_tool_result(field_style, texts=["fallback"], structured=None)
+    assert _convert_mcp_tool_result(result) is None
+
+
+@pytest.mark.extra
+def test_explicit_null_structured_content_is_preserved():
+    from mcp.types import CallToolResult
+
+    if "structured_content" in CallToolResult.model_fields:
+        result = CallToolResult(content=[], structured_content=None)
+    elif "structuredContent" in CallToolResult.model_fields:
+        result = CallToolResult(content=[], structuredContent=None)
+    else:
+        pytest.skip("This MCP version predates structured content")
+
+    assert _convert_mcp_tool_result(result) is None
+
+
+@pytest.mark.extra
+@pytest.mark.parametrize("field_style", ["camel", "snake"])
+def test_error_result_raises(field_style):
+    result = make_call_tool_result(field_style, texts=["boom"], is_error=True)
+    with pytest.raises(RuntimeError, match="Failed to call a MCP tool: boom"):
+        _convert_mcp_tool_result(result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.extra
+async def test_convert_mcp_tool_accepts_snake_case_tool_and_compatible_client():
+    class Client:
+        async def call_tool(self, name, arguments=None):
+            assert name == "increment"
+            return make_call_tool_result("snake", texts=["2"], structured={"result": 2})
+
+    tool = SimpleNamespace(
+        name="increment",
+        title="Increment",
+        description=None,
+        input_schema={
+            "type": "object",
+            "properties": {"value": {"type": "integer"}},
+            "required": ["value"],
+        },
+    )
+    converted = convert_mcp_tool(Client(), tool)
+
+    assert converted.desc == "Increment"
+    assert converted.args == {"value": {"type": "integer"}}
+    assert await converted.acall(value=1) == {"result": 2}
+
+
+@pytest.mark.asyncio
+@pytest.mark.extra
+async def test_convert_mcp_tool_with_v2_client():
+    if int(version("mcp").split(".")[0]) < 2:
+        pytest.skip("The high-level MCP client is available in SDK v2")
+
+    from mcp.client import Client
+    from mcp.server import MCPServer
+
+    server = MCPServer("test")
+
+    @server.tool()
+    def increment(value: int) -> int:
+        return value + 1
+
+    async with Client(server) as client:
+        response = await client.list_tools()
+        increment_tool = convert_mcp_tool(client, response.tools[0])
+        assert await increment_tool.acall(value=1) == {"result": 2}
 
 
 @pytest.mark.asyncio
@@ -14,8 +128,9 @@ if importlib.util.find_spec("mcp") is None:
 async def test_convert_mcp_tool():
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
+
     server_params = StdioServerParameters(
-        command="python",
+        command=sys.executable,
         args=["tests/utils/resources/mcp_server.py"],
         env=None,
     )
@@ -23,76 +138,47 @@ async def test_convert_mcp_tool():
         async with ClientSession(read, write) as session:
             await asyncio.wait_for(session.initialize(), timeout=5)
             response = await session.list_tools()
+            mcp_tools = {tool.name: tool for tool in response.tools}
+            tools = {name: convert_mcp_tool(session, tool) for name, tool in mcp_tools.items()}
 
-            # Check add
-            add_tool = convert_mcp_tool(session, response.tools[0])
+            add_tool = tools["add"]
             assert add_tool.name == "add"
             assert add_tool.desc == "Add two numbers"
-            assert add_tool.args == {"a": {"title": "A", "type": "integer"}, "b": {"title": "B", "type": "integer"}}
             assert add_tool.arg_types == {"a": int, "b": int}
-            assert add_tool.arg_desc == {
-                "a": "No description provided. (Required)",
-                "b": "No description provided. (Required)",
-            }
-            assert await add_tool.acall(a=1, b=2) == "3"
+            assert await add_tool.acall(a=1, b=2) == expected_result(mcp_tools["add"], {"result": 3}, "3")
 
-            # Check hello
-            hello_tool = convert_mcp_tool(session, response.tools[1])
-            assert hello_tool.name == "hello"
-            assert hello_tool.desc == "Greet people"
-            assert hello_tool.args == {"names": {"title": "Names", "type": "array", "items": {"type": "string"}}}
+            hello_tool = tools["hello"]
             assert hello_tool.arg_types == {"names": list}
-            assert hello_tool.arg_desc == {"names": "No description provided. (Required)"}
-            assert await hello_tool.acall(names=["Bob", "Tom"]) == ["Hello, Bob!", "Hello, Tom!"]
+            greetings = ["Hello, Bob!", "Hello, Tom!"]
+            assert await hello_tool.acall(names=["Bob", "Tom"]) == expected_result(
+                mcp_tools["hello"], {"result": greetings}, greetings
+            )
 
-            # Check error handling
-            error_tool = convert_mcp_tool(session, response.tools[2])
-            assert error_tool.name == "wrong_tool"
-            assert error_tool.desc == "This tool raises an error"
-            with pytest.raises(
-                RuntimeError, match="Failed to call a MCP tool: Error executing tool wrong_tool: error!"
-            ):
-                await error_tool.acall()
+            with pytest.raises(RuntimeError, match="error!"):
+                await tools["wrong_tool"].acall()
 
-            # Check nested Pydantic arg
-            nested_pydantic_tool = convert_mcp_tool(session, response.tools[3])
-
-            assert nested_pydantic_tool.name == "get_account_name"
-            assert nested_pydantic_tool.desc == "This extracts the name from account"
-            assert nested_pydantic_tool.args == {
-                "account": {
-                    "title": "Account",
-                    "type": "object",
-                    "required": ["profile", "account_id"],
-                    "properties": {
-                        "profile": {
-                            "title": "Profile",
-                            "type": "object",
-                            "properties": {
-                                "name": {"title": "Name", "type": "string"},
-                                "age": {"title": "Age", "type": "integer"},
-                            },
-                            "required": ["name", "age"],
-                        },
-                        "account_id": {"title": "Account Id", "type": "string"},
-                    },
-                }
-            }
+            nested_pydantic_tool = tools["get_account_name"]
+            account_schema = nested_pydantic_tool.args["account"]
+            assert set(account_schema["properties"]) == {"profile", "account_id"}
             account_in_json = {
-                "profile": {
-                    "name": "Bob",
-                    "age": 20,
-                },
+                "profile": {"name": "Bob", "age": 20},
                 "account_id": "123",
             }
-            result = await nested_pydantic_tool.acall(account=account_in_json)
-            assert result == "Bob"
+            assert await nested_pydantic_tool.acall(account=account_in_json) == "Bob"
 
-            # Check no input parameter current_datetime tool
-            current_datetime_tool = convert_mcp_tool(session, response.tools[4])
-            assert current_datetime_tool.name == "current_datetime"
-            assert current_datetime_tool.desc == "Get the current datetime"
+            current_datetime_tool = tools["current_datetime"]
             assert current_datetime_tool.args == {}
-            assert current_datetime_tool.arg_types == {}
-            assert current_datetime_tool.arg_desc == {}
-            assert await current_datetime_tool.acall() == "2025-07-23T09:10:10.0+00:00"
+            datetime = "2025-07-23T09:10:10.0+00:00"
+            assert await current_datetime_tool.acall() == expected_result(
+                mcp_tools["current_datetime"], {"result": datetime}, datetime
+            )
+
+            profile_result = await tools["get_profile"].acall()
+            if isinstance(profile_result, str):
+                profile_result = json.loads(profile_result)
+            assert profile_result == {"name": "Ann", "age": 30}
+
+            single_field_result = await tools["genuine_single_field"].acall()
+            if isinstance(single_field_result, str):
+                single_field_result = json.loads(single_field_result)
+            assert single_field_result == {"result": 42}


### PR DESCRIPTION
## Summary

Add MCP Python SDK v2 compatibility without changing DSPy's MCP tool semantics.

- Read the SDK v1 camelCase fields and their v2 snake_case replacements (`inputSchema`/`input_schema`, `isError`/`is_error`).
- Accept both v1's `ClientSession` and v2's high-level `Client` through the existing `call_tool` boundary.
- Preserve the existing result contract: text content remains a string/list of strings, non-text content remains unchanged, and structured content does not replace the historical result.
- Keep existing SDK v1 support, including the currently locked MCP 1.5 version.
- Document the v1-to-v2 client migration and test the public `dspy.Tool.from_mcp_tool` flow against MCP v2.
- Add a focused MCP v2 CI job without changing the optional dependency floor or regenerating `uv.lock`.

## Deliberate scope

This follows the thin-bridge boundary established in #8130: the MCP SDK owns connection, transport, authentication, and session lifecycle; DSPy converts listed MCP tools into `dspy.Tool` instances. It also follows the narrow field-alias compatibility approach proposed in #9681.

This PR deliberately does **not**:

- change tool return values to prefer `structuredContent`;
- infer or unwrap the SDK's `{“result”: ...}` structured envelope;
- add DSPy-owned handling for v2's multi-round-trip request lifecycle;
- fall back from a missing description to the tool title;
- raise the MCP dependency floor or refresh unrelated locked dependencies.

Structured output may be useful, but it is a separate user-visible result contract and can be added as an explicit opt-in follow-up rather than bundled into compatibility.

## Compatibility contract

| SDK/client | Conversion | Result behavior |
| --- | --- | --- |
| MCP 1.x `ClientSession` | Supported | Existing behavior |
| MCP 2.x `ClientSession` | Supported | Existing behavior |
| MCP 2.x high-level `Client` | Supported | Existing behavior |

For example, a typed MCP tool returning `2` still produces the DSPy result `"2"`, even when MCP v2 also supplies structured content.

## Regression evidence

Against current `main`, converting a tool listed by MCP v2 through `dspy.Tool.from_mcp_tool` fails with:

```text
AttributeError: 'Tool' object has no attribute 'inputSchema'. Did you mean: 'input_schema'?
```

With this change, the same public flow succeeds and returns the historical text result.

Focused verification after rebasing onto current `main`:

- `mcp==1.5.0`: 4 passed, 1 skipped (v2-only client test)
- `mcp==1.10.0`: 4 passed, 1 skipped (v2-only client test)
- `mcp==2.0.0`: 5 passed
- Ruff check and format checks on touched Python files: passed
- Workflow YAML parse and `git diff --check`: passed
