### PR TITLE
Promote cache token usage aliases

### DIFF
--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -881,7 +881,61 @@ def usage_from_response(response: Any) -> LMUsage | None:
             if value is not None and not callable(value):
                 data[key] = value
         usage = data
-    return LMUsage(**dict(usage))
+    usage = dict(usage)
+    _add_cache_usage_aliases(usage)
+    return LMUsage(**usage)
+
+
+def _usage_mapping(data: Any) -> dict[str, Any] | None:
+    if isinstance(data, dict):
+        return data
+    if hasattr(data, "model_dump"):
+        return model_dump(data)
+    return None
+
+
+def _numeric_usage_value(data: Any, *keys: str) -> int | None:
+    usage_data = _usage_mapping(data)
+    if usage_data is None:
+        return None
+    for key in keys:
+        value = usage_data.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+    return None
+
+
+def _add_cache_usage_aliases(usage: dict[str, Any]) -> None:
+    """Populate DSPy's normalized cache token fields from provider-specific usage details."""
+    input_details = usage.get("input_tokens_details") or usage.get("prompt_tokens_details")
+    cache_read_tokens = _numeric_usage_value(
+        usage,
+        "cache_read_tokens",
+        "cache_read_input_tokens",
+        "cached_tokens",
+    )
+    if cache_read_tokens is None:
+        cache_read_tokens = _numeric_usage_value(input_details, "cached_tokens", "cache_read_input_tokens")
+    if cache_read_tokens is not None and usage.get("cache_read_tokens") is None:
+        usage["cache_read_tokens"] = cache_read_tokens
+
+    cache_write_tokens = _numeric_usage_value(
+        usage,
+        "cache_write_tokens",
+        "cache_write_input_tokens",
+        "cache_creation_input_tokens",
+    )
+    if cache_write_tokens is None:
+        cache_write_tokens = _numeric_usage_value(
+            input_details,
+            "cache_write_tokens",
+            "cache_creation_tokens",
+            "cache_creation_input_tokens",
+        )
+    if cache_write_tokens is not None and usage.get("cache_write_tokens") is None:
+        usage["cache_write_tokens"] = cache_write_tokens
 
 
 # ---------------------------------------------------------------------------

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -926,6 +926,7 @@ def _add_cache_usage_aliases(usage: dict[str, Any]) -> None:
         "cache_write_tokens",
         "cache_write_input_tokens",
         "cache_creation_input_tokens",
+        "cache_creation_tokens",
     )
     if cache_write_tokens is None:
         cache_write_tokens = _numeric_usage_value(

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -395,6 +395,49 @@ def test_usage_normalizes_existing_user_visible_token_aliases():
     assert canonical_usage.total_tokens == 3
 
 
+def test_usage_from_response_promotes_openai_cache_token_details():
+    from dspy.clients.openai_format import usage_from_response
+
+    usage = usage_from_response(
+        {
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "total_tokens": 120,
+                "prompt_tokens_details": {
+                    "cached_tokens": 64,
+                    "cache_write_tokens": 16,
+                },
+            }
+        }
+    )
+
+    assert usage.cache_read_tokens == 64
+    assert usage.cache_write_tokens == 16
+    assert usage.prompt_tokens_details == {
+        "cached_tokens": 64,
+        "cache_write_tokens": 16,
+    }
+
+
+def test_usage_from_response_promotes_anthropic_cache_token_details():
+    from dspy.clients.openai_format import usage_from_response
+
+    usage = usage_from_response(
+        {
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 60,
+                "cache_creation_input_tokens": 12,
+            }
+        }
+    )
+
+    assert usage.cache_read_tokens == 60
+    assert usage.cache_write_tokens == 12
+
+
 def test_default_config_does_not_serialize_empty_stop_sequences():
     request = LMRequest.from_call(model="model", prompt="hi")
     entry = LMHistoryEntry(

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -438,6 +438,22 @@ def test_usage_from_response_promotes_anthropic_cache_token_details():
     assert usage.cache_write_tokens == 12
 
 
+def test_usage_from_response_promotes_top_level_cache_creation_tokens():
+    from dspy.clients.openai_format import usage_from_response
+
+    usage = usage_from_response(
+        {
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 1,
+                "cache_creation_tokens": 7,
+            }
+        }
+    )
+
+    assert usage.cache_write_tokens == 7
+
+
 def test_default_config_does_not_serialize_empty_stop_sequences():
     request = LMRequest.from_call(model="model", prompt="hi")
     entry = LMHistoryEntry(


### PR DESCRIPTION
## Summary

Populate DSPy's normalized `LMUsage.cache_read_tokens` and `cache_write_tokens` fields from provider-specific usage payloads.

This keeps the existing raw provider details intact, while making DSPy's existing cache token fields useful for downstream usage tracking and history inspection.

## Why

Providers expose cache usage in different places:

- OpenAI/LiteLLM-compatible payloads can report cache reads under `prompt_tokens_details.cached_tokens` or `input_tokens_details.cached_tokens`
- cache writes can appear under `cache_write_tokens`, `cache_creation_tokens`, or Anthropic-style `cache_creation_input_tokens`

Before this change, `usage_from_response()` preserved those provider-specific fields as extra data but did not promote them into DSPy's normalized cache fields.

## Validation

- `uv run --extra dev pytest tests/core/test_types.py -q`
- `uv run --extra dev ruff check dspy/clients/openai_format.py tests/core/test_types.py`
- `python3 -m compileall -q dspy/clients/openai_format.py tests/core/test_types.py`
- `git diff --check`
