### PR TITLE
feat(gepa): parallelize candidate evaluation

### DIFF
--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -279,7 +279,8 @@ class GEPA(Teleprompter):
         add_format_failure_as_feedback: Whether to add format failures as feedback. Default is False.
         use_merge: Whether to use merge-based optimization. Default is True.
         max_merge_invocations: The maximum number of merge invocations to perform. Default is 5.
-        num_threads: The number of threads to use for evaluation with `Evaluate`. Optional.
+        num_threads: The total number of threads available for candidate and example evaluation. Multi-proposal
+            candidate evaluations share this budget. Optional.
         failure_score: The score to assign to failed examples. Default is 0.0.
         perfect_score: The maximum score achievable by the metric. Default is 1.0. Used by GEPA
             to determine if all examples in a minibatch are perfect.
@@ -325,7 +326,7 @@ class GEPA(Teleprompter):
             - mlflow_tracking_uri: The tracking URI to use for MLflow (when use_mlflow=True).
             - mlflow_experiment_name: The experiment name to use for MLflow (when use_mlflow=True).
             - sampling_strategy, selection_strategy, acceptance_criterion: GEPA 0.1.4 proposal controls.
-              DSPy supports these using GEPA's sequential candidate-evaluation fallback.
+              DSPy evaluates proposal candidates concurrently within the `num_threads` budget.
             - wandb_attach_existing, mlflow_attach_existing, tracking_key_prefix: GEPA 0.1.4 tracking controls.
 
             `max_reflection_cost` is not supported yet because DSPy LMs do not expose the cumulative cost
@@ -346,8 +347,9 @@ class GEPA(Teleprompter):
         Merge Configuration: GEPA can merge successful program variants using `use_merge=True`.
         The `max_merge_invocations` parameter controls how many merge attempts are made during optimization.
 
-        Evaluation Configuration: Use `num_threads` to parallelize evaluation. The `failure_score` and
-        `perfect_score` parameters help GEPA understand your metric's range and optimize accordingly.
+        Evaluation Configuration: `num_threads` controls total evaluation concurrency and is shared across
+        candidates in multi-proposal batches. The `failure_score` and `perfect_score` parameters help GEPA
+        understand your metric's range and optimize accordingly.
 
         Logging Configuration: Set `log_dir` to save detailed logs and enable checkpoint resuming.
         Use `track_stats=True` to access detailed optimization results via the `detailed_results` attribute.

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -273,21 +273,25 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
 
     def batch_evaluate(self, items, *, capture_traces=True):
         total_threads = self.num_threads or dspy.settings.num_threads
-        candidate_threads = min(len(items), total_threads) or 1
-        threads_per_candidate = max(1, total_threads // candidate_threads)
+        candidate_workers = min(len(items), total_threads) or 1
+        threads_per_candidate, extra_threads = divmod(total_threads, candidate_workers)
 
         def evaluate(item):
-            context, (candidate, batch) = item
+            context, (candidate, batch), num_threads = item
             return context.run(
                 self.evaluate,
                 batch,
                 candidate,
                 capture_traces=capture_traces,
-                num_threads=threads_per_candidate,
+                num_threads=num_threads,
             )
 
-        with ThreadPoolExecutor(max_workers=candidate_threads) as executor:
-            return list(executor.map(evaluate, [(copy_context(), item) for item in items]))
+        work = [
+            (copy_context(), item, threads_per_candidate + (index < extra_threads))
+            for index, item in enumerate(items)
+        ]
+        with ThreadPoolExecutor(max_workers=candidate_workers) as executor:
+            return list(executor.map(evaluate, work))
 
     def get_adapter_state(self) -> dict[str, Any]:
         return {"rng_state": self.rng.getstate()}

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -1,5 +1,7 @@
 import logging
 import random
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from typing import Any, Callable, Protocol, TypedDict
 
 from gepa import EvaluationBatch, GEPAAdapter
@@ -189,7 +191,8 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
 
         return new_prog
 
-    def evaluate(self, batch, candidate, capture_traces=False):
+    def evaluate(self, batch, candidate, capture_traces=False, num_threads=None):
+        num_threads = self.num_threads if num_threads is None else num_threads
         try:
             program = self.build_program(candidate)
         except (SyntaxError, CodeInterpreterError) as e:
@@ -217,7 +220,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 program,
                 batch,
                 metric_fn=self.metric_fn,
-                num_threads=self.num_threads,
+                num_threads=num_threads,
                 failure_score=self.failure_score,
                 callback_metadata=callback_metadata,
                 capture_traces=capture_traces,
@@ -231,7 +234,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 program=program,
                 dataset=batch,
                 metric=self.metric_fn,
-                num_threads=self.num_threads,
+                num_threads=num_threads,
                 raise_on_error=False,
                 capture_failed_parses=True,
                 failure_score=self.failure_score,
@@ -255,7 +258,7 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
             evaluator = Evaluate(
                 devset=batch,
                 metric=self.metric_fn,
-                num_threads=self.num_threads,
+                num_threads=num_threads,
                 return_all_scores=True,
                 failure_score=self.failure_score,
                 provide_traceback=True,
@@ -267,6 +270,24 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
             scores = [r[2] for r in res.results]
             scores = [s["score"] if hasattr(s, "score") else s for s in scores]
             return EvaluationBatch(outputs=outputs, scores=scores, trajectories=None)
+
+    def batch_evaluate(self, items, *, capture_traces=True):
+        total_threads = self.num_threads or dspy.settings.num_threads
+        candidate_threads = min(len(items), total_threads) or 1
+        threads_per_candidate = max(1, total_threads // candidate_threads)
+
+        def evaluate(item):
+            context, (candidate, batch) = item
+            return context.run(
+                self.evaluate,
+                batch,
+                candidate,
+                capture_traces=capture_traces,
+                num_threads=threads_per_candidate,
+            )
+
+        with ThreadPoolExecutor(max_workers=candidate_threads) as executor:
+            return list(executor.map(evaluate, [(copy_context(), item) for item in items]))
 
     def get_adapter_state(self) -> dict[str, Any]:
         return {"rng_state": self.rng.getstate()}

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -661,3 +661,37 @@ def test_adapter_state_round_trips_rng():
     adapter.rng.random()
     adapter.set_adapter_state(state)
     assert adapter.rng.random() == expected
+
+
+def test_batch_evaluate_is_parallel_and_preserves_context():
+    from gepa import EvaluationBatch
+
+    from dspy.teleprompt.gepa.gepa_utils import DspyAdapter
+    from dspy.utils.callback_context import ACTIVE_CALL_ID
+
+    adapter = DspyAdapter(SimpleModule("input -> output"), simple_metric, {}, num_threads=4)
+    barrier = threading.Barrier(2)
+    trace_modes = []
+    thread_budgets = []
+
+    def evaluate(batch, candidate, capture_traces=False, num_threads=None):
+        if capture_traces:
+            barrier.wait(timeout=1)
+        trace_modes.append(capture_traces)
+        thread_budgets.append(num_threads)
+        return EvaluationBatch(outputs=[(candidate, dspy.settings.lm, ACTIVE_CALL_ID.get())], scores=[1.0])
+
+    adapter.evaluate = evaluate
+    lm = DummyLM([])
+    token = ACTIVE_CALL_ID.set("parent")
+    try:
+        with dspy.context(lm=lm):
+            results = adapter.batch_evaluate([("first", []), ("second", [])])
+    finally:
+        ACTIVE_CALL_ID.reset(token)
+
+    assert [result.outputs[0] for result in results] == [("first", lm, "parent"), ("second", lm, "parent")]
+
+    adapter.batch_evaluate([("first", [])], capture_traces=False)
+    assert trace_modes == [True, True, False]
+    assert thread_budgets == [2, 2, 4]

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -695,3 +695,9 @@ def test_batch_evaluate_is_parallel_and_preserves_context():
     adapter.batch_evaluate([("first", [])], capture_traces=False)
     assert trace_modes == [True, True, False]
     assert thread_budgets == [2, 2, 4]
+
+    adapter.num_threads = 8
+    adapter.batch_evaluate([("first", []), ("second", []), ("third", [])], capture_traces=False)
+    assert trace_modes == [True, True, False, False, False, False]
+    assert sorted(thread_budgets[-3:]) == [2, 3, 3]
+    assert sum(thread_budgets[-3:]) == 8


### PR DESCRIPTION
## Why this PR exists

Stacked on #10209, which upgrades DSPy to GEPA 0.1.4 while retaining GEPA's sequential candidate-evaluation fallback.

GEPA 0.1.4 can sample multiple proposals in one iteration, but leaves execution policy to `adapter.batch_evaluate()`. Without that method, DSPy evaluates candidates one after another. This PR implements that adapter capability while preserving DSPy's normal meaning of `num_threads` as the **total** evaluation budget.

## Before and after

| | #10209 | This PR |
|---|---|---|
| Candidate evaluation | Ordered sequential fallback | Concurrent within `num_threads` |
| Examples within one candidate | Up to `num_threads` | A share of the same budget |
| Maximum controlled concurrency | `num_threads` | `num_threads` |
| New concurrency setting | None | None |
| `max_reflection_cost` | Explicitly unsupported | Still explicitly unsupported |

Candidate and example concurrency do not multiply. Four candidates with `num_threads=8` receive two example workers each; one candidate receives all eight. If candidates outnumber threads, at most eight run at once with one worker each.

With GEPA's default one-proposal strategy, execution remains equivalent to ordinary DSPy evaluation. Strategies such as `IndependentSampling(4)` or `PxNSampling(2, 2)` cause DSPy to partition the existing budget across candidates.

## Design

`DspyAdapter.batch_evaluate()`:

1. receives ordered `(candidate, batch)` items from GEPA;
2. resolves DSPy's existing `num_threads` setting;
3. runs at most `min(number_of_candidates, num_threads)` candidates concurrently;
4. divides the thread budget across candidate evaluations;
5. preserves DSPy `ContextVar` state and callback ancestry;
6. preserves result order;
7. forwards `capture_traces`; and
8. propagates exceptions without retry.

```text
GEPA proposal batch
└── candidate workers × example workers ≤ num_threads
```

It uses a small `ThreadPoolExecutor` rather than DSPy's `ParallelExecutor`. `ParallelExecutor` catches failures and may resubmit stragglers; at this boundary, resubmission could duplicate paid LM calls.

## Deliberately not included: reflection-cost accounting

GEPA's `max_reflection_cost` expects cumulative `total_cost`. DSPy's LM history records response cost, but history can be disabled, bounded/evicted, cleared, or replaced. Summing retained history would be unreliable, while adding a mutable `_total_cost` would create a second source of truth plus locking and serialization behavior.

This PR does neither. Non-`None` `max_reflection_cost` remains explicitly rejected. Cost budgeting should use a coherent DSPy-wide accounting design rather than GEPA-specific LM state.

## User example

```python
import dspy
from gepa.strategies.proposal_sampling import IndependentSampling
from gepa.strategies.proposal_selection import BestImprovement

optimizer = dspy.GEPA(
    metric=metric,
    max_metric_calls=2_000,
    reflection_lm=dspy.LM("openai/gpt-5", temperature=1.0, max_tokens=32_000),
    reflection_minibatch_size=8,
    num_threads=8,  # Total across candidates and examples, as elsewhere in DSPy.
    log_dir="./gepa-run",
    track_stats=True,
    gepa_kwargs={
        "sampling_strategy": IndependentSampling(4),
        "selection_strategy": BestImprovement(),
        "acceptance_criterion": "strict_improvement",
    },
)

optimized = optimizer.compile(student, trainset=trainset, valset=valset)
```

This samples four independent proposals, evaluates them concurrently within eight total threads, retains the best improvement, and supports checkpoint resume through `log_dir`.

## Measured behavior

A controlled end-to-end GEPA 0.1.4 benchmark compared this branch with #10209. Both used `num_threads=4` for one complete `IndependentSampling(4)` iteration with four distinct improvements, `AllImprovements`, and an 80 ms simulated candidate evaluation:

| | #10209 fallback | Shared-budget batching |
|---|---:|---:|
| Median of 3 runs | 1.051 s | 0.333 s |
| Peak candidates | 1 | 4 |
| Threads per candidate | N/A | 1 |
| Metric calls | 13 | 13 |
| Candidates including seed | 5 | 5 |

That is a **3.16× speedup with identical work/results**, consistent with GEPA's advertised “up to about 3 to 4×” result. It is a controlled latency benchmark, not a guarantee or a reproduction of GEPA's quality benchmarks.

A second probe used the real DSPy `Evaluate` path with four candidates × eight examples and `num_threads=8`. Peak simultaneous example evaluations remained exactly **8**, proving this does not create 32 workers. All four ordered eight-example results were retained.

## Risks and compatibility

### Scheduling shape

More candidate program instances can be active concurrently, while each receives fewer example workers. Total DSPy-controlled concurrency remains bounded by `num_threads`. Uneven candidate durations may change utilization, but users do not need a second concurrency knob.

### GEPA 0.1.4 → 0.1.5

GEPA 0.1.4 calls `batch_evaluate(items)` and always requests trajectories, including accepted-candidate full-validation evaluation. That is [gepa-ai/gepa#428](https://github.com/gepa-ai/gepa/issues/428).

This adapter accepts the trace-aware contract expected from [gepa-ai/gepa#430](https://github.com/gepa-ai/gepa/pull/430): `batch_evaluate(items, *, capture_traces=...)`. Under that change, reflection requests traces while seed/full-validation evaluation do not. Against 0.1.4, the keyword is omitted and DSPy's default remains `True`, so the known limitation remains. Updating to 0.1.5 will activate correct routing without another adapter redesign; no temporary monkeypatch is included.

## Review guide

The complete diff against #10209 is three files:

- `dspy/teleprompt/gepa/gepa_utils.py`: candidate batching and thread-budget partitioning
- `dspy/teleprompt/gepa/gepa.py`: documents shared `num_threads` semantics
- `tests/teleprompt/test_gepa.py`: overlap, ordering, context, trace forwarding, and 2+2 / 4 budget allocation

There are no new public concurrency parameters and no `BaseLM`, history, cost, lock, copy, or serialization changes.

## Verification

- `uv run pytest tests/teleprompt -q` — 82 passed
- `uv run pytest -q tests/clients/test_lm.py tests/teleprompt/test_gepa.py` — 108 passed
- `uv run pre-commit run --all-files` — passed
- `uv lock --check` — passed
- `git diff --check` — passed
