### PR TITLE
fix: validate TypedDict input annotations instead of crashing in _check_type

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,7 +1,7 @@
 import logging
 import random
 import types
-from typing import Any, Literal, Union, get_args, get_origin, is_typeddict
+from typing import Any, Literal, Union, get_args, get_origin, get_type_hints, is_typeddict
 
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
@@ -330,11 +330,17 @@ def _check_type(value: Any, expected: type) -> bool:
     args = get_args(expected)
 
     # TypedDict: typing forbids isinstance checks against it, so validate the
-    # shape directly. Downstream pydantic serialization handles the values.
+    # shape directly: required keys must be present, no unknown keys, and each
+    # declared member checked against its own annotation.
     if is_typeddict(expected):
         if not isinstance(value, dict):
             return False
-        return expected.__required_keys__ <= value.keys()
+        hints = get_type_hints(expected)
+        if not expected.__required_keys__ <= value.keys():
+            return False
+        if not value.keys() <= hints.keys():
+            return False
+        return all(_check_type(item, hints[key]) for key, item in value.items())
 
     # Union / Optional (X | None)
     if origin is Union or origin is types.UnionType:

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -2,7 +2,18 @@ import logging
 import random
 import sys
 import types
-from typing import Any, Literal, Union, get_args, get_origin, get_type_hints, is_typeddict
+from typing import Any, Literal, Union, get_args, get_origin, get_type_hints
+
+try:
+    # typing.is_typeddict does not recognise classes built with
+    # typing_extensions.TypedDict, and an unrecognised one falls through to the
+    # isinstance check, which raises "TypedDict does not support instance and
+    # class checks". typing_extensions.is_typeddict recognises both flavours. It
+    # ships with pydantic, which is a hard dependency, but the import is guarded
+    # so a missing typing_extensions degrades instead of breaking imports.
+    from typing_extensions import is_typeddict
+except ImportError:
+    from typing import is_typeddict
 
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,5 +1,6 @@
 import logging
 import random
+import sys
 import types
 from typing import Any, Literal, Union, get_args, get_origin, get_type_hints, is_typeddict
 
@@ -321,6 +322,25 @@ def _is_value_compatible_with_type(value: Any, expected: type) -> bool:
     return _check_type(value, expected)
 
 
+def _resolvable_member_hints(typed_dict: type) -> dict[str, Any]:
+    """Resolve the members of a TypedDict that can be resolved, and skip the rest.
+
+    get_type_hints is all or nothing: a single member naming a type that is not
+    importable from the definition site raises, and the annotations of every other
+    member are lost with it. Each member is resolved on its own here so an
+    unresolvable one costs only its own check.
+    """
+    namespace = getattr(sys.modules.get(typed_dict.__module__), "__dict__", {})
+    hints: dict[str, Any] = {}
+    for key, annotation in getattr(typed_dict, "__annotations__", {}).items():
+        holder = type("_Member", (), {"__annotations__": {key: annotation}})
+        try:
+            hints[key] = get_type_hints(holder, namespace)[key]
+        except Exception:
+            continue
+    return hints
+
+
 def _check_type(value: Any, expected: type) -> bool:
     """Stdlib replacement for typeguard.check_type."""
     if expected is Any:
@@ -342,12 +362,11 @@ def _check_type(value: Any, expected: type) -> bool:
         try:
             hints = get_type_hints(expected)
         except (NameError, TypeError):
-            # A forward reference that does not resolve from here, or a member
-            # annotated with something that is not a type. The keys have already
-            # been checked above without needing resolution, so report on the
-            # shape rather than raising out of a type check and ending the
-            # prediction, which is the crash this function exists to avoid.
-            return True
+            # One member with an unresolvable forward reference makes get_type_hints
+            # raise for the whole TypedDict. Resolving member by member keeps the
+            # rest checkable, so a sibling with the wrong value type is still
+            # reported instead of the unresolvable member excusing the payload.
+            hints = _resolvable_member_hints(expected)
         return all(_check_type(item, hints[key]) for key, item in value.items() if key in hints)
 
     # Union / Optional (X | None)

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -335,12 +335,20 @@ def _check_type(value: Any, expected: type) -> bool:
     if is_typeddict(expected):
         if not isinstance(value, dict):
             return False
-        hints = get_type_hints(expected)
         if not expected.__required_keys__ <= value.keys():
             return False
-        if not value.keys() <= hints.keys():
+        if not value.keys() <= expected.__annotations__.keys():
             return False
-        return all(_check_type(item, hints[key]) for key, item in value.items())
+        try:
+            hints = get_type_hints(expected)
+        except (NameError, TypeError):
+            # A forward reference that does not resolve from here, or a member
+            # annotated with something that is not a type. The keys have already
+            # been checked above without needing resolution, so report on the
+            # shape rather than raising out of a type check and ending the
+            # prediction, which is the crash this function exists to avoid.
+            return True
+        return all(_check_type(item, hints[key]) for key, item in value.items() if key in hints)
 
     # Union / Optional (X | None)
     if origin is Union or origin is types.UnionType:

--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -1,7 +1,7 @@
 import logging
 import random
 import types
-from typing import Any, Literal, Union, get_args, get_origin
+from typing import Any, Literal, Union, get_args, get_origin, is_typeddict
 
 from pydantic import BaseModel
 from pydantic_core import PydanticUndefined
@@ -328,6 +328,13 @@ def _check_type(value: Any, expected: type) -> bool:
 
     origin = get_origin(expected)
     args = get_args(expected)
+
+    # TypedDict: typing forbids isinstance checks against it, so validate the
+    # shape directly. Downstream pydantic serialization handles the values.
+    if is_typeddict(expected):
+        if not isinstance(value, dict):
+            return False
+        return expected.__required_keys__ <= value.keys()
 
     # Union / Optional (X | None)
     if origin is Union or origin is types.UnionType:

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1780,3 +1780,40 @@ def test_custom_signature_types(caplog, enable_type_warnings):
         assert "Type mismatch for field 'query': expected Query" in caplog.text
     else:
         assert "Type mismatch" not in caplog.text
+
+
+def test_typeddict_type_validation(caplog):
+    """TypedDict-annotated inputs must validate instead of crashing (#10214)."""
+    log_test_helper()
+
+    from typing import TypedDict
+
+    class EmailRecord(TypedDict):
+        subject: str
+        sender_email: str
+
+    class TypedDictSignature(dspy.Signature):
+        email: EmailRecord = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    predict_instance = Predict(TypedDictSignature)
+    lm = DummyLM([{"result": "test output 1"}, {"result": "test output 2"}, {"result": "test output 3"}])
+    dspy.configure(lm=lm)
+
+    # Valid dict: no crash, no warning
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(email={"subject": "hi", "sender_email": "a@b.c"})
+    assert "Type mismatch" not in caplog.text
+
+    # Missing required key warns rather than passing silently
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(email={"subject": "hi"})
+    assert "Type mismatch for field 'email'" in caplog.text
+
+    # Non-dict value warns
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(email="not a dict")
+    assert "Type mismatch for field 'email'" in caplog.text

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1856,3 +1856,33 @@ def test_typeddict_optional_members(caplog):
     with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
         predict_instance(profile={"name": "arthi", "age": "thirty"})
     assert "Type mismatch for field 'profile'" in caplog.text
+
+
+def test_typeddict_unresolvable_forward_reference(caplog):
+    """An annotation that cannot be resolved must not end the prediction (#10215 review)."""
+    log_test_helper()
+
+    from typing import TypedDict
+
+    class Unresolvable(TypedDict):
+        # A forward reference to a name that does not exist anywhere. get_type_hints
+        # raises NameError on this, and that used to propagate out of _check_type.
+        item: "NoSuchTypeAnywhere"
+
+    class UnresolvableSignature(dspy.Signature):
+        payload: Unresolvable = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    predict_instance = Predict(UnresolvableSignature)
+    dspy.configure(lm=DummyLM([{"result": "ok"}, {"result": "ok"}]))
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        prediction = predict_instance(payload={"item": 1})
+    assert prediction.result == "ok"
+
+    # The key checks still apply, because they do not need the annotation resolved.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(payload={"unknown_key": 1})
+    assert "Type mismatch for field 'payload'" in caplog.text

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import enum
 import logging
+import sys
 import time
 import types
 from datetime import datetime
@@ -1786,7 +1787,7 @@ def test_typeddict_type_validation(caplog):
     """TypedDict-annotated inputs must validate instead of crashing (#10214)."""
     log_test_helper()
 
-    from typing import TypedDict
+    from typing_extensions import TypedDict
 
     class EmailRecord(TypedDict):
         subject: str
@@ -1829,7 +1830,7 @@ def test_typeddict_optional_members(caplog):
     """NotRequired members may be absent, but must type-check when present."""
     log_test_helper()
 
-    from typing import NotRequired, TypedDict
+    from typing_extensions import NotRequired, TypedDict
 
     class Profile(TypedDict):
         name: str
@@ -1862,7 +1863,7 @@ def test_typeddict_unresolvable_forward_reference(caplog):
     """An annotation that cannot be resolved must not end the prediction (#10215 review)."""
     log_test_helper()
 
-    from typing import TypedDict
+    from typing_extensions import TypedDict
 
     class Unresolvable(TypedDict):
         # A forward reference to a name that does not exist anywhere. get_type_hints
@@ -1892,7 +1893,7 @@ def test_typeddict_unresolvable_member_does_not_excuse_its_siblings(caplog):
     """One unresolvable member must not suppress a mismatch on a resolvable one."""
     log_test_helper()
 
-    from typing import TypedDict
+    from typing_extensions import TypedDict
 
     class Mixed(TypedDict):
         # get_type_hints raises for the whole class because of this member alone.
@@ -1947,6 +1948,39 @@ def test_typing_extensions_typeddict_is_recognised(caplog):
     assert "Type mismatch" not in caplog.text
 
     # And it must actually be validated, not merely survive.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(record={"sender": "arthi", "count": "two"})
+    assert "Type mismatch for field 'record'" in caplog.text
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 12),
+    reason="pydantic rejects typing.TypedDict below 3.12 and asks for typing_extensions instead",
+)
+def test_stdlib_typeddict_is_recognised(caplog):
+    """The typing.TypedDict path still needs cover on the versions that allow it."""
+    log_test_helper()
+
+    from typing import TypedDict as StdTypedDict
+
+    class StdRecord(StdTypedDict):
+        sender: str
+        count: int
+
+    class StdSignature(dspy.Signature):
+        record: StdRecord = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    predict_instance = Predict(StdSignature)
+    dspy.configure(lm=DummyLM([{"result": "ok"}, {"result": "ok"}]))
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        prediction = predict_instance(record={"sender": "arthi", "count": 2})
+    assert prediction.result == "ok"
+    assert "Type mismatch" not in caplog.text
+
     caplog.clear()
     with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
         predict_instance(record={"sender": "arthi", "count": "two"})

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1918,3 +1918,36 @@ def test_typeddict_unresolvable_member_does_not_excuse_its_siblings(caplog):
     with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
         predict_instance(payload={"opaque": object(), "count": "three"})
     assert "Type mismatch for field 'payload'" in caplog.text
+
+
+def test_typing_extensions_typeddict_is_recognised(caplog):
+    """typing_extensions.TypedDict must take the TypedDict path, not the isinstance one."""
+    log_test_helper()
+
+    from typing_extensions import TypedDict as ExtTypedDict
+
+    class ExtRecord(ExtTypedDict):
+        sender: str
+        count: int
+
+    class ExtSignature(dspy.Signature):
+        record: ExtRecord = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    predict_instance = Predict(ExtSignature)
+    dspy.configure(lm=DummyLM([{"result": "ok"}, {"result": "ok"}, {"result": "ok"}]))
+
+    # typing.is_typeddict returns False for this class, so before the fix it reached
+    # isinstance(value, expected) and raised TypedDict does not support instance and
+    # class checks, ending the prediction.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        prediction = predict_instance(record={"sender": "arthi", "count": 2})
+    assert prediction.result == "ok"
+    assert "Type mismatch" not in caplog.text
+
+    # And it must actually be validated, not merely survive.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(record={"sender": "arthi", "count": "two"})
+    assert "Type mismatch for field 'record'" in caplog.text

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1886,3 +1886,35 @@ def test_typeddict_unresolvable_forward_reference(caplog):
     with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
         predict_instance(payload={"unknown_key": 1})
     assert "Type mismatch for field 'payload'" in caplog.text
+
+
+def test_typeddict_unresolvable_member_does_not_excuse_its_siblings(caplog):
+    """One unresolvable member must not suppress a mismatch on a resolvable one."""
+    log_test_helper()
+
+    from typing import TypedDict
+
+    class Mixed(TypedDict):
+        # get_type_hints raises for the whole class because of this member alone.
+        opaque: "StillNoSuchType"
+        # This one resolves perfectly well and must still be checked.
+        count: int
+
+    class MixedSignature(dspy.Signature):
+        payload: Mixed = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    predict_instance = Predict(MixedSignature)
+    dspy.configure(lm=DummyLM([{"result": "ok"}, {"result": "ok"}]))
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(payload={"opaque": object(), "count": 3})
+    assert "Type mismatch" not in caplog.text
+
+    # count is a str where the annotation says int. The unresolvable sibling must not
+    # turn this into a whole-payload pass.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(payload={"opaque": object(), "count": "three"})
+    assert "Type mismatch for field 'payload'" in caplog.text

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1797,7 +1797,7 @@ def test_typeddict_type_validation(caplog):
         result: str = dspy.OutputField()
 
     predict_instance = Predict(TypedDictSignature)
-    lm = DummyLM([{"result": "test output 1"}, {"result": "test output 2"}, {"result": "test output 3"}])
+    lm = DummyLM([{"result": f"test output {i}"} for i in range(6)])
     dspy.configure(lm=lm)
 
     # Valid dict: no crash, no warning
@@ -1817,3 +1817,42 @@ def test_typeddict_type_validation(caplog):
     with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
         predict_instance(email="not a dict")
     assert "Type mismatch for field 'email'" in caplog.text
+
+    # A member value that contradicts its declared annotation warns
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(email={"subject": 123, "sender_email": "a@b.c"})
+    assert "Type mismatch for field 'email'" in caplog.text
+
+
+def test_typeddict_optional_members(caplog):
+    """NotRequired members may be absent, but must type-check when present."""
+    log_test_helper()
+
+    from typing import NotRequired, TypedDict
+
+    class Profile(TypedDict):
+        name: str
+        age: NotRequired[int]
+
+    class ProfileSignature(dspy.Signature):
+        profile: Profile = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    predict_instance = Predict(ProfileSignature)
+    dspy.configure(lm=DummyLM([{"result": "ok"}, {"result": "ok"}, {"result": "ok"}]))
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(profile={"name": "arthi"})
+    assert "Type mismatch" not in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(profile={"name": "arthi", "age": 30})
+    assert "Type mismatch" not in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(profile={"name": "arthi", "age": "thirty"})
+    assert "Type mismatch for field 'profile'" in caplog.text


### PR DESCRIPTION
Fixes #10214; the mechanism is exactly as dbreunig diagnosed.

A TypedDict class passes the `isinstance(expected, type)` guard (metaclass `typing._TypedDictMeta`), so `_check_type` fell through to `isinstance(value, expected)`, which `typing` forbids for TypedDicts and raises. Every signature with a TypedDict-annotated input field crashed on valid dict inputs, and through `dspy.Flex` the error resurfaced as an opaque `CodeExecutionError` with no pointer at `_check_type`.

The fix adds an `is_typeddict` branch ahead of the plain-type case, per the direction sketched in the issue: the value must be a dict and its keys must cover `__required_keys__`. So a valid dict validates cleanly, a missing required key produces the same type-mismatch WARNING every other annotation gets, and nothing raises.

Test added in the existing caplog style next to `test_list_type_validation`: valid dict produces no warning, missing required key warns, non-dict warns. It fails on current main with the issue's exact `TypeError` and passes with this change (verified both ways before pushing). The issue's original repro snippet also runs green end to end on this branch.
