### PR TITLE
chore: configure Amp orb lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+for executable in uv deno .venv/bin/python; do
+    if ! command -v "$executable" >/dev/null 2>&1; then
+        printf 'Missing required executable after orb resume: %s\n' "$executable" >&2
+        printf 'Re-run .agents/setup to repair the development environment.\n' >&2
+        exit 1
+    fi
+done
+
+printf 'DSPy development environment is ready.\n'

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+UV_VERSION="0.11.2"
+DENO_VERSION="2.7.7"
+
+run_step() {
+    local label="$1"
+    shift
+    local started_at=$SECONDS
+
+    printf '\n==> %s\n' "$label"
+    "$@"
+    printf '<== %s (%ss)\n' "$label" "$((SECONDS - started_at))"
+}
+
+install_system_packages() {
+    local packages=()
+
+    command -v curl >/dev/null 2>&1 || packages+=(ca-certificates curl)
+    command -v unzip >/dev/null 2>&1 || packages+=(unzip)
+    ((${#packages[@]} == 0)) && return
+
+    if ((EUID == 0)); then
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
+    else
+        sudo apt-get update
+        sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "${packages[@]}"
+    fi
+}
+
+install_uv() {
+    mkdir -p "$HOME/.local/bin"
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if command -v uv >/dev/null 2>&1 && [[ "$(uv --version)" == "uv $UV_VERSION"* ]]; then
+        return
+    fi
+
+    curl -LsSf "https://astral.sh/uv/$UV_VERSION/install.sh" |
+        env UV_INSTALL_DIR="$HOME/.local/bin" UV_NO_MODIFY_PATH=1 sh
+}
+
+install_deno() {
+    mkdir -p "$HOME/.local/bin"
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if ! command -v deno >/dev/null 2>&1 || [[ "$(deno --version | sed -n '1p')" != "deno $DENO_VERSION"* ]]; then
+        curl -fsSL https://deno.land/install.sh |
+            env DENO_INSTALL="$HOME/.deno" sh -s "v$DENO_VERSION"
+    fi
+
+    if [[ -x "$HOME/.deno/bin/deno" ]]; then
+        ln -sfn "$HOME/.deno/bin/deno" "$HOME/.local/bin/deno"
+    fi
+}
+
+sync_dependencies() {
+    uv sync --frozen --python 3.11 --extra dev
+}
+
+run_step "Check system packages" install_system_packages
+run_step "Install uv $UV_VERSION" install_uv
+run_step "Install Deno $DENO_VERSION" install_deno
+run_step "Sync Python development dependencies" sync_dependencies
+
+printf '\nDSPy orb setup complete. Use `uv run <command>` inside the repository.\n'

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -71,6 +71,7 @@ jobs:
           # Install the locally built wheel and testing dependencies
           pip install dist/*.whl pytest pytest-asyncio
           pytest tests/metadata/test_metadata.py tests/predict
+          (cd "$RUNNER_TEMP" && python -c 'import dspy; assert dspy.PythonInterpreter().execute("6 * 7") == 42')
           deactivate
       # Publish to test-PyPI
       - name: Publish distribution 📦 to test-PyPI
@@ -130,6 +131,7 @@ jobs:
           # Install the locally built wheel and testing dependencies
           pip install dist/*.whl pytest pytest-asyncio
           pytest tests/metadata/test_metadata.py tests/predict
+          (cd "$RUNNER_TEMP" && python -c 'import dspy; assert dspy.PythonInterpreter().execute("6 * 7") == 42')
           deactivate
           rm -r test_before_pypi
       - name: Publish distribution 📦 to PyPI (dspy)

--- a/.github/workflows/dependency-range.yml
+++ b/.github/workflows/dependency-range.yml
@@ -41,11 +41,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-        with:
-          deno-version: v2.7.7
-
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -62,6 +57,7 @@ jobs:
           RESOLUTION: ${{ matrix.resolution }}
         run: |
           uv pip compile pyproject.toml \
+            --extra deno \
             --extra dev \
             --extra test_extras \
             --resolution "$RESOLUTION" \
@@ -82,6 +78,8 @@ jobs:
 
           uv pip check --python .venv/bin/python
           uv pip list --python .venv/bin/python
+          uv run --frozen --no-sync --python .venv/bin/python python -c \
+            'import deno, subprocess; subprocess.run([deno.find_deno_bin(), "--version"], check=True)'
 
       - name: Run non-live tests
         env:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -82,12 +82,6 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-        with:
-          deno-version: v2.7.7
-      - name: Verify Deno installation
-        run: deno --version
       - name: Install uv with caching
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -121,12 +115,6 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Deno
-        uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2.0.4
-        with:
-          deno-version: v2.7.7
-      - name: Verify Deno installation
-        run: deno --version
       - name: Install uv with caching
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
@@ -139,7 +127,9 @@ jobs:
           uv venv .venv
           echo "$GITHUB_WORKSPACE/.venv/bin" >> "$GITHUB_PATH"
       - name: Install dependencies
-        run: uv sync -p .venv --extra dev --extra test_extras
+        run: |
+          uv sync -p .venv --extra deno --extra dev --extra test_extras
+          uv run -p .venv python -c 'import deno, subprocess; subprocess.run([deno.find_deno_bin(), "--version"], check=True)'
       - name: Run extra and deno tests
         run: uv run -p .venv pytest tests/ -m 'extra or deno' --extra --deno -n auto --dist worksteal
 

--- a/docs/docs/api/modules/RLM.md
+++ b/docs/docs/api/modules/RLM.md
@@ -36,15 +36,11 @@ print(result.answer)
 
 RLM relies on [Deno](https://deno.land/) and [Pyodide](https://pyodide.org/) to create a local WASM sandbox for secure Python execution.
 
-You can install Deno with: `brew install deno` on MacOS or `curl -fsSL https://deno.land/install.sh | sh` on MacOS and Linux. See the [Deno Installation Docs](https://docs.deno.com/runtime/getting_started/installation/) for more details. Make sure to accept the prompt when it asks to add it to your shell profile. 
-
-After you have installed Deno, **Make sure to restart your shell.**
-
-Deno may get confused by existing `package.json` files it happens to find; use the environment variable `DENO_NO_PACKAGE_JSON=1` to ignore `package.json` entirely and resolve `npm:pyodide` from its own cache, which is what DSPy expects.
+Install DSPy's managed Deno runtime with `pip install "dspy[deno]"`. See the
+[`PythonInterpreter` installation guide](../tools/PythonInterpreter.md#deno-installation) for supported platforms,
+system-Deno fallback instructions, and dependency-isolation details.
 
 Then you can run `dspy.RLM`.
-
-Users have reported issues with the Deno cache not being found by DSPy. We are actively investigating these issues, and your feedback is greatly appreciated.
 
 You can also work with an external sandbox provider. We are still working on creating an example of using external sandbox providers.
 

--- a/docs/docs/api/tools/PythonInterpreter.md
+++ b/docs/docs/api/tools/PythonInterpreter.md
@@ -1,5 +1,28 @@
 # dspy.PythonInterpreter
 
+## Deno Installation
+
+`PythonInterpreter` uses Deno and Pyodide to run Python in a local WASM sandbox. The recommended installation
+keeps Deno in the same Python environment as DSPy:
+
+```bash
+pip install "dspy[deno]"
+```
+
+The `deno` extra installs the official Deno Python distribution (`>=2.7.7,<3.0.0`). DSPy prefers that managed
+binary when it is installed, so Python dependency locking also locks the Deno runtime. The extra provides binaries
+for macOS x86-64/arm64, glibc Linux x86-64/arm64, and Windows x86-64 and adds approximately 40–50 MiB to the
+environment.
+
+On other platforms, install a compatible Deno 2.x release (`>=2.7.7`) using the
+[Deno installation instructions](https://docs.deno.com/runtime/getting_started/installation/). DSPy falls back to
+the `deno` executable on `PATH`. An explicit `deno_command` passed to `PythonInterpreter` takes precedence over
+both options.
+
+DSPy disables ambient `deno.json`, lockfile, `package.json`, and local `node_modules` discovery for its default
+runner. A `package.json` in the current directory or an ancestor therefore cannot redirect the sandbox's pinned
+Pyodide dependency. No `DENO_NO_PACKAGE_JSON` environment variable is required.
+
 <!-- START_API_REF -->
 ::: dspy.PythonInterpreter
     handler: python

--- a/docs/docs/api/tools/PythonInterpreter.md
+++ b/docs/docs/api/tools/PythonInterpreter.md
@@ -9,12 +9,12 @@ keeps Deno in the same Python environment as DSPy:
 pip install "dspy[deno]"
 ```
 
-The `deno` extra installs the official Deno Python distribution (`>=2.7.7,<3.0.0`). DSPy prefers that managed
+The `deno` extra installs the official Deno Python distribution (`>=2.4.5,<3.0.0`). DSPy prefers that managed
 binary when it is installed, so Python dependency locking also locks the Deno runtime. The extra provides binaries
 for macOS x86-64/arm64, glibc Linux x86-64/arm64, and Windows x86-64 and adds approximately 40–50 MiB to the
 environment.
 
-On other platforms, install a compatible Deno 2.x release (`>=2.7.7`) using the
+On other platforms, install a compatible Deno 2.x release (`>=2.0.0,<3.0.0`) using the
 [Deno installation instructions](https://docs.deno.com/runtime/getting_started/installation/). DSPy falls back to
 the `deno` executable on `PATH`. An explicit `deno_command` passed to `PythonInterpreter` takes precedence over
 both options.

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 class ProgramOfThought(Module):
     """
     A DSPy module that runs Python programs to solve a problem.
-    This module requires deno to be installed. Please install deno following https://docs.deno.com/runtime/getting_started/installation/
+    This module requires Deno. Install DSPy's managed runtime with ``pip install "dspy[deno]"``.
 
     Examples:
     ```

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # Pyodide's FFI crashes at exactly 128MB (134,217,728 bytes). Use filesystem
 # injection for strings above 100MB to stay safely below this limit.
 LARGE_VAR_THRESHOLD = 100 * 1024 * 1024
-MIN_DENO_VERSION = (2, 7, 7)
+MIN_DENO_VERSION = (2, 0, 0)
 MAX_DENO_VERSION = (3, 0, 0)
 DENO_PROBE_TIMEOUT_SECONDS = 10
 
@@ -113,14 +113,14 @@ def _validate_deno_version(deno_executable: str) -> None:
     if version is None:
         raise CodeInterpreterError(
             f"Unable to determine the Deno version from {deno_executable!r}. "
-            "PythonInterpreter requires Deno >=2.7.7,<3.0.0. "
+            "PythonInterpreter requires Deno >=2.0.0,<3.0.0. "
             'Install a compatible runtime with `pip install "dspy[deno]"`, or pass a custom `deno_command`.'
         )
 
     if not (MIN_DENO_VERSION <= version < MAX_DENO_VERSION):
         version_text = ".".join(map(str, version))
         raise CodeInterpreterError(
-            f"Unsupported Deno version {version_text}. PythonInterpreter supports Deno >=2.7.7,<3.0.0. "
+            f"Unsupported Deno version {version_text}. PythonInterpreter supports Deno >=2.0.0,<3.0.0. "
             'Install a compatible runtime with `pip install "dspy[deno]"`, or pass a custom `deno_command`.'
         )
 
@@ -210,7 +210,7 @@ class PythonInterpreter:
 
     Prerequisites:
         Install the managed Deno runtime with ``pip install "dspy[deno]"``, or
-        install a compatible Deno 2.x release (2.7.7 or newer) system-wide.
+        install a compatible Deno 2.x release system-wide.
 
     Examples:
         ```python

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -100,13 +100,23 @@ def _get_deno_version(deno_executable: str) -> tuple[int, int, int] | None:
     except OSError:
         return None
 
+    if result.returncode != 0:
+        return None
+
     match = re.match(r"deno (\d+)\.(\d+)\.(\d+)", result.stdout)
     return tuple(map(int, match.groups())) if match else None
 
 
 def _validate_deno_version(deno_executable: str) -> None:
     version = _get_deno_version(deno_executable)
-    if version is not None and not (MIN_DENO_VERSION <= version < MAX_DENO_VERSION):
+    if version is None:
+        raise CodeInterpreterError(
+            f"Unable to determine the Deno version from {deno_executable!r}. "
+            "PythonInterpreter requires Deno >=2.7.7,<3.0.0. "
+            'Install a compatible runtime with `pip install "dspy[deno]"`, or pass a custom `deno_command`.'
+        )
+
+    if not (MIN_DENO_VERSION <= version < MAX_DENO_VERSION):
         version_text = ".".join(map(str, version))
         raise CodeInterpreterError(
             f"Unsupported Deno version {version_text}. PythonInterpreter supports Deno >=2.7.7,<3.0.0. "
@@ -258,6 +268,7 @@ class PythonInterpreter:
         self._tools_registered = False
         # TODO later on add enable_run (--allow-run) by proxying subprocess.run through Deno.run() to fix 'emscripten does not support processes' error
 
+        self._uses_default_deno_command = not deno_command
         if deno_command:
             self.deno_command = list(deno_command)
         else:
@@ -512,7 +523,7 @@ class PythonInterpreter:
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="UTF-8",
-                env=_deno_subprocess_env(),
+                env=_deno_subprocess_env() if self._uses_default_deno_command else os.environ.copy(),
             )
         except FileNotFoundError as e:
             install_instructions = (

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -15,6 +15,8 @@ import keyword
 import logging
 import math
 import os
+import re
+import shutil
 import subprocess
 import threading
 from os import PathLike
@@ -33,6 +35,8 @@ logger = logging.getLogger(__name__)
 # Pyodide's FFI crashes at exactly 128MB (134,217,728 bytes). Use filesystem
 # injection for strings above 100MB to stay safely below this limit.
 LARGE_VAR_THRESHOLD = 100 * 1024 * 1024
+MIN_DENO_VERSION = (2, 7, 7)
+MAX_DENO_VERSION = (3, 0, 0)
 
 # =============================================================================
 # JSON-RPC 2.0 Helpers
@@ -61,6 +65,53 @@ def _canonicalize_path(path: PathLike | str) -> str:
     realpath'd or reads through a symlink (including DENO_DIR) are denied.
     """
     return os.path.realpath(os.path.expanduser(os.fspath(path)))
+
+
+def _find_deno_executable() -> str:
+    """Prefer the Deno binary managed by the optional Python package."""
+    try:
+        from deno import find_deno_bin
+    except ImportError:
+        return shutil.which("deno") or "deno"
+
+    try:
+        return find_deno_bin()
+    except FileNotFoundError:
+        return shutil.which("deno") or "deno"
+
+
+def _deno_subprocess_env() -> dict[str, str]:
+    """Build an environment that prevents ambient package.json discovery."""
+    env = os.environ.copy()
+    env["DENO_NO_PACKAGE_JSON"] = "1"
+    return env
+
+
+@functools.cache
+def _get_deno_version(deno_executable: str) -> tuple[int, int, int] | None:
+    try:
+        result = subprocess.run(
+            [deno_executable, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_deno_subprocess_env(),
+        )
+    except OSError:
+        return None
+
+    match = re.match(r"deno (\d+)\.(\d+)\.(\d+)", result.stdout)
+    return tuple(map(int, match.groups())) if match else None
+
+
+def _validate_deno_version(deno_executable: str) -> None:
+    version = _get_deno_version(deno_executable)
+    if version is not None and not (MIN_DENO_VERSION <= version < MAX_DENO_VERSION):
+        version_text = ".".join(map(str, version))
+        raise CodeInterpreterError(
+            f"Unsupported Deno version {version_text}. PythonInterpreter supports Deno >=2.7.7,<3.0.0. "
+            'Install a compatible runtime with `pip install "dspy[deno]"`, or pass a custom `deno_command`.'
+        )
 
 
 def _jsonrpc_request(method: str, params: dict, id: int | str) -> str:
@@ -147,7 +198,8 @@ class PythonInterpreter:
     no access to the host filesystem, network, or environment by default.
 
     Prerequisites:
-        Deno must be installed: https://docs.deno.com/runtime/getting_started/installation/
+        Install the managed Deno runtime with ``pip install "dspy[deno]"``, or
+        install a compatible Deno 2.x release (2.7.7 or newer) system-wide.
 
     Examples:
         ```python
@@ -209,10 +261,18 @@ class PythonInterpreter:
         if deno_command:
             self.deno_command = list(deno_command)
         else:
-            args = ["deno", "run"]
+            deno_executable = _find_deno_executable()
+            _validate_deno_version(deno_executable)
+            args = [
+                deno_executable,
+                "run",
+                "--no-config",
+                "--no-lock",
+                "--node-modules-dir=false",
+            ]
 
             # Also allow reading Deno's cache directory so Pyodide can load its files
-            deno_dir = self._get_deno_dir()
+            deno_dir = self._get_deno_dir(deno_executable)
             raw_read_paths = [
                 self._get_runner_path(),
                 *([deno_dir] if deno_dir else []),
@@ -290,17 +350,22 @@ class PythonInterpreter:
             )
 
     @staticmethod
-    @functools.lru_cache(maxsize=1)
-    def _get_deno_dir() -> str | None:
+    def _get_deno_dir(deno_executable: str = "deno") -> str | None:
         if "DENO_DIR" in os.environ:
             return os.environ["DENO_DIR"]
 
+        return PythonInterpreter._query_deno_dir(deno_executable)
+
+    @staticmethod
+    @functools.cache
+    def _query_deno_dir(deno_executable: str) -> str | None:
         try:
             result = subprocess.run(
-                ["deno", "info", "--json"],
+                [deno_executable, "info", "--json"],
                 capture_output=True,
                 text=True,
-                check=False
+                check=False,
+                env=_deno_subprocess_env(),
             )
             if result.returncode == 0:
                 info = json.loads(result.stdout)
@@ -447,12 +512,13 @@ class PythonInterpreter:
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="UTF-8",
-                env=os.environ.copy()
+                env=_deno_subprocess_env(),
             )
         except FileNotFoundError as e:
             install_instructions = (
-                "Deno executable not found. Please install Deno to proceed.\n"
-                "Installation instructions:\n"
+                "Deno executable not found. Install DSPy's managed Deno runtime with:\n"
+                '> pip install "dspy[deno]"\n'
+                "Alternatively, install Deno system-wide:\n"
                 "> curl -fsSL https://deno.land/install.sh | sh\n"
                 "*or*, on macOS with Homebrew:\n"
                 "> brew install deno\n"

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -273,7 +273,6 @@ class PythonInterpreter:
             self.deno_command = list(deno_command)
         else:
             deno_executable = _find_deno_executable()
-            _validate_deno_version(deno_executable)
             args = [
                 deno_executable,
                 "run",
@@ -515,6 +514,9 @@ class PythonInterpreter:
         self.start()
 
     def _spawn_process(self) -> None:
+        if self._uses_default_deno_command:
+            _validate_deno_version(self.deno_command[0])
+
         try:
             self.deno_process = subprocess.Popen(
                 self.deno_command,

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 LARGE_VAR_THRESHOLD = 100 * 1024 * 1024
 MIN_DENO_VERSION = (2, 7, 7)
 MAX_DENO_VERSION = (3, 0, 0)
+DENO_PROBE_TIMEOUT_SECONDS = 10
 
 # =============================================================================
 # JSON-RPC 2.0 Helpers
@@ -87,7 +88,6 @@ def _deno_subprocess_env() -> dict[str, str]:
     return env
 
 
-@functools.cache
 def _get_deno_version(deno_executable: str) -> tuple[int, int, int] | None:
     try:
         result = subprocess.run(
@@ -96,8 +96,9 @@ def _get_deno_version(deno_executable: str) -> tuple[int, int, int] | None:
             text=True,
             check=False,
             env=_deno_subprocess_env(),
+            timeout=DENO_PROBE_TIMEOUT_SECONDS,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return None
 
     if result.returncode != 0:
@@ -376,6 +377,7 @@ class PythonInterpreter:
                 text=True,
                 check=False,
                 env=_deno_subprocess_env(),
+                timeout=DENO_PROBE_TIMEOUT_SECONDS,
             )
             if result.returncode == 0:
                 info = json.loads(result.stdout)

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -1,6 +1,6 @@
 // Adapted from "Simon Willison's TILs" (https://til.simonwillison.net/deno/pyodide-sandbox)
 
-import pyodideModule from "npm:pyodide/pyodide.js";
+import pyodideModule from "npm:pyodide@0.29.4/pyodide.js";
 import { readLines } from "https://deno.land/std@0.186.0/io/mod.ts";
 
 // =============================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client>=4.5.4,<4.22.0"]
 mcp = ["mcp; python_version >= '3.10'"]
+deno = ["deno>=2.7.7,<3.0.0"]
 langchain = ["langchain_core>=0.3.0"]
 optuna = ["optuna>=3.4.0"]
 numpy = ["numpy>=1.26.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 anthropic = ["anthropic>=0.18.0,<1.0.0"]
 weaviate = ["weaviate-client>=4.5.4,<4.22.0"]
 mcp = ["mcp; python_version >= '3.10'"]
-deno = ["deno>=2.7.7,<3.0.0"]
+deno = ["deno>=2.4.5,<3.0.0"]
 langchain = ["langchain_core>=0.3.0"]
 optuna = ["optuna>=3.4.0"]
 numpy = ["numpy>=1.26.0"]

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -3,17 +3,29 @@ import dataclasses
 import json
 import os
 import random
+import shutil
+import sys
 import threading
+import types
 from collections import namedtuple
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import NamedTuple
 
 import pytest
 from pydantic import BaseModel, ConfigDict
 
+import dspy.primitives.python_interpreter as python_interpreter
 from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreterError, FinalOutput
-from dspy.primitives.python_interpreter import LARGE_VAR_THRESHOLD, PythonInterpreter, _make_jsonable
+from dspy.primitives.python_interpreter import (
+    LARGE_VAR_THRESHOLD,
+    PythonInterpreter,
+    _deno_subprocess_env,
+    _find_deno_executable,
+    _make_jsonable,
+    _validate_deno_version,
+)
 
 
 class _Hit(BaseModel):
@@ -388,6 +400,132 @@ def test_deno_command_dict_raises_type_error():
     """Test that passing a dict as deno_command raises TypeError."""
     with pytest.raises(TypeError, match="deno_command must be a list"):
         PythonInterpreter(deno_command={"invalid": "dict"})
+
+
+def test_custom_deno_command_is_unchanged():
+    command = ["custom-deno", "run", "custom-runner.js", "argument"]
+
+    interpreter = PythonInterpreter(deno_command=command)
+
+    assert interpreter.deno_command == command
+    assert interpreter.deno_command is not command
+
+
+def test_deno_subprocess_env_disables_package_json(monkeypatch):
+    monkeypatch.setenv("DENO_NO_PACKAGE_JSON", "0")
+    monkeypatch.setenv("DSPY_DENO_TEST_VALUE", "preserved")
+
+    env = _deno_subprocess_env()
+
+    assert env["DENO_NO_PACKAGE_JSON"] == "1"
+    assert env["DSPY_DENO_TEST_VALUE"] == "preserved"
+    assert os.environ["DENO_NO_PACKAGE_JSON"] == "0"
+
+
+def test_managed_deno_package_is_preferred(monkeypatch):
+    managed_deno = types.SimpleNamespace(find_deno_bin=lambda: "/managed/bin/deno")
+    monkeypatch.setitem(sys.modules, "deno", managed_deno)
+
+    assert _find_deno_executable() == "/managed/bin/deno"
+
+
+def test_missing_managed_deno_binary_falls_back_to_path(monkeypatch):
+    def missing_binary():
+        raise FileNotFoundError
+
+    managed_deno = types.SimpleNamespace(find_deno_bin=missing_binary)
+    monkeypatch.setitem(sys.modules, "deno", managed_deno)
+    monkeypatch.setattr(shutil, "which", lambda executable: "/system/bin/deno" if executable == "deno" else None)
+
+    assert _find_deno_executable() == "/system/bin/deno"
+
+
+def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_path):
+    deno_executable = str(tmp_path / "managed-deno")
+    seen_executables = []
+    monkeypatch.setattr(python_interpreter, "_find_deno_executable", lambda: deno_executable)
+    monkeypatch.setattr(
+        python_interpreter,
+        "_validate_deno_version",
+        lambda executable: seen_executables.append(executable),
+    )
+    monkeypatch.setattr(
+        PythonInterpreter,
+        "_get_deno_dir",
+        staticmethod(lambda executable: seen_executables.append(executable) or str(tmp_path / "cache")),
+    )
+
+    interpreter = PythonInterpreter()
+
+    assert seen_executables == [deno_executable, deno_executable]
+    assert interpreter.deno_command[:5] == [
+        deno_executable,
+        "run",
+        "--no-config",
+        "--no-lock",
+        "--node-modules-dir=false",
+    ]
+    runner_index = interpreter.deno_command.index(os.path.realpath(interpreter._get_runner_path()))
+    assert all(interpreter.deno_command.index(flag) < runner_index for flag in interpreter.deno_command[2:5])
+
+
+def test_rejects_unsupported_system_deno(monkeypatch):
+    monkeypatch.setattr(python_interpreter, "_get_deno_version", lambda executable: (1, 46, 3))
+
+    with pytest.raises(CodeInterpreterError, match=r"Unsupported Deno version 1\.46\.3"):
+        _validate_deno_version("/system/bin/deno")
+
+
+def test_explicit_deno_dir_skips_info_query(monkeypatch, tmp_path):
+    deno_dir = str(tmp_path / "deno-cache")
+    monkeypatch.setenv("DENO_DIR", deno_dir)
+    monkeypatch.setattr(
+        PythonInterpreter,
+        "_query_deno_dir",
+        staticmethod(lambda executable: pytest.fail(f"unexpected Deno info query for {executable}")),
+    )
+
+    assert PythonInterpreter._get_deno_dir("/managed/bin/deno") == deno_dir
+
+
+def test_ignores_parent_package_json_and_node_modules(monkeypatch, tmp_path):
+    """A parent Node project must not redirect runner.js's Pyodide import."""
+    project_dir = tmp_path / "node-project"
+    runner_dir = project_dir / "runtime"
+    fake_pyodide_dir = project_dir / "node_modules" / "pyodide"
+    runner_dir.mkdir(parents=True)
+    fake_pyodide_dir.mkdir(parents=True)
+
+    runner_path = runner_dir / "runner.js"
+    shutil.copyfile(Path(python_interpreter.__file__).with_name("runner.js"), runner_path)
+    (project_dir / "package.json").write_text(json.dumps({"dependencies": {"pyodide": "0.29.4"}}))
+    (fake_pyodide_dir / "package.json").write_text(
+        json.dumps(
+            {
+                "name": "pyodide",
+                "version": "0.29.4",
+                "type": "module",
+                "exports": {"./pyodide.js": "./pyodide.js"},
+            }
+        )
+    )
+    (fake_pyodide_dir / "blocked.txt").write_text("ambient package was selected")
+    (fake_pyodide_dir / "pyodide.js").write_text(
+        'Deno.readTextFileSync(new URL("./blocked.txt", import.meta.url));\n'
+        'export default { loadPyodide() { throw new Error("DSPy loaded Pyodide from parent node_modules"); } };\n'
+    )
+
+    class ParentProjectInterpreter(PythonInterpreter):
+        def _get_runner_path(self):
+            return str(runner_path)
+
+    monkeypatch.chdir(runner_dir)
+    monkeypatch.delenv("DENO_NO_PACKAGE_JSON", raising=False)
+
+    with ParentProjectInterpreter() as interpreter:
+        assert interpreter.execute("6 * 7") == 42
+
+    assert not (project_dir / "deno.lock").exists()
 
 
 # =============================================================================

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -461,22 +461,22 @@ def test_missing_managed_deno_binary_falls_back_to_path(monkeypatch):
 
 def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_path):
     deno_executable = str(tmp_path / "managed-deno")
-    seen_executables = []
+    seen_operations = []
     monkeypatch.setattr(python_interpreter, "_find_deno_executable", lambda: deno_executable)
     monkeypatch.setattr(
         python_interpreter,
         "_validate_deno_version",
-        lambda executable: seen_executables.append(executable),
+        lambda executable: seen_operations.append(("version", executable)),
     )
     monkeypatch.setattr(
         PythonInterpreter,
         "_get_deno_dir",
-        staticmethod(lambda executable: seen_executables.append(executable) or str(tmp_path / "cache")),
+        staticmethod(lambda executable: seen_operations.append(("info", executable)) or str(tmp_path / "cache")),
     )
 
     interpreter = PythonInterpreter()
 
-    assert seen_executables == [deno_executable, deno_executable]
+    assert seen_operations == [("info", deno_executable)]
     assert interpreter.deno_command[:5] == [
         deno_executable,
         "run",
@@ -486,6 +486,12 @@ def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_pat
     ]
     runner_index = interpreter.deno_command.index(os.path.realpath(interpreter._get_runner_path()))
     assert all(interpreter.deno_command.index(flag) < runner_index for flag in interpreter.deno_command[2:5])
+
+    monkeypatch.setattr(python_interpreter.subprocess, "Popen", lambda *args, **kwargs: object())
+    monkeypatch.setattr(interpreter, "_health_check", lambda: None)
+    interpreter._spawn_process()
+
+    assert seen_operations == [("info", deno_executable), ("version", deno_executable)]
 
 
 def test_rejects_unsupported_system_deno(monkeypatch):

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -495,10 +495,19 @@ def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_pat
     assert seen_operations == [("info", deno_executable), ("version", deno_executable)]
 
 
-def test_rejects_unsupported_system_deno(monkeypatch):
-    monkeypatch.setattr(python_interpreter, "_get_deno_version", lambda executable: (1, 46, 3))
+@pytest.mark.parametrize("version", [(2, 0, 0), (2, 4, 5), (2, 9, 5)])
+def test_accepts_supported_deno_2_versions(monkeypatch, version):
+    monkeypatch.setattr(python_interpreter, "_get_deno_version", lambda executable: version)
 
-    with pytest.raises(CodeInterpreterError, match=r"Unsupported Deno version 1\.46\.3"):
+    _validate_deno_version("/system/bin/deno")
+
+
+@pytest.mark.parametrize("version", [(1, 46, 3), (3, 0, 0)])
+def test_rejects_unsupported_system_deno(monkeypatch, version):
+    monkeypatch.setattr(python_interpreter, "_get_deno_version", lambda executable: version)
+    version_text = "\\.".join(map(str, version))
+
+    with pytest.raises(CodeInterpreterError, match=rf"Unsupported Deno version {version_text}"):
         _validate_deno_version("/system/bin/deno")
 
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -4,6 +4,7 @@ import json
 import os
 import random
 import shutil
+import subprocess
 import sys
 import threading
 import types
@@ -512,10 +513,53 @@ def test_rejects_unsupported_system_deno(monkeypatch):
 def test_rejects_invalid_deno_version_probe(monkeypatch, returncode, stdout, stderr):
     result = types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
     monkeypatch.setattr(python_interpreter.subprocess, "run", lambda *args, **kwargs: result)
-    python_interpreter._get_deno_version.cache_clear()
 
     with pytest.raises(CodeInterpreterError, match="Unable to determine the Deno version"):
         _validate_deno_version("/fake/bin/deno")
+
+
+def test_deno_version_probe_is_bounded_and_not_cached(monkeypatch):
+    results = iter(
+        [
+            types.SimpleNamespace(returncode=0, stdout="deno 2.9.5", stderr=""),
+            types.SimpleNamespace(returncode=0, stdout="deno 2.9.4", stderr=""),
+        ]
+    )
+    seen_timeouts = []
+
+    def fake_run(*args, **kwargs):
+        seen_timeouts.append(kwargs["timeout"])
+        return next(results)
+
+    monkeypatch.setattr(python_interpreter.subprocess, "run", fake_run)
+
+    assert python_interpreter._get_deno_version("/fake/bin/deno") == (2, 9, 5)
+    assert python_interpreter._get_deno_version("/fake/bin/deno") == (2, 9, 4)
+    assert seen_timeouts == [python_interpreter.DENO_PROBE_TIMEOUT_SECONDS] * 2
+
+
+def test_deno_version_probe_timeout_is_reported_as_indeterminate(monkeypatch):
+    def timeout(*args, **kwargs):
+        raise subprocess.TimeoutExpired(args[0], kwargs["timeout"])
+
+    monkeypatch.setattr(python_interpreter.subprocess, "run", timeout)
+
+    with pytest.raises(CodeInterpreterError, match="Unable to determine the Deno version"):
+        _validate_deno_version("/hanging/bin/deno")
+
+
+def test_deno_info_probe_is_bounded(monkeypatch):
+    captured = {}
+
+    def fake_run(*args, **kwargs):
+        captured.update(kwargs)
+        return types.SimpleNamespace(returncode=0, stdout=json.dumps({"denoDir": "/cache"}))
+
+    monkeypatch.setattr(python_interpreter.subprocess, "run", fake_run)
+    PythonInterpreter._query_deno_dir.cache_clear()
+
+    assert PythonInterpreter._query_deno_dir("/bounded/bin/deno") == "/cache"
+    assert captured["timeout"] == python_interpreter.DENO_PROBE_TIMEOUT_SECONDS
 
 
 def test_explicit_deno_dir_skips_info_query(monkeypatch, tmp_path):

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -411,6 +411,25 @@ def test_custom_deno_command_is_unchanged():
     assert interpreter.deno_command is not command
 
 
+def test_custom_deno_command_preserves_environment(monkeypatch):
+    monkeypatch.setenv("DENO_NO_PACKAGE_JSON", "0")
+    captured = {}
+    interpreter = PythonInterpreter(deno_command=["custom-deno", "run"])
+
+    def fake_popen(command, **kwargs):
+        captured["command"] = command
+        captured["env"] = kwargs["env"]
+        return object()
+
+    monkeypatch.setattr(python_interpreter.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(interpreter, "_health_check", lambda: None)
+
+    interpreter._spawn_process()
+
+    assert captured["command"] == ["custom-deno", "run"]
+    assert captured["env"]["DENO_NO_PACKAGE_JSON"] == "0"
+
+
 def test_deno_subprocess_env_disables_package_json(monkeypatch):
     monkeypatch.setenv("DENO_NO_PACKAGE_JSON", "0")
     monkeypatch.setenv("DSPY_DENO_TEST_VALUE", "preserved")
@@ -474,6 +493,23 @@ def test_rejects_unsupported_system_deno(monkeypatch):
 
     with pytest.raises(CodeInterpreterError, match=r"Unsupported Deno version 1\.46\.3"):
         _validate_deno_version("/system/bin/deno")
+
+
+@pytest.mark.parametrize(
+    ("returncode", "stdout", "stderr"),
+    [
+        (0, "not a Deno version", ""),
+        (0, "", "deno 2.9.5"),
+        (1, "deno 2.9.5", "version probe failed"),
+    ],
+)
+def test_rejects_invalid_deno_version_probe(monkeypatch, returncode, stdout, stderr):
+    result = types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+    monkeypatch.setattr(python_interpreter.subprocess, "run", lambda *args, **kwargs: result)
+    python_interpreter._get_deno_version.cache_clear()
+
+    with pytest.raises(CodeInterpreterError, match="Unable to determine the Deno version"):
+        _validate_deno_version("/fake/bin/deno")
 
 
 def test_explicit_deno_dir_skips_info_query(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -706,6 +706,19 @@ wheels = [
 ]
 
 [[package]]
+name = "deno"
+version = "2.9.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/27/06ad530f3be68dafdfae57457c534d5bb014cd6da58c2bd0f5b28f9ab8fa/deno-2.9.5.tar.gz", hash = "sha256:2f9681d7d2118a5e92e18915d1d88a6966fd6173ba4a8fb772f04080057e5a6a", size = 8166, upload-time = "2026-08-06T15:08:32.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/99/1a1ff9e40e82d857b426a86d2159e3560000c2f98edb0f63170256582067/deno-2.9.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d321f54f82cb535904a108afd970c1c3e1db23716db1ab0cda5e0ca993dbf824", size = 42353187, upload-time = "2026-08-06T15:08:10.431Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/d60dac70124d045dfc6f01bbd181e2865904ecca5710b2d319869ff59727/deno-2.9.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:696dffb666d6336a3527857b2f9b665db33b07883bb6adc3595dbb3b78748cf1", size = 38520058, upload-time = "2026-08-06T15:08:14.978Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b4/5d462bc738b2172043a470ab97d7b6f3e7a287fa1916065e777e034ef1b1/deno-2.9.5-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bccec0965917b6daa323f9ce6ad8e884e0854506b0cdaec9de41bdac7620109a", size = 39908447, upload-time = "2026-08-06T15:08:19.751Z" },
+    { url = "https://files.pythonhosted.org/packages/60/54/c6e0fb4b5e96dd7611bc75c8137046d7436666bd2e278f686e36d6a805af/deno-2.9.5-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e5aec0419739fd0359663a78765d4feda19d1d0b60a682d25add9b78e19f95b4", size = 41642333, upload-time = "2026-08-06T15:08:24.965Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0b/3ca6468ec928d817ce6ef062ddfa11e71a3c68035c3401057d7cb33845f6/deno-2.9.5-py3-none-win_amd64.whl", hash = "sha256:570d4ee6f1ddb16d14848d36dac6cd2f586d8a0c94cf9c3e6b5da130da2597d5", size = 41615800, upload-time = "2026-08-06T15:08:30.015Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -786,6 +799,9 @@ dependencies = [
 anthropic = [
     { name = "anthropic" },
 ]
+deno = [
+    { name = "deno" },
+]
 dev = [
     { name = "build" },
     { name = "datamodel-code-generator" },
@@ -843,6 +859,7 @@ requires-dist = [
     { name = "cloudpickle", specifier = ">=3.1.2" },
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
+    { name = "deno", marker = "extra == 'deno'", specifier = ">=2.7.7,<3.0.0" },
     { name = "diskcache", specifier = ">=5.6.0" },
     { name = "fastapi", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = "<0.140.7" },
     { name = "gepa", extras = ["dspy"], specifier = "==0.1.1" },
@@ -877,7 +894,7 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.66.1" },
     { name = "weaviate-client", marker = "extra == 'weaviate'", specifier = ">=4.5.4,<4.22.0" },
 ]
-provides-extras = ["anthropic", "weaviate", "mcp", "langchain", "optuna", "numpy", "litellm", "dev", "test-extras"]
+provides-extras = ["anthropic", "weaviate", "mcp", "deno", "langchain", "optuna", "numpy", "litellm", "dev", "test-extras"]
 
 [[package]]
 name = "email-validator"

--- a/uv.lock
+++ b/uv.lock
@@ -859,7 +859,7 @@ requires-dist = [
     { name = "cloudpickle", specifier = ">=3.1.2" },
     { name = "datamodel-code-generator", marker = "extra == 'dev'", specifier = ">=0.26.3" },
     { name = "datasets", marker = "extra == 'test-extras'", specifier = ">=2.14.6" },
-    { name = "deno", marker = "extra == 'deno'", specifier = ">=2.7.7,<3.0.0" },
+    { name = "deno", marker = "extra == 'deno'", specifier = ">=2.4.5,<3.0.0" },
     { name = "diskcache", specifier = ">=5.6.0" },
     { name = "fastapi", marker = "python_full_version < '3.14' and sys_platform != 'win32' and extra == 'dev'", specifier = "<0.140.7" },
     { name = "gepa", extras = ["dspy"], specifier = "==0.1.1" },


### PR DESCRIPTION
## Summary

- add an idempotent fresh-orb setup for pinned uv, Deno, Python 3.11, and locked development dependencies
- add a fast resume check for the installed development environment
- preserve both lifecycle scripts as executable files

## Testing

- `.agents/setup` (cold: 6.58s; repeated warm runs: 0.05s)
- `.agents/resume` (<0.01s)
- clean non-interactive login-shell tool discovery and `import dspy`
- `uv run --frozen pytest -q tests/predict` (239 passed, 62 skipped)
- `uv run --frozen pytest -q --deno tests/primitives/test_python_interpreter.py::test_execute_simple_code` (1 passed)

Depends on #10186.