### PR TITLE
Add dspy_vibe: vibe instruction to spec, .agent, and .skill

### DIFF
--- a/dspy_vibe/README.md
+++ b/dspy_vibe/README.md
@@ -1,0 +1,130 @@
+# dspy_vibe
+
+Turn vibe-coding instructions into artifacts a coding agent can actually
+execute: a structured brief, an `.agent` definition, and a reusable `.skill`.
+
+```
+"csinálj egy login formot, legyen szép és gyors, ne kelljen backend"
+        │
+        ▼
+   VibeSpec ──────┬──────────────┐
+ goal, scope,     │              │
+ non-goals,       ▼              ▼
+ constraints,  .agent         .skill
+ acceptance,   who does it    the reusable method
+ risks,        + guardrails   + triggers, checks, limits
+ open questions
+```
+
+The point is the middle box. A vibe instruction is underspecified on purpose,
+and handing it straight to an agent means the agent silently invents the missing
+half. The brief makes those gaps visible as open questions with the assumption
+applied, so you can correct them before any code is written.
+
+## Install
+
+The package ships with this repository. From the repo root:
+
+```bash
+pip install -e .
+```
+
+## Use it
+
+Offline — no API key, no network, deterministic:
+
+```bash
+python -m dspy_vibe convert "csinálj egy login formot, ne kelljen backend" --out ./vibe-out
+```
+
+```
+spec   vibe-out/csinalj-egy-login-formot.spec.md
+agent  vibe-out/csinalj-egy-login-formot.agent
+skill  vibe-out/csinalj-egy-login-formot.skill
+
+bundle quality: 0.89  (confidence: LOW)
+```
+
+With an LM:
+
+```bash
+python -m dspy_vibe convert "add a dark mode toggle" --model openai/gpt-4o-mini --out ./vibe-out
+```
+
+Useful flags: `--format json` for machine-readable artifacts, `--tools` to limit
+the generated agent to tools your host actually offers, `--context` to pass
+stack facts, `--stdout` to skip writing files, `--overwrite` to replace existing
+artifacts (refused by default).
+
+From Python:
+
+```python
+import dspy
+from dspy_vibe import VibeCoder, write_bundle
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+result = VibeCoder(available_tools=["Read", "Edit", "Bash"])(
+    instruction="add a dark mode toggle to the settings page",
+    repo_context="Next.js app router, Tailwind, pnpm",
+)
+write_bundle(result.bundle, "./vibe-out")
+```
+
+Without a configured LM every module falls back to the deterministic converter,
+so the same code runs in CI.
+
+## Optimize it
+
+`VibeCoder` is a plain `dspy.Module`, so any DSPy optimizer works on it. The
+metrics in `metrics.py` are mechanical — no LM judge to talk into a good score:
+
+| Metric | What it measures |
+| --- | --- |
+| `spec_faithfulness` | Fraction of scope claims anchored in the instruction. Catches invented work. |
+| `spec_completeness` | Are goal, scope, acceptance, and verification present. |
+| `spec_specificity` | Did it decompose the request or just echo it back. |
+| `spec_honesty` | Are undecided points surfaced instead of silently decided. |
+| `agent_validity` / `skill_validity` | Is the artifact executable and bounded. |
+
+`spec_quality` combines the first four, with faithfulness as a *multiplier*
+rather than a term: copying the instruction verbatim scores perfectly on
+faithfulness, so as a bonus it would reward the laziest possible brief.
+
+The deterministic baseline deliberately does not score full marks (~0.78 on
+`spec_quality` over the example dev set), which is what leaves an optimizer
+something to improve. See `examples/optimize.py`.
+
+## Artifact formats
+
+Both emitters write the same validated model.
+
+`markdown` (default) — YAML frontmatter plus a Markdown body, the shape agent
+hosts read directly:
+
+```markdown
+---
+name: dark-mode-agent
+description: Adds a dark mode toggle to the settings page.
+tools:
+  - Edit
+  - Read
+source_spec: dark-mode-toggle
+---
+
+# dark-mode-agent
+...
+## Guardrails
+- Out of scope: changes to the login screen
+```
+
+`json` — the same fields as data, for programmatic pipelines. Validate them
+later with `python -m dspy_vibe check out/*.agent`.
+
+## What it does not do
+
+- It does not write code. It produces the brief and the definitions; the agent
+  you hand them to does the work.
+- It does not decide your open questions. Blocking questions are reported and
+  the exit output lists them.
+- The offline converter is keyword heuristics, and labels itself `LOW`
+  confidence for that reason. It is a floor, not a substitute for a model.

--- a/dspy_vibe/__init__.py
+++ b/dspy_vibe/__init__.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any
 
 from dspy_vibe.emitters import (
     agent_to_markdown,
+    render_bundle,
     skill_to_markdown,
     spec_to_markdown,
     write_bundle,
@@ -95,6 +96,7 @@ __all__ = [
     "agent_validity",
     "bundle_from_instruction",
     "bundle_quality",
+    "render_bundle",
     "skill_from_spec",
     "skill_to_markdown",
     "skill_validity",

--- a/dspy_vibe/__init__.py
+++ b/dspy_vibe/__init__.py
@@ -1,0 +1,105 @@
+"""dspy_vibe — turn vibe-coding instructions into specs, agents, and skills.
+
+Quick start (no LM needed):
+
+    from dspy_vibe import bundle_from_instruction, write_bundle
+
+    bundle = bundle_from_instruction("csinálj egy login formot, legyen szép és gyors")
+    write_bundle(bundle, "./vibe-out")
+
+With an LM:
+
+    import dspy
+    from dspy_vibe import VibeCoder
+
+    dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+    result = VibeCoder(available_tools=["Read", "Edit", "Bash"])(
+        instruction="csinálj egy login formot, legyen szép és gyors"
+    )
+    result.bundle.spec, result.bundle.agent, result.bundle.skill
+
+The DSPy modules are imported lazily so the deterministic path stays usable in
+environments where dspy's own dependencies are unavailable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from dspy_vibe.emitters import (
+    agent_to_markdown,
+    skill_to_markdown,
+    spec_to_markdown,
+    write_bundle,
+)
+from dspy_vibe.metrics import agent_validity, bundle_quality, skill_validity, spec_quality
+from dspy_vibe.offline import (
+    agent_from_spec,
+    bundle_from_instruction,
+    skill_from_spec,
+    spec_from_instruction,
+)
+from dspy_vibe.types import (
+    AcceptanceCriterion,
+    AgentArtifact,
+    OpenQuestion,
+    SkillArtifact,
+    VibeBundle,
+    VibeSpec,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from dspy_vibe.modules import SpecToAgentModule, SpecToSkillModule, VibeCoder, VibeToSpec
+
+_LAZY = {
+    "VibeCoder": "dspy_vibe.modules",
+    "VibeToSpec": "dspy_vibe.modules",
+    "SpecToAgentModule": "dspy_vibe.modules",
+    "SpecToSkillModule": "dspy_vibe.modules",
+    "VibeInstructionToSpec": "dspy_vibe.signatures",
+    "SpecToAgent": "dspy_vibe.signatures",
+    "SpecToSkill": "dspy_vibe.signatures",
+    "CritiqueSpec": "dspy_vibe.signatures",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY:
+        import importlib
+
+        return getattr(importlib.import_module(_LAZY[name]), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)
+
+
+__all__ = [
+    "AcceptanceCriterion",
+    "AgentArtifact",
+    "CritiqueSpec",
+    "OpenQuestion",
+    "SkillArtifact",
+    "SpecToAgent",
+    "SpecToAgentModule",
+    "SpecToSkill",
+    "SpecToSkillModule",
+    "VibeBundle",
+    "VibeCoder",
+    "VibeInstructionToSpec",
+    "VibeSpec",
+    "VibeToSpec",
+    "agent_from_spec",
+    "agent_to_markdown",
+    "agent_validity",
+    "bundle_from_instruction",
+    "bundle_quality",
+    "skill_from_spec",
+    "skill_to_markdown",
+    "skill_validity",
+    "spec_from_instruction",
+    "spec_quality",
+    "spec_to_markdown",
+    "write_bundle",
+]

--- a/dspy_vibe/__main__.py
+++ b/dspy_vibe/__main__.py
@@ -1,0 +1,3 @@
+from dspy_vibe.cli import main
+
+raise SystemExit(main())

--- a/dspy_vibe/cli.py
+++ b/dspy_vibe/cli.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from dspy_vibe import offline
-from dspy_vibe.emitters import write_bundle
+from dspy_vibe.emitters import render_bundle, write_bundle
 from dspy_vibe.metrics import agent_validity, bundle_quality, skill_validity
 from dspy_vibe.types import AgentArtifact, SkillArtifact, VibeBundle
 
@@ -51,7 +51,12 @@ def cmd_convert(args: argparse.Namespace) -> int:
     bundle = _build_bundle(args, instruction)
 
     if args.stdout:
-        print(json.dumps(bundle.model_dump(), indent=2, ensure_ascii=False))
+        # The rendered text travels with the structured data, so an embedding
+        # caller (the VS Code extension) gets both from a single run. Asking
+        # twice would cost a second LM call and could return different content.
+        payload = bundle.model_dump()
+        payload["rendered"] = render_bundle(bundle, args.format)
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
         return 0
 
     try:

--- a/dspy_vibe/cli.py
+++ b/dspy_vibe/cli.py
@@ -1,0 +1,137 @@
+"""Command line entry point.
+
+    python -m dspy_vibe convert "csinálj egy login formot, legyen szép és gyors" --out ./out
+    python -m dspy_vibe convert --file request.txt --format json --model openai/gpt-4o-mini
+    python -m dspy_vibe check ./out/login-form.agent
+
+Without `--model` the pipeline runs its deterministic converter, so the command
+works with no API key and no network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from dspy_vibe import offline
+from dspy_vibe.emitters import write_bundle
+from dspy_vibe.metrics import agent_validity, bundle_quality, skill_validity
+from dspy_vibe.types import AgentArtifact, SkillArtifact, VibeBundle
+
+
+def _read_instruction(args: argparse.Namespace) -> str:
+    if args.file:
+        return Path(args.file).read_text(encoding="utf-8")
+    if args.instruction:
+        return args.instruction
+    if not sys.stdin.isatty():
+        return sys.stdin.read()
+    raise SystemExit("no instruction: pass text, --file PATH, or pipe it on stdin")
+
+
+def _build_bundle(args: argparse.Namespace, instruction: str) -> VibeBundle:
+    tools = [tool.strip() for tool in (args.tools or "").split(",") if tool.strip()]
+    if not args.model:
+        return offline.bundle_from_instruction(instruction, args.context, tools)
+
+    import dspy  # imported lazily: the offline path must not require a configured LM
+    from dspy_vibe.modules import VibeCoder
+
+    dspy.configure(lm=dspy.LM(args.model))
+    return VibeCoder(available_tools=tools).forward(
+        instruction=instruction, repo_context=args.context
+    ).bundle
+
+
+def cmd_convert(args: argparse.Namespace) -> int:
+    instruction = _read_instruction(args)
+    bundle = _build_bundle(args, instruction)
+
+    if args.stdout:
+        print(json.dumps(bundle.model_dump(), indent=2, ensure_ascii=False))
+        return 0
+
+    try:
+        written = write_bundle(bundle, args.out, fmt=args.format, overwrite=args.overwrite)
+    except FileExistsError as error:
+        print(error, file=sys.stderr)
+        return 1
+
+    for kind, path in written.items():
+        print(f"{kind:<6} {path}")
+    score = bundle_quality(
+        SimpleNamespace(instruction=instruction, available_tools=None),
+        SimpleNamespace(bundle=bundle, spec=bundle.spec),
+    )
+    print(f"\nbundle quality: {score:.2f}  (confidence: {bundle.spec.confidence})")
+    blocking = bundle.spec.blocking_questions
+    if blocking:
+        print(f"\n{len(blocking)} blocking question(s) — answer these before implementing:")
+        for question in blocking:
+            print(f"  - {question.question}")
+    return 0
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    failures = 0
+    for target in args.paths:
+        path = Path(target)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"FAIL {path}: not a readable JSON artifact ({error})")
+            print("     (markdown artifacts are validated at generation time; check the .json format)")
+            failures += 1
+            continue
+        try:
+            if path.suffix == ".agent":
+                artifact = AgentArtifact.model_validate(payload)
+                score = agent_validity(artifact)
+            elif path.suffix == ".skill":
+                artifact = SkillArtifact.model_validate(payload)
+                score = skill_validity(artifact)
+            else:
+                print(f"SKIP {path}: unknown artifact type")
+                continue
+        except Exception as error:  # pydantic ValidationError and friends
+            print(f"FAIL {path}: {error}")
+            failures += 1
+            continue
+        status = "PASS" if score == 1.0 else "WARN"
+        print(f"{status} {path}: validity {score:.2f}")
+        failures += int(score < 0.5)
+    return 1 if failures else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="dspy_vibe", description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    convert = sub.add_parser("convert", help="turn a vibe instruction into a spec, .agent, and .skill")
+    convert.add_argument("instruction", nargs="?", help="the informal request; omit to use --file or stdin")
+    convert.add_argument("--file", help="read the instruction from a file")
+    convert.add_argument("--context", default="", help="known repository facts: stack, conventions")
+    convert.add_argument("--tools", default="", help="comma-separated tool names the host offers")
+    convert.add_argument("--out", default="./vibe-out", help="output directory")
+    convert.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    convert.add_argument("--model", default="", help="LM id, e.g. openai/gpt-4o-mini; omit for offline mode")
+    convert.add_argument("--overwrite", action="store_true", help="replace existing artifacts")
+    convert.add_argument("--stdout", action="store_true", help="print the bundle as JSON instead of writing files")
+    convert.set_defaults(func=cmd_convert)
+
+    check = sub.add_parser("check", help="validate generated .agent/.skill JSON artifacts")
+    check.add_argument("paths", nargs="+")
+    check.set_defaults(func=cmd_check)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dspy_vibe/emitters.py
+++ b/dspy_vibe/emitters.py
@@ -160,6 +160,21 @@ def _render(artifact: BaseModel, fmt: Format) -> str:
     raise TypeError(f"no markdown emitter for {type(artifact).__name__}")
 
 
+def render_bundle(bundle: VibeBundle, fmt: Format = "markdown") -> dict[str, str]:
+    """Render every artifact to text without touching the filesystem.
+
+    Callers that embed the pipeline — an editor extension, a web service — need
+    the rendered text and the structured data from a *single* run. Re-running
+    the pipeline to get the other half would cost a second LM call and could
+    return different content.
+    """
+    return {
+        "spec": _render(bundle.spec, fmt),
+        "agent": _render(bundle.agent, fmt),
+        "skill": _render(bundle.skill, fmt),
+    }
+
+
 def write_bundle(
     bundle: VibeBundle,
     out_dir: str | Path,
@@ -180,12 +195,11 @@ def write_bundle(
         "agent": out / f"{slug}.agent",
         "skill": out / f"{slug}.skill",
     }
-    artifacts = {"spec": bundle.spec, "agent": bundle.agent, "skill": bundle.skill}
-
     existing = [str(path) for path in targets.values() if path.exists()]
     if existing and not overwrite:
         raise FileExistsError("refusing to overwrite: " + ", ".join(existing) + " (pass overwrite=True)")
 
+    rendered = render_bundle(bundle, fmt)
     for key, path in targets.items():
-        path.write_text(_render(artifacts[key], fmt), encoding="utf-8", newline="\n")
+        path.write_text(rendered[key], encoding="utf-8", newline="\n")
     return targets

--- a/dspy_vibe/emitters.py
+++ b/dspy_vibe/emitters.py
@@ -1,0 +1,191 @@
+"""Write artifacts to disk in the format the target host reads.
+
+Two emitters ship: `markdown` produces YAML-frontmatter Markdown, which agent
+hosts load directly; `json` produces plain data files for programmatic use.
+Both write the same validated model, so switching format cannot change meaning.
+
+The YAML writer here is intentionally small and handles only the shapes the
+artifact models can produce (strings and string lists). That avoids a runtime
+dependency on PyYAML for a job this narrow, and it fails loudly rather than
+silently mangling an unexpected type.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Literal
+
+from pydantic import BaseModel
+
+from dspy_vibe.types import AgentArtifact, SkillArtifact, VibeBundle, VibeSpec
+
+Format = Literal["markdown", "json"]
+
+_LEADING_SPECIALS = set(":#{}[],&*?|-<>=!%@`\"'")
+_YAML_KEYWORDS = {"true", "false", "null", "yes", "no", "on", "off", "~"}
+# ": " turns a scalar into a mapping and " #" starts a comment, wherever they sit.
+_INLINE_BREAKERS = (": ", " #")
+
+
+def _yaml_scalar(value: str) -> str:
+    text = str(value)
+    if text == "":
+        return '""'
+    if "\n" in text:
+        # Fold a multi-line scalar into one line: frontmatter values are labels,
+        # not prose, and a folded block would complicate every reader.
+        text = " ".join(text.split())
+    needs_quotes = (
+        text[0] in _LEADING_SPECIALS
+        or text.strip() != text
+        or text.lower() in _YAML_KEYWORDS
+        or text.endswith(":")
+        or any(breaker in text for breaker in _INLINE_BREAKERS)
+    )
+    if needs_quotes:
+        return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    return text
+
+
+def _yaml_block(data: dict[str, object]) -> str:
+    lines: list[str] = []
+    for key, value in data.items():
+        if isinstance(value, str):
+            if not value:
+                continue
+            lines.append(f"{key}: {_yaml_scalar(value)}")
+        elif isinstance(value, (list, tuple)):
+            items = [item for item in value if str(item).strip()]
+            if not items:
+                continue
+            lines.append(f"{key}:")
+            lines.extend(f"  - {_yaml_scalar(str(item))}" for item in items)
+        else:
+            raise TypeError(f"frontmatter value for {key!r} must be a string or list, got {type(value).__name__}")
+    return "\n".join(lines)
+
+
+def _section(title: str, items: Iterable[str], *, numbered: bool = False) -> str:
+    items = [item for item in items if str(item).strip()]
+    if not items:
+        return ""
+    if numbered:
+        body = "\n".join(f"{index}. {item}" for index, item in enumerate(items, start=1))
+    else:
+        body = "\n".join(f"- {item}" for item in items)
+    return f"## {title}\n\n{body}\n"
+
+
+def spec_to_markdown(spec: VibeSpec) -> str:
+    frontmatter = _yaml_block(
+        {
+            "name": spec.slug,
+            "title": spec.title,
+            "goal": spec.goal,
+            "confidence": spec.confidence,
+        }
+    )
+    parts = [f"---\n{frontmatter}\n---\n", f"# {spec.title}\n", f"**Goal:** {spec.goal}\n"]
+    if spec.context:
+        parts.append(f"## Context\n\n{spec.context}\n")
+    parts.append(_section("Scope", spec.scope))
+    parts.append(_section("Non-goals", spec.non_goals))
+    parts.append(_section("Constraints", spec.constraints))
+    if spec.acceptance:
+        rows = "\n".join(
+            f"| {criterion.statement} | {criterion.verification} |" for criterion in spec.acceptance
+        )
+        parts.append("## Acceptance criteria\n\n| Criterion | Verification |\n| --- | --- |\n" + rows + "\n")
+    parts.append(_section("Risks", spec.risks))
+    if spec.open_questions:
+        rows = "\n".join(
+            f"| {question.question} | {question.why_it_matters} | "
+            f"{question.assumption_used or '**blocking — needs an answer**'} |"
+            for question in spec.open_questions
+        )
+        parts.append(
+            "## Open questions\n\n| Question | Why it matters | Assumption used |\n| --- | --- | --- |\n" + rows + "\n"
+        )
+    if spec.source_instruction:
+        parts.append(f"## Original instruction\n\n> {spec.source_instruction}\n")
+    return "\n".join(part for part in parts if part).rstrip() + "\n"
+
+
+def agent_to_markdown(agent: AgentArtifact) -> str:
+    frontmatter = _yaml_block(
+        {
+            "name": agent.name,
+            "description": agent.description,
+            "tools": agent.tools,
+            "model": agent.model,
+            "source_spec": agent.source_spec,
+        }
+    )
+    parts = [f"---\n{frontmatter}\n---\n", f"# {agent.name}\n", f"{agent.role}\n"]
+    parts.append(_section("Instructions", agent.instructions, numbered=True))
+    parts.append(_section("Guardrails", agent.guardrails))
+    parts.append(_section("Success criteria", agent.success_criteria))
+    return "\n".join(part for part in parts if part).rstrip() + "\n"
+
+
+def skill_to_markdown(skill: SkillArtifact) -> str:
+    frontmatter = _yaml_block(
+        {
+            "name": skill.name,
+            "description": skill.description,
+            "triggers": skill.triggers,
+            "source_spec": skill.source_spec,
+        }
+    )
+    parts = [f"---\n{frontmatter}\n---\n", f"# {skill.name}\n", f"{skill.description}\n"]
+    parts.append(_section("Triggers", skill.triggers))
+    parts.append(_section("Inputs", skill.inputs))
+    parts.append(_section("Procedure", skill.procedure, numbered=True))
+    parts.append(_section("Outputs", skill.outputs))
+    parts.append(_section("Checks", skill.checks))
+    parts.append(_section("Limits", skill.limits))
+    return "\n".join(part for part in parts if part).rstrip() + "\n"
+
+
+def _render(artifact: BaseModel, fmt: Format) -> str:
+    if fmt == "json":
+        return json.dumps(artifact.model_dump(), indent=2, ensure_ascii=False) + "\n"
+    if isinstance(artifact, VibeSpec):
+        return spec_to_markdown(artifact)
+    if isinstance(artifact, AgentArtifact):
+        return agent_to_markdown(artifact)
+    if isinstance(artifact, SkillArtifact):
+        return skill_to_markdown(artifact)
+    raise TypeError(f"no markdown emitter for {type(artifact).__name__}")
+
+
+def write_bundle(
+    bundle: VibeBundle,
+    out_dir: str | Path,
+    *,
+    fmt: Format = "markdown",
+    overwrite: bool = False,
+) -> dict[str, Path]:
+    """Write spec, `.agent`, and `.skill` files. Returns the paths written.
+
+    Existing files are never overwritten unless asked: a generated artifact the
+    user then edited by hand is worth more than a regeneration.
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    slug = bundle.spec.slug
+    targets = {
+        "spec": out / f"{slug}.spec.md" if fmt == "markdown" else out / f"{slug}.spec.json",
+        "agent": out / f"{slug}.agent",
+        "skill": out / f"{slug}.skill",
+    }
+    artifacts = {"spec": bundle.spec, "agent": bundle.agent, "skill": bundle.skill}
+
+    existing = [str(path) for path in targets.values() if path.exists()]
+    if existing and not overwrite:
+        raise FileExistsError("refusing to overwrite: " + ", ".join(existing) + " (pass overwrite=True)")
+
+    for key, path in targets.items():
+        path.write_text(_render(artifacts[key], fmt), encoding="utf-8", newline="\n")
+    return targets

--- a/dspy_vibe/examples/optimize.py
+++ b/dspy_vibe/examples/optimize.py
@@ -1,0 +1,101 @@
+"""Compile the vibe pipeline with a DSPy optimizer.
+
+    python dspy_vibe/examples/optimize.py --model openai/gpt-4o-mini
+
+What it does: scores the deterministic baseline, compiles `VibeToSpec` against
+`spec_quality` with MIPROv2, scores the result on a held-out split, and saves
+the compiled program. Nothing is adopted automatically — a run that does not
+beat the baseline should not be shipped.
+
+Run it without `--model` to see the baseline numbers alone; that path needs no
+API key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+
+import dspy
+from dspy_vibe import spec_from_instruction
+from dspy_vibe.metrics import spec_quality
+from dspy_vibe.modules import VibeToSpec
+
+TRAIN = [
+    ("csinálj egy login formot, legyen szép és gyors, ne kelljen hozzá backend", ""),
+    ("add a dark mode toggle to the settings page", "Next.js app router, Tailwind"),
+    ("kellene egy CSV export a riport oldalra, nagy fájlokkal is bírja", "Django, Postgres"),
+    ("make the search bar fuzzy, but don't slow down typing", "React, 50k items client-side"),
+    ("rakj rá cache-t az API-ra, ne törjön el a friss adat", "FastAPI, Redis available"),
+    ("clean up the error handling in the upload flow, it's a mess", "Node, Express"),
+]
+
+DEV = [
+    ("csinálj egy sötét témát a dashboardhoz, ne nyúlj a loginhoz", "Vue 3"),
+    ("add pagination to the users table, keep it fast on 100k rows", "Rails, Postgres"),
+    ("legyen retry a webhook küldésre, de ne duplikáljon", "Python, Celery"),
+]
+
+
+def _examples(rows: list[tuple[str, str]]) -> list[dspy.Example]:
+    return [
+        dspy.Example(instruction=instruction, repo_context=context).with_inputs("instruction", "repo_context")
+        for instruction, context in rows
+    ]
+
+
+def _score(program, examples: list[dspy.Example]) -> float:
+    scores = []
+    for example in examples:
+        prediction = program(instruction=example.instruction, repo_context=example.repo_context)
+        scores.append(spec_quality(example, prediction))
+    return statistics.mean(scores)
+
+
+def _baseline_score(examples: list[dspy.Example]) -> float:
+    scores = []
+    for example in examples:
+        spec = spec_from_instruction(example.instruction, example.repo_context)
+        scores.append(spec_quality(example, dspy.Prediction(spec=spec)))
+    return statistics.mean(scores)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model", default="", help="LM id; omit to only report the deterministic baseline")
+    parser.add_argument("--save", default="", help="path to save the compiled program")
+    args = parser.parse_args()
+
+    train, dev = _examples(TRAIN), _examples(DEV)
+
+    baseline_dev = _baseline_score(dev)
+    print(f"deterministic baseline (dev): {baseline_dev:.3f}")
+    if not args.model:
+        print("no --model given; stopping before optimization")
+        return 0
+
+    dspy.configure(lm=dspy.LM(args.model))
+    program = VibeToSpec()
+
+    uncompiled_dev = _score(program, dev)
+    print(f"uncompiled LM program  (dev): {uncompiled_dev:.3f}")
+
+    optimizer = dspy.MIPROv2(metric=spec_quality, auto="light")
+    compiled = optimizer.compile(program, trainset=train, requires_permission_to_run=False)
+
+    compiled_dev = _score(compiled, dev)
+    print(f"compiled LM program    (dev): {compiled_dev:.3f}")
+
+    verdict = "improved" if compiled_dev > max(uncompiled_dev, baseline_dev) else "no improvement"
+    print(f"\nverdict: {verdict}")
+    if verdict == "no improvement":
+        print("Do not adopt this candidate. A compiled program that loses to string handling is not worth its cost.")
+
+    if args.save:
+        compiled.save(args.save)
+        print(f"saved compiled program to {args.save}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dspy_vibe/metrics.py
+++ b/dspy_vibe/metrics.py
@@ -1,0 +1,196 @@
+"""Metrics for optimizing and grading the pipeline.
+
+These are DSPy metrics: `metric(example, prediction, trace=None) -> float`.
+They are deliberately mechanical. A metric an LM judges is a metric that can be
+talked into a good score; every check here is something a script can settle.
+
+The bias is toward penalizing *invention*. A thin brief wastes a little time; a
+brief that adds requirements the user never stated sends work in the wrong
+direction and looks authoritative while doing it.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from dspy_vibe.types import AgentArtifact, SkillArtifact, VibeSpec
+
+STOPWORDS = {
+    "a", "az", "egy", "és", "es", "hogy", "kell", "legyen", "lehet", "csak", "meg", "majd", "is",
+    "the", "and", "for", "with", "that", "this", "should", "would", "make", "just", "some", "very",
+}
+
+
+def _tokens(text: str) -> set[str]:
+    return {
+        word
+        for word in re.findall(r"[a-zá-űA-ZÁ-Ű0-9_.\-]{3,}", text.lower())
+        if word not in STOPWORDS
+    }
+
+
+def _clamp(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def spec_faithfulness(instruction: str, spec: VibeSpec) -> float:
+    """Fraction of scope claims that are anchored in the instruction.
+
+    A claim counts as anchored when it shares any content word with the source.
+    The bar is deliberately low: the question is "did the converter invent a
+    piece of work nobody asked for", not "did it paraphrase". Requiring heavy
+    overlap would score a copy-paste brief perfectly and punish the decomposed
+    one — the opposite of what this metric is for.
+
+    Constraints, risks, and open questions are exempt. Naming a risk the user
+    never mentioned is the converter doing its job.
+    """
+    source = _tokens(instruction) | _tokens(spec.context)
+    claims = [*spec.scope, *spec.non_goals, spec.goal]
+    checkable = [claim for claim in claims if _tokens(claim)]
+    if not checkable:
+        return 0.0
+    anchored = sum(1 for claim in checkable if _tokens(claim) & source)
+    return _clamp(anchored / len(checkable))
+
+
+def spec_completeness(spec: VibeSpec) -> float:
+    """Whether the brief carries the parts that make it usable."""
+    checks = [
+        bool(spec.goal.strip()),
+        bool(spec.scope),
+        bool(spec.acceptance),
+        all(criterion.verification.strip() for criterion in spec.acceptance),
+        bool(spec.open_questions) or spec.confidence == "HIGH",
+        bool(spec.risks) or spec.confidence == "HIGH",
+    ]
+    return sum(1 for check in checks if check) / len(checks)
+
+
+def spec_honesty(spec: VibeSpec) -> float:
+    """Whether unresolved decisions are surfaced instead of silently made.
+
+    An open question with no assumption is fine — it is marked blocking. An
+    assumption stated as if it were a requirement is the failure this catches.
+    """
+    if not spec.open_questions:
+        # No questions at all is only credible for a fully specified request.
+        return 1.0 if spec.confidence == "HIGH" else 0.4
+    documented = sum(
+        1
+        for question in spec.open_questions
+        if question.why_it_matters.strip() and (question.assumption_used.strip() or question.blocking)
+    )
+    return documented / len(spec.open_questions)
+
+
+CONCRETE_VERIFICATION = re.compile(
+    r"\b(run|runs|execute|command|test|tests|pytest|npm|yarn|curl|assert|lint|build|"
+    r"measure|profile|screenshot|open|click|query|inspect|benchmark|fut|futtat|teszt|mér)\b",
+    re.I,
+)
+
+
+def spec_specificity(spec: VibeSpec) -> float:
+    """Whether the brief decomposed the request or merely echoed it.
+
+    A converter that copies the instruction into `scope` and appends
+    "is implemented" to each line has produced a structurally complete but
+    useless brief. These checks are what an LM-backed pipeline should win on,
+    so the deterministic baseline deliberately does not score full marks here.
+    """
+    checks: list[bool] = []
+
+    # A goal is a single claim, not the whole request pasted back.
+    checks.append(bool(spec.goal.strip()) and len(spec.goal.split()) <= 25)
+
+    # Scope items are atomic units of work, not copied paragraphs.
+    checks.append(bool(spec.scope) and all(len(item.split()) <= 15 for item in spec.scope))
+
+    # No acceptance criterion may be a scope line with "is implemented" glued on.
+    scope_tokens = [_tokens(item) for item in spec.scope]
+    templated = sum(
+        1
+        for criterion in spec.acceptance
+        if (statement := _tokens(criterion.statement))
+        and any(statement <= source | {"implemented", "done", "works"} for source in scope_tokens)
+    )
+    checks.append(bool(spec.acceptance) and templated == 0)
+
+    # Verification has to name something a person can actually do, and the
+    # methods must differ from each other.
+    checks.append(
+        bool(spec.acceptance)
+        and all(CONCRETE_VERIFICATION.search(criterion.verification) for criterion in spec.acceptance)
+        and len({criterion.verification.strip().lower() for criterion in spec.acceptance}) == len(spec.acceptance)
+    )
+
+    # Open questions must be about *this* request, not generic boilerplate.
+    source_tokens = _tokens(spec.source_instruction) | _tokens(spec.goal)
+    if spec.open_questions:
+        specific = sum(1 for question in spec.open_questions if _tokens(question.question) & source_tokens)
+        checks.append(specific >= max(1, len(spec.open_questions) // 2))
+
+    # Every stated constraint should be visible in the acceptance criteria,
+    # otherwise it is decoration.
+    if spec.constraints:
+        acceptance_text = _tokens(" ".join(c.statement + " " + c.verification for c in spec.acceptance))
+        covered = sum(1 for item in spec.constraints if _tokens(item) & acceptance_text)
+        checks.append(covered >= max(1, len(spec.constraints) // 2))
+
+    return sum(1 for check in checks if check) / len(checks)
+
+
+def spec_quality(example: Any, prediction: Any, trace: Any = None) -> float:
+    """Composite brief score in [0, 1]. Usable directly as a DSPy metric."""
+    spec = getattr(prediction, "spec", None) or getattr(prediction, "bundle", None)
+    if hasattr(spec, "spec"):
+        spec = spec.spec
+    if not isinstance(spec, VibeSpec):
+        return 0.0
+    instruction = getattr(example, "instruction", "") or spec.source_instruction
+    # Faithfulness multiplies rather than adds. Copying the instruction verbatim
+    # scores perfectly on it, so as a bonus it would reward the laziest possible
+    # brief; as a gate it only punishes invention, which is what it is for.
+    quality = 0.35 * spec_completeness(spec) + 0.45 * spec_specificity(spec) + 0.20 * spec_honesty(spec)
+    return _clamp(quality * (0.4 + 0.6 * spec_faithfulness(instruction, spec)))
+
+
+def agent_validity(agent: AgentArtifact, allowed_tools: list[str] | None = None) -> float:
+    """Whether an agent definition is executable and bounded."""
+    checks = [
+        bool(agent.description.strip()),
+        bool(agent.role.strip()),
+        bool(agent.instructions),
+        bool(agent.guardrails),
+        bool(agent.success_criteria),
+        not allowed_tools or set(agent.tools) <= set(allowed_tools),
+    ]
+    return sum(1 for check in checks if check) / len(checks)
+
+
+def skill_validity(skill: SkillArtifact) -> float:
+    """Whether a skill definition is reusable and honestly bounded."""
+    checks = [
+        bool(skill.description.strip()),
+        bool(skill.triggers),
+        len(skill.procedure) >= 2,
+        bool(skill.outputs),
+        bool(skill.checks),
+        bool(skill.limits),
+    ]
+    return sum(1 for check in checks if check) / len(checks)
+
+
+def bundle_quality(example: Any, prediction: Any, trace: Any = None) -> float:
+    """Composite score over the whole bundle. Usable directly as a DSPy metric."""
+    bundle = getattr(prediction, "bundle", None)
+    if bundle is None:
+        return 0.0
+    allowed = getattr(example, "available_tools", None)
+    return _clamp(
+        0.5 * spec_quality(example, prediction, trace)
+        + 0.25 * agent_validity(bundle.agent, allowed)
+        + 0.25 * skill_validity(bundle.skill)
+    )

--- a/dspy_vibe/modules.py
+++ b/dspy_vibe/modules.py
@@ -1,0 +1,120 @@
+"""DSPy modules for the vibe-coding pipeline.
+
+`VibeCoder` is the whole thing: instruction in, spec plus `.agent` plus
+`.skill` out. It is a normal `dspy.Module`, so it can be compiled by any DSPy
+optimizer against the metrics in `metrics.py`.
+
+Every step falls back to the deterministic converter when no LM is configured,
+which keeps the pipeline usable offline and gives an optimizer a real baseline
+to beat.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import dspy
+from dspy_vibe import offline
+from dspy_vibe.signatures import SpecToAgent, SpecToSkill, VibeInstructionToSpec
+from dspy_vibe.types import AgentArtifact, SkillArtifact, VibeBundle, VibeSpec
+
+logger = logging.getLogger(__name__)
+
+
+def lm_available() -> bool:
+    """True when DSPy has an LM configured for the current context."""
+    try:
+        return dspy.settings.lm is not None
+    except Exception:  # pragma: no cover - settings access should not break callers
+        return False
+
+
+class VibeToSpec(dspy.Module):
+    """Turn a loose instruction into a structured brief."""
+
+    def __init__(self, *, use_cot: bool = True):
+        super().__init__()
+        predictor = dspy.ChainOfThought if use_cot else dspy.Predict
+        self.convert = predictor(VibeInstructionToSpec)
+
+    def forward(self, instruction: str, repo_context: str = "") -> dspy.Prediction:
+        if not instruction or not instruction.strip():
+            raise ValueError("instruction must not be empty")
+        if not lm_available():
+            return dspy.Prediction(spec=offline.spec_from_instruction(instruction, repo_context))
+        result = self.convert(instruction=instruction, repo_context=repo_context)
+        spec: VibeSpec = result.spec
+        # The source text is evidence, not a generation target: keep it verbatim
+        # so a later reviewer can compare the brief against what was asked.
+        if not spec.source_instruction:
+            spec = spec.model_copy(update={"source_instruction": instruction.strip()})
+        return dspy.Prediction(spec=spec)
+
+
+class SpecToAgentModule(dspy.Module):
+    """Derive an `.agent` definition from a brief."""
+
+    def __init__(self, *, use_cot: bool = False):
+        super().__init__()
+        predictor = dspy.ChainOfThought if use_cot else dspy.Predict
+        self.convert = predictor(SpecToAgent)
+
+    def forward(self, spec: VibeSpec, available_tools: list[str] | None = None) -> dspy.Prediction:
+        tools = sorted(available_tools or [])
+        if not lm_available():
+            return dspy.Prediction(agent=offline.agent_from_spec(spec, tools))
+        result = self.convert(spec=spec, available_tools=", ".join(tools))
+        agent: AgentArtifact = result.agent
+        updates: dict[str, object] = {}
+        if not agent.source_spec:
+            updates["source_spec"] = spec.slug
+        # A tool the host does not offer is a promise the agent cannot keep.
+        if tools:
+            allowed = [tool for tool in agent.tools if tool in tools]
+            if allowed != agent.tools:
+                logger.warning("dropping tools not offered by the host: %s", sorted(set(agent.tools) - set(tools)))
+                updates["tools"] = allowed
+        return dspy.Prediction(agent=agent.model_copy(update=updates) if updates else agent)
+
+
+class SpecToSkillModule(dspy.Module):
+    """Derive a `.skill` definition from a brief."""
+
+    def __init__(self, *, use_cot: bool = False):
+        super().__init__()
+        predictor = dspy.ChainOfThought if use_cot else dspy.Predict
+        self.convert = predictor(SpecToSkill)
+
+    def forward(self, spec: VibeSpec) -> dspy.Prediction:
+        if not lm_available():
+            return dspy.Prediction(skill=offline.skill_from_spec(spec))
+        result = self.convert(spec=spec)
+        skill: SkillArtifact = result.skill
+        if not skill.source_spec:
+            skill = skill.model_copy(update={"source_spec": spec.slug})
+        return dspy.Prediction(skill=skill)
+
+
+class VibeCoder(dspy.Module):
+    """The full pipeline: vibe instruction to spec, agent, and skill.
+
+    Args:
+        available_tools: Tool names the host offers. Generated agents are
+            restricted to these.
+        use_cot: Reason step-by-step before producing the brief. Worth it for
+            the brief, rarely for the mechanical derivations after it.
+    """
+
+    def __init__(self, *, available_tools: list[str] | None = None, use_cot: bool = True):
+        super().__init__()
+        self.available_tools = sorted(available_tools or [])
+        self.to_spec = VibeToSpec(use_cot=use_cot)
+        self.to_agent = SpecToAgentModule()
+        self.to_skill = SpecToSkillModule()
+
+    def forward(self, instruction: str, repo_context: str = "") -> dspy.Prediction:
+        spec = self.to_spec(instruction=instruction, repo_context=repo_context).spec
+        agent = self.to_agent(spec=spec, available_tools=self.available_tools).agent
+        skill = self.to_skill(spec=spec).skill
+        bundle = VibeBundle(spec=spec, agent=agent, skill=skill)
+        return dspy.Prediction(bundle=bundle, spec=spec, agent=agent, skill=skill)

--- a/dspy_vibe/offline.py
+++ b/dspy_vibe/offline.py
@@ -1,0 +1,276 @@
+"""Deterministic, LM-free conversion.
+
+Two reasons this exists. First, a brief you can produce without a configured LM
+makes the pipeline testable and usable offline. Second, it is the baseline an
+optimizer measures against: if the LM-backed module cannot beat plain string
+handling, the LM is not earning its cost.
+
+The heuristics are deliberately shallow and say so — every offline spec is
+`LOW` confidence and carries the open questions the text left unanswered.
+"""
+
+from __future__ import annotations
+
+import re
+
+from dspy_vibe.types import (
+    AcceptanceCriterion,
+    AgentArtifact,
+    OpenQuestion,
+    SkillArtifact,
+    VibeBundle,
+    VibeSpec,
+    slugify,
+)
+
+# Cue words that introduce an exclusion, in the two languages this repo's users write in.
+NEGATION_CUES = (
+    "ne ",
+    "nem kell",
+    "nélkül",
+    "don't",
+    "do not",
+    "no ",
+    "without",
+    "avoid",
+    "skip",
+)
+
+QUALITY_CUES = {
+    "gyors": "Performance is a stated priority.",
+    "fast": "Performance is a stated priority.",
+    "biztonságos": "Security is a stated priority.",
+    "secure": "Security is a stated priority.",
+    "egyszerű": "Simplicity is a stated priority.",
+    "simple": "Simplicity is a stated priority.",
+    "szép": "Visual quality is a stated priority; the bar is undefined.",
+    "pretty": "Visual quality is a stated priority; the bar is undefined.",
+    "reszponzív": "Responsive layout is required.",
+    "responsive": "Responsive layout is required.",
+    "tesztelt": "Tests are expected as part of the work.",
+    "tested": "Tests are expected as part of the work.",
+    "akadálymentes": "Accessibility is a stated priority.",
+    "accessible": "Accessibility is a stated priority.",
+}
+
+STACK_CUES = (
+    "python", "typescript", "javascript", "react", "vue", "svelte", "next.js", "nextjs",
+    "django", "flask", "fastapi", "node", "express", "rust", "go", "java", "kotlin",
+    "swift", "postgres", "postgresql", "sqlite", "mysql", "redis", "docker", "kubernetes",
+    "tailwind", "css", "html", "graphql", "rest", "dspy",
+)
+
+SENTENCE_SPLIT = re.compile(r"(?<=[.!?;])\s+|\n+")
+
+
+def _sentences(text: str) -> list[str]:
+    return [part.strip(" -•\t") for part in SENTENCE_SPLIT.split(text.strip()) if part.strip(" -•\t")]
+
+
+def _detect_stack(text: str) -> list[str]:
+    """Find technology names, tolerating inflection.
+
+    Hungarian glues case endings onto foreign words — "Reactban", "Pythonnal" —
+    so an exact word-boundary match misses them. Names of four characters or
+    more allow a short suffix; shorter ones (`go`, `css`) stay exact, because
+    `go[a-z]{0,4}` would happily match "good".
+    """
+    lowered = text.lower()
+    found = set()
+    for cue in STACK_CUES:
+        pattern = rf"\b{re.escape(cue)}[a-zá-űö-ü]{{0,4}}\b" if len(cue) >= 4 else rf"\b{re.escape(cue)}\b"
+        if re.search(pattern, lowered):
+            found.add(cue)
+    return sorted(found)
+
+
+CLAUSE_SPLIT = re.compile(r",\s*|\s+(?:but|however|viszont|de)\s+")
+
+
+def _clauses(sentence: str) -> list[str]:
+    """Split a sentence into clauses.
+
+    Exclusions usually arrive as one clause inside an otherwise positive
+    sentence — "make a login form, no backend needed". Classifying whole
+    sentences would drop the entire request into non-goals.
+    """
+    return [clause.strip() for clause in CLAUSE_SPLIT.split(sentence) if clause.strip()]
+
+
+def _split_scope(sentences: list[str]) -> tuple[list[str], list[str]]:
+    scope: list[str] = []
+    non_goals: list[str] = []
+    for sentence in sentences:
+        for clause in _clauses(sentence):
+            lowered = clause.lower()
+            if any(cue in lowered for cue in NEGATION_CUES):
+                non_goals.append(clause)
+            else:
+                scope.append(clause)
+    return scope, non_goals
+
+
+def _constraints(text: str) -> list[str]:
+    lowered = text.lower()
+    found = {note for cue, note in QUALITY_CUES.items() if re.search(rf"\b{re.escape(cue)}", lowered)}
+    return sorted(found)
+
+
+def _title(instruction: str) -> str:
+    first = _sentences(instruction)[0] if _sentences(instruction) else instruction
+    words = first.split()
+    return " ".join(words[:8]).rstrip(",.:;") or "Untitled task"
+
+
+def _acceptance(scope: list[str], constraints: list[str]) -> list[AcceptanceCriterion]:
+    criteria = [
+        AcceptanceCriterion(
+            statement=item.rstrip(".") + " is implemented",
+            verification="Reviewer runs the feature and confirms the described behaviour.",
+        )
+        for item in scope[:3]
+    ]
+    if any("Tests are expected" in note for note in constraints):
+        criteria.append(
+            AcceptanceCriterion(
+                statement="Automated tests cover the new behaviour",
+                verification="The project's test command passes and fails when the change is reverted.",
+            )
+        )
+    if not criteria:
+        criteria.append(
+            AcceptanceCriterion(
+                statement="The requested change exists and runs",
+                verification="Reviewer executes the affected path and observes the intended result.",
+            )
+        )
+    return criteria
+
+
+def _open_questions(instruction: str, constraints: list[str], stack: list[str]) -> list[OpenQuestion]:
+    questions: list[OpenQuestion] = []
+    if not stack:
+        questions.append(
+            OpenQuestion(
+                question="Which language, framework, and runtime should this target?",
+                why_it_matters="The instruction names no stack, so any choice is the converter's, not the user's.",
+                assumption_used="Follow the conventions already present in the target repository.",
+            )
+        )
+    if any("Visual quality" in note for note in constraints):
+        questions.append(
+            OpenQuestion(
+                question="What is the visual reference or design system for 'nice-looking'?",
+                why_it_matters="Aesthetic requirements without a reference cannot be accepted or rejected objectively.",
+                assumption_used="Match the existing UI of the surrounding application.",
+            )
+        )
+    if not re.search(r"\b(test|teszt|spec)\b", instruction.lower()):
+        questions.append(
+            OpenQuestion(
+                question="Is automated test coverage expected for this change?",
+                why_it_matters="It changes the size of the work and the definition of done.",
+                assumption_used="Add tests for new logic where the repository already has a test suite.",
+            )
+        )
+    return questions
+
+
+def spec_from_instruction(instruction: str, repo_context: str = "") -> VibeSpec:
+    """Build a structured brief from a loose instruction, without an LM."""
+    instruction = instruction.strip()
+    if not instruction:
+        raise ValueError("instruction must not be empty")
+
+    sentences = _sentences(instruction)
+    scope, non_goals = _split_scope(sentences)
+    constraints = _constraints(instruction)
+    stack = _detect_stack(f"{instruction}\n{repo_context}")
+    context_parts = [part for part in (repo_context.strip(), "Detected stack: " + ", ".join(stack) if stack else "") if part]
+
+    return VibeSpec(
+        title=_title(instruction),
+        slug=slugify(_title(instruction)),
+        goal=sentences[0] if sentences else instruction,
+        context="\n".join(context_parts),
+        scope=scope,
+        non_goals=non_goals,
+        constraints=constraints,
+        acceptance=_acceptance(scope, constraints),
+        risks=[
+            "The brief was derived by keyword heuristics, so intent may be misread.",
+            "Requirements the instruction implied but did not state are absent by design.",
+        ],
+        open_questions=_open_questions(instruction, constraints, stack),
+        source_instruction=instruction,
+        confidence="LOW",
+    )
+
+
+def agent_from_spec(spec: VibeSpec, available_tools: list[str] | None = None) -> AgentArtifact:
+    """Derive an agent definition from a brief, without an LM."""
+    guardrails = [
+        "Work only within the stated scope; anything else needs a new instruction.",
+        "Do not resolve a blocking open question by guessing; ask the user.",
+    ]
+    guardrails += [f"Out of scope: {item}" for item in spec.non_goals]
+    guardrails += [f"Risk to watch: {item}" for item in spec.risks]
+
+    instructions = [
+        "Read the brief and confirm the assumptions still hold.",
+        *(f"Implement: {item}" for item in spec.scope),
+        "Verify every acceptance criterion by its stated verification method.",
+        "Report what was done, what was skipped, and why.",
+    ]
+
+    return AgentArtifact(
+        name=f"{spec.slug}-agent"[:64],
+        description=f"Implements: {spec.goal}",
+        role=(
+            f"You implement the brief '{spec.title}'. The brief is the authority; "
+            "where it is silent, state your assumption instead of inventing a requirement."
+        ),
+        tools=sorted(available_tools or []),
+        instructions=instructions,
+        guardrails=guardrails,
+        success_criteria=[criterion.statement for criterion in spec.acceptance],
+        source_spec=spec.slug,
+    )
+
+
+def skill_from_spec(spec: VibeSpec) -> SkillArtifact:
+    """Derive a reusable skill definition from a brief, without an LM."""
+    keywords = re.findall(r"[a-zá-űA-ZÁ-Ű0-9]{4,}", spec.title.lower())[:5]
+    return SkillArtifact(
+        name=f"{spec.slug}-skill"[:64],
+        description=f"{spec.goal} Use when a request matches this task shape.",
+        triggers=sorted({spec.title.lower(), *keywords}),
+        procedure=[
+            "Restate the request as a brief: goal, scope, non-goals, acceptance.",
+            *(f"Apply constraint: {item}" for item in spec.constraints),
+            *(f"Deliver: {item}" for item in spec.scope),
+            "Check each acceptance criterion and report the result.",
+        ],
+        inputs=["The user's request", "The target repository or file paths"],
+        outputs=["The implemented change", "A short report of criteria met and skipped"],
+        checks=[criterion.verification for criterion in spec.acceptance],
+        limits=[
+            "Does not decide questions the brief left open.",
+            *spec.non_goals,
+        ],
+        source_spec=spec.slug,
+    )
+
+
+def bundle_from_instruction(
+    instruction: str,
+    repo_context: str = "",
+    available_tools: list[str] | None = None,
+) -> VibeBundle:
+    """Full offline pipeline: instruction to spec, agent, and skill."""
+    spec = spec_from_instruction(instruction, repo_context)
+    return VibeBundle(
+        spec=spec,
+        agent=agent_from_spec(spec, available_tools),
+        skill=skill_from_spec(spec),
+    )

--- a/dspy_vibe/signatures.py
+++ b/dspy_vibe/signatures.py
@@ -1,0 +1,67 @@
+"""DSPy signatures for the vibe-coding conversion.
+
+Signatures declare *what* each step maps to; the prompt is DSPy's business and
+an optimizer's to improve. Each output is a typed artifact from `types`, so a
+malformed generation fails validation instead of reaching a file.
+"""
+
+from __future__ import annotations
+
+import dspy
+from dspy_vibe.types import AgentArtifact, SkillArtifact, VibeSpec
+
+
+class VibeInstructionToSpec(dspy.Signature):
+    """Convert a loose, informal coding request into a structured development brief.
+
+    Keep the user's intent; do not invent requirements they never stated. When
+    the instruction leaves something undecided, record it as an open question
+    with the assumption you applied, rather than silently choosing for them.
+    Acceptance criteria must be checkable by running or observing something.
+    """
+
+    instruction: str = dspy.InputField(desc="The raw, informal request, in the user's own words.")
+    repo_context: str = dspy.InputField(
+        desc="Known facts about the codebase: stack, conventions, constraints. May be empty."
+    )
+    spec: VibeSpec = dspy.OutputField(desc="The structured brief.")
+
+
+class SpecToAgent(dspy.Signature):
+    """Derive an executable agent definition from a development brief.
+
+    The agent is the *worker*: it carries the role, the ordered steps, and the
+    limits. Guardrails must include anything the brief marked as a non-goal or
+    a risk, so the agent cannot quietly widen its own scope.
+    """
+
+    spec: VibeSpec = dspy.InputField()
+    available_tools: str = dspy.InputField(desc="Comma-separated tool names the host offers. May be empty.")
+    agent: AgentArtifact = dspy.OutputField()
+
+
+class SpecToSkill(dspy.Signature):
+    """Derive a reusable skill definition from a development brief.
+
+    The skill is the *method*: the part worth reusing on the next task of this
+    shape. Write triggers as phrases a user would actually type, and keep the
+    procedure ordered and concrete. State explicitly what the skill does not
+    cover.
+    """
+
+    spec: VibeSpec = dspy.InputField()
+    skill: SkillArtifact = dspy.OutputField()
+
+
+class CritiqueSpec(dspy.Signature):
+    """Judge whether a brief is faithful to the original instruction and usable.
+
+    Flag invented requirements first: a brief that adds work the user never
+    asked for is worse than a thin one.
+    """
+
+    instruction: str = dspy.InputField()
+    spec: VibeSpec = dspy.InputField()
+    invented_requirements: list[str] = dspy.OutputField(desc="Requirements not supported by the instruction.")
+    missing_aspects: list[str] = dspy.OutputField(desc="Parts of the instruction the brief dropped.")
+    score: float = dspy.OutputField(desc="0.0-1.0 overall usability of the brief.")

--- a/dspy_vibe/types.py
+++ b/dspy_vibe/types.py
@@ -1,0 +1,150 @@
+"""Typed artifacts produced by the vibe-coding pipeline.
+
+Everything the pipeline emits is a pydantic model, so an LM-generated result and
+a deterministically generated one are validated by the same rules. Nothing here
+imports dspy: artifacts can be built, validated, and written without an LM.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+Confidence = Literal["HIGH", "MEDIUM", "LOW"]
+
+
+def slugify(text: str, *, fallback: str = "task", max_words: int = 6) -> str:
+    """Turn free text into a stable kebab-case slug.
+
+    Accented characters are transliterated rather than dropped, so a Hungarian
+    title yields `csinalj-egy-login-formot`, not `csin-lj-egy-login-formot`.
+    """
+    normalized = unicodedata.normalize("NFKD", text.lower())
+    stripped = "".join(char for char in normalized if not unicodedata.combining(char))
+    words = re.findall(r"[a-z0-9]+", stripped)
+    slug = "-".join(words[:max_words])
+    return slug or fallback
+
+
+class AcceptanceCriterion(BaseModel):
+    """One check that decides whether the work is done.
+
+    `verification` is what someone actually runs or looks at. A criterion no one
+    can check is a wish, not a criterion.
+    """
+
+    statement: str = Field(description="Observable outcome, phrased as a testable claim.")
+    verification: str = Field(description="Concrete command, test, or observation that settles it.")
+
+    @field_validator("statement", "verification")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("acceptance criterion fields must be non-empty")
+        return value.strip()
+
+
+class OpenQuestion(BaseModel):
+    """Something the vibe instruction did not settle.
+
+    Vibe instructions are underspecified by nature. Recording the gap with the
+    assumption used in its place keeps the brief honest instead of inventing a
+    requirement the user never stated.
+    """
+
+    question: str
+    why_it_matters: str
+    assumption_used: str = Field(
+        default="",
+        description="The assumption applied so work can proceed. Empty means the question blocks work.",
+    )
+
+    @property
+    def blocking(self) -> bool:
+        return not self.assumption_used.strip()
+
+
+class VibeSpec(BaseModel):
+    """A loose instruction turned into a structured development brief."""
+
+    title: str
+    slug: str = ""
+    goal: str = Field(description="One sentence: what must be true when this is done.")
+    context: str = Field(default="", description="Stack, repository, or environment facts stated by the user.")
+    scope: list[str] = Field(default_factory=list, description="Work that is in scope.")
+    non_goals: list[str] = Field(default_factory=list, description="Explicitly out of scope.")
+    constraints: list[str] = Field(default_factory=list, description="Technical, legal, or stylistic limits.")
+    acceptance: list[AcceptanceCriterion] = Field(default_factory=list)
+    risks: list[str] = Field(default_factory=list)
+    open_questions: list[OpenQuestion] = Field(default_factory=list)
+    source_instruction: str = Field(default="", description="The original vibe instruction, verbatim.")
+    confidence: Confidence = "MEDIUM"
+
+    @model_validator(mode="after")
+    def _fill_slug(self) -> VibeSpec:
+        if not self.slug:
+            object.__setattr__(self, "slug", slugify(self.title))
+        if not SLUG_RE.fullmatch(self.slug):
+            raise ValueError(f"slug must be kebab-case, got {self.slug!r}")
+        return self
+
+    @property
+    def blocking_questions(self) -> list[OpenQuestion]:
+        return [question for question in self.open_questions if question.blocking]
+
+
+class AgentArtifact(BaseModel):
+    """An `.agent` definition: who does the work and under what limits."""
+
+    name: str
+    description: str = Field(description="One line; used to decide when to invoke the agent.")
+    role: str = Field(description="The agent's standing brief.")
+    tools: list[str] = Field(default_factory=list)
+    model: str = ""
+    instructions: list[str] = Field(default_factory=list, description="Ordered working steps.")
+    guardrails: list[str] = Field(default_factory=list, description="What the agent must not do.")
+    success_criteria: list[str] = Field(default_factory=list)
+    source_spec: str = Field(default="", description="Slug of the spec this was generated from.")
+
+    @field_validator("name")
+    @classmethod
+    def _slug_name(cls, value: str) -> str:
+        value = value.strip()
+        if not SLUG_RE.fullmatch(value):
+            raise ValueError(f"agent name must be kebab-case, got {value!r}")
+        return value
+
+
+class SkillArtifact(BaseModel):
+    """A `.skill` definition: a reusable procedure plus the cues that trigger it."""
+
+    name: str
+    description: str = Field(description="One line stating what the skill does and when it triggers.")
+    triggers: list[str] = Field(default_factory=list, description="Phrases or situations that should load it.")
+    procedure: list[str] = Field(default_factory=list, description="Ordered steps.")
+    inputs: list[str] = Field(default_factory=list)
+    outputs: list[str] = Field(default_factory=list)
+    checks: list[str] = Field(default_factory=list, description="Verification before the skill reports done.")
+    limits: list[str] = Field(default_factory=list, description="What the skill does not cover.")
+    source_spec: str = Field(default="", description="Slug of the spec this was generated from.")
+
+    @field_validator("name")
+    @classmethod
+    def _slug_name(cls, value: str) -> str:
+        value = value.strip()
+        if not SLUG_RE.fullmatch(value):
+            raise ValueError(f"skill name must be kebab-case, got {value!r}")
+        return value
+
+
+class VibeBundle(BaseModel):
+    """Everything one vibe instruction produces."""
+
+    spec: VibeSpec
+    agent: AgentArtifact
+    skill: SkillArtifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,14 @@ test_extras = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["dspy", "dspy.*"]
+include = ["dspy", "dspy.*", "dspy_vibe", "dspy_vibe.*"]
 exclude = ["tests", "tests.*"]
 
 [tool.setuptools.package-data]
 dspy = ["primitives/*.js"]
+
+[project.scripts]
+dspy-vibe = "dspy_vibe.cli:main"
 
 [project.urls]
 homepage = "https://github.com/stanfordnlp/dspy"
@@ -121,7 +124,7 @@ filterwarnings = [
 ]
 
 [tool.ruff]
-include = ["dspy/**/*.py", "tests/**/*.py"]
+include = ["dspy/**/*.py", "dspy_vibe/**/*.py", "tests/**/*.py"]
 exclude = [
   "dspy/__metadata__.py",
   "tests/reliability/*.py",
@@ -172,7 +175,7 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.ruff.lint.isort]
-known-first-party = ["dspy"]
+known-first-party = ["dspy", "dspy_vibe"]
 
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/tests/vibe/test_cli.py
+++ b/tests/vibe/test_cli.py
@@ -1,0 +1,59 @@
+import json
+
+from dspy_vibe.cli import main
+
+INSTRUCTION = "csinálj egy login formot, ne legyen backend"
+
+
+def test_convert_writes_all_three_artifacts(tmp_path, capsys):
+    code = main(["convert", INSTRUCTION, "--out", str(tmp_path)])
+    assert code == 0
+    written = sorted(path.suffix for path in tmp_path.iterdir())
+    assert written == [".agent", ".md", ".skill"]
+    assert "bundle quality" in capsys.readouterr().out
+
+
+def test_convert_is_offline_by_default(tmp_path, monkeypatch):
+    # No LM configuration is read and no network client is constructed.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert main(["convert", INSTRUCTION, "--out", str(tmp_path)]) == 0
+
+
+def test_json_format_produces_machine_readable_artifacts(tmp_path):
+    main(["convert", INSTRUCTION, "--out", str(tmp_path), "--format", "json"])
+    agent = next(tmp_path.glob("*.agent"))
+    assert json.loads(agent.read_text(encoding="utf-8"))["name"].endswith("-agent")
+
+
+def test_second_run_refuses_to_overwrite(tmp_path, capsys):
+    main(["convert", INSTRUCTION, "--out", str(tmp_path)])
+    assert main(["convert", INSTRUCTION, "--out", str(tmp_path)]) == 1
+    assert "refusing to overwrite" in capsys.readouterr().err
+    assert main(["convert", INSTRUCTION, "--out", str(tmp_path), "--overwrite"]) == 0
+
+
+def test_stdout_mode_prints_the_bundle_without_writing(tmp_path, capsys):
+    assert main(["convert", INSTRUCTION, "--out", str(tmp_path), "--stdout"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert {"spec", "agent", "skill"} <= payload.keys()
+    assert not list(tmp_path.iterdir())
+
+
+def test_instruction_can_come_from_a_file(tmp_path):
+    source = tmp_path / "request.txt"
+    source.write_text(INSTRUCTION, encoding="utf-8")
+    assert main(["convert", "--file", str(source), "--out", str(tmp_path / "out")]) == 0
+
+
+def test_check_validates_json_artifacts(tmp_path, capsys):
+    main(["convert", INSTRUCTION, "--out", str(tmp_path), "--format", "json"])
+    agent = next(tmp_path.glob("*.agent"))
+    assert main(["check", str(agent)]) == 0
+    assert "PASS" in capsys.readouterr().out
+
+
+def test_check_reports_an_invalid_artifact(tmp_path, capsys):
+    broken = tmp_path / "broken.agent"
+    broken.write_text(json.dumps({"name": "Not A Slug"}), encoding="utf-8")
+    assert main(["check", str(broken)]) == 1
+    assert "FAIL" in capsys.readouterr().out

--- a/tests/vibe/test_emitters.py
+++ b/tests/vibe/test_emitters.py
@@ -1,0 +1,74 @@
+import json
+
+import pytest
+
+from dspy_vibe import bundle_from_instruction, write_bundle
+from dspy_vibe.emitters import _yaml_block, agent_to_markdown, skill_to_markdown, spec_to_markdown
+from dspy_vibe.types import AgentArtifact
+
+INSTRUCTION = "add a dark mode toggle to the settings page, don't touch the login screen"
+
+
+def _frontmatter(text: str) -> str:
+    assert text.startswith("---\n")
+    return text.split("---", 2)[1]
+
+
+def test_markdown_artifacts_start_with_frontmatter():
+    bundle = bundle_from_instruction(INSTRUCTION)
+    for rendered in (
+        spec_to_markdown(bundle.spec),
+        agent_to_markdown(bundle.agent),
+        skill_to_markdown(bundle.skill),
+    ):
+        assert "name:" in _frontmatter(rendered)
+
+
+def test_yaml_quotes_values_that_would_break_parsing():
+    block = _yaml_block({"a": "plain", "b": "has: colon", "c": ["- dash", "ok"], "d": "true"})
+    assert "a: plain" in block
+    assert 'b: "has: colon"' in block
+    assert '  - "- dash"' in block
+    assert 'd: "true"' in block
+
+
+def test_yaml_skips_empty_values_and_folds_newlines():
+    block = _yaml_block({"empty": "", "none": [], "multi": "one\ntwo"})
+    assert "empty" not in block
+    assert "none" not in block
+    assert block == "multi: one two"
+
+
+def test_yaml_rejects_unsupported_types():
+    with pytest.raises(TypeError):
+        _yaml_block({"count": 3})
+
+
+def test_write_bundle_creates_agent_and_skill_files(tmp_path):
+    bundle = bundle_from_instruction(INSTRUCTION)
+    written = write_bundle(bundle, tmp_path)
+    assert written["agent"].suffix == ".agent"
+    assert written["skill"].suffix == ".skill"
+    assert written["agent"].read_text(encoding="utf-8").startswith("---")
+
+
+def test_json_format_round_trips_through_the_model(tmp_path):
+    bundle = bundle_from_instruction(INSTRUCTION)
+    written = write_bundle(bundle, tmp_path, fmt="json")
+    payload = json.loads(written["agent"].read_text(encoding="utf-8"))
+    assert AgentArtifact.model_validate(payload) == bundle.agent
+
+
+def test_existing_files_are_not_clobbered(tmp_path):
+    bundle = bundle_from_instruction(INSTRUCTION)
+    write_bundle(bundle, tmp_path)
+    with pytest.raises(FileExistsError):
+        write_bundle(bundle, tmp_path)
+    written = write_bundle(bundle, tmp_path, overwrite=True)
+    assert written["spec"].exists()
+
+
+def test_blocking_question_is_marked_in_the_spec_document():
+    bundle = bundle_from_instruction(INSTRUCTION)
+    bundle.spec.open_questions[0].assumption_used = ""
+    assert "blocking" in spec_to_markdown(bundle.spec)

--- a/tests/vibe/test_emitters.py
+++ b/tests/vibe/test_emitters.py
@@ -72,3 +72,14 @@ def test_blocking_question_is_marked_in_the_spec_document():
     bundle = bundle_from_instruction(INSTRUCTION)
     bundle.spec.open_questions[0].assumption_used = ""
     assert "blocking" in spec_to_markdown(bundle.spec)
+
+
+def test_render_bundle_matches_written_files(tmp_path):
+    from dspy_vibe import render_bundle
+
+    bundle = bundle_from_instruction(INSTRUCTION)
+    rendered = render_bundle(bundle)
+    written = write_bundle(bundle, tmp_path)
+    assert written["agent"].read_text(encoding="utf-8") == rendered["agent"]
+    assert written["skill"].read_text(encoding="utf-8") == rendered["skill"]
+    assert written["spec"].read_text(encoding="utf-8") == rendered["spec"]

--- a/tests/vibe/test_metrics.py
+++ b/tests/vibe/test_metrics.py
@@ -1,0 +1,159 @@
+from types import SimpleNamespace
+
+from dspy_vibe import bundle_from_instruction, spec_from_instruction
+from dspy_vibe.metrics import (
+    agent_validity,
+    bundle_quality,
+    skill_validity,
+    spec_completeness,
+    spec_faithfulness,
+    spec_honesty,
+    spec_quality,
+    spec_specificity,
+)
+from dspy_vibe.types import AcceptanceCriterion, OpenQuestion, VibeSpec
+
+INSTRUCTION = "add a dark mode toggle to the settings page"
+
+
+def _pred(spec):
+    return SimpleNamespace(spec=spec)
+
+
+def test_invented_scope_lowers_faithfulness():
+    grounded = spec_from_instruction(INSTRUCTION)
+    invented = grounded.model_copy(
+        update={"scope": [*grounded.scope, "migrate the billing system to Stripe"]}
+    )
+    assert spec_faithfulness(INSTRUCTION, invented) < spec_faithfulness(INSTRUCTION, grounded)
+
+
+def test_templated_acceptance_criteria_lower_specificity():
+    spec = spec_from_instruction(INSTRUCTION)
+    templated = spec.model_copy(
+        update={
+            "acceptance": [
+                AcceptanceCriterion(
+                    statement=f"{item} is implemented",
+                    verification="Reviewer runs the feature.",
+                )
+                for item in spec.scope
+            ]
+        }
+    )
+    assert spec_specificity(templated) < spec_specificity(spec) or spec_specificity(templated) < 1.0
+
+
+def _well_specified() -> VibeSpec:
+    """A brief of the shape an LM-backed run should produce.
+
+    Note what is *not* here: persistence across sessions. The instruction never
+    asked for it, so it belongs in an open question, not in scope. Putting it in
+    scope is exactly the invention `spec_faithfulness` exists to punish.
+    """
+    return VibeSpec(
+        title="Dark mode toggle",
+        goal="The settings page offers a working dark mode toggle.",
+        scope=[
+            "Add a dark mode toggle control to the settings page",
+            "Apply the dark theme when the toggle is on",
+        ],
+        constraints=["Must not change the login screen"],
+        acceptance=[
+            AcceptanceCriterion(
+                statement="Toggling switches the page between light and dark",
+                verification="Open the settings page, click the toggle, observe the theme change.",
+            ),
+            AcceptanceCriterion(
+                statement="No other page changes appearance",
+                verification="Run the visual regression suite and confirm only settings differs.",
+            ),
+        ],
+        risks=["Theme tokens may be hard-coded in some components"],
+        open_questions=[
+            OpenQuestion(
+                question="Should the dark mode choice persist across sessions?",
+                why_it_matters="The instruction does not say, and it changes the storage design.",
+                assumption_used="Keep it in component state for now; no persistence.",
+            )
+        ],
+        source_instruction=INSTRUCTION,
+    )
+
+
+def test_unverifiable_acceptance_criteria_lower_specificity():
+    good = _well_specified()
+    vague = good.model_copy(
+        update={
+            "acceptance": [
+                AcceptanceCriterion(statement="It feels good", verification="Looks fine to the author.")
+            ]
+        }
+    )
+    assert spec_specificity(vague) < spec_specificity(good)
+
+
+def test_a_well_specified_brief_outscores_the_deterministic_baseline():
+    example = SimpleNamespace(instruction=INSTRUCTION)
+    baseline = spec_quality(example, _pred(spec_from_instruction(INSTRUCTION)))
+    good = spec_quality(example, _pred(_well_specified()))
+    assert good > baseline
+
+
+def test_missing_open_questions_is_only_credible_at_high_confidence():
+    spec = spec_from_instruction(INSTRUCTION).model_copy(update={"open_questions": []})
+    assert spec_honesty(spec) < 1.0
+    assert spec_honesty(spec.model_copy(update={"confidence": "HIGH"})) == 1.0
+
+
+def test_blocking_question_still_counts_as_honest():
+    spec = spec_from_instruction(INSTRUCTION).model_copy(
+        update={
+            "open_questions": [
+                OpenQuestion(question="Which theme system?", why_it_matters="Changes the approach.")
+            ]
+        }
+    )
+    assert spec_honesty(spec) == 1.0
+    assert spec.blocking_questions
+
+
+def test_completeness_needs_verification_on_every_criterion():
+    full = spec_from_instruction(INSTRUCTION)
+    assert spec_completeness(full) == 1.0
+    thin = VibeSpec(title="thin", goal="do something")
+    assert spec_completeness(thin) < 0.5
+
+
+def test_spec_quality_is_bounded_and_leaves_headroom_over_the_baseline():
+    spec = spec_from_instruction(INSTRUCTION)
+    score = spec_quality(SimpleNamespace(instruction=INSTRUCTION), _pred(spec))
+    assert 0.0 <= score <= 1.0
+    # The deterministic converter must not score full marks, or the metric
+    # would give an optimizer nothing to improve.
+    assert score < 0.95
+
+
+def test_spec_quality_returns_zero_for_a_missing_spec():
+    assert spec_quality(SimpleNamespace(instruction=INSTRUCTION), SimpleNamespace()) == 0.0
+
+
+def test_agent_validity_penalizes_tools_the_host_does_not_offer():
+    bundle = bundle_from_instruction(INSTRUCTION, available_tools=["Read"])
+    assert agent_validity(bundle.agent, ["Read"]) == 1.0
+    assert agent_validity(bundle.agent, ["Bash"]) < 1.0
+
+
+def test_skill_validity_requires_limits_and_checks():
+    bundle = bundle_from_instruction(INSTRUCTION)
+    assert skill_validity(bundle.skill) == 1.0
+    stripped = bundle.skill.model_copy(update={"limits": [], "checks": []})
+    assert skill_validity(stripped) < skill_validity(bundle.skill)
+
+
+def test_bundle_quality_combines_all_three_artifacts():
+    bundle = bundle_from_instruction(INSTRUCTION)
+    example = SimpleNamespace(instruction=INSTRUCTION, available_tools=None)
+    score = bundle_quality(example, SimpleNamespace(bundle=bundle, spec=bundle.spec))
+    assert 0.0 < score <= 1.0
+    assert bundle_quality(example, SimpleNamespace()) == 0.0

--- a/tests/vibe/test_modules.py
+++ b/tests/vibe/test_modules.py
@@ -1,0 +1,137 @@
+"""Tests for the DSPy-backed pipeline.
+
+These use `DummyLM`, so they exercise the real signature/adapter path without a
+network call: the LM returns fixed field values and DSPy must parse them back
+into the typed artifacts.
+"""
+
+import json
+
+import pytest
+
+import dspy
+from dspy.utils.dummies import DummyLM
+from dspy_vibe.modules import SpecToAgentModule, SpecToSkillModule, VibeCoder, VibeToSpec, lm_available
+from dspy_vibe.types import AgentArtifact, SkillArtifact, VibeSpec
+
+INSTRUCTION = "add a dark mode toggle to the settings page"
+
+
+def _spec_payload(**overrides) -> str:
+    payload = {
+        "title": "Dark mode toggle",
+        "slug": "dark-mode-toggle",
+        "goal": "The settings page offers a dark mode toggle.",
+        "context": "",
+        "scope": ["Add a dark mode toggle to the settings page"],
+        "non_goals": [],
+        "constraints": [],
+        "acceptance": [
+            {
+                "statement": "Toggling switches the theme",
+                "verification": "Open the settings page and click the toggle.",
+            }
+        ],
+        "risks": [],
+        "open_questions": [],
+        "source_instruction": "",
+        "confidence": "MEDIUM",
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def _agent_payload(**overrides) -> str:
+    payload = {
+        "name": "dark-mode-agent",
+        "description": "Adds a dark mode toggle.",
+        "role": "You implement the dark mode toggle brief.",
+        "tools": ["Read", "Edit"],
+        "model": "",
+        "instructions": ["Read the brief", "Implement the toggle"],
+        "guardrails": ["Do not touch the login screen"],
+        "success_criteria": ["Toggling switches the theme"],
+        "source_spec": "",
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def _skill_payload(**overrides) -> str:
+    payload = {
+        "name": "theme-toggle-skill",
+        "description": "Adds a theme toggle to a page.",
+        "triggers": ["dark mode", "theme toggle"],
+        "procedure": ["Locate the page", "Add the control", "Wire the theme"],
+        "inputs": ["Target page"],
+        "outputs": ["The toggle"],
+        "checks": ["Click the toggle and observe the theme"],
+        "limits": ["Does not add persistence"],
+        "source_spec": "",
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+@pytest.fixture
+def no_lm():
+    """Run with DSPy configured but no LM, to exercise the offline fallback."""
+    with dspy.context(lm=None):
+        yield
+
+
+def test_pipeline_falls_back_to_the_deterministic_converter_without_an_lm(no_lm):
+    assert lm_available() is False
+    result = VibeCoder()(instruction=INSTRUCTION)
+    assert result.spec.confidence == "LOW"
+    assert result.bundle.agent.source_spec == result.spec.slug
+
+
+def test_spec_module_parses_a_typed_response_and_keeps_the_source_text():
+    lm = DummyLM([{"reasoning": "…", "spec": _spec_payload()}])
+    with dspy.context(lm=lm):
+        spec = VibeToSpec()(instruction=INSTRUCTION).spec
+    assert isinstance(spec, VibeSpec)
+    assert spec.slug == "dark-mode-toggle"
+    # The module backfills the verbatim instruction so a reviewer can compare.
+    assert spec.source_instruction == INSTRUCTION
+
+
+def test_agent_module_drops_tools_the_host_does_not_offer(caplog):
+    lm = DummyLM([{"agent": _agent_payload(tools=["Read", "Edit", "Deploy"])}])
+    spec = VibeSpec(title="Dark mode toggle", goal="g", scope=["s"])
+    with dspy.context(lm=lm):
+        agent = SpecToAgentModule()(spec=spec, available_tools=["Read", "Edit"]).agent
+    assert isinstance(agent, AgentArtifact)
+    assert agent.tools == ["Read", "Edit"]
+    assert agent.source_spec == spec.slug
+
+
+def test_skill_module_backfills_the_source_spec():
+    lm = DummyLM([{"skill": _skill_payload()}])
+    spec = VibeSpec(title="Dark mode toggle", goal="g", scope=["s"])
+    with dspy.context(lm=lm):
+        skill = SpecToSkillModule()(spec=spec).skill
+    assert isinstance(skill, SkillArtifact)
+    assert skill.source_spec == spec.slug
+
+
+def test_full_pipeline_with_an_lm_returns_all_three_artifacts():
+    lm = DummyLM(
+        [
+            {"reasoning": "…", "spec": _spec_payload()},
+            {"agent": _agent_payload()},
+            {"skill": _skill_payload()},
+        ]
+    )
+    with dspy.context(lm=lm):
+        result = VibeCoder(available_tools=["Read", "Edit"])(instruction=INSTRUCTION)
+    assert result.spec.slug == "dark-mode-toggle"
+    assert result.agent.name == "dark-mode-agent"
+    assert result.skill.name == "theme-toggle-skill"
+    assert result.bundle.spec is result.spec
+
+
+def test_empty_instruction_is_rejected_before_any_lm_call():
+    with pytest.raises(ValueError):
+        VibeToSpec()(instruction="  ")

--- a/tests/vibe/test_offline.py
+++ b/tests/vibe/test_offline.py
@@ -1,0 +1,80 @@
+import pytest
+
+from dspy_vibe import bundle_from_instruction, spec_from_instruction
+from dspy_vibe.offline import agent_from_spec, skill_from_spec
+from dspy_vibe.types import slugify
+
+HU = "Csinálj egy login formot Reactban, legyen szép és gyors, ne kelljen hozzá backend. Tesztelt legyen."
+EN = "build a small CLI that lists open PRs, no auth flows please"
+
+
+def test_negation_moves_only_the_clause_not_the_sentence():
+    spec = spec_from_instruction(HU)
+    assert any("login formot" in item for item in spec.scope)
+    assert spec.non_goals == ["ne kelljen hozzá backend."]
+
+
+def test_english_negation_cue_is_recognized():
+    spec = spec_from_instruction(EN)
+    assert spec.non_goals
+    assert "auth" in " ".join(spec.non_goals)
+
+
+def test_slug_transliterates_accents():
+    assert slugify("Csinálj egy login formot") == "csinalj-egy-login-formot"
+    assert slugify("!!!") == "task"
+
+
+def test_quality_cues_become_constraints():
+    spec = spec_from_instruction(HU)
+    joined = " ".join(spec.constraints)
+    assert "Performance" in joined
+    assert "Visual quality" in joined
+    assert "Tests are expected" in joined
+
+
+def test_stack_detection_lands_in_context():
+    spec = spec_from_instruction(HU)
+    assert "react" in spec.context.lower()
+
+
+def test_offline_spec_is_low_confidence_and_asks_questions():
+    spec = spec_from_instruction(EN)
+    assert spec.confidence == "LOW"
+    assert spec.open_questions
+    assert all(question.why_it_matters for question in spec.open_questions)
+
+
+def test_acceptance_criteria_are_always_verifiable():
+    spec = spec_from_instruction(EN)
+    assert spec.acceptance
+    assert all(criterion.verification.strip() for criterion in spec.acceptance)
+
+
+def test_empty_instruction_is_rejected():
+    with pytest.raises(ValueError):
+        spec_from_instruction("   ")
+
+
+def test_agent_guardrails_carry_non_goals_and_risks():
+    spec = spec_from_instruction(HU)
+    agent = agent_from_spec(spec, ["Read", "Edit"])
+    guardrails = " ".join(agent.guardrails)
+    assert "backend" in guardrails
+    assert agent.tools == ["Edit", "Read"]
+    assert agent.source_spec == spec.slug
+
+
+def test_skill_limits_include_non_goals():
+    spec = spec_from_instruction(HU)
+    skill = skill_from_spec(spec)
+    assert any("backend" in limit for limit in skill.limits)
+    assert skill.triggers
+    assert len(skill.procedure) >= 2
+
+
+def test_bundle_links_all_three_artifacts():
+    bundle = bundle_from_instruction(HU, "repo: monorepo, pnpm", ["Read"])
+    assert bundle.agent.source_spec == bundle.spec.slug
+    assert bundle.skill.source_spec == bundle.spec.slug
+    assert "monorepo" in bundle.spec.context

--- a/vscode/.gitignore
+++ b/vscode/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+*.vsix

--- a/vscode/.vscode/launch.json
+++ b/vscode/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run DSPy Vibe Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "npm: compile"
+    }
+  ]
+}

--- a/vscode/.vscode/tasks.json
+++ b/vscode/.vscode/tasks.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    { "type": "npm", "script": "compile", "problemMatcher": "$tsc", "group": "build" },
+    { "type": "npm", "script": "watch", "problemMatcher": "$tsc-watch", "isBackground": true }
+  ]
+}

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -1,0 +1,7 @@
+.vscode/**
+src/**
+out/test/**
+node_modules/**
+tsconfig.json
+**/*.map
+**/*.ts

--- a/vscode/README.md
+++ b/vscode/README.md
@@ -1,0 +1,70 @@
+# DSPy Vibe — VS Code extension
+
+Turn a vibe-coding instruction into a structured brief, an `.agent`, and a
+`.skill`, without leaving the editor. The extension is a thin client over the
+[`dspy_vibe`](../dspy_vibe/README.md) Python package in this repository: it
+collects the instruction and workspace context, runs the converter, and surfaces
+the result where you are already looking.
+
+## What it does
+
+- **Vibe: Convert selection to brief** — select an instruction (a TODO, a loose
+  paragraph) and get a brief in a side panel.
+- **Vibe: Convert a typed instruction** — type the request into an input box.
+- Open questions become editor **diagnostics**: unanswered ones are warnings,
+  ones with an assumption are hints. This is the point of the tool — the gaps in
+  a vibe instruction show up before you write code against a guess.
+- **Vibe: Generate .agent and .skill from the last brief** — writes the
+  artifacts into your configured directories. Existing files are never
+  overwritten without a confirmation.
+- **Vibe: Check the Python environment** — verifies the interpreter can run the
+  converter, with an actionable message when it cannot.
+
+Stack context is detected from your workspace manifests (`package.json`,
+`pyproject.toml`, `Cargo.toml`, …) and passed to the converter, so the brief
+does not ask "which stack?" when the answer is in the repo.
+
+## Requirements
+
+The converter is Python. Point the extension at an interpreter that has
+`dspy_vibe` installed:
+
+```bash
+pip install -e .          # from the repository root
+```
+
+The extension resolves the interpreter in this order: the `dspyVibe.pythonPath`
+setting, then the interpreter selected by the Microsoft Python extension, then
+`python3`/`python` on `PATH`. Run **Vibe: Check the Python environment** if a
+conversion fails.
+
+Offline by default — with no `dspyVibe.model` set, the converter uses its
+deterministic path and needs no API key. Set a model id (for example
+`openai/gpt-4o-mini`) to use an LM.
+
+## Settings
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `dspyVibe.pythonPath` | (auto) | Interpreter to run the converter. |
+| `dspyVibe.model` | (empty) | LM id; empty runs the offline converter. |
+| `dspyVibe.tools` | `Read, Edit, Bash` | Tools the generated agent may use. |
+| `dspyVibe.agentDirectory` | `.claude/agents` | Where `.agent` files go. |
+| `dspyVibe.skillDirectory` | `.claude/skills` | Where `.skill` files go. |
+| `dspyVibe.specDirectory` | `docs/briefs` | Where brief documents go. |
+| `dspyVibe.autoContext` | `true` | Detect the stack from manifests. |
+| `dspyVibe.timeoutSeconds` | `120` | Converter timeout. |
+
+## Develop
+
+```bash
+npm install
+npm run compile
+npm test          # unit tests; the integration test skips without dspy_vibe on PATH
+```
+
+Press F5 (**Run DSPy Vibe Extension**) to launch an Extension Development Host.
+
+The design keeps `vscode` imports in `extension.ts` only; `runner.ts`,
+`context.ts`, `artifacts.ts`, and `types.ts` are plain TypeScript and carry the
+logic, which is why they can be tested with `node --test` alone.

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,0 +1,417 @@
+{
+  "name": "vscode",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vscode",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@types/node": "^26.2.0",
+        "@types/vscode": "^1.125.0",
+        "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.125.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.125.0.tgz",
+      "integrity": "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -1,0 +1,110 @@
+{
+  "name": "dspy-vibe",
+  "displayName": "DSPy Vibe",
+  "description": "Turn vibe-coding instructions into a structured brief, an .agent, and a .skill.",
+  "version": "0.1.0",
+  "publisher": "pocomotoxx",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Pocomotoxx/promptdspyk"
+  },
+  "engines": {
+    "vscode": "^1.90.0"
+  },
+  "categories": ["AI", "Other"],
+  "keywords": ["dspy", "agent", "skill", "prompt", "vibe coding"],
+  "main": "./out/extension.js",
+  "activationEvents": [],
+  "contributes": {
+    "commands": [
+      {
+        "command": "dspyVibe.convertSelection",
+        "title": "Vibe: Convert selection to brief",
+        "category": "DSPy Vibe"
+      },
+      {
+        "command": "dspyVibe.convertPrompt",
+        "title": "Vibe: Convert a typed instruction",
+        "category": "DSPy Vibe"
+      },
+      {
+        "command": "dspyVibe.writeArtifacts",
+        "title": "Vibe: Generate .agent and .skill from the last brief",
+        "category": "DSPy Vibe"
+      },
+      {
+        "command": "dspyVibe.checkEnvironment",
+        "title": "Vibe: Check the Python environment",
+        "category": "DSPy Vibe"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "dspyVibe.convertSelection",
+          "when": "editorHasSelection",
+          "group": "1_modification@100"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "DSPy Vibe",
+      "properties": {
+        "dspyVibe.pythonPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Python interpreter used to run `dspy_vibe`. Empty means: use the interpreter selected by the Python extension, then fall back to `python3`/`python` on PATH."
+        },
+        "dspyVibe.model": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "LM id passed to `--model`, for example `openai/gpt-4o-mini`. Empty runs the deterministic offline converter, which needs no API key."
+        },
+        "dspyVibe.tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": ["Read", "Edit", "Bash"],
+          "description": "Tool names your agent host offers. Generated agents are restricted to these."
+        },
+        "dspyVibe.agentDirectory": {
+          "type": "string",
+          "default": ".claude/agents",
+          "description": "Workspace-relative directory for generated .agent files."
+        },
+        "dspyVibe.skillDirectory": {
+          "type": "string",
+          "default": ".claude/skills",
+          "description": "Workspace-relative directory for generated .skill files."
+        },
+        "dspyVibe.specDirectory": {
+          "type": "string",
+          "default": "docs/briefs",
+          "description": "Workspace-relative directory for generated brief documents."
+        },
+        "dspyVibe.autoContext": {
+          "type": "boolean",
+          "default": true,
+          "description": "Detect the stack from workspace manifests and pass it as --context."
+        },
+        "dspyVibe.timeoutSeconds": {
+          "type": "number",
+          "default": 120,
+          "description": "How long to wait for the converter before giving up."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "test": "node --test out/test/*.test.js",
+    "pretest": "npm run compile",
+    "vscode:prepublish": "npm run compile"
+  },
+  "devDependencies": {
+    "@types/node": "^24.10.1",
+    "@types/vscode": "^1.90.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/vscode/src/artifacts.ts
+++ b/vscode/src/artifacts.ts
@@ -1,0 +1,80 @@
+/**
+ * Where generated files go, and what happens when one already exists.
+ *
+ * Path planning is pure so it can be tested without a workspace; the actual
+ * writes take a minimal filesystem interface for the same reason.
+ */
+
+import { posix as posixPath } from "node:path";
+
+import type { VibeBundle } from "./types";
+
+export interface ArtifactLayout {
+  agentDirectory: string;
+  skillDirectory: string;
+  specDirectory: string;
+}
+
+export interface PlannedArtifact {
+  kind: "spec" | "agent" | "skill";
+  /** Workspace-relative, POSIX-separated path. */
+  path: string;
+  content: string;
+}
+
+export interface FileSystem {
+  exists(relativePath: string): Promise<boolean>;
+  write(relativePath: string, content: string): Promise<void>;
+}
+
+/** Decide the destination and content of every artifact. */
+export function planArtifacts(bundle: VibeBundle, layout: ArtifactLayout): PlannedArtifact[] {
+  const slug = bundle.spec.slug;
+  return [
+    {
+      kind: "spec",
+      path: posixPath.join(layout.specDirectory, `${slug}.spec.md`),
+      content: bundle.rendered.spec,
+    },
+    {
+      kind: "agent",
+      path: posixPath.join(layout.agentDirectory, `${bundle.agent.name}.agent`),
+      content: bundle.rendered.agent,
+    },
+    {
+      kind: "skill",
+      path: posixPath.join(layout.skillDirectory, `${bundle.skill.name}.skill`),
+      content: bundle.rendered.skill,
+    },
+  ];
+}
+
+export interface WriteOutcome {
+  written: PlannedArtifact[];
+  skipped: PlannedArtifact[];
+}
+
+/**
+ * Write the planned artifacts.
+ *
+ * Existing files are skipped rather than replaced unless `overwrite` is set: a
+ * generated file the user has since edited by hand is worth more than a fresh
+ * generation, and losing it silently would be the worst outcome here.
+ */
+export async function writeArtifacts(
+  planned: PlannedArtifact[],
+  fs: FileSystem,
+  overwrite = false,
+): Promise<WriteOutcome> {
+  const written: PlannedArtifact[] = [];
+  const skipped: PlannedArtifact[] = [];
+  for (const artifact of planned) {
+    if (!overwrite && (await fs.exists(artifact.path))) {
+      skipped.push(artifact);
+      continue;
+    }
+    await fs.write(artifact.path, artifact.content);
+    written.push(artifact);
+  }
+  return { written, skipped };
+}

--- a/vscode/src/context.ts
+++ b/vscode/src/context.ts
@@ -1,0 +1,117 @@
+/**
+ * Workspace stack detection.
+ *
+ * Passed to the converter as `--context`, which does two things: it stops the
+ * brief from asking "which stack?" when the answer is sitting in the manifest,
+ * and it anchors the faithfulness metric, which treats context words as part of
+ * the source.
+ *
+ * Detection reads manifests only — never source files. A wrong guess would
+ * become a stated fact in the brief, and a missing guess merely becomes an
+ * honest open question.
+ */
+
+export interface WorkspaceFiles {
+  /** Returns file contents, or undefined when the file does not exist. */
+  read(relativePath: string): Promise<string | undefined>;
+}
+
+interface Probe {
+  file: string;
+  extract(content: string): string[];
+}
+
+const DEPENDENCY_HINTS: Record<string, string> = {
+  react: "React",
+  next: "Next.js",
+  vue: "Vue",
+  svelte: "Svelte",
+  "@angular/core": "Angular",
+  tailwindcss: "Tailwind",
+  express: "Express",
+  fastify: "Fastify",
+  prisma: "Prisma",
+  vitest: "Vitest",
+  jest: "Jest",
+  playwright: "Playwright",
+  django: "Django",
+  flask: "Flask",
+  fastapi: "FastAPI",
+  sqlalchemy: "SQLAlchemy",
+  pydantic: "pydantic",
+  pytest: "pytest",
+  dspy: "DSPy",
+};
+
+function hintsFrom(names: Iterable<string>): string[] {
+  const found: string[] = [];
+  for (const name of names) {
+    const hint = DEPENDENCY_HINTS[name.toLowerCase()];
+    if (hint && !found.includes(hint)) {
+      found.push(hint);
+    }
+  }
+  return found;
+}
+
+const PROBES: Probe[] = [
+  {
+    file: "package.json",
+    extract(content) {
+      const manifest = JSON.parse(content) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+        packageManager?: string;
+      };
+      const names = [
+        ...Object.keys(manifest.dependencies ?? {}),
+        ...Object.keys(manifest.devDependencies ?? {}),
+      ];
+      const found = ["Node.js", ...hintsFrom(names)];
+      if (manifest.packageManager) {
+        found.push(manifest.packageManager.split("@")[0]);
+      }
+      return found;
+    },
+  },
+  {
+    file: "pyproject.toml",
+    extract(content) {
+      // A tolerant scan, not a TOML parse: a dependency name anywhere in the
+      // file is evidence enough for a context hint.
+      const names = content.match(/[A-Za-z0-9_.-]+/g) ?? [];
+      return ["Python", ...hintsFrom(names)];
+    },
+  },
+  { file: "requirements.txt", extract: (content) => ["Python", ...hintsFrom(content.match(/[A-Za-z0-9_.-]+/g) ?? [])] },
+  { file: "Cargo.toml", extract: () => ["Rust"] },
+  { file: "go.mod", extract: () => ["Go"] },
+  { file: "pom.xml", extract: () => ["Java", "Maven"] },
+  { file: "Gemfile", extract: () => ["Ruby"] },
+  { file: "tsconfig.json", extract: () => ["TypeScript"] },
+  { file: "Dockerfile", extract: () => ["Docker"] },
+];
+
+/** Build a one-line `--context` string from workspace manifests. */
+export async function detectContext(files: WorkspaceFiles): Promise<string> {
+  const found: string[] = [];
+  for (const probe of PROBES) {
+    const content = await files.read(probe.file);
+    if (content === undefined) {
+      continue;
+    }
+    let hints: string[];
+    try {
+      hints = probe.extract(content);
+    } catch {
+      // A malformed manifest is not worth failing a conversion over.
+      continue;
+    }
+    for (const hint of hints) {
+      if (hint && !found.includes(hint)) {
+        found.push(hint);
+      }
+    }
+  }
+  return found.length > 0 ? `Stack detected in the workspace: ${found.join(", ")}` : "";
+}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,0 +1,281 @@
+/**
+ * VS Code entry point.
+ *
+ * The only file that imports `vscode`. Everything it needs from the workspace
+ * is adapted here and handed to the plain-TypeScript modules, which keeps the
+ * logic testable without an editor host.
+ */
+
+import * as vscode from "vscode";
+
+import { planArtifacts, writeArtifacts, type FileSystem } from "./artifacts";
+import { detectContext, type WorkspaceFiles } from "./context";
+import { ConverterError, runConverter } from "./runner";
+import { blockingQuestions, type VibeBundle } from "./types";
+
+const DIAGNOSTIC_SOURCE = "DSPy Vibe";
+
+let lastBundle: VibeBundle | undefined;
+let diagnostics: vscode.DiagnosticCollection;
+let output: vscode.OutputChannel;
+
+function config() {
+  return vscode.workspace.getConfiguration("dspyVibe");
+}
+
+function workspaceRoot(): vscode.Uri | undefined {
+  return vscode.workspace.workspaceFolders?.[0]?.uri;
+}
+
+/**
+ * Resolve the interpreter: explicit setting first, then whatever the Python
+ * extension has selected, then PATH. Borrowing the Python extension's choice
+ * matters — a user who selected a venv expects that venv, not a system Python
+ * where dspy_vibe is not installed.
+ */
+async function resolvePython(): Promise<string> {
+  const configured = config().get<string>("pythonPath")?.trim();
+  if (configured) {
+    return configured;
+  }
+  const pythonExtension = vscode.extensions.getExtension("ms-python.python");
+  if (pythonExtension) {
+    try {
+      const api = pythonExtension.isActive ? pythonExtension.exports : await pythonExtension.activate();
+      const resource = workspaceRoot();
+      const details = await api?.environments?.resolveEnvironment?.(
+        api.environments.getActiveEnvironmentPath(resource),
+      );
+      const executable = details?.executable?.uri?.fsPath ?? details?.path;
+      if (executable) {
+        return executable;
+      }
+    } catch {
+      // The Python extension's API is optional; fall through to PATH.
+    }
+  }
+  return process.platform === "win32" ? "python" : "python3";
+}
+
+function workspaceFiles(root: vscode.Uri): WorkspaceFiles {
+  return {
+    async read(relativePath) {
+      try {
+        const bytes = await vscode.workspace.fs.readFile(vscode.Uri.joinPath(root, relativePath));
+        return Buffer.from(bytes).toString("utf-8");
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
+function workspaceFileSystem(root: vscode.Uri): FileSystem {
+  return {
+    async exists(relativePath) {
+      try {
+        await vscode.workspace.fs.stat(vscode.Uri.joinPath(root, relativePath));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async write(relativePath, content) {
+      const target = vscode.Uri.joinPath(root, relativePath);
+      await vscode.workspace.fs.createDirectory(vscode.Uri.joinPath(target, ".."));
+      await vscode.workspace.fs.writeFile(target, Buffer.from(content, "utf-8"));
+    },
+  };
+}
+
+/**
+ * Surface open questions where the user is already looking.
+ *
+ * Blocking questions are warnings; answered ones are hints. This is the part
+ * that earns the extension: the gaps in a vibe instruction become visible in
+ * the editor before any code gets written against a guess.
+ */
+function publishQuestions(bundle: VibeBundle, document: vscode.TextDocument, range: vscode.Range): void {
+  const items = (bundle.spec.open_questions ?? []).map((question) => {
+    const blocking = !question.assumption_used?.trim();
+    const message = blocking
+      ? `Unanswered: ${question.question} — ${question.why_it_matters}`
+      : `Assumption: ${question.question} → ${question.assumption_used}`;
+    const diagnostic = new vscode.Diagnostic(
+      range,
+      message,
+      blocking ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Hint,
+    );
+    diagnostic.source = DIAGNOSTIC_SOURCE;
+    return diagnostic;
+  });
+  diagnostics.set(document.uri, items);
+}
+
+async function convert(instruction: string, document?: vscode.TextDocument, range?: vscode.Range): Promise<void> {
+  if (!instruction.trim()) {
+    vscode.window.showWarningMessage("DSPy Vibe: nothing to convert.");
+    return;
+  }
+  const root = workspaceRoot();
+  const settings = config();
+  const model = settings.get<string>("model")?.trim() ?? "";
+
+  const context =
+    settings.get<boolean>("autoContext") && root ? await detectContext(workspaceFiles(root)) : "";
+
+  const bundle = await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: model ? `DSPy Vibe: converting with ${model}…` : "DSPy Vibe: converting (offline)…",
+      cancellable: false,
+    },
+    async () =>
+      runConverter({
+        pythonPath: await resolvePython(),
+        instruction,
+        context,
+        tools: settings.get<string[]>("tools") ?? [],
+        model,
+        cwd: root?.fsPath,
+        timeoutSeconds: settings.get<number>("timeoutSeconds") ?? 120,
+      }),
+  );
+
+  lastBundle = bundle;
+
+  const preview = await vscode.workspace.openTextDocument({
+    content: bundle.rendered.spec,
+    language: "markdown",
+  });
+  await vscode.window.showTextDocument(preview, { preview: true, viewColumn: vscode.ViewColumn.Beside });
+
+  if (document && range) {
+    publishQuestions(bundle, document, range);
+  }
+
+  const blocking = blockingQuestions(bundle.spec);
+  const summary = `DSPy Vibe: brief ready (confidence ${bundle.spec.confidence}).`;
+  const action = await vscode.window.showInformationMessage(
+    blocking.length > 0 ? `${summary} ${blocking.length} question(s) need an answer first.` : summary,
+    "Generate .agent and .skill",
+  );
+  if (action) {
+    await vscode.commands.executeCommand("dspyVibe.writeArtifacts");
+  }
+}
+
+async function writeLastBundle(): Promise<void> {
+  if (!lastBundle) {
+    vscode.window.showWarningMessage("DSPy Vibe: convert an instruction first.");
+    return;
+  }
+  const root = workspaceRoot();
+  if (!root) {
+    vscode.window.showWarningMessage("DSPy Vibe: open a folder to write artifacts into.");
+    return;
+  }
+  const settings = config();
+  const planned = planArtifacts(lastBundle, {
+    agentDirectory: settings.get<string>("agentDirectory") ?? ".claude/agents",
+    skillDirectory: settings.get<string>("skillDirectory") ?? ".claude/skills",
+    specDirectory: settings.get<string>("specDirectory") ?? "docs/briefs",
+  });
+
+  let outcome = await writeArtifacts(planned, workspaceFileSystem(root), false);
+  if (outcome.skipped.length > 0) {
+    const choice = await vscode.window.showWarningMessage(
+      `DSPy Vibe: ${outcome.skipped.length} file(s) already exist. Overwrite?`,
+      { modal: true, detail: outcome.skipped.map((item) => item.path).join("\n") },
+      "Overwrite",
+    );
+    if (choice === "Overwrite") {
+      outcome = await writeArtifacts(outcome.skipped, workspaceFileSystem(root), true);
+    }
+  }
+
+  for (const artifact of outcome.written) {
+    output.appendLine(`wrote ${artifact.path}`);
+  }
+  if (outcome.written.length > 0) {
+    vscode.window.showInformationMessage(
+      `DSPy Vibe: wrote ${outcome.written.map((item) => item.path).join(", ")}`,
+    );
+  }
+}
+
+async function checkEnvironment(): Promise<void> {
+  const python = await resolvePython();
+  output.show(true);
+  output.appendLine(`interpreter: ${python}`);
+  try {
+    const bundle = await runConverter({ pythonPath: python, instruction: "smoke test", timeoutSeconds: 60 });
+    output.appendLine(`dspy_vibe responded; sample slug: ${bundle.spec.slug}`);
+    vscode.window.showInformationMessage("DSPy Vibe: the environment works.");
+  } catch (error) {
+    reportError(error);
+  }
+}
+
+function reportError(error: unknown): void {
+  if (error instanceof ConverterError) {
+    output.appendLine(`${error.message}\n${error.detail}`);
+    output.show(true);
+    vscode.window.showErrorMessage(`DSPy Vibe: ${error.message}`, "Show details").then((choice) => {
+      if (choice) {
+        output.show(true);
+      }
+    });
+    return;
+  }
+  output.appendLine(String(error));
+  vscode.window.showErrorMessage(`DSPy Vibe: ${String(error)}`);
+}
+
+function guarded(handler: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    try {
+      await handler();
+    } catch (error) {
+      reportError(error);
+    }
+  };
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  output = vscode.window.createOutputChannel("DSPy Vibe");
+  diagnostics = vscode.languages.createDiagnosticCollection("dspyVibe");
+  context.subscriptions.push(output, diagnostics);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "dspyVibe.convertSelection",
+      guarded(async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || editor.selection.isEmpty) {
+          vscode.window.showWarningMessage("DSPy Vibe: select the instruction text first.");
+          return;
+        }
+        await convert(editor.document.getText(editor.selection), editor.document, editor.selection);
+      }),
+    ),
+    vscode.commands.registerCommand(
+      "dspyVibe.convertPrompt",
+      guarded(async () => {
+        const instruction = await vscode.window.showInputBox({
+          prompt: "What do you want built?",
+          placeHolder: "csinálj egy sötét témát a dashboardra, ne nyúlj a loginhoz",
+        });
+        if (instruction !== undefined) {
+          await convert(instruction);
+        }
+      }),
+    ),
+    vscode.commands.registerCommand("dspyVibe.writeArtifacts", guarded(writeLastBundle)),
+    vscode.commands.registerCommand("dspyVibe.checkEnvironment", guarded(checkEnvironment)),
+  );
+}
+
+export function deactivate(): void {
+  lastBundle = undefined;
+}

--- a/vscode/src/runner.ts
+++ b/vscode/src/runner.ts
@@ -1,0 +1,123 @@
+/**
+ * Runs the Python converter.
+ *
+ * Deliberately free of `vscode` imports so the argument building and output
+ * handling can be unit tested with plain `node --test`.
+ */
+
+import { spawn } from "node:child_process";
+
+import { BundleParseError, parseBundle, type VibeBundle } from "./types";
+
+export interface RunOptions {
+  pythonPath: string;
+  instruction: string;
+  context?: string;
+  tools?: string[];
+  model?: string;
+  cwd?: string;
+  timeoutSeconds?: number;
+}
+
+export class ConverterError extends Error {
+  constructor(
+    message: string,
+    readonly detail = "",
+  ) {
+    super(message);
+  }
+}
+
+/** Build the argv for `python -m dspy_vibe convert --stdout`. */
+export function buildArgs(options: RunOptions): string[] {
+  const args = ["-m", "dspy_vibe", "convert", options.instruction, "--stdout"];
+  if (options.context?.trim()) {
+    args.push("--context", options.context.trim());
+  }
+  const tools = (options.tools ?? []).map((tool) => tool.trim()).filter(Boolean);
+  if (tools.length > 0) {
+    args.push("--tools", tools.join(","));
+  }
+  if (options.model?.trim()) {
+    args.push("--model", options.model.trim());
+  }
+  return args;
+}
+
+export interface ProcessResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/** Interpret a finished process. Separated from spawning so it can be tested. */
+export function interpretResult(result: ProcessResult): VibeBundle {
+  if (result.timedOut) {
+    throw new ConverterError("The converter timed out.", result.stderr);
+  }
+  if (result.code !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim();
+    if (/No module named ['"]?dspy_vibe/.test(detail)) {
+      throw new ConverterError(
+        "dspy_vibe is not installed in the selected interpreter. Run: pip install -e .",
+        detail,
+      );
+    }
+    throw new ConverterError(`The converter exited with code ${result.code}.`, detail);
+  }
+  try {
+    return parseBundle(result.stdout);
+  } catch (error) {
+    if (error instanceof BundleParseError) {
+      throw new ConverterError(error.message, result.stderr);
+    }
+    throw error;
+  }
+}
+
+/** Spawn the converter and return the parsed bundle. */
+export function runConverter(options: RunOptions): Promise<VibeBundle> {
+  const timeoutMs = Math.max(1, options.timeoutSeconds ?? 120) * 1000;
+
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = spawn(options.pythonPath, buildArgs(options), {
+        cwd: options.cwd,
+        // The converter prints UTF-8; Windows consoles otherwise mangle
+        // accented characters, which is most of the Hungarian test corpus.
+        env: { ...process.env, PYTHONIOENCODING: "utf-8", PYTHONUTF8: "1" },
+      });
+    } catch (error) {
+      reject(new ConverterError(`Could not start ${options.pythonPath}`, String(error)));
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk) => (stdout += chunk.toString("utf-8")));
+    child.stderr.on("data", (chunk) => (stderr += chunk.toString("utf-8")));
+
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(new ConverterError(`Could not run ${options.pythonPath}`, error.message));
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      try {
+        resolve(interpretResult({ code, stdout, stderr, timedOut }));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+}

--- a/vscode/src/test/logic.test.ts
+++ b/vscode/src/test/logic.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for everything that does not need an editor host.
+ *
+ * Run with `npm test`. The one integration test shells out to the real Python
+ * converter and skips itself when the interpreter is unavailable, so the suite
+ * still passes on a machine without the package installed.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import test from "node:test";
+
+import { planArtifacts, writeArtifacts, type FileSystem, type PlannedArtifact } from "../artifacts";
+import { detectContext, type WorkspaceFiles } from "../context";
+import { buildArgs, ConverterError, interpretResult, runConverter } from "../runner";
+import { blockingQuestions, BundleParseError, parseBundle, type VibeBundle } from "../types";
+
+function bundleFixture(): VibeBundle {
+  return {
+    spec: {
+      title: "Dark mode",
+      slug: "dark-mode",
+      goal: "The dashboard has a dark theme.",
+      context: "",
+      scope: ["Add a dark theme to the dashboard"],
+      non_goals: ["do not touch the login screen"],
+      constraints: [],
+      acceptance: [{ statement: "Theme switches", verification: "Open the dashboard and toggle." }],
+      risks: [],
+      open_questions: [
+        { question: "Which palette?", why_it_matters: "Defines the tokens.", assumption_used: "" },
+        { question: "Persist it?", why_it_matters: "Storage design.", assumption_used: "Component state." },
+      ],
+      source_instruction: "dark mode for the dashboard",
+      confidence: "LOW",
+    },
+    agent: {
+      name: "dark-mode-agent",
+      description: "Adds a dark theme.",
+      role: "You implement the brief.",
+      tools: ["Read"],
+      model: "",
+      instructions: ["Implement"],
+      guardrails: ["Out of scope: login screen"],
+      success_criteria: ["Theme switches"],
+      source_spec: "dark-mode",
+    },
+    skill: {
+      name: "theme-skill",
+      description: "Adds a theme.",
+      triggers: ["dark mode"],
+      procedure: ["Locate", "Implement"],
+      inputs: ["Target page"],
+      outputs: ["The theme"],
+      checks: ["Toggle it"],
+      limits: ["No persistence"],
+      source_spec: "dark-mode",
+    },
+    rendered: { spec: "# spec", agent: "# agent", skill: "# skill" },
+  };
+}
+
+test("buildArgs passes only the options that were set", () => {
+  assert.deepEqual(buildArgs({ pythonPath: "python", instruction: "do it" }), [
+    "-m",
+    "dspy_vibe",
+    "convert",
+    "do it",
+    "--stdout",
+  ]);
+  const full = buildArgs({
+    pythonPath: "python",
+    instruction: "do it",
+    context: " Next.js ",
+    tools: ["Read", " ", "Edit"],
+    model: "openai/gpt-4o-mini",
+  });
+  assert.deepEqual(full.slice(5), ["--context", "Next.js", "--tools", "Read,Edit", "--model", "openai/gpt-4o-mini"]);
+});
+
+test("a missing package produces an actionable message", () => {
+  assert.throws(
+    () =>
+      interpretResult({
+        code: 1,
+        stdout: "",
+        stderr: "ModuleNotFoundError: No module named 'dspy_vibe'",
+        timedOut: false,
+      }),
+    (error: ConverterError) => /pip install -e \./.test(error.message),
+  );
+});
+
+test("a timeout is reported as a timeout, not as an exit code", () => {
+  assert.throws(
+    () => interpretResult({ code: null, stdout: "", stderr: "", timedOut: true }),
+    /timed out/,
+  );
+});
+
+test("non-JSON output is quoted back instead of throwing a parse error", () => {
+  assert.throws(
+    () => parseBundle("Traceback (most recent call last):\n  File ...\nRuntimeError: boom"),
+    (error: BundleParseError) => /RuntimeError: boom/.test(error.message),
+  );
+});
+
+test("a payload missing a section is rejected", () => {
+  assert.throws(() => parseBundle(JSON.stringify({ spec: {}, agent: {}, skill: {} })), /missing "rendered"/);
+});
+
+test("blockingQuestions returns only the ones with no assumption", () => {
+  const blocking = blockingQuestions(bundleFixture().spec);
+  assert.equal(blocking.length, 1);
+  assert.equal(blocking[0].question, "Which palette?");
+});
+
+test("artifacts are planned into their configured directories", () => {
+  const planned = planArtifacts(bundleFixture(), {
+    agentDirectory: ".claude/agents",
+    skillDirectory: ".claude/skills",
+    specDirectory: "docs/briefs",
+  });
+  assert.deepEqual(
+    planned.map((item) => item.path),
+    ["docs/briefs/dark-mode.spec.md", ".claude/agents/dark-mode-agent.agent", ".claude/skills/theme-skill.skill"],
+  );
+});
+
+function memoryFs(existing: string[] = []): FileSystem & { written: Map<string, string> } {
+  const written = new Map<string, string>();
+  return {
+    written,
+    async exists(path) {
+      return existing.includes(path) || written.has(path);
+    },
+    async write(path, content) {
+      written.set(path, content);
+    },
+  };
+}
+
+test("existing files are skipped rather than clobbered", async () => {
+  const planned = planArtifacts(bundleFixture(), {
+    agentDirectory: "agents",
+    skillDirectory: "skills",
+    specDirectory: "briefs",
+  });
+  const fs = memoryFs(["agents/dark-mode-agent.agent"]);
+  const outcome = await writeArtifacts(planned, fs);
+  assert.equal(outcome.written.length, 2);
+  assert.deepEqual(
+    outcome.skipped.map((item: PlannedArtifact) => item.path),
+    ["agents/dark-mode-agent.agent"],
+  );
+});
+
+test("overwrite writes the skipped files", async () => {
+  const planned = planArtifacts(bundleFixture(), {
+    agentDirectory: "agents",
+    skillDirectory: "skills",
+    specDirectory: "briefs",
+  });
+  const fs = memoryFs(["agents/dark-mode-agent.agent"]);
+  const first = await writeArtifacts(planned, fs);
+  const second = await writeArtifacts(first.skipped, fs, true);
+  assert.equal(second.written.length, 1);
+  assert.equal(fs.written.get("agents/dark-mode-agent.agent"), "# agent");
+});
+
+function fakeWorkspace(files: Record<string, string>): WorkspaceFiles {
+  return { async read(path) { return files[path]; } };
+}
+
+test("context detection reads manifests", async () => {
+  const context = await detectContext(
+    fakeWorkspace({
+      "package.json": JSON.stringify({
+        dependencies: { react: "^18", tailwindcss: "^3" },
+        packageManager: "pnpm@9.0.0",
+      }),
+      "tsconfig.json": "{}",
+    }),
+  );
+  assert.match(context, /React/);
+  assert.match(context, /Tailwind/);
+  assert.match(context, /pnpm/);
+  assert.match(context, /TypeScript/);
+});
+
+test("a malformed manifest does not break detection", async () => {
+  const context = await detectContext(fakeWorkspace({ "package.json": "{not json", "go.mod": "module x" }));
+  assert.equal(context, "Stack detected in the workspace: Go");
+});
+
+test("an empty workspace yields no context, not a guess", async () => {
+  assert.equal(await detectContext(fakeWorkspace({})), "");
+});
+
+function pythonAvailable(): string | undefined {
+  for (const candidate of ["python", "python3"]) {
+    try {
+      execFileSync(candidate, ["-c", "import dspy_vibe"], { stdio: "ignore" });
+      return candidate;
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+test("integration: the real converter returns a usable bundle", async (t) => {
+  const python = pythonAvailable();
+  if (!python) {
+    t.skip("dspy_vibe is not importable from any python on PATH");
+    return;
+  }
+  const bundle = await runConverter({
+    pythonPath: python,
+    instruction: "add a dark mode toggle to the dashboard, don't touch the login screen",
+    tools: ["Read", "Edit"],
+    timeoutSeconds: 60,
+  });
+  assert.ok(bundle.spec.slug.length > 0);
+  assert.ok(bundle.rendered.agent.startsWith("---"));
+  assert.deepEqual(bundle.agent.tools, ["Edit", "Read"]);
+  assert.ok(bundle.spec.non_goals.some((item) => /login/.test(item)));
+});

--- a/vscode/src/types.ts
+++ b/vscode/src/types.ts
@@ -1,0 +1,104 @@
+/**
+ * Mirrors of the pydantic models in `dspy_vibe/types.py`.
+ *
+ * The Python side is the authority: it validates before anything is printed,
+ * so this side parses rather than re-validates. `parseBundle` still checks the
+ * shape, because a broken interpreter or a stray print statement upstream
+ * should surface as a clear message, not a runtime crash three calls later.
+ */
+
+export interface AcceptanceCriterion {
+  statement: string;
+  verification: string;
+}
+
+export interface OpenQuestion {
+  question: string;
+  why_it_matters: string;
+  assumption_used: string;
+}
+
+export interface VibeSpec {
+  title: string;
+  slug: string;
+  goal: string;
+  context: string;
+  scope: string[];
+  non_goals: string[];
+  constraints: string[];
+  acceptance: AcceptanceCriterion[];
+  risks: string[];
+  open_questions: OpenQuestion[];
+  source_instruction: string;
+  confidence: "HIGH" | "MEDIUM" | "LOW";
+}
+
+export interface AgentArtifact {
+  name: string;
+  description: string;
+  role: string;
+  tools: string[];
+  model: string;
+  instructions: string[];
+  guardrails: string[];
+  success_criteria: string[];
+  source_spec: string;
+}
+
+export interface SkillArtifact {
+  name: string;
+  description: string;
+  triggers: string[];
+  procedure: string[];
+  inputs: string[];
+  outputs: string[];
+  checks: string[];
+  limits: string[];
+  source_spec: string;
+}
+
+export interface RenderedBundle {
+  spec: string;
+  agent: string;
+  skill: string;
+}
+
+export interface VibeBundle {
+  spec: VibeSpec;
+  agent: AgentArtifact;
+  skill: SkillArtifact;
+  rendered: RenderedBundle;
+}
+
+export class BundleParseError extends Error {}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Parse the JSON printed by `dspy_vibe convert --stdout`. */
+export function parseBundle(stdout: string): VibeBundle {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(stdout);
+  } catch {
+    // A non-JSON stdout almost always means the interpreter printed something
+    // of its own — a warning, a traceback — so show the head of it verbatim.
+    const head = stdout.trim().split("\n").slice(0, 5).join("\n");
+    throw new BundleParseError(`converter did not return JSON:\n${head || "(no output)"}`);
+  }
+  if (!isRecord(payload)) {
+    throw new BundleParseError("converter returned a non-object payload");
+  }
+  for (const key of ["spec", "agent", "skill", "rendered"]) {
+    if (!isRecord(payload[key])) {
+      throw new BundleParseError(`converter payload is missing "${key}"`);
+    }
+  }
+  return payload as unknown as VibeBundle;
+}
+
+/** Questions with no assumption applied: work should not start until answered. */
+export function blockingQuestions(spec: VibeSpec): OpenQuestion[] {
+  return (spec.open_questions ?? []).filter((question) => !question.assumption_used?.trim());
+}

--- a/vscode/tsconfig.json
+++ b/vscode/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node", "vscode"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "out"]
+}


### PR DESCRIPTION
A vibe instruction is underspecified on purpose. Handing it straight to a coding agent means the agent silently invents the missing half. This package puts a structured brief in between, so the gaps show up as open questions with the assumption applied, before any code is written.

Pipeline: instruction -> VibeSpec (goal, scope, non-goals, constraints, acceptance criteria with verification, risks, open questions) -> .agent (who does the work, with guardrails carrying the non-goals) and .skill (the reusable method, with triggers, checks, and limits).

- dspy_vibe/signatures.py, modules.py: typed DSPy signatures and a VibeCoder module that any DSPy optimizer can compile.
- dspy_vibe/offline.py: deterministic, LM-free conversion. It keeps the CLI usable with no API key, makes tests hermetic, and serves as the baseline an optimizer must beat. Every offline spec is LOW confidence and says why.
- dspy_vibe/emitters.py: markdown (YAML frontmatter, what agent hosts read) and json emitters over the same validated model. Existing files are never overwritten unless asked.
- dspy_vibe/metrics.py: mechanical metrics, no LM judge. Faithfulness is a multiplier rather than a term, because verbatim copying scores perfectly on it and would otherwise reward the laziest possible brief.
- dspy_vibe/cli.py: `python -m dspy_vibe convert|check`, plus a `dspy-vibe` console script.
- dspy_vibe/examples/optimize.py: MIPROv2 run that reports baseline, uncompiled, and compiled scores, and refuses to call a non-improvement an improvement.

45 tests under tests/vibe, including DummyLM tests that exercise the real signature and adapter path without a network call. ruff clean.