### PR TITLE
docs: prototype hosted PR previews and visual diffs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: docs/mkdocs.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
## Prototype

This is a deliberately small spike for hosted documentation review. The repository change is **one 13-line configuration file**; Read the Docs' GitHub App supplies the build, temporary URL, status check, PR comment, retention, and rendered-page diff.

Once connected, a docs PR gets:

- a hosted MkDocs preview, rebuilt on every push;
- a check linking to the preview/build log;
- one PR comment listing rendered pages that changed;
- an interactive visual diff on those pages (toggle with `d`);
- automatic expiry 90 days after the PR closes or merges.

![Read the Docs build overview comment](https://docs.readthedocs.com/platform/latest/_images/build-overview-comment.png)

![Read the Docs visual diff UI](https://docs.readthedocs.com/platform/latest/_images/screenshot-viz-diff-ui.png)

## Why this option

I compared the common OSS approaches:

| Approach | Repo code | Fork PRs | Preview | Visual review | Main drawback |
| --- | ---: | --- | --- | --- | --- |
| **Read the Docs App (this PR)** | **13 lines** | App-managed, no repo secret | Yes | Changed-page comment + rendered HTML diff | Adds a second docs host for previews |
| Point existing Vercel project at this repo (`docs/` root) | 0 lines | App-managed | Yes | Preview comments, but no automatic visual diff | Requires changing the existing Vercel project/repo binding |
| Netlify Git integration | 0–5 lines | App-managed | Yes | Reviewers can capture/annotate screenshots in its preview drawer and sync them to GitHub | New hosting provider; screenshots are reviewer-created, not automatic |
| GitHub Pages + `rossjrw/pr-preview-action` | ~30 workflow lines | Not safely by default | Yes | No | Branch writes, comment permissions, cleanup |
| Playwright + Argos/Percy | 25–60+ lines | OIDC/App-dependent | Visual report, not primarily docs hosting | True pixel screenshots/diffs | Browser tests, baselines, and another service |
| Custom Playwright screenshots in comments | 60–100+ lines | Needs privileged publish stage | Depends on separate host | Literal screenshots | We would own capture, image hosting, comments, and cleanup |

This chooses rendered HTML diffs rather than literal screenshot attachments: they show exactly what changed, remain navigable/responsive, and eliminate browser/image-hosting machinery. If literal screenshots are still important after trying this UX, Argos is the smallest sensible second component; custom screenshot automation is not worth maintaining.

Examples surveyed include Django (Read the Docs), kubernetes/website (Netlify), Primer React (Pages + Playwright), Storybook (Chromatic), Cloudflare Workers SDK (Cloudflare previews), and Argos itself.

## One-time setup (not expressible as code)

A DSPy/Read the Docs admin would need to:

1. Import `stanfordnlp/dspy` through the Read the Docs GitHub App.
2. Enable **Settings → Pull request builds → Build pull requests**.
3. Enable **Show build overview in a comment**.
4. Enable **Addons → Visual diff** (and optionally the PR-preview warning banner).

The project is public, so previews should remain public. Do **not** make untrusted fork previews private: Read the Docs documents a session/API exposure risk for that configuration.

No GitHub Actions write token or deployment secret is added. The existing Vercel production path and docs build check remain unchanged during this experiment.

## Validation

- `check-jsonschema --schemafile <Read-the-Docs-v2-schema> .readthedocs.yaml`
- `mkdocs build --config-file docs/mkdocs.yml`
- `git diff --check`

All passed locally. The MkDocs build retains existing documentation warnings.

## References

- [Pull request previews](https://docs.readthedocs.com/platform/latest/pull-requests.html)
- [Visual diff](https://docs.readthedocs.com/platform/latest/visual-diff.html)
- [Configuration v2](https://docs.readthedocs.com/platform/latest/config-file/v2.html)