### PR TITLE
docs: fix four dead external links (SGLang, Substack, Langtrace, OpenLIT)

### DIFF
--- a/docs/docs/community/built-with-dspy.md
+++ b/docs/docs/community/built-with-dspy.md
@@ -93,7 +93,7 @@ These are community-maintained projects and are not officially supported by the 
 | **LlamaIndex** | [Link](https://github.com/stanfordnlp/dspy/blob/main/examples/llamaindex/dspy_llamaindex_rag.ipynb) |
 | **Langtrace** | [Link](https://docs.langtrace.ai/supported-integrations/llm-frameworks/dspy) |
 | **Langfuse** | [Link](https://langfuse.com/docs/integrations/dspy) |
-| **OpenLIT** | [Link](https://docs.openlit.io/latest/integrations/dspy) |
+| **OpenLIT** | [Link](https://docs.openlit.io/latest/sdk/integrations/dspy) |
 | **Relevance AI** | [Link](https://relevanceai.com/blog/dspy-programming---not-prompting---language-models) |
 | **Advancing Analytics** | [Link](https://www.advancinganalytics.co.uk/blog/prompt-optimisation-an-introduction-to-dspy) |
 

--- a/docs/docs/community/community-resources.md
+++ b/docs/docs/community/community-resources.md
@@ -13,7 +13,6 @@ This is the list of tutorials and blog posts on DSPy. If you would like to add y
 |---|---|
 | **Why I bet on DSPy** | [Blog](https://blog.isaacbmiller.com/posts/dspy) |
 | **Not Your Average Prompt Engineering** | [Blog](https://jina.ai/news/dspy-not-your-average-prompt-engineering/) |
-| **Why I'm excited about DSPy** | [Blog](https://stephenso.substack.com/p/why-im-excited-about-dspy) |
 | **Achieving GPT-4 Performance at Lower Cost** | [Link](https://gradient.ai/blog/achieving-gpt-4-level-performance-at-lower-cost-using-dspy) |
 | **Prompt engineering is a task best left to AI models** | [Link](https://www.theregister.com/2024/02/22/prompt_engineering_ai_models/) |
 | **What makes DSPy a valuable framework for developing complex language model pipelines?** | [Link](https://medium.com/@sujathamudadla1213/what-makes-dspy-a-valuable-framework-for-developing-complex-language-model-pipelines-edfa5b4bcf9b) |

--- a/docs/docs/community/community-resources.md
+++ b/docs/docs/community/community-resources.md
@@ -13,7 +13,7 @@ This is the list of tutorials and blog posts on DSPy. If you would like to add y
 |---|---|
 | **Why I bet on DSPy** | [Blog](https://blog.isaacbmiller.com/posts/dspy) |
 | **Not Your Average Prompt Engineering** | [Blog](https://jina.ai/news/dspy-not-your-average-prompt-engineering/) |
-| **Why I'm excited about DSPy** | [Blog](https://substack.stephen.so/p/why-im-excited-about-dspy) |
+| **Why I'm excited about DSPy** | [Blog](https://stephenso.substack.com/p/why-im-excited-about-dspy) |
 | **Achieving GPT-4 Performance at Lower Cost** | [Link](https://gradient.ai/blog/achieving-gpt-4-level-performance-at-lower-cost-using-dspy) |
 | **Prompt engineering is a task best left to AI models** | [Link](https://www.theregister.com/2024/02/22/prompt_engineering_ai_models/) |
 | **What makes DSPy a valuable framework for developing complex language model pipelines?** | [Link](https://medium.com/@sujathamudadla1213/what-makes-dspy-a-valuable-framework-for-developing-complex-language-model-pipelines-edfa5b4bcf9b) |
@@ -41,7 +41,7 @@ This is the list of tutorials and blog posts on DSPy. If you would like to add y
 | **Adding Depth to DSPy Programs** | [Link](https://www.youtube.com/watch?v=0c7Ksd6BG88) |
 | **Programming Foundation Models with DSPy** | [Link](https://www.youtube.com/watch?v=Y94tw4eDHW0) |
 | **DSPy End-to-End: SF Meetup** | [Link](https://www.youtube.com/watch?v=Y81DoFmt-2U) |
-| **Monitoring & Tracing DSPy with Langtrace** | [Link](https://langtrace.ai/blog/announcing-dspy-support-in-langtrace) |
+| **Monitoring & Tracing DSPy with Langtrace** | [Link](https://docs.langtrace.ai/supported-integrations/llm-frameworks/dspy) |
 | **Teaching chat models to solve chess puzzles using DSPy + Finetuning** | [Link](https://raw.sh/posts/chess_puzzles) |
 | **Build Self-Improving AI Agents with DSPy (No Code)** | [Link](https://www.youtube.com/watch?v=UY8OsMlV21Y) |
 | **DSPy 3.0 and DSPy at Databricks** | [Link](https://www.youtube.com/watch?v=grIuzesOwwU) |

--- a/docs/docs/learn/programming/language_models.md
+++ b/docs/docs/learn/programming/language_models.md
@@ -89,7 +89,7 @@ dspy.configure(lm=lm)
         ```
 
     === "Local LMs on a GPU server"
-          First, install [SGLang](https://sgl-project.github.io/start/install.html) and launch its server with your LM.
+          First, install [SGLang](https://docs.sglang.ai/docs/get-started/install) and launch its server with your LM.
 
           ```bash
           > pip install "sglang[all]"


### PR DESCRIPTION
Four external links 404 because the target sites restructured. All replacements verified live (200):

1. **learn/programming/language_models.md** - SGLang install page moved from `sgl-project.github.io/start/install.html` to `docs.sglang.ai/docs/get-started/install`.
2. **community/community-resources.md** - the Stephen's Substack post moved when the custom domain was dropped: `substack.stephen.so/...` -> `stephenso.substack.com/p/why-im-excited-about-dspy`.
3. **community/community-resources.md** - the Langtrace blog announcement URL is gone (`langtrace.ai/blog/...`); pointed at the live Langtrace docs page for DSPy support, which is the same topic.
4. **community/built-with-dspy.md** - OpenLIT integration docs restructured: `/latest/integrations/dspy` -> `/latest/sdk/integrations/dspy`.