### PR TITLE
Make PythonInterpreter request handling robust

### DIFF
--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -339,6 +339,7 @@ class PythonInterpreter:
         self._mounted_files = False
         self._last_diagnostic: str | None = None
         self._owner_thread: int | None = None
+        self._handling_tool_call = False
         self._pending_large_vars = {}
         self._session_ended = False
 
@@ -763,7 +764,7 @@ class PythonInterpreter:
         code: str,
         variables: dict[str, Any] | None = None,
     ) -> Any:
-        if getattr(self, "_handling_tool_call", False):
+        if self._handling_tool_call:
             raise CodeInterpreterError("PythonInterpreter cannot execute recursively from one of its tools.")
         self._check_session_active()
         self._check_thread_ownership()
@@ -794,8 +795,6 @@ class PythonInterpreter:
             # Handle incoming requests (tool calls from sandbox)
             if "method" in msg:
                 if msg["method"] == "tool_call":
-                    if not isinstance(params := msg.get("params"), dict) or params.get("exec_id") != execute_request_id:
-                        self._raise_terminal_error("Received an unauthenticated tool call from the sandbox.")
                     self._handle_tool_call(msg)
                     continue
 

--- a/dspy/primitives/python_interpreter.py
+++ b/dspy/primitives/python_interpreter.py
@@ -16,6 +16,7 @@ import logging
 import math
 import os
 import re
+import secrets
 import shutil
 import subprocess
 import threading
@@ -336,7 +337,6 @@ class PythonInterpreter:
 
         self.deno_process = None
         self._mounted_files = False
-        self._request_id = 0
         self._last_diagnostic: str | None = None
         self._owner_thread: int | None = None
         self._pending_large_vars = {}
@@ -503,7 +503,11 @@ class PythonInterpreter:
         kwargs = params.get("kwargs", {})
 
         try:
-            result = self.invoke_tool(tool_name, kwargs)
+            self._handling_tool_call = True
+            try:
+                result = self.invoke_tool(tool_name, kwargs)
+            finally:
+                self._handling_tool_call = False
             result = _make_jsonable(result)
             if result is None or isinstance(result, str):
                 response = _jsonrpc_result({"value": str(result) if result is not None else "", "type": "string"}, request_id)
@@ -594,10 +598,9 @@ class PythonInterpreter:
             logger.debug("Skipping malformed JSON during %s: %s", context, response_line[:100])
             return None
 
-    def _next_request_id(self) -> int:
-        self._request_id += 1
+    def _next_request_id(self) -> str:
         self._last_diagnostic = None
-        return self._request_id
+        return secrets.token_hex(16)
 
     def _handle_out_of_band_message(self, msg: dict, context: str) -> bool:
         """Consume a message that is not a response to any request (a notification
@@ -760,6 +763,8 @@ class PythonInterpreter:
         code: str,
         variables: dict[str, Any] | None = None,
     ) -> Any:
+        if getattr(self, "_handling_tool_call", False):
+            raise CodeInterpreterError("PythonInterpreter cannot execute recursively from one of its tools.")
         self._check_session_active()
         self._check_thread_ownership()
         variables = variables or {}
@@ -789,6 +794,8 @@ class PythonInterpreter:
             # Handle incoming requests (tool calls from sandbox)
             if "method" in msg:
                 if msg["method"] == "tool_call":
+                    if not isinstance(params := msg.get("params"), dict) or params.get("exec_id") != execute_request_id:
+                        self._raise_terminal_error("Received an unauthenticated tool call from the sandbox.")
                     self._handle_tool_call(msg)
                     continue
 

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -20,7 +20,7 @@ sys.stdout, sys.stderr = buf_stdout, buf_stderr
 def last_exception_args():
     return json.dumps(sys.last_exc.args) if sys.last_exc else None
 
-class FinalOutput(BaseException):
+class _DSPyFinalOutput(BaseException):
     # Control-flow exception to signal completion (like StopIteration)
     pass
 
@@ -28,24 +28,24 @@ class FinalOutput(BaseException):
 # Only define if not already registered with typed signatures.
 if 'SUBMIT' not in dir():
     def SUBMIT(output):
-        raise FinalOutput({"output": output})
+        raise _DSPyFinalOutput({"output": output})
 `;
 
 // Generate a tool wrapper function with typed signature.
 // Parameters is an array of {name, type?, default?} objects.
 // Convert a JavaScript/JSON value to Python literal syntax
 const toPythonLiteral = (value) => {
-  if (value === null) return 'None';
-  if (value === true) return 'True';
-  if (value === false) return 'False';
-  return JSON.stringify(value);  // Works for strings, numbers, arrays, objects
+  const serialized = JSON.stringify(value);
+  return `__import__("json").loads(${JSON.stringify(serialized)})`;
 };
+
+const toPythonType = (type) => type === "NoneType" ? "type(None)" : type;
 
 const makeToolWrapper = (toolName, parameters = []) => {
   // Build signature parts: "query: str, limit: int = 10"
   const sigParts = parameters.map(p => {
     let part = p.name;
-    if (p.type) part += `: ${p.type}`;
+    if (p.type) part += `: ${toPythonType(p.type)}`;
     if (p.default !== undefined) part += ` = ${toPythonLiteral(p.default)}`;
     return part;
   });
@@ -72,20 +72,20 @@ const makeSubmitWrapper = (outputs) => {
     // Fallback to single-arg SUBMIT if no outputs defined
     return `
 def SUBMIT(output):
-    raise FinalOutput({"output": output})
+    raise _DSPyFinalOutput({"output": output})
 `;
   }
 
   const sigParts = outputs.map(o => {
     let part = o.name;
-    if (o.type) part += `: ${o.type}`;
+    if (o.type) part += `: ${toPythonType(o.type)}`;
     return part;
   });
   const dictParts = outputs.map(o => `"${o.name}": ${o.name}`);
 
   return `
 def SUBMIT(${sigParts.join(', ')}):
-    raise FinalOutput({${dictParts.join(', ')}})
+    raise _DSPyFinalOutput({${dictParts.join(', ')}})
 `;
 };
 
@@ -352,8 +352,8 @@ while (true) {
       // error.message is mostly blank.
       const errorMessage = (error.message || "").trim();
 
-      // Handle FinalOutput as a success result, not an error
-      if (errorType === "FinalOutput") {
+      // Handle SUBMIT's control-flow exception as a success result, not an error
+      if (errorType === "_DSPyFinalOutput") {
         const last_exception_args = pyodide.globals.get("last_exception_args");
         const errorArgs = JSON.parse(last_exception_args()) || [];
         const answer = errorArgs[0] || null;

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -3,11 +3,6 @@
 import pyodideModule from "npm:pyodide@0.29.4/pyodide.js";
 import { readLines } from "https://deno.land/std@0.186.0/io/mod.ts";
 
-// Capture protocol primitives before guest JavaScript can replace their global bindings.
-const JSON = Object.freeze(globalThis.JSON);
-const console = Object.freeze(globalThis.console);
-const encodeProtocolMessage = (message) => JSON.stringify({ __proto__: null, ...message });
-
 // =============================================================================
 // Python Code Templates
 // =============================================================================
@@ -119,21 +114,21 @@ const JSONRPC_APP_ERRORS = {
 };
 
 const jsonrpcRequest = (method, params, id) =>
-  encodeProtocolMessage({ jsonrpc: "2.0", method, params: { __proto__: null, ...params }, id });
+  JSON.stringify({ jsonrpc: "2.0", method, params, id });
 
 const jsonrpcNotification = (method, params = null) => {
   const msg = { jsonrpc: "2.0", method };
   if (params) msg.params = params;
-  return encodeProtocolMessage(msg);
+  return JSON.stringify(msg);
 };
 
 const jsonrpcResult = (result, id) =>
-  encodeProtocolMessage({ jsonrpc: "2.0", result: { __proto__: null, ...result }, id });
+  JSON.stringify({ jsonrpc: "2.0", result, id });
 
 const jsonrpcError = (code, message, id, data = null) => {
-  const err = { __proto__: null, code, message };
-  if (data) err.data = { __proto__: null, ...data };
-  return encodeProtocolMessage({ jsonrpc: "2.0", error: err, id });
+  const err = { code, message };
+  if (data) err.data = data;
+  return JSON.stringify({ jsonrpc: "2.0", error: err, id });
 };
 
 // Global handler to prevent uncaught promise rejections from crashing Deno
@@ -153,23 +148,20 @@ if (denoDir) await Deno.permissions.revoke({ name: "read", path: denoDir });
 // The stdin reader is shared so tool_call can read responses during execution
 const stdinReader = readLines(Deno.stdin);
 let requestIdCounter = 0;
-let executionRequestId = null;
 
 const TOOL_BRIDGE_ERROR_KEY = "__dspy_tool_bridge_error__";
 
 // This function is called from Python to invoke a host-side tool
-async function toolCallBridge(executionId, name, argsJson) {
+async function toolCallBridge(name, argsJson) {
   const requestId = `tc_${Date.now()}_${++requestIdCounter}`;
 
   try {
-    if (executionId !== executionRequestId) throw new Error("execution is no longer active");
     const parsedArgs = JSON.parse(argsJson);
 
     // Send tool call request to host using JSON-RPC
     console.log(jsonrpcRequest("tool_call", {
       name: name,
-      kwargs: parsedArgs.kwargs || {},
-      exec_id: executionId
+      kwargs: parsedArgs.kwargs || {}
     }, requestId));
 
     // Wait for response from host
@@ -212,6 +204,9 @@ async function toolCallBridge(executionId, name, argsJson) {
     };
   }
 }
+
+// Expose the bridge to Python
+pyodide.globals.set("_js_tool_call", toolCallBridge);
 
 try {
   const env_vars = (Deno.args[0] ?? "").split(",").filter(Boolean);
@@ -334,8 +329,6 @@ while (true) {
   }
 
   if (method === "execute") {
-    executionRequestId = requestId;
-    pyodide.globals.set("_js_tool_call", (name, args) => toolCallBridge(requestId, name, args));
     const code = params.code || "";
     let setupCompleted = false;  // Track if PYTHON_SETUP_CODE ran successfully
 
@@ -381,7 +374,6 @@ while (true) {
       const errorCode = JSONRPC_APP_ERRORS[errorType] || JSONRPC_APP_ERRORS.Unknown;
       console.log(jsonrpcError(errorCode, errorMessage, requestId, { type: errorType, args: errorArgs }));
     } finally {
-      executionRequestId = null;
       // Always restore stdout/stderr if setup completed, even after errors.
       // This prevents stream corruption where subsequent executions capture
       // StringIO buffers as old_stdout/old_stderr instead of real streams.

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -3,6 +3,11 @@
 import pyodideModule from "npm:pyodide@0.29.4/pyodide.js";
 import { readLines } from "https://deno.land/std@0.186.0/io/mod.ts";
 
+// Capture protocol primitives before guest JavaScript can replace their global bindings.
+const JSON = Object.freeze(globalThis.JSON);
+const console = Object.freeze(globalThis.console);
+const encodeProtocolMessage = (message) => JSON.stringify({ __proto__: null, ...message });
+
 // =============================================================================
 // Python Code Templates
 // =============================================================================
@@ -114,21 +119,21 @@ const JSONRPC_APP_ERRORS = {
 };
 
 const jsonrpcRequest = (method, params, id) =>
-  JSON.stringify({ jsonrpc: "2.0", method, params, id });
+  encodeProtocolMessage({ jsonrpc: "2.0", method, params: { __proto__: null, ...params }, id });
 
 const jsonrpcNotification = (method, params = null) => {
   const msg = { jsonrpc: "2.0", method };
   if (params) msg.params = params;
-  return JSON.stringify(msg);
+  return encodeProtocolMessage(msg);
 };
 
 const jsonrpcResult = (result, id) =>
-  JSON.stringify({ jsonrpc: "2.0", result, id });
+  encodeProtocolMessage({ jsonrpc: "2.0", result: { __proto__: null, ...result }, id });
 
 const jsonrpcError = (code, message, id, data = null) => {
-  const err = { code, message };
-  if (data) err.data = data;
-  return JSON.stringify({ jsonrpc: "2.0", error: err, id });
+  const err = { __proto__: null, code, message };
+  if (data) err.data = { __proto__: null, ...data };
+  return encodeProtocolMessage({ jsonrpc: "2.0", error: err, id });
 };
 
 // Global handler to prevent uncaught promise rejections from crashing Deno
@@ -148,20 +153,23 @@ if (denoDir) await Deno.permissions.revoke({ name: "read", path: denoDir });
 // The stdin reader is shared so tool_call can read responses during execution
 const stdinReader = readLines(Deno.stdin);
 let requestIdCounter = 0;
+let executionRequestId = null;
 
 const TOOL_BRIDGE_ERROR_KEY = "__dspy_tool_bridge_error__";
 
 // This function is called from Python to invoke a host-side tool
-async function toolCallBridge(name, argsJson) {
+async function toolCallBridge(executionId, name, argsJson) {
   const requestId = `tc_${Date.now()}_${++requestIdCounter}`;
 
   try {
+    if (executionId !== executionRequestId) throw new Error("execution is no longer active");
     const parsedArgs = JSON.parse(argsJson);
 
     // Send tool call request to host using JSON-RPC
     console.log(jsonrpcRequest("tool_call", {
       name: name,
-      kwargs: parsedArgs.kwargs || {}
+      kwargs: parsedArgs.kwargs || {},
+      exec_id: executionId
     }, requestId));
 
     // Wait for response from host
@@ -204,9 +212,6 @@ async function toolCallBridge(name, argsJson) {
     };
   }
 }
-
-// Expose the bridge to Python
-pyodide.globals.set("_js_tool_call", toolCallBridge);
 
 try {
   const env_vars = (Deno.args[0] ?? "").split(",").filter(Boolean);
@@ -329,6 +334,8 @@ while (true) {
   }
 
   if (method === "execute") {
+    executionRequestId = requestId;
+    pyodide.globals.set("_js_tool_call", (name, args) => toolCallBridge(requestId, name, args));
     const code = params.code || "";
     let setupCompleted = false;  // Track if PYTHON_SETUP_CODE ran successfully
 
@@ -374,6 +381,7 @@ while (true) {
       const errorCode = JSONRPC_APP_ERRORS[errorType] || JSONRPC_APP_ERRORS.Unknown;
       console.log(jsonrpcError(errorCode, errorMessage, requestId, { type: errorType, args: errorArgs }));
     } finally {
+      executionRequestId = null;
       // Always restore stdout/stderr if setup completed, even after errors.
       // This prevents stream corruption where subsequent executions capture
       // StringIO buffers as old_stdout/old_stderr instead of real streams.

--- a/dspy/primitives/runner.js
+++ b/dspy/primitives/runner.js
@@ -3,6 +3,7 @@
 import pyodideModule from "npm:pyodide@0.29.4/pyodide.js";
 import { readLines } from "https://deno.land/std@0.186.0/io/mod.ts";
 
+const JSON = Object.freeze(globalThis.JSON), console = Object.freeze(globalThis.console);
 // =============================================================================
 // Python Code Templates
 // =============================================================================
@@ -114,7 +115,7 @@ const JSONRPC_APP_ERRORS = {
 };
 
 const jsonrpcRequest = (method, params, id) =>
-  JSON.stringify({ jsonrpc: "2.0", method, params, id });
+  JSON.stringify({ __proto__: null, jsonrpc: "2.0", method, params: { __proto__: null, ...params }, id });
 
 const jsonrpcNotification = (method, params = null) => {
   const msg = { jsonrpc: "2.0", method };

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -798,6 +798,108 @@ def test_protocol_failure_ends_session(monkeypatch):
             interpreter.execute("2 + 2")
 
 
+def test_request_ids_are_128_bit_capabilities():
+    interpreter = PythonInterpreter(deno_command=["deno"])
+    request_ids = {interpreter._next_request_id() for _ in range(100)}
+
+    assert len(request_ids) == 100
+    assert all(len(request_id) == 32 and int(request_id, 16) >= 0 for request_id in request_ids)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "globalThis.JSON = {parse: JSON.parse, stringify: () => 'not json'}",
+        "globalThis.console = {log: () => {}, error: console.error}",
+    ],
+)
+def test_guest_cannot_replace_runner_protocol_bindings(mutation):
+    with PythonInterpreter() as interpreter:
+        assert interpreter.execute(f"import js\njs.eval({mutation!r})\n'genuine'") == "genuine"
+        assert interpreter.execute("40 + 2") == 42
+
+
+def test_guest_prototype_hook_cannot_redirect_authenticated_tool_call():
+    calls = []
+
+    def benign():
+        calls.append("benign")
+        return "safe"
+
+    def danger():
+        calls.append("danger")
+        return "unsafe"
+
+    with PythonInterpreter(tools={"benign": benign, "danger": danger}) as interpreter:
+        result = interpreter.execute(
+            "import js\n"
+            "js.eval('Object.prototype.toJSON = function() { "
+            'if (Object.hasOwn(this, "exec_id")) return {name: "danger", kwargs: {}, exec_id: this.exec_id}; '
+            "return this; }')\n"
+            "benign()"
+        )
+
+    assert result == "safe"
+    assert calls == ["benign"]
+
+
+def test_guest_prototype_hooks_cannot_rewrite_protocol_results_or_errors():
+    with PythonInterpreter() as interpreter:
+        assert interpreter.execute(
+            "import js\n"
+            "js.eval('Object.prototype.toJSON = function() { "
+            'if (Object.hasOwn(this, "output")) return {output: "forged"}; '
+            'if (Object.hasOwn(this, "code")) return {code: -32000, message: "forged"}; '
+            "return this; }')\n"
+            "'genuine'"
+        ) == "genuine"
+        with pytest.raises(CodeExecutionError, match="ValueError.*real"):
+            interpreter.execute("raise ValueError('real')")
+        assert interpreter.execute("40 + 2") == 42
+
+
+def test_forged_tool_call_fails_closed_without_invoking_tool():
+    calls = []
+    with PythonInterpreter(tools={"danger": lambda: calls.append(True)}) as interpreter:
+        with pytest.raises(CodeInterpreterError, match="unauthenticated tool call"):
+            interpreter.execute(
+                "import js\n"
+                "js.console.log('{\"jsonrpc\":\"2.0\",\"method\":\"tool_call\","
+                "\"params\":{\"name\":\"danger\",\"kwargs\":{}},\"id\":\"forged\"}')\n"
+                "'safe'"
+            )
+    assert calls == []
+
+
+def test_stale_tool_bridge_cannot_inherit_next_execution_id():
+    calls = []
+    with PythonInterpreter(tools={"danger": lambda: calls.append(True)}) as interpreter:
+        assert interpreter.execute(
+            "import js\n"
+            "from pyodide.ffi import create_proxy\n"
+            "old_bridge = _js_tool_call\n"
+            "stale_callback = create_proxy(lambda: old_bridge('danger', '{\"kwargs\":{}}'))\n"
+            "js.setTimeout(stale_callback, 50)\n"
+            "'scheduled'"
+        ) == "scheduled"
+        assert interpreter.execute("import asyncio\nawait asyncio.sleep(0.15)\n42") == 42
+        assert interpreter.execute("6 * 7") == 42
+    assert calls == []
+
+
+def test_tool_cannot_reenter_same_interpreter():
+    holder = {}
+
+    def nested_execute():
+        return holder["interpreter"].execute("'nested'")
+
+    with PythonInterpreter(tools={"nested_execute": nested_execute}) as interpreter:
+        holder["interpreter"] = interpreter
+        with pytest.raises(CodeExecutionError, match="cannot execute recursively"):
+            interpreter.execute("nested_execute()")
+        assert interpreter.execute("40 + 2") == 42
+
+
 def test_failed_health_check_ends_session(monkeypatch):
     interpreter = PythonInterpreter()
     monkeypatch.setattr(
@@ -1524,9 +1626,11 @@ def test_id_less_protocol_errors_are_terminal():
         interpreter._handle_out_of_band_message(parse_error, "during test")
 
 
-def test_unsolicited_error_line_is_not_consumed_as_the_response():
+def test_unsolicited_error_line_is_not_consumed_as_the_response(monkeypatch):
     """#10165: an id-less async error arriving ahead of the real response (the
     wire trace an unhandled rejection produces) must not be mistaken for it."""
+    request_id = "a" * 32
+    monkeypatch.setattr(python_interpreter.secrets, "token_hex", lambda _: request_id)
 
     class FakeDeno:
         def __init__(self, lines):
@@ -1540,7 +1644,7 @@ def test_unsolicited_error_line_is_not_consumed_as_the_response():
     interpreter = PythonInterpreter()
     interpreter.deno_process = FakeDeno([
         json.dumps({"jsonrpc": "2.0", "error": {"code": -32007, "message": "Unhandled async error: PythonError"}, "id": None}),
-        json.dumps({"jsonrpc": "2.0", "result": {"output": "ok\n"}, "id": 1}),
+        json.dumps({"jsonrpc": "2.0", "result": {"output": "ok\n"}, "id": request_id}),
     ])
     assert interpreter.execute("print('ok')") == "ok\n"
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -806,6 +806,30 @@ def test_request_ids_are_128_bit_random_values():
     assert all(len(request_id) == 32 and int(request_id, 16) >= 0 for request_id in request_ids)
 
 
+def test_guest_prototype_hook_cannot_redirect_tool_wrapper():
+    calls = []
+
+    def benign():
+        calls.append("benign")
+        return "safe"
+
+    def danger():
+        calls.append("danger")
+        return "unsafe"
+
+    with PythonInterpreter(tools={"benign": benign, "danger": danger}) as interpreter:
+        result = interpreter.execute(
+            "import js\n"
+            "js.eval('Object.prototype.toJSON = function() { "
+            'if (Object.hasOwn(this, "name")) return {name: "danger", kwargs: {}}; '
+            "return this; }')\n"
+            "benign()"
+        )
+
+    assert result == "safe"
+    assert calls == ["benign"]
+
+
 def test_tool_cannot_reenter_same_interpreter():
     holder = {}
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -720,6 +720,26 @@ def test_tool_with_typed_signature(configure_pooled_interpreter):
     assert result == "searched 'test' with limit 5"
 
 
+def test_tool_none_type_and_nested_json_default():
+    def tool(value: type(None) = None, items: list = [None]):  # noqa: B006
+        return [value, items]
+
+    with PythonInterpreter(tools={"tool": tool}) as interpreter:
+        assert interpreter.execute("tool()") == [None, [None]]
+
+
+@pytest.mark.parametrize(
+    ("field", "code", "expected"),
+    [
+        ({"name": "nothing", "type": "NoneType"}, "SUBMIT(nothing=None)", {"nothing": None}),
+        ({"name": "FinalOutput", "type": "str"}, "SUBMIT(FinalOutput='ok')", {"FinalOutput": "ok"}),
+    ],
+)
+def test_submit_valid_runtime_edge_cases(field, code, expected):
+    with PythonInterpreter(output_fields=[field]) as interpreter:
+        assert interpreter.execute(code) == FinalOutput(expected)
+
+
 def test_tool_positional_args(configure_pooled_interpreter):
     """Test that tools work with positional arguments."""
 

--- a/tests/primitives/test_python_interpreter.py
+++ b/tests/primitives/test_python_interpreter.py
@@ -798,93 +798,12 @@ def test_protocol_failure_ends_session(monkeypatch):
             interpreter.execute("2 + 2")
 
 
-def test_request_ids_are_128_bit_capabilities():
+def test_request_ids_are_128_bit_random_values():
     interpreter = PythonInterpreter(deno_command=["deno"])
     request_ids = {interpreter._next_request_id() for _ in range(100)}
 
     assert len(request_ids) == 100
     assert all(len(request_id) == 32 and int(request_id, 16) >= 0 for request_id in request_ids)
-
-
-@pytest.mark.parametrize(
-    "mutation",
-    [
-        "globalThis.JSON = {parse: JSON.parse, stringify: () => 'not json'}",
-        "globalThis.console = {log: () => {}, error: console.error}",
-    ],
-)
-def test_guest_cannot_replace_runner_protocol_bindings(mutation):
-    with PythonInterpreter() as interpreter:
-        assert interpreter.execute(f"import js\njs.eval({mutation!r})\n'genuine'") == "genuine"
-        assert interpreter.execute("40 + 2") == 42
-
-
-def test_guest_prototype_hook_cannot_redirect_authenticated_tool_call():
-    calls = []
-
-    def benign():
-        calls.append("benign")
-        return "safe"
-
-    def danger():
-        calls.append("danger")
-        return "unsafe"
-
-    with PythonInterpreter(tools={"benign": benign, "danger": danger}) as interpreter:
-        result = interpreter.execute(
-            "import js\n"
-            "js.eval('Object.prototype.toJSON = function() { "
-            'if (Object.hasOwn(this, "exec_id")) return {name: "danger", kwargs: {}, exec_id: this.exec_id}; '
-            "return this; }')\n"
-            "benign()"
-        )
-
-    assert result == "safe"
-    assert calls == ["benign"]
-
-
-def test_guest_prototype_hooks_cannot_rewrite_protocol_results_or_errors():
-    with PythonInterpreter() as interpreter:
-        assert interpreter.execute(
-            "import js\n"
-            "js.eval('Object.prototype.toJSON = function() { "
-            'if (Object.hasOwn(this, "output")) return {output: "forged"}; '
-            'if (Object.hasOwn(this, "code")) return {code: -32000, message: "forged"}; '
-            "return this; }')\n"
-            "'genuine'"
-        ) == "genuine"
-        with pytest.raises(CodeExecutionError, match="ValueError.*real"):
-            interpreter.execute("raise ValueError('real')")
-        assert interpreter.execute("40 + 2") == 42
-
-
-def test_forged_tool_call_fails_closed_without_invoking_tool():
-    calls = []
-    with PythonInterpreter(tools={"danger": lambda: calls.append(True)}) as interpreter:
-        with pytest.raises(CodeInterpreterError, match="unauthenticated tool call"):
-            interpreter.execute(
-                "import js\n"
-                "js.console.log('{\"jsonrpc\":\"2.0\",\"method\":\"tool_call\","
-                "\"params\":{\"name\":\"danger\",\"kwargs\":{}},\"id\":\"forged\"}')\n"
-                "'safe'"
-            )
-    assert calls == []
-
-
-def test_stale_tool_bridge_cannot_inherit_next_execution_id():
-    calls = []
-    with PythonInterpreter(tools={"danger": lambda: calls.append(True)}) as interpreter:
-        assert interpreter.execute(
-            "import js\n"
-            "from pyodide.ffi import create_proxy\n"
-            "old_bridge = _js_tool_call\n"
-            "stale_callback = create_proxy(lambda: old_bridge('danger', '{\"kwargs\":{}}'))\n"
-            "js.setTimeout(stale_callback, 50)\n"
-            "'scheduled'"
-        ) == "scheduled"
-        assert interpreter.execute("import asyncio\nawait asyncio.sleep(0.15)\n42") == 42
-        assert interpreter.execute("6 * 7") == 42
-    assert calls == []
 
 
 def test_tool_cannot_reenter_same_interpreter():


### PR DESCRIPTION
## Summary

- use unpredictable 128-bit request IDs instead of sequential counters
- preserve wrapper A → tool A identity under guest prototype/global mutation
- reject recursive same-interpreter execution before transport desynchronization
- render valid `NoneType`, nested JSON defaults, and `FinalOutput` output names correctly

## Scope

This does not prevent generated code from invoking explicitly bound tools; generated code already receives that authority. It guarantees request correlation, wrapper dispatch identity, recoverable reentrancy rejection, and valid generated Python signatures/defaults.

## Size

Production diff: **+25/-18**. Tests: +69/-2.

## Validation

- real-Deno PythonInterpreter suite: 111 passed
- focused request identity, prototype isolation, reentrancy, SUBMIT termination, filesystem security, `NoneType`, nested defaults, and `FinalOutput` cases passed
- candidate-only Ruff and diff hygiene clean

## Independent adversarial review

- **Verdict:** PASS on exact SHA `e71a56d8017b5ec148ff79843da11ed6e452b1c9`
- **Receipt:** https://ampcode.com/threads/T-01a00218-e406-733b-a61a-b20e8732328d
- **Residual risks:** guest-controlled nested kwargs remain guest-controlled data; runtime review covered Linux/Python 3.11/Deno 2.9.5 rather than the complete CI matrix.
