### PR TITLE
feat(predict): add history_processor hook to ReActV2

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -21,10 +21,27 @@ if TYPE_CHECKING:
 
 @experimental
 class ReActV2(Module):
-    def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
+    def __init__(
+        self,
+        signature: type[Signature],
+        tools: list[Callable | Tool],
+        max_iters: int = 20,
+        history_processor: Callable[[dspy.History], dspy.History] | None = None,
+    ):
+        """
+        Args:
+            signature: The signature of the module, which defines the input and output of the react module.
+            tools: A list of functions, callable objects, or `dspy.Tool` instances available to the agent.
+            max_iters: The maximum number of iterations to run. Can be overridden per call via
+                `forward(..., max_iters=...)`.
+            history_processor: Optional `dspy.History -> dspy.History` callable applied before each LM
+                call, e.g. for context compaction. Its result is adopted as the module's history and
+                returned in `Prediction.history`.
+        """
         super().__init__()
         self.signature = ensure_signature(signature)
         self.max_iters = max_iters
+        self.history_processor = history_processor
 
         user_tools = [tool if isinstance(tool, Tool) else Tool(tool) for tool in tools]
         self.tools = {tool.name: tool for tool in user_tools}
@@ -87,11 +104,13 @@ class ReActV2(Module):
 
     def forward(self, **input_args):
         max_iters = input_args.pop("max_iters", self.max_iters)
+        history_processor = input_args.pop("history_processor", self.history_processor)
         history = _coerce_history(input_args.pop("history", None))
         pending_inputs = {name: input_args[name] for name in self.signature.input_fields if name in input_args}
 
         break_reason = "max_iters"
         for turn_index in range(max_iters):
+            history = _apply_history_processor(history_processor, history)
             try:
                 pred = self.react(
                     history=history,
@@ -123,7 +142,7 @@ class ReActV2(Module):
             if final_outputs is not None:
                 return Prediction(**final_outputs, history=history, termination_reason="submit")
 
-        return self._forced_submit(history, pending_inputs, break_reason, max_iters)
+        return self._forced_submit(history, pending_inputs, break_reason, max_iters, history_processor)
 
     def _execute_tool_calls(self, tool_calls: ToolCalls) -> tuple[ToolCallResults, dict[str, Any] | None]:
         values = []
@@ -170,7 +189,9 @@ class ReActV2(Module):
         pending_inputs: dict[str, Any],
         break_reason: str,
         turn_index: int,
+        history_processor: Callable[[dspy.History], dspy.History] | None = None,
     ) -> Prediction:
+        history = _apply_history_processor(history_processor, history)
         try:
             pred = self.react(
                 history=history,
@@ -216,6 +237,25 @@ def _optional_annotation(annotation: Any) -> Any:
         return annotation | None
     except TypeError:
         return annotation
+
+
+def _apply_history_processor(
+    processor: Callable[[dspy.History], dspy.History] | None, history: dspy.History
+) -> dspy.History:
+    if processor is None:
+        return history
+    try:
+        processed = processor(history)
+        if processed is None:
+            logger.warning("history_processor returned None; continuing with unprocessed history.")
+            return history
+        return _coerce_history(processed)
+    except Exception as err:
+        logger.warning(
+            "history_processor raised; continuing with unprocessed history: %s",
+            format_error_for_lm(err, traceback_frames=5),
+        )
+        return history
 
 
 def _coerce_history(history: Any) -> dspy.History:

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -1,5 +1,31 @@
+import logging
+
 import dspy
 from dspy.dsp.utils.utils import dotdict
+
+
+def _lookup_then_submit_outputs():
+    return [
+        {
+            "next_thought": "I should look this up.",
+            "tool_calls": dspy.ToolCalls.from_dict_list(
+                [{"name": "lookup", "args": {"query": "cats"}}]
+            ),
+        },
+        {
+            "next_thought": "I can answer now.",
+            "tool_calls": dspy.ToolCalls.from_dict_list(
+                [{"name": "submit", "args": {"answer": "found cats"}}]
+            ),
+        },
+    ]
+
+
+def _lookup_tool():
+    def lookup(query: str) -> str:
+        return f"found {query}"
+
+    return lookup
 
 
 class ReasoningDummyLM(dspy.utils.DummyLM):
@@ -324,3 +350,173 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
         "call_provider_1",
         "call_provider_2",
     ]
+
+
+def test_react_v2_history_processor_none_is_byte_identical():
+    lm_baseline = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    with dspy.context(lm=lm_baseline, adapter=dspy.ChatAdapter()):
+        baseline = dspy.ReActV2("question -> answer", tools=[_lookup_tool()])(question="cats")
+
+    lm_hooked = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    with dspy.context(lm=lm_hooked, adapter=dspy.ChatAdapter()):
+        hooked = dspy.ReActV2(
+            "question -> answer", tools=[_lookup_tool()], history_processor=None
+        )(question="cats")
+
+    assert baseline.answer == hooked.answer
+    assert [call["messages"] for call in lm_baseline.history] == [
+        call["messages"] for call in lm_hooked.history
+    ]
+
+
+def test_react_v2_identity_history_processor_is_byte_identical():
+    lm_baseline = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    with dspy.context(lm=lm_baseline, adapter=dspy.ChatAdapter()):
+        baseline = dspy.ReActV2("question -> answer", tools=[_lookup_tool()])(question="cats")
+
+    lm_hooked = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    with dspy.context(lm=lm_hooked, adapter=dspy.ChatAdapter()):
+        hooked = dspy.ReActV2(
+            "question -> answer", tools=[_lookup_tool()], history_processor=lambda h: h
+        )(question="cats")
+
+    assert baseline.answer == hooked.answer
+    assert [call["messages"] for call in lm_baseline.history] == [
+        call["messages"] for call in lm_hooked.history
+    ]
+
+
+def test_react_v2_history_processor_invoked_per_iteration_with_ratchet_adoption():
+    received = []
+    returned = []
+
+    def processor(history):
+        received.append(history)
+        fresh = dspy.History(messages=list(history.messages))
+        returned.append(fresh)
+        return fresh
+
+    lm = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2(
+            "question -> answer", tools=[_lookup_tool()], history_processor=processor
+        )(question="cats")
+
+    assert pred.answer == "found cats"
+    assert len(received) == 2
+    assert received[0].messages == []
+    # Ratchet: the second call sees the object the first call returned.
+    assert received[1] is returned[0]
+    assert len(received[1].messages) == 1
+    # The adopted history is the one the module appends to and returns.
+    assert pred.history is returned[1]
+
+
+def test_react_v2_history_processor_runs_before_forced_submit():
+    calls = []
+
+    def processor(history):
+        calls.append(len(history.messages))
+        return history
+
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "I should look this up.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [{"name": "lookup", "args": {"query": "cats"}}]
+                ),
+            },
+            {
+                "next_thought": "Forced final.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [{"name": "submit", "args": {"answer": "forced"}}]
+                ),
+            },
+        ]
+    )
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2(
+            "question -> answer", tools=[_lookup_tool()], max_iters=1, history_processor=processor
+        )(question="cats")
+
+    assert pred.answer == "forced"
+    assert pred.termination_reason == "forced_submit"
+    # Once for the single loop iteration, once before the forced submit call.
+    assert len(calls) == 2
+
+
+def test_react_v2_raising_history_processor_degrades_to_unprocessed_history(caplog):
+    def processor(history):
+        raise RuntimeError("compaction bug")
+
+    lm = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    # The dspy logger does not propagate to root by default, so caplog cannot see it.
+    dspy_logger = logging.getLogger("dspy")
+    original_propagate = dspy_logger.propagate
+    dspy_logger.propagate = True
+    try:
+        with caplog.at_level(logging.WARNING, logger="dspy.predict.react_v2"):
+            with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+                pred = dspy.ReActV2(
+                    "question -> answer", tools=[_lookup_tool()], history_processor=processor
+                )(question="cats")
+    finally:
+        dspy_logger.propagate = original_propagate
+
+    assert pred.answer == "found cats"
+    assert pred.termination_reason == "submit"
+    assert len(pred.history.messages) == 2
+    assert "history_processor raised" in caplog.text
+
+
+def test_react_v2_history_processor_returning_none_keeps_unprocessed_history():
+    def processor(history):
+        return None  # buggy processor: forgot the return value
+
+    lm = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2(
+            "question -> answer", tools=[_lookup_tool()], history_processor=processor
+        )(question="cats")
+
+    assert pred.answer == "found cats"
+    assert len(pred.history.messages) == 2
+
+
+def test_react_v2_module_history_processor_is_discoverable_for_optimization():
+    class Summarizer(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.summarize = dspy.Predict("text -> summary")
+
+        def forward(self, history):
+            return history
+
+    agent = dspy.ReActV2("question -> answer", tools=[], history_processor=Summarizer())
+
+    predictor_names = [name for name, _ in agent.named_predictors()]
+    assert any("history_processor" in name for name in predictor_names)
+
+
+def test_react_v2_per_call_history_processor_overrides_constructor():
+    constructor_calls = []
+    call_calls = []
+
+    def constructor_processor(history):
+        constructor_calls.append(history)
+        return history
+
+    def call_processor(history):
+        call_calls.append(history)
+        return history
+
+    lm = dspy.utils.DummyLM(_lookup_then_submit_outputs())
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2(
+            "question -> answer", tools=[_lookup_tool()], history_processor=constructor_processor
+        )(question="cats", history_processor=call_processor)
+
+    assert pred.answer == "found cats"
+    assert not constructor_calls
+    assert len(call_calls) == 2


### PR DESCRIPTION
## What this adds

`ReActV2` runs a loop that calls the LM once per iteration and appends an event to the history each time. There is no way to step in between iterations. This has two costs:

- There is no way to shorten the history. When the context window is exceeded, the loop breaks and the forced submit then sends the same oversized history, which usually fails the same way.
- Compacting the history today requires subclassing `ReActV2` and wrapping `self.react`, which depends on internal attribute names.

This PR adds an optional `history_processor` argument to `ReActV2`. It is a callable that takes a `dspy.History` and returns a `dspy.History`. The module calls it before every LM call, including the forced submit after the loop ends. This lets context compaction and cache management live outside the module.

```python
agent = dspy.ReActV2(
    "question -> answer",
    tools=[...],
    history_processor=my_compactor,
)
```

The hook can also be passed per call, the same way `max_iters` can. This helps when sweeping compaction settings during evaluation without rebuilding the program. A `dspy.Module` passed as the processor shows up in `named_predictors()`, so it can be optimized along with the agent. There is a test for this.

With the argument unset, behavior is unchanged. Two tests pin this by comparing the full rendered messages of paired runs byte for byte.

## Design choices to review

**The module adopts the processor's result.** The returned history becomes the history the module appends to and returns in `Prediction.history`. The alternative is to send the processed history to the LM but keep appending to the original. We chose adoption because a summarizer that is not deterministic would rewrite the start of the prompt on every iteration, and the provider prompt cache would never hit. It would also rerun the summarizer over a growing history each iteration. The cost of adoption is that `Prediction.history` holds the compacted history. Anyone who needs the full record can capture it with callbacks or `lm.history`. If you prefer the non-destructive option, it is a one line change.

**Errors degrade instead of aborting.** If the processor raises, or returns `None`, the module logs a warning and continues with the unprocessed history. The idea is that a compaction bug should make the run slow and expensive, not kill the agent. This matches how `forward` already handles parse failures. The opposite choice, failing loudly so bugs surface in development, is also reasonable. We are happy to change it if you prefer that.

## Scope

This PR only adds the hook. It does not ship a compaction strategy, and it does not change how `ContextWindowExceededError` is handled. Once the hook exists, the overflow path could apply the processor and retry the iteration instead of breaking, which would restore the recovery behavior that `dspy.ReAct` v1 had. That is a behavior change, so we would propose it in a follow-up PR.

`ReActV2` is experimental, so adding a constructor parameter now is cheap.

## Tests

Eight tests were added, all using `DummyLM` with no network calls:

- unset and identity processors produce byte identical rendered messages
- the processor runs once per iteration and sees its own prior output
- the processor runs before the forced submit call
- a raising processor logs a warning and the run completes on the unprocessed history
- a processor that returns `None` is treated the same way
- a `dspy.Module` processor appears in `named_predictors()`
- a per-call processor overrides the constructor one
