### PR TITLE
Isolate the PythonInterpreter Deno cache

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -152,10 +152,6 @@ def _get_runner_dependency_paths(deno_executable: str, runner_path: str) -> list
             env=_deno_subprocess_env(),
             timeout=DENO_PROBE_TIMEOUT_SECONDS,
         )
-    except FileNotFoundError:
-        # Preserve PythonInterpreter's lazy missing-runtime behavior. start()
-        # performs the existing version check and reports the installation error.
-        return [_canonicalize_path(runner_path)]
     except subprocess.TimeoutExpired as e:
         raise CodeInterpreterError(
             f"Deno dependency preflight timed out after {DENO_PROBE_TIMEOUT_SECONDS} seconds."

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -132,64 +132,6 @@ def _validate_deno_version(deno_executable: str) -> None:
         )
 
 
-def _get_runner_dependency_paths(deno_executable: str, runner_path: str) -> list[str]:
-    """Resolve the exact cached files runner.js needs without exposing DENO_DIR."""
-    command = [
-        deno_executable,
-        "info",
-        "--json",
-        "--no-config",
-        "--no-lock",
-        "--node-modules-dir=false",
-        runner_path,
-    ]
-    try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            check=False,
-            env=_deno_subprocess_env(),
-            timeout=DENO_PROBE_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired as e:
-        raise CodeInterpreterError(
-            f"Deno dependency preflight timed out after {DENO_PROBE_TIMEOUT_SECONDS} seconds."
-        ) from e
-    except OSError as e:
-        raise CodeInterpreterError(f"Unable to run Deno dependency preflight: {e}") from e
-
-    if result.returncode != 0:
-        diagnostic = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
-        raise CodeInterpreterError(f"Deno dependency preflight failed (code {result.returncode}): {diagnostic}")
-
-    try:
-        info = json.loads(result.stdout)
-    except (json.JSONDecodeError, TypeError) as e:
-        raise CodeInterpreterError("Deno dependency preflight returned invalid JSON.") from e
-
-    modules = info.get("modules") if isinstance(info, dict) else None
-    npm_packages = info.get("npmPackages") if isinstance(info, dict) else None
-    if not isinstance(modules, list) or not isinstance(npm_packages, dict):
-        raise CodeInterpreterError("Deno dependency preflight returned malformed dependency information.")
-
-    paths = {_canonicalize_path(runner_path)}
-    for module in modules:
-        if not isinstance(module, dict):
-            raise CodeInterpreterError("Deno dependency preflight returned malformed module information.")
-        local = module.get("local")
-        if local is not None:
-            if not isinstance(local, str) or not local:
-                raise CodeInterpreterError("Deno dependency preflight returned a malformed module path.")
-            paths.add(_canonicalize_path(local))
-    for package in npm_packages.values():
-        local_path = package.get("localPath") if isinstance(package, dict) else None
-        if not isinstance(local_path, str) or not local_path:
-            raise CodeInterpreterError("Deno dependency preflight returned a malformed npm package path.")
-        paths.add(_canonicalize_path(local_path))
-    return sorted(paths)
-
-
 def _jsonrpc_request(method: str, params: dict, id: int | str) -> str:
     """Create a JSON-RPC 2.0 request (expects response)."""
     return json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": id})
@@ -339,18 +281,19 @@ class PythonInterpreter:
             self.deno_command = list(deno_command)
         else:
             deno_executable = _find_deno_executable()
-            runner_path = _canonicalize_path(self._get_runner_path())
             args = [
                 deno_executable,
                 "run",
                 "--no-config",
                 "--no-lock",
                 "--node-modules-dir=false",
-                "--cached-only",
             ]
 
+            # Also allow reading Deno's cache directory so Pyodide can load its files
+            deno_dir = self._get_deno_dir(deno_executable)
             raw_read_paths = [
-                *_get_runner_dependency_paths(deno_executable, runner_path),
+                self._get_runner_path(),
+                *([deno_dir] if deno_dir else []),
                 *self.enable_read_paths,
                 *self.enable_write_paths,
             ]
@@ -367,7 +310,7 @@ class PythonInterpreter:
             if self.enable_write_paths:
                 args.append(f"--allow-write={','.join(_canonicalize_path(x) for x in self.enable_write_paths)}")
 
-            args.append(runner_path)
+            args.append(_canonicalize_path(self._get_runner_path()))
 
             # For runner.js to load in env vars
             if self._env_arg:

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -132,6 +132,64 @@ def _validate_deno_version(deno_executable: str) -> None:
         )
 
 
+def _get_runner_dependency_paths(deno_executable: str, runner_path: str) -> list[str]:
+    """Resolve the exact cached files runner.js needs without exposing DENO_DIR."""
+    command = [
+        deno_executable,
+        "info",
+        "--json",
+        "--no-config",
+        "--no-lock",
+        "--node-modules-dir=false",
+        runner_path,
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_deno_subprocess_env(),
+            timeout=DENO_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise CodeInterpreterError(
+            f"Deno dependency preflight timed out after {DENO_PROBE_TIMEOUT_SECONDS} seconds."
+        ) from e
+    except OSError as e:
+        raise CodeInterpreterError(f"Unable to run Deno dependency preflight: {e}") from e
+
+    if result.returncode != 0:
+        diagnostic = result.stderr.strip() or result.stdout.strip() or "no diagnostic output"
+        raise CodeInterpreterError(f"Deno dependency preflight failed (code {result.returncode}): {diagnostic}")
+
+    try:
+        info = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError) as e:
+        raise CodeInterpreterError("Deno dependency preflight returned invalid JSON.") from e
+
+    modules = info.get("modules") if isinstance(info, dict) else None
+    npm_packages = info.get("npmPackages") if isinstance(info, dict) else None
+    if not isinstance(modules, list) or not isinstance(npm_packages, dict):
+        raise CodeInterpreterError("Deno dependency preflight returned malformed dependency information.")
+
+    paths = {_canonicalize_path(runner_path)}
+    for module in modules:
+        if not isinstance(module, dict):
+            raise CodeInterpreterError("Deno dependency preflight returned malformed module information.")
+        local = module.get("local")
+        if local is not None:
+            if not isinstance(local, str) or not local:
+                raise CodeInterpreterError("Deno dependency preflight returned a malformed module path.")
+            paths.add(_canonicalize_path(local))
+    for package in npm_packages.values():
+        local_path = package.get("localPath") if isinstance(package, dict) else None
+        if not isinstance(local_path, str) or not local_path:
+            raise CodeInterpreterError("Deno dependency preflight returned a malformed npm package path.")
+        paths.add(_canonicalize_path(local_path))
+    return sorted(paths)
+
+
 def _jsonrpc_request(method: str, params: dict, id: int | str) -> str:
     """Create a JSON-RPC 2.0 request (expects response)."""
     return json.dumps({"jsonrpc": "2.0", "method": method, "params": params, "id": id})
@@ -281,19 +339,18 @@ class PythonInterpreter:
             self.deno_command = list(deno_command)
         else:
             deno_executable = _find_deno_executable()
+            runner_path = _canonicalize_path(self._get_runner_path())
             args = [
                 deno_executable,
                 "run",
                 "--no-config",
                 "--no-lock",
                 "--node-modules-dir=false",
+                "--cached-only",
             ]
 
-            # Also allow reading Deno's cache directory so Pyodide can load its files
-            deno_dir = self._get_deno_dir(deno_executable)
             raw_read_paths = [
-                self._get_runner_path(),
-                *([deno_dir] if deno_dir else []),
+                *_get_runner_dependency_paths(deno_executable, runner_path),
                 *self.enable_read_paths,
                 *self.enable_write_paths,
             ]
@@ -310,7 +367,7 @@ class PythonInterpreter:
             if self.enable_write_paths:
                 args.append(f"--allow-write={','.join(_canonicalize_path(x) for x in self.enable_write_paths)}")
 
-            args.append(_canonicalize_path(self._get_runner_path()))
+            args.append(runner_path)
 
             # For runner.js to load in env vars
             if self._env_arg:

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -152,6 +152,10 @@ def _get_runner_dependency_paths(deno_executable: str, runner_path: str) -> list
             env=_deno_subprocess_env(),
             timeout=DENO_PROBE_TIMEOUT_SECONDS,
         )
+    except FileNotFoundError:
+        # Preserve PythonInterpreter's lazy missing-runtime behavior. start()
+        # performs the existing version check and reports the installation error.
+        return [_canonicalize_path(runner_path)]
     except subprocess.TimeoutExpired as e:
         raise CodeInterpreterError(
             f"Deno dependency preflight timed out after {DENO_PROBE_TIMEOUT_SECONDS} seconds."

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -75,6 +75,11 @@ def _canonicalize_path(path: PathLike | str) -> str:
     return os.path.realpath(os.path.expanduser(os.fspath(path)))
 
 
+def _paths_overlap(first: str, second: str) -> bool:
+    first, second = (os.path.normcase(path).rstrip(os.sep) for path in (first, second))
+    return first == second or first.startswith(second + os.sep) or second.startswith(first + os.sep)
+
+
 def _find_deno_executable() -> str:
     """Prefer the Deno binary managed by the optional Python package."""
     try:
@@ -277,6 +282,7 @@ class PythonInterpreter:
         # TODO later on add enable_run (--allow-run) by proxying subprocess.run through Deno.run() to fix 'emscripten does not support processes' error
 
         self._uses_default_deno_command = not deno_command
+        self._deno_dir = None
         if deno_command:
             self.deno_command = list(deno_command)
         else:
@@ -290,7 +296,12 @@ class PythonInterpreter:
             ]
 
             # Also allow reading Deno's cache directory so Pyodide can load its files
-            deno_dir = self._get_deno_dir(deno_executable)
+            shared_deno_dir = self._get_deno_dir(deno_executable)
+            deno_dir = os.path.join(shared_deno_dir, "dspy") if shared_deno_dir else None
+            self._deno_dir = deno_dir
+            protected = [_canonicalize_path(self._get_runner_path()), *([_canonicalize_path(deno_dir)] if deno_dir else [])]
+            if any(_paths_overlap(_canonicalize_path(path), item) for path in self.enable_write_paths for item in protected):
+                raise CodeInterpreterError("Write paths cannot overlap PythonInterpreter runtime files.")
             raw_read_paths = [
                 self._get_runner_path(),
                 *([deno_dir] if deno_dir else []),
@@ -526,6 +537,9 @@ class PythonInterpreter:
     def _spawn_process(self) -> None:
         if self._uses_default_deno_command:
             _validate_deno_version(self.deno_command[0])
+        env = _deno_subprocess_env() if self._uses_default_deno_command else os.environ.copy()
+        if self._deno_dir:
+            env["DENO_DIR"] = self._deno_dir
 
         try:
             self.deno_process = subprocess.Popen(
@@ -535,7 +549,7 @@ class PythonInterpreter:
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="UTF-8",
-                env=_deno_subprocess_env() if self._uses_default_deno_command else os.environ.copy(),
+                env=env,
             )
         except FileNotFoundError as e:
             install_instructions = (

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -282,7 +282,6 @@ class PythonInterpreter:
         # TODO later on add enable_run (--allow-run) by proxying subprocess.run through Deno.run() to fix 'emscripten does not support processes' error
 
         self._uses_default_deno_command = not deno_command
-        self._deno_dir = None
         if deno_command:
             self.deno_command = list(deno_command)
         else:
@@ -296,9 +295,7 @@ class PythonInterpreter:
             ]
 
             # Also allow reading Deno's cache directory so Pyodide can load its files
-            shared_deno_dir = self._get_deno_dir(deno_executable)
-            deno_dir = os.path.join(shared_deno_dir, "dspy") if shared_deno_dir else None
-            self._deno_dir = deno_dir
+            deno_dir = self._get_deno_dir(deno_executable)
             protected = [_canonicalize_path(self._get_runner_path()), *([_canonicalize_path(deno_dir)] if deno_dir else [])]
             if any(_paths_overlap(_canonicalize_path(path), item) for path in self.enable_write_paths for item in protected):
                 raise CodeInterpreterError("Write paths cannot overlap PythonInterpreter runtime files.")
@@ -323,9 +320,10 @@ class PythonInterpreter:
 
             args.append(_canonicalize_path(self._get_runner_path()))
 
-            # For runner.js to load in env vars
-            if self._env_arg:
-                args.append(self._env_arg)
+            # For runner.js to load in env vars and revoke cache access after startup
+            args.append(self._env_arg)
+            if deno_dir:
+                args.append(f"--dspy-deno-dir={_canonicalize_path(deno_dir)}")
             self.deno_command = args
 
         self.deno_process = None
@@ -537,9 +535,6 @@ class PythonInterpreter:
     def _spawn_process(self) -> None:
         if self._uses_default_deno_command:
             _validate_deno_version(self.deno_command[0])
-        env = _deno_subprocess_env() if self._uses_default_deno_command else os.environ.copy()
-        if self._deno_dir:
-            env["DENO_DIR"] = self._deno_dir
 
         try:
             self.deno_process = subprocess.Popen(
@@ -549,7 +544,7 @@ class PythonInterpreter:
                 stderr=subprocess.PIPE,
                 text=True,
                 encoding="UTF-8",
-                env=env,
+                env=_deno_subprocess_env() if self._uses_default_deno_command else os.environ.copy(),
             )
         except FileNotFoundError as e:
             install_instructions = (

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -141,6 +141,8 @@ globalThis.addEventListener("unhandledrejection", (event) => {
 });
 
 const pyodide = await pyodideModule.loadPyodide();
+const denoDir = Deno.args.find((arg) => arg.startsWith("--dspy-deno-dir="))?.slice(16);
+if (denoDir) await Deno.permissions.revoke({ name: "read", path: denoDir });
 
 // Tool call support: allows Python code to call host-side functions
 // The stdin reader is shared so tool_call can read responses during execution

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -597,17 +597,6 @@ def test_runner_dependency_preflight_timeout_is_useful(monkeypatch):
         _get_runner_dependency_paths("deno", "/runner.js")
 
 
-def test_runner_dependency_preflight_defers_missing_deno_error(monkeypatch, tmp_path):
-    runner = tmp_path / "runner.js"
-
-    def missing_deno(*args, **kwargs):
-        raise FileNotFoundError("deno")
-
-    monkeypatch.setattr(python_interpreter.subprocess, "run", missing_deno)
-
-    assert _get_runner_dependency_paths("deno", str(runner)) == [str(runner.resolve())]
-
-
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 4, 5), (2, 9, 5)])
 def test_accepts_supported_deno_2_versions(monkeypatch, version):
     monkeypatch.setattr(python_interpreter, "_get_deno_version", lambda executable: version)

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -25,6 +25,7 @@ from dspy.primitives.python_interpreter import (
     PythonInterpreter,
     _deno_subprocess_env,
     _find_deno_executable,
+    _get_runner_dependency_paths,
     _make_jsonable,
     _validate_deno_version,
 )
@@ -269,6 +270,31 @@ except Exception as e:
         assert secret_content in output
 
 
+def test_default_command_does_not_expose_unrelated_deno_cache_file():
+    deno_executable = _find_deno_executable()
+    deno_dir = PythonInterpreter._get_deno_dir(deno_executable)
+    if not deno_dir:
+        pytest.skip("Deno cache directory could not be determined")
+    canary = Path(deno_dir) / f"dspy-canary-{random.randint(1, 10**9)}.txt"
+    canary.write_text("unrelated DENO_DIR secret")
+    try:
+        with PythonInterpreter() as interpreter:
+            result = interpreter.execute(
+                f"""import js
+try:
+    js.Deno.readTextFileSync({str(canary)!r})
+    result = "disclosed"
+except Exception as e:
+    result = str(e)
+result"""
+            )
+            assert "disclosed" not in result
+            assert "read access" in result.lower()
+            assert interpreter.execute("import math\nmath.factorial(5)") == 120
+    finally:
+        canary.unlink(missing_ok=True)
+
+
 def test_tools_dict_is_copied():
     """Test that tools dict is defensively copied, not stored by reference."""
     tools = {"my_tool": lambda: "result"}
@@ -463,6 +489,7 @@ def test_missing_managed_deno_binary_falls_back_to_path(monkeypatch):
 
 def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_path):
     deno_executable = str(tmp_path / "managed-deno")
+    dependency = tmp_path / "cache" / "dependency.ts"
     seen_operations = []
     monkeypatch.setattr(python_interpreter, "_find_deno_executable", lambda: deno_executable)
     monkeypatch.setattr(
@@ -471,29 +498,103 @@ def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_pat
         lambda executable: seen_operations.append(("version", executable)),
     )
     monkeypatch.setattr(
-        PythonInterpreter,
-        "_get_deno_dir",
-        staticmethod(lambda executable: seen_operations.append(("info", executable)) or str(tmp_path / "cache")),
+        python_interpreter,
+        "_get_runner_dependency_paths",
+        lambda executable, runner: seen_operations.append(("info", executable, runner)) or [str(dependency)],
     )
 
     interpreter = PythonInterpreter()
 
-    assert seen_operations == [("info", deno_executable)]
-    assert interpreter.deno_command[:5] == [
+    assert seen_operations == [("info", deno_executable, os.path.realpath(interpreter._get_runner_path()))]
+    assert interpreter.deno_command[:6] == [
         deno_executable,
         "run",
         "--no-config",
         "--no-lock",
         "--node-modules-dir=false",
+        "--cached-only",
     ]
     runner_index = interpreter.deno_command.index(os.path.realpath(interpreter._get_runner_path()))
-    assert all(interpreter.deno_command.index(flag) < runner_index for flag in interpreter.deno_command[2:5])
+    assert all(interpreter.deno_command.index(flag) < runner_index for flag in interpreter.deno_command[2:6])
+    allow_read = next(arg for arg in interpreter.deno_command if arg.startswith("--allow-read="))
+    assert os.path.realpath(dependency) in allow_read
 
     monkeypatch.setattr(python_interpreter.subprocess, "Popen", lambda *args, **kwargs: object())
     monkeypatch.setattr(interpreter, "_health_check", lambda: None)
     interpreter._spawn_process()
 
-    assert seen_operations == [("info", deno_executable), ("version", deno_executable)]
+    assert seen_operations == [
+        ("info", deno_executable, os.path.realpath(interpreter._get_runner_path())),
+        ("version", deno_executable),
+    ]
+
+
+def test_runner_dependency_preflight_collects_exact_paths(monkeypatch, tmp_path):
+    runner = tmp_path / "runner.js"
+    module = tmp_path / "cache" / "module.ts"
+    package = tmp_path / "cache" / "npm" / "package"
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured.update(kwargs)
+        return types.SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "modules": [{"local": str(module)}, {"specifier": "node:fs"}],
+                    "npmPackages": {"package@1.0.0": {"localPath": str(package)}},
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(python_interpreter.subprocess, "run", fake_run)
+
+    assert _get_runner_dependency_paths("/managed/deno", str(runner)) == sorted(
+        map(os.path.realpath, [runner, module, package])
+    )
+    assert captured["command"] == [
+        "/managed/deno",
+        "info",
+        "--json",
+        "--no-config",
+        "--no-lock",
+        "--node-modules-dir=false",
+        str(runner),
+    ]
+    assert captured["timeout"] == python_interpreter.DENO_PROBE_TIMEOUT_SECONDS
+    assert captured["env"]["DENO_NO_PACKAGE_JSON"] == "1"
+
+
+@pytest.mark.parametrize(
+    "info",
+    [
+        {},
+        {"modules": {}, "npmPackages": {}},
+        {"modules": [None], "npmPackages": {}},
+        {"modules": [], "npmPackages": {"bad": {}}},
+    ],
+)
+def test_runner_dependency_preflight_rejects_malformed_info(monkeypatch, info):
+    monkeypatch.setattr(
+        python_interpreter.subprocess,
+        "run",
+        lambda *args, **kwargs: types.SimpleNamespace(returncode=0, stdout=json.dumps(info), stderr=""),
+    )
+
+    with pytest.raises(CodeInterpreterError, match="malformed"):
+        _get_runner_dependency_paths("deno", "/runner.js")
+
+
+def test_runner_dependency_preflight_timeout_is_useful(monkeypatch):
+    def timeout(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    monkeypatch.setattr(python_interpreter.subprocess, "run", timeout)
+
+    with pytest.raises(CodeInterpreterError, match="dependency preflight timed out"):
+        _get_runner_dependency_paths("deno", "/runner.js")
 
 
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 4, 5), (2, 9, 5)])

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -291,6 +291,18 @@ result"""
     assert "read access" in result.lower()
 
 
+def test_default_runner_starts_offline_from_warm_shared_cache(monkeypatch, tmp_path):
+    shared_cache = tmp_path / "deno"
+    runner = str(Path(python_interpreter.__file__).with_name("runner.js"))
+    env = {**_deno_subprocess_env(), "DENO_DIR": str(shared_cache)}
+    subprocess.run([_find_deno_executable(), "cache", "--no-config", "--no-lock", runner], env=env, check=True)
+    monkeypatch.setenv("DENO_DIR", str(shared_cache))
+
+    with PythonInterpreter() as interpreter:
+        interpreter.deno_command.insert(interpreter.deno_command.index(os.path.realpath(runner)), "--cached-only")
+        assert interpreter.execute("1 + 1") == 2
+
+
 def test_tools_dict_is_copied():
     """Test that tools dict is defensively copied, not stored by reference."""
     tools = {"my_tool": lambda: "result"}
@@ -518,13 +530,13 @@ def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_pat
     assert seen_operations == [("info", deno_executable), ("version", deno_executable)]
 
 
-def test_default_command_uses_dedicated_dspy_cache(monkeypatch, tmp_path):
+def test_default_command_revokes_shared_cache_after_startup(monkeypatch, tmp_path):
     shared_cache = tmp_path / "deno"
     monkeypatch.setattr(PythonInterpreter, "_get_deno_dir", staticmethod(lambda executable: str(shared_cache)))
     interpreter = PythonInterpreter()
 
-    assert interpreter._deno_dir == str(shared_cache / "dspy")
-    assert str(shared_cache / "dspy") in next(arg for arg in interpreter.deno_command if arg.startswith("--allow-read="))
+    assert str(shared_cache) in next(arg for arg in interpreter.deno_command if arg.startswith("--allow-read="))
+    assert f"--dspy-deno-dir={shared_cache}" in interpreter.deno_command
 
 
 def test_rejects_write_paths_overlapping_runtime_files(monkeypatch, tmp_path):

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -25,7 +25,6 @@ from dspy.primitives.python_interpreter import (
     PythonInterpreter,
     _deno_subprocess_env,
     _find_deno_executable,
-    _get_runner_dependency_paths,
     _make_jsonable,
     _validate_deno_version,
 )
@@ -270,31 +269,6 @@ except Exception as e:
         assert secret_content in output
 
 
-def test_default_command_does_not_expose_unrelated_deno_cache_file():
-    deno_executable = _find_deno_executable()
-    deno_dir = PythonInterpreter._get_deno_dir(deno_executable)
-    if not deno_dir:
-        pytest.skip("Deno cache directory could not be determined")
-    canary = Path(deno_dir) / f"dspy-canary-{random.randint(1, 10**9)}.txt"
-    canary.write_text("unrelated DENO_DIR secret")
-    try:
-        with PythonInterpreter() as interpreter:
-            result = interpreter.execute(
-                f"""import js
-try:
-    js.Deno.readTextFileSync({str(canary)!r})
-    result = "disclosed"
-except Exception as e:
-    result = str(e)
-result"""
-            )
-            assert "disclosed" not in result
-            assert "read access" in result.lower()
-            assert interpreter.execute("import math\nmath.factorial(5)") == 120
-    finally:
-        canary.unlink(missing_ok=True)
-
-
 def test_tools_dict_is_copied():
     """Test that tools dict is defensively copied, not stored by reference."""
     tools = {"my_tool": lambda: "result"}
@@ -489,7 +463,6 @@ def test_missing_managed_deno_binary_falls_back_to_path(monkeypatch):
 
 def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_path):
     deno_executable = str(tmp_path / "managed-deno")
-    dependency = tmp_path / "cache" / "dependency.ts"
     seen_operations = []
     monkeypatch.setattr(python_interpreter, "_find_deno_executable", lambda: deno_executable)
     monkeypatch.setattr(
@@ -498,103 +471,29 @@ def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_pat
         lambda executable: seen_operations.append(("version", executable)),
     )
     monkeypatch.setattr(
-        python_interpreter,
-        "_get_runner_dependency_paths",
-        lambda executable, runner: seen_operations.append(("info", executable, runner)) or [str(dependency)],
+        PythonInterpreter,
+        "_get_deno_dir",
+        staticmethod(lambda executable: seen_operations.append(("info", executable)) or str(tmp_path / "cache")),
     )
 
     interpreter = PythonInterpreter()
 
-    assert seen_operations == [("info", deno_executable, os.path.realpath(interpreter._get_runner_path()))]
-    assert interpreter.deno_command[:6] == [
+    assert seen_operations == [("info", deno_executable)]
+    assert interpreter.deno_command[:5] == [
         deno_executable,
         "run",
         "--no-config",
         "--no-lock",
         "--node-modules-dir=false",
-        "--cached-only",
     ]
     runner_index = interpreter.deno_command.index(os.path.realpath(interpreter._get_runner_path()))
-    assert all(interpreter.deno_command.index(flag) < runner_index for flag in interpreter.deno_command[2:6])
-    allow_read = next(arg for arg in interpreter.deno_command if arg.startswith("--allow-read="))
-    assert os.path.realpath(dependency) in allow_read
+    assert all(interpreter.deno_command.index(flag) < runner_index for flag in interpreter.deno_command[2:5])
 
     monkeypatch.setattr(python_interpreter.subprocess, "Popen", lambda *args, **kwargs: object())
     monkeypatch.setattr(interpreter, "_health_check", lambda: None)
     interpreter._spawn_process()
 
-    assert seen_operations == [
-        ("info", deno_executable, os.path.realpath(interpreter._get_runner_path())),
-        ("version", deno_executable),
-    ]
-
-
-def test_runner_dependency_preflight_collects_exact_paths(monkeypatch, tmp_path):
-    runner = tmp_path / "runner.js"
-    module = tmp_path / "cache" / "module.ts"
-    package = tmp_path / "cache" / "npm" / "package"
-    captured = {}
-
-    def fake_run(command, **kwargs):
-        captured["command"] = command
-        captured.update(kwargs)
-        return types.SimpleNamespace(
-            returncode=0,
-            stdout=json.dumps(
-                {
-                    "modules": [{"local": str(module)}, {"specifier": "node:fs"}],
-                    "npmPackages": {"package@1.0.0": {"localPath": str(package)}},
-                }
-            ),
-            stderr="",
-        )
-
-    monkeypatch.setattr(python_interpreter.subprocess, "run", fake_run)
-
-    assert _get_runner_dependency_paths("/managed/deno", str(runner)) == sorted(
-        map(os.path.realpath, [runner, module, package])
-    )
-    assert captured["command"] == [
-        "/managed/deno",
-        "info",
-        "--json",
-        "--no-config",
-        "--no-lock",
-        "--node-modules-dir=false",
-        str(runner),
-    ]
-    assert captured["timeout"] == python_interpreter.DENO_PROBE_TIMEOUT_SECONDS
-    assert captured["env"]["DENO_NO_PACKAGE_JSON"] == "1"
-
-
-@pytest.mark.parametrize(
-    "info",
-    [
-        {},
-        {"modules": {}, "npmPackages": {}},
-        {"modules": [None], "npmPackages": {}},
-        {"modules": [], "npmPackages": {"bad": {}}},
-    ],
-)
-def test_runner_dependency_preflight_rejects_malformed_info(monkeypatch, info):
-    monkeypatch.setattr(
-        python_interpreter.subprocess,
-        "run",
-        lambda *args, **kwargs: types.SimpleNamespace(returncode=0, stdout=json.dumps(info), stderr=""),
-    )
-
-    with pytest.raises(CodeInterpreterError, match="malformed"):
-        _get_runner_dependency_paths("deno", "/runner.js")
-
-
-def test_runner_dependency_preflight_timeout_is_useful(monkeypatch):
-    def timeout(command, **kwargs):
-        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
-
-    monkeypatch.setattr(python_interpreter.subprocess, "run", timeout)
-
-    with pytest.raises(CodeInterpreterError, match="dependency preflight timed out"):
-        _get_runner_dependency_paths("deno", "/runner.js")
+    assert seen_operations == [("info", deno_executable), ("version", deno_executable)]
 
 
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 4, 5), (2, 9, 5)])

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -269,6 +269,28 @@ except Exception as e:
         assert secret_content in output
 
 
+def test_default_runner_cannot_read_shared_deno_cache(monkeypatch, tmp_path):
+    shared_cache = tmp_path / "deno"
+    shared_cache.mkdir()
+    canary = shared_cache / "secret.txt"
+    canary.write_text("shared cache secret")
+    monkeypatch.setenv("DENO_DIR", str(shared_cache))
+
+    with PythonInterpreter() as interpreter:
+        result = interpreter.execute(
+            f"""import js
+try:
+    js.Deno.readTextFileSync({str(canary)!r})
+    result = "disclosed"
+except Exception as error:
+    result = str(error)
+result"""
+        )
+
+    assert "disclosed" not in result
+    assert "read access" in result.lower()
+
+
 def test_tools_dict_is_copied():
     """Test that tools dict is defensively copied, not stored by reference."""
     tools = {"my_tool": lambda: "result"}
@@ -494,6 +516,23 @@ def test_default_command_uses_managed_deno_for_info_and_run(monkeypatch, tmp_pat
     interpreter._spawn_process()
 
     assert seen_operations == [("info", deno_executable), ("version", deno_executable)]
+
+
+def test_default_command_uses_dedicated_dspy_cache(monkeypatch, tmp_path):
+    shared_cache = tmp_path / "deno"
+    monkeypatch.setattr(PythonInterpreter, "_get_deno_dir", staticmethod(lambda executable: str(shared_cache)))
+    interpreter = PythonInterpreter()
+
+    assert interpreter._deno_dir == str(shared_cache / "dspy")
+    assert str(shared_cache / "dspy") in next(arg for arg in interpreter.deno_command if arg.startswith("--allow-read="))
+
+
+def test_rejects_write_paths_overlapping_runtime_files(monkeypatch, tmp_path):
+    cache = tmp_path / "deno"
+    monkeypatch.setattr(PythonInterpreter, "_get_deno_dir", staticmethod(lambda executable: str(cache)))
+
+    with pytest.raises(CodeInterpreterError, match="runtime files"):
+        PythonInterpreter(enable_write_paths=[cache])
 
 
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 4, 5), (2, 9, 5)])

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -597,6 +597,17 @@ def test_runner_dependency_preflight_timeout_is_useful(monkeypatch):
         _get_runner_dependency_paths("deno", "/runner.js")
 
 
+def test_runner_dependency_preflight_defers_missing_deno_error(monkeypatch, tmp_path):
+    runner = tmp_path / "runner.js"
+
+    def missing_deno(*args, **kwargs):
+        raise FileNotFoundError("deno")
+
+    monkeypatch.setattr(python_interpreter.subprocess, "run", missing_deno)
+
+    assert _get_runner_dependency_paths("deno", str(runner)) == [str(runner.resolve())]
+
+
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 4, 5), (2, 9, 5)])
 def test_accepts_supported_deno_2_versions(monkeypatch, version):
     monkeypatch.setattr(python_interpreter, "_get_deno_version", lambda executable: version)


### PR DESCRIPTION
## Summary

- preserve the shared Deno cache so already-warm installations still start offline
- revoke the runner's cache read permission after Pyodide has loaded, preventing guest code from reading unrelated cache contents
- reject write mounts overlapping either the bundled runner or its Deno cache
- leave custom `deno_command` behavior unchanged

## Scope

The production diff is 17 changed lines across `python_interpreter.py` and `runner.js` (14 additions, 3 deletions).

## Verification

- `uv run pytest tests/primitives/test_python_interpreter.py -q --deno` — 102 passed
- focused live tests verify both that a cache canary is unreadable to guest code and that a warm shared cache starts under `--cached-only`
- `ruff check --fix-only --diff --exit-non-zero-on-fix ...` — clean
- `git diff --check` — clean