### PR TITLE
Deprecate CodeAct and ProgramOfThought

### DIFF
--- a/docs/docs/api/modules/CodeAct.md
+++ b/docs/docs/api/modules/CodeAct.md
@@ -1,5 +1,9 @@
 # dspy.CodeAct
 
+!!! warning "Deprecated"
+
+    `CodeAct` is deprecated and will be removed in DSPy 3.5. [`RLM`](RLM.md) is the preferred replacement.
+
 <!-- START_API_REF -->
 ::: dspy.CodeAct
     handler: python

--- a/docs/docs/api/modules/ProgramOfThought.md
+++ b/docs/docs/api/modules/ProgramOfThought.md
@@ -1,5 +1,9 @@
 # dspy.ProgramOfThought
 
+!!! warning "Deprecated"
+
+    `ProgramOfThought` is deprecated and will be removed in DSPy 3.5. [`RLM`](RLM.md) is the preferred replacement.
+
 <!-- START_API_REF -->
 ::: dspy.ProgramOfThought
     handler: python

--- a/docs/docs/diving-deeper/flex.md
+++ b/docs/docs/diving-deeper/flex.md
@@ -90,7 +90,7 @@ The optimizer-authored code does not run against the real `dspy` package. Inside
 **Available**
 
 - `dspy.Module` — the base class the generated source subclasses. `__init__` assigns predictors; `forward` runs in the sandbox.
-- `dspy.Predict`, `dspy.ChainOfThought`, `dspy.ReAct`, `dspy.ReActV2`, `dspy.RLM`, `dspy.CodeAct`, `dspy.ProgramOfThought` — constructed in the sandbox but *built on the host*, where the real LM calls happen. Constructor kwargs cross as JSON.
+- `dspy.Predict`, `dspy.ChainOfThought`, `dspy.ReAct`, `dspy.ReActV2`, `dspy.RLM` — constructed in the sandbox but *built on the host*, where the real LM calls happen. Constructor kwargs cross as JSON.
 - `dspy.Signature("inputs -> outputs", "instructions")` — the string form only, used to give an inner predictor its instructions. It is a marker the host turns back into a real `Signature`, not the class: it has no methods, no `with_instructions()`, and no `dspy.InputField` / `dspy.OutputField` class form.
 - `dspy.Prediction(**fields)` — the return value of `forward`. Holds fields; it is not the host `Prediction` type.
 - `dspy.Tool(func)` — a pass-through wrapper. Only tools you passed to `dspy.Flex(tools=...)` can be handed to a bridged sub-predictor; they are already in scope by name, so wrapping is optional.

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 class CodeAct(ReAct, ProgramOfThought):
     """
-    .. deprecated:: 3.5
+    .. deprecated:: 3.4
         CodeAct is deprecated. RLM is the preferred replacement.
 
     CodeAct is a module that utilizes the Code Interpreter and predefined tools to solve the problem.

--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import warnings
 from typing import Callable
 
 import dspy
@@ -12,8 +13,12 @@ from dspy.signatures.signature import Signature, ensure_signature
 
 logger = logging.getLogger(__name__)
 
+
 class CodeAct(ReAct, ProgramOfThought):
     """
+    .. deprecated:: 3.5
+        CodeAct is deprecated. RLM is the preferred replacement.
+
     CodeAct is a module that utilizes the Code Interpreter and predefined tools to solve the problem.
     """
 
@@ -45,15 +50,18 @@ class CodeAct(ReAct, ProgramOfThought):
             act(n=5) # 120
             ```
         """
+        warnings.warn(
+            "CodeAct is deprecated and will be removed in 3.5. RLM is the preferred replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         _validate_interpreter_factory(interpreter_factory)
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
         self.history = []
 
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]
-        if any(
-            not inspect.isfunction(tool.func) for tool in tools
-        ):
+        if any(not inspect.isfunction(tool.func) for tool in tools):
             raise ValueError("CodeAct only accepts functions and not callable objects.")
         tools = {tool.name: tool for tool in tools}
 
@@ -62,7 +70,13 @@ class CodeAct(ReAct, ProgramOfThought):
         codeact_signature = (
             dspy.Signature({**self.signature.input_fields}, "\n".join(instructions))
             .append("trajectory", dspy.InputField(), type_=str)
-            .append("generated_code", dspy.OutputField(desc="Python code that when executed, produces output relevant to answering the question"), type_=str)
+            .append(
+                "generated_code",
+                dspy.OutputField(
+                    desc="Python code that when executed, produces output relevant to answering the question"
+                ),
+                type_=str,
+            )
             .append("finished", dspy.OutputField(desc="a boolean flag to determine if the process is done"), type_=bool)
         )
 

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 
 class ProgramOfThought(Module):
     """
-    .. deprecated:: 3.5
+    .. deprecated:: 3.4
         ProgramOfThought is deprecated. RLM is the preferred replacement.
 
     A DSPy module that runs Python programs to solve a problem.

--- a/dspy/predict/program_of_thought.py
+++ b/dspy/predict/program_of_thought.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import re
+import warnings
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 
@@ -23,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 class ProgramOfThought(Module):
     """
+    .. deprecated:: 3.5
+        ProgramOfThought is deprecated. RLM is the preferred replacement.
+
     A DSPy module that runs Python programs to solve a problem.
     This module requires deno to be installed. Please install deno following https://docs.deno.com/runtime/getting_started/installation/
 
@@ -51,6 +55,11 @@ class ProgramOfThought(Module):
                 callable may be invoked concurrently, and DSPy shuts down each interpreter it returns.
         """
         super().__init__()
+        warnings.warn(
+            "ProgramOfThought is deprecated and will be removed in 3.5. RLM is the preferred replacement.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         _validate_interpreter_factory(interpreter_factory)
         self.signature = signature = ensure_signature(signature)
         self.max_iters = max_iters

--- a/tests/predict/test_code_act.py
+++ b/tests/predict/test_code_act.py
@@ -31,9 +31,19 @@ class RaisingPredictor:
     def __call__(self, **kwargs):
         raise ValueError("unexpected extractor failure")
 
+
 def add(a: float, b: float) -> float:
     "add two numbers"
     return a + b
+
+
+def test_codeact_warns_that_rlm_is_preferred():
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"CodeAct is deprecated and will be removed in 3\.5\. RLM is the preferred replacement\.",
+    ):
+        CodeAct(BasicQA, tools=[add])
+
 
 def test_codeact_code_generation(pooled_interpreter):
     lm = DummyLM(
@@ -61,9 +71,11 @@ class ExtremumFinder(Signature):
     maximum = dspy.OutputField(desc="The maximum of the given numbers")
     minimum = dspy.OutputField(desc="The minimum of the given numbers")
 
+
 def extract_maximum_minimum(input_list: str) -> dict[str, float]:
     numbers = list(map(float, input_list.split(",")))
     return {"maximum": max(numbers), "minimum": min(numbers)}
+
 
 def test_codeact_support_multiple_fields(pooled_interpreter):
     lm = DummyLM(
@@ -82,7 +94,7 @@ def test_codeact_support_multiple_fields(pooled_interpreter):
     assert res.maximum == "6"
     assert res.minimum == "2"
     assert res.trajectory == {
-        "code_output_0": '"{\'maximum\': 6.0, \'minimum\': 2.0}\\n"',
+        "code_output_0": "\"{'maximum': 6.0, 'minimum': 2.0}\\n\"",
         "generated_code_0": "result = extract_maximum_minimum('2, 3, 5, 6')\nprint(result)",
     }
 
@@ -137,7 +149,7 @@ def test_codeact_code_execution_failure(pooled_interpreter):
     assert res.answer == "2"
     assert res.trajectory == {
         "generated_code_0": "unknown+1",
-        "observation_0": 'Failed to execute the generated code: NameError: ["name \'unknown\' is not defined"]',
+        "observation_0": "Failed to execute the generated code: NameError: [\"name 'unknown' is not defined\"]",
         "generated_code_1": "result = add(1,1)\nprint(result)",
         "code_output_1": '"2\\n"',
     }
@@ -157,8 +169,7 @@ def test_codeact_evaluate_creates_one_interpreter_per_example():
     program.codeact = StaticPredictor(generated_code="print(add(1, 1))", finished=True)
     program.extractor = StaticPredictor(answer="2")
     devset = [
-        dspy.Example(question=f"What is 1+1? ({index})", answer="2").with_inputs("question")
-        for index in range(4)
+        dspy.Example(question=f"What is 1+1? ({index})", answer="2").with_inputs("question") for index in range(4)
     ]
 
     result = dspy.Evaluate(
@@ -197,9 +208,7 @@ def test_codeact_factory_creates_fresh_interpreter_per_sequential_call():
 def test_codeact_allows_interpreter_as_signature_input():
     factory = MockInterpreterFactory(responses=["", "CPython\n"])
     program = CodeAct("interpreter -> answer", tools=[add], interpreter_factory=factory)
-    program.codeact = Mock(
-        return_value=dspy.Prediction(generated_code="print(interpreter)", finished=True)
-    )
+    program.codeact = Mock(return_value=dspy.Prediction(generated_code="print(interpreter)", finished=True))
     program.extractor = StaticPredictor(answer="CPython")
 
     result = program(interpreter="CPython")
@@ -271,6 +280,7 @@ def test_codeact_propagates_terminal_interpreter_failure_and_shuts_down():
 class CustomTool:
     def __call__(self, a: float, b: float) -> float:
         return a + b
+
 
 def test_codeact_tool_validation():
     with pytest.raises(ValueError, match=r"CodeAct only accepts functions and not callable objects."):

--- a/tests/predict/test_program_of_thought.py
+++ b/tests/predict/test_program_of_thought.py
@@ -39,6 +39,14 @@ class RecordingPythonInterpreterFactory:
         return interpreter
 
 
+def test_pot_warns_that_rlm_is_preferred():
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"ProgramOfThought is deprecated and will be removed in 3\.5\. RLM is the preferred replacement\.",
+    ):
+        ProgramOfThought(BasicQA)
+
+
 @pytest.mark.deno
 def test_pot_code_generation(pooled_interpreter):
     lm = DummyLM(
@@ -123,8 +131,7 @@ def test_pot_evaluate_creates_one_interpreter_per_example():
     pot.code_generate = StaticPredictor(generated_code="SUBMIT({'answer': 2})")
     pot.generate_output = StaticPredictor(answer="2")
     devset = [
-        dspy.Example(question=f"What is 1+1? ({index})", answer="2").with_inputs("question")
-        for index in range(4)
+        dspy.Example(question=f"What is 1+1? ({index})", answer="2").with_inputs("question") for index in range(4)
     ]
 
     result = dspy.Evaluate(


### PR DESCRIPTION
## Summary

- emit deprecation warnings when constructing `CodeAct` or `ProgramOfThought`
- schedule both modules for removal in DSPy 3.5 and recommend `RLM` as the preferred replacement
- add API documentation notices and regression tests for the warning messages

## Testing

- `uv run --extra dev pytest --deno -q tests/predict/test_program_of_thought.py::test_pot_warns_that_rlm_is_preferred tests/predict/test_code_act.py::test_codeact_warns_that_rlm_is_preferred`
- `uv run --extra dev ruff check dspy/predict/program_of_thought.py dspy/predict/code_act.py tests/predict/test_program_of_thought.py tests/predict/test_code_act.py`
- `uv run --extra dev ruff format --check dspy/predict/program_of_thought.py dspy/predict/code_act.py tests/predict/test_program_of_thought.py tests/predict/test_code_act.py`