### PR TITLE
fix(adapters): render tool calls with a stable key order

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -764,7 +764,10 @@ def _tool_result_content(value: Any) -> str:
     if isinstance(value, str):
         return value
 
-    return json.dumps(serialize_for_json(value), ensure_ascii=False)
+    # sort_keys: a tool result's key order comes from the data, not from a schema, so it
+    # is not stable across a history that round-trips through a store. Both Anthropic and
+    # OpenAI key their prompt caches on an exact byte match of the rendered prefix.
+    return json.dumps(serialize_for_json(value), ensure_ascii=False, sort_keys=True)
 
 
 def _tool_call_as_openai_message_tool_call(tool_call: ToolCalls.ToolCall) -> dict[str, Any]:
@@ -773,6 +776,7 @@ def _tool_call_as_openai_message_tool_call(tool_call: ToolCalls.ToolCall) -> dic
         "type": "function",
         "function": {
             "name": tool_call.name,
-            "arguments": json.dumps(serialize_for_json(tool_call.args), ensure_ascii=False),
+            # sort_keys: see _tool_result_content above.
+            "arguments": json.dumps(serialize_for_json(tool_call.args), ensure_ascii=False, sort_keys=True),
         },
     }

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -263,13 +263,21 @@ class Tool(Type):
 def _sorted_json_keys(value: Any) -> Any:
     """Recursively re-key JSON-like containers in sorted order.
 
-    Only mappings are reordered; list order is data, not key order, and is preserved.
-    Values are returned as-is, so this never coerces or drops anything.
+    Only mappings are reordered; sequence order is data, not key order, and is preserved.
+    Values are returned as-is, so this never coerces or drops anything -- a tuple stays a
+    tuple even though the round trip that motivates this function turns it into a list.
+
+    ``dict``, ``list`` and ``tuple`` are exactly the containers ``json.dumps`` can emit;
+    a set raises ``TypeError`` there, so it has no rendering to stabilize. Descending into
+    a strict subset of them is worse than not descending at all: it makes the rendering
+    of two equal calls depend on which container type they happen to be carrying.
     """
     if isinstance(value, dict):
         return {key: _sorted_json_keys(value[key]) for key in sorted(value, key=str)}
     if isinstance(value, list):
         return [_sorted_json_keys(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_sorted_json_keys(item) for item in value)
     return value
 
 

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -260,6 +260,19 @@ class Tool(Type):
         return f"{self.name}{desc} {arg_desc}"
 
 
+def _sorted_json_keys(value: Any) -> Any:
+    """Recursively re-key JSON-like containers in sorted order.
+
+    Only mappings are reordered; list order is data, not key order, and is preserved.
+    Values are returned as-is, so this never coerces or drops anything.
+    """
+    if isinstance(value, dict):
+        return {key: _sorted_json_keys(value[key]) for key in sorted(value, key=str)}
+    if isinstance(value, list):
+        return [_sorted_json_keys(item) for item in value]
+    return value
+
+
 class ToolCalls(Type):
     class ToolCall(Type):
         id: str | None = None
@@ -279,7 +292,17 @@ class ToolCalls(Type):
             return schema
 
         def format(self):
-            return {"name": self.name, "args": self.args}
+            # ``args`` keys are sorted here rather than at each renderer: the order comes
+            # from the data, so it does not survive a history that round-trips through a
+            # store that normalizes key order, and every path that renders a tool call
+            # for the LM goes through this method. JSON objects are unordered by
+            # specification and tool dispatch reads ``self.args``, not this copy.
+            #
+            # The sort is RECURSIVE. The renderer on the non-native path calls
+            # ``json.dumps`` without ``sort_keys``, so a top-level-only sort still leaves
+            # a nested object inside an argument value in whatever order the store
+            # returned it.
+            return {"name": self.name, "args": _sorted_json_keys(self.args)}
 
         def execute(self, functions: dict[str, Any] | list[Tool] | None = None) -> Any:
             """Execute this individual tool call and return its result.

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -1,6 +1,7 @@
 import asyncio
-from typing import Any
+from typing import Any, ClassVar
 
+import pydantic
 import pytest
 from pydantic import BaseModel, TypeAdapter
 
@@ -766,3 +767,118 @@ def test_tool_call_execute_with_local_functions():
             globals().pop("local_add", None)
 
     main()
+
+
+class TestToolCallRenderingIsKeyOrderStable:
+    """Rendered tool calls must be byte-identical for the same semantic call.
+
+    Anthropic and OpenAI key their prompt caches on an exact byte match of the rendered
+    prefix, so any path that changes key order between requests turns every subsequent
+    call into a cache miss. Python dicts are insertion-ordered and ``json.dumps``
+    preserves that, so a history built and replayed in one process is stable; the break
+    happens when it crosses a store that normalizes key order. Postgres ``jsonb`` orders
+    keys by length and then bytewise, which is what ``_jsonb_like`` imitates.
+    """
+
+    @staticmethod
+    def _jsonb_like(value):
+        if isinstance(value, dict):
+            return {
+                k: TestToolCallRenderingIsKeyOrderStable._jsonb_like(value[k])
+                for k in sorted(value, key=lambda k: (len(str(k)), str(k)))
+            }
+        if isinstance(value, list):
+            return [TestToolCallRenderingIsKeyOrderStable._jsonb_like(v) for v in value]
+        return value
+
+    ARGS: ClassVar[dict] = {"zeta": 1, "alpha": 2, "mid": 3}
+    NESTED: ClassVar[dict] = {"filter": {"zeta": 1, "alpha": 2, "mid": 3}, "q": "x"}
+
+    def _round_tripped(self, args):
+        """The same call after a store that normalizes key order has handed it back."""
+        call = ToolCalls.ToolCall(id="c1", name="search", args=args)
+        stored = ToolCalls.ToolCall.model_validate({**call.model_dump(), "args": self._jsonb_like(args)})
+        # The control: the store really did change the order, otherwise the assertions
+        # below pass for the wrong reason.
+        assert list(stored.args) != list(call.args)
+        return call, stored
+
+    def test_jsonb_like_reorders_the_fixture(self):
+        assert list(self._jsonb_like(self.ARGS)) == ["mid", "zeta", "alpha"]
+
+    def test_native_function_call_arguments_are_byte_stable(self):
+        from dspy.adapters.base import _tool_call_as_openai_message_tool_call
+
+        call, stored = self._round_tripped(self.ARGS)
+        assert (
+            _tool_call_as_openai_message_tool_call(call)["function"]["arguments"]
+            == _tool_call_as_openai_message_tool_call(stored)["function"]["arguments"]
+        )
+
+    def test_native_function_call_arguments_are_byte_stable_when_nested(self):
+        from dspy.adapters.base import _tool_call_as_openai_message_tool_call
+
+        call, stored = self._round_tripped(self.NESTED)
+        assert (
+            _tool_call_as_openai_message_tool_call(call)["function"]["arguments"]
+            == _tool_call_as_openai_message_tool_call(stored)["function"]["arguments"]
+        )
+
+    def test_dict_tool_result_is_byte_stable(self):
+        from dspy.adapters.base import _tool_result_content
+
+        result = {"zeta": 1, "alpha": 2, "mid": {"inner_b": 1, "a": 2}}
+        assert _tool_result_content(result) == _tool_result_content(self._jsonb_like(result))
+
+    def test_non_native_rendering_is_byte_stable(self):
+        """``ToolCalls`` rendered into a text field, i.e. the non-native path."""
+        from dspy.adapters.utils import format_field_value
+        from dspy.signatures.signature import make_signature
+
+        signature = make_signature("q: str -> tool_calls: ToolCalls", custom_types={"ToolCalls": ToolCalls})
+        field = signature.output_fields["tool_calls"]
+        call, stored = self._round_tripped(self.ARGS)
+        assert format_field_value(field, ToolCalls(tool_calls=[call])) == format_field_value(
+            field, ToolCalls(tool_calls=[stored])
+        )
+
+    def test_non_native_rendering_is_byte_stable_when_nested(self):
+        """A top-level-only sort passes the test above and still fails this one: the
+        non-native renderer calls ``json.dumps`` without ``sort_keys``."""
+        from dspy.adapters.utils import format_field_value
+        from dspy.signatures.signature import make_signature
+
+        signature = make_signature("q: str -> tool_calls: ToolCalls", custom_types={"ToolCalls": ToolCalls})
+        field = signature.output_fields["tool_calls"]
+        call, stored = self._round_tripped(self.NESTED)
+        assert format_field_value(field, ToolCalls(tool_calls=[call])) == format_field_value(
+            field, ToolCalls(tool_calls=[stored])
+        )
+
+    def test_format_does_not_mutate_or_drop_the_call(self):
+        """Sorting is a rendering concern. Dispatch reads ``self.args``, which is
+        untouched, and no key or value may be lost on the way through."""
+        args = {"zeta": 1, "alpha": {"b": [1, {"y": 1, "x": 2}]}, "mid": None}
+        call = ToolCalls.ToolCall(id="c1", name="search", args=args)
+        formatted = call.format()
+        assert list(call.args) == ["zeta", "alpha", "mid"]
+        assert formatted["args"] == args
+        assert formatted["name"] == "search"
+
+    def test_list_order_inside_args_is_preserved(self):
+        """Lists are data, not key order. Reordering one would change meaning."""
+        call = ToolCalls.ToolCall(id="c1", name="search", args={"xs": [3, 1, 2]})
+        assert call.format()["args"]["xs"] == [3, 1, 2]
+
+    def test_top_level_non_string_keys_are_refused_by_the_boundary(self):
+        """Not a sorting concern: ``args`` is typed ``dict[str, Any]``, so pydantic
+        refuses a non-string key before any renderer sees it."""
+        with pytest.raises(pydantic.ValidationError):
+            ToolCalls.ToolCall(id="c1", name="search", args={"a": 1, 2: "b"})
+
+    def test_nested_non_string_keys_do_not_raise(self):
+        """``Any`` values are not constrained, so a nested mapping CAN carry mixed key
+        types. Bare ``sorted`` raises TypeError on those, which is why the sort key is
+        ``str`` — this fails with ``TypeError`` if that guard is removed."""
+        call = ToolCalls.ToolCall(id="c1", name="search", args={"outer": {"a": 1, 2: "b"}})
+        assert set(call.format()["args"]["outer"]) == {"a", 2}

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -882,3 +882,50 @@ class TestToolCallRenderingIsKeyOrderStable:
         ``str`` — this fails with ``TypeError`` if that guard is removed."""
         call = ToolCalls.ToolCall(id="c1", name="search", args={"outer": {"a": 1, 2: "b"}})
         assert set(call.format()["args"]["outer"]) == {"a", 2}
+
+    # ---------------------------------------------------------------- tuples
+    # A tuple is a container ``json.dumps`` renders as an array and pydantic keeps as a
+    # tuple under ``Any``, so a call can hold one on the way in and a list on the way
+    # back. Descending into lists but not tuples makes the sort itself the thing that
+    # splits the two -- these three tests fail if the tuple branch is removed, and they
+    # pass on a version of ``format`` that sorts nothing at all.
+
+    TUPLE_ARGS: ClassVar[dict] = {"payload": ({"zeta": 1, "alpha": 2},), "q": "x"}
+    TUPLE_NESTED: ClassVar[dict] = {"payload": ({"zeta": 1, "alpha": 2}, [{"q": 0, "b": 1}])}
+
+    @staticmethod
+    def _json_round_tripped(args):
+        """The same call after it has been serialized to JSON and read back.
+
+        This is the round trip a stored history really takes, and it is the one that
+        turns the tuple into a list -- the control below fails if it ever stops doing so.
+        """
+        call = ToolCalls.ToolCall(id="c1", name="search", args=args)
+        stored = ToolCalls.ToolCall.model_validate_json(call.model_dump_json())
+        assert isinstance(call.args["payload"], tuple)
+        assert isinstance(stored.args["payload"], list)
+        return call, stored
+
+    def _render(self, call):
+        from dspy.adapters.utils import format_field_value
+        from dspy.signatures.signature import make_signature
+
+        signature = make_signature("q: str -> tool_calls: ToolCalls", custom_types={"ToolCalls": ToolCalls})
+        return format_field_value(signature.output_fields["tool_calls"], ToolCalls(tool_calls=[call]))
+
+    def test_non_native_rendering_is_byte_stable_across_a_tuple_to_list_round_trip(self):
+        call, stored = self._json_round_tripped(self.TUPLE_ARGS)
+        assert self._render(call) == self._render(stored)
+
+    def test_non_native_rendering_is_byte_stable_when_a_tuple_holds_a_list(self):
+        """The recursion has to continue *through* the tuple, not merely enter it."""
+        call, stored = self._json_round_tripped(self.TUPLE_NESTED)
+        assert self._render(call) == self._render(stored)
+
+    def test_tuple_stays_a_tuple_and_keeps_its_order(self):
+        """Rendering normalizes key order only. It is not a place to change types, and
+        tuple order is data in the same way list order is."""
+        call = ToolCalls.ToolCall(id="c1", name="search", args={"xs": (3, 1, 2)})
+        formatted = call.format()["args"]["xs"]
+        assert formatted == (3, 1, 2)
+        assert isinstance(formatted, tuple)


### PR DESCRIPTION
Fixes #10216.

## What the issue asks for, and the one place I did it differently

The issue names three call sites and proposes `sort_keys=True` at each. Two of them are tool-specific and I did exactly that. The third, `dspy/adapters/utils.py:63` (`format_field_value`), is the **general** field renderer, and sorting there costs more than the bug does. So the non-native path is fixed at its source instead — `ToolCalls.ToolCall.format()` — which covers the same path and leaves everything else byte-identical.

**The measurement behind that choice, with a control.** `format_field_value` renders every input and output field, most of which are pydantic-typed. Those provably do not have this instability, because pydantic reconstructs in **declaration** order:

```
class Model:  zeta, alpha, mid          # declaration order, deliberately not length-sorted
stored bytes after a jsonb-like store : {"mid": "m_test", "zeta": 5, "alpha": "a_test"}
rendered before the round trip        : {"zeta": 5, "alpha": "a_test", "mid": "m_test"}
rendered after  the round trip        : {"zeta": 5, "alpha": "a_test", "mid": "m_test"}   REORDERS: False
```

The control that can fail — the same probe on an untyped `dict` field:

```
rendered before : {"zeta": 1, "alpha": 2, "mid": 3}
rendered after  : {"mid": 3, "zeta": 1, "alpha": 2}                                       REORDERS: True
```

So `sort_keys=True` at `format_field_value` would reorder every pydantic model in every prompt — including the field order a signature author wrote deliberately — to fix an instability those fields do not have. Concretely it turns `{"id": 5, "name": ..., "email": ...}` into `{"email": ..., "id": 5, "name": ...}` in the rendered prompt, and **11 existing golden tests change**. Sorting in `format()` gets the reported bug on both the native and the non-native path with **zero** change to unrelated rendering: the suite is 273 passed / 1 failed before and after, the same failure both times (`test_in_memory_resource_construction`, an unrelated missing-Pillow ImportError on this box).

If you would rather have the blanket version, say so — it is a one-line change plus the 11 golden updates, and I will push it.

## A fourth site, which the issue does not name

`dspy/adapters/json_adapter.py:224` — the **assistant**-turn branch of `format_field_with_value` — renders with `json.dumps(serialize_for_json(d), indent=2, ensure_ascii=False)` and has the identical defect. That is the rendered history, which is the thing the issue says crosses a store:

```
as-built                 : '{\n  "plan": {\n    "zeta": 1,\n    "alpha": 2,\n    "mid": 3\n  }\n}'
after a store round trip : '{\n  "plan": {\n    "mid": 3,\n    "zeta": 1,\n    "alpha": 2\n  }\n}'
```

**I have not touched it in this PR**, because it is the same over-broad question as `format_field_value` — it reorders pydantic outputs too — and it is a scope call rather than a bug fix. It affects untyped `dict`-valued fields, not tool calls, so it is not needed to close this issue. Happy to do it here or in a follow-up, whichever you prefer.

## The recursion, which is the part I got wrong first

My first version sorted only the top level of `args`. It passes the flat case and still fails on a nested one, because the non-native renderer calls `json.dumps` **without** `sort_keys`:

```
before : {"tool_calls": [{"name": "search", "args": {"filter": {"zeta": 1, "alpha": 2, "mid": 3}, "q": "x"}}]}
after  : {"tool_calls": [{"name": "search", "args": {"filter": {"mid": 3, "zeta": 1, "alpha": 2}, "q": "x"}}]}
```

Found by running it, not by reading it. `_sorted_json_keys` is recursive, and there is a test that a top-level-only sort fails.

## Two things I checked and did NOT change

- **`dspy/adapters/types/base_type.py:75`** — looks like the same shape, is not. `ToolCalls.format()` returns a `dict`, so `serialize_model` returns it directly and never reaches that `json.dumps`. Measured: `serialize_model()` output is byte-equal across a reordering round trip.
- **`dspy/adapters/base.py:302`** — `json.dumps(block, ensure_ascii=False)` with no `serialize_for_json`. Adding `sort_keys=True` there **would be a regression**: `{"a": 1, 2: "b"}` renders today and raises `TypeError: '<' not supported between instances of 'int' and 'str'` with it. This is also why the three sites that *are* patched are safe — `serialize_for_json` coerces keys to strings first, which I verified rather than assumed.

## What proves it

10 tests in `TestToolCallRenderingIsKeyOrderStable`, **5 of which fail on pristine `main`** (`git stash push dspy/`, re-run, restore). The 5 that pass are meant to: the fixture control, list-order preservation, the no-mutation pin, and the two key-type boundary cases.

Every test asserts against a `_jsonb_like` round trip — postgres `jsonb` key order, length then bytewise — and `_round_tripped` asserts the store **actually** reordered the keys before comparing, so none of them can pass for the wrong reason.

Seven mutations of the patch, all red:

| mutation | result |
|---|---|
| drop `sort_keys` in the native tool-call renderer | 2 failed |
| drop `sort_keys` in the tool-result renderer | 1 failed |
| revert `ToolCall.format()` to the original | 2 failed |
| sort the top level only, not recursively | 1 failed |
| remove the `key=str` guard | 1 failed |
| sort list elements too | 1 failed |
| only sort mappings whose values are scalars | 1 failed |

No survivors. `ruff check` clean on all three files. **`ruff format` was already dirty on `tests/adapters/test_tool.py` before this branch** (5 hunks, all above line 711, none mine) — I formatted only the block I added rather than reformatting the file, so the hunk set is unchanged from `main`.

`pytest tests/adapters tests/predict/test_react.py` — **294 passed, 1 skipped, 1 failed**, that one failure pre-existing and unrelated (missing Pillow). **The full suite was NOT run** on this box; do not read the above as a green whole suite.

## Scope

Tool call rendering only. Parsing, `ToolCalls` validation and tool dispatch are untouched — dispatch reads `self.args`, not `format()`'s copy, and there is a test pinning that `format()` neither mutates nor drops anything. Of the currently open PRs, seven touch `dspy/adapters/base.py` or `dspy/adapters/utils.py`; none touches these lines or `dspy/adapters/types/tool.py`, so there is no overlap, but #10016 is nearest and whichever lands second may want a rebase.

Note for reviewers: this does invalidate existing prompt caches **once**, on the first request after upgrade, for anyone whose tool call args are not already in sorted order. That is unavoidable for any fix to this issue and is a one-off.

---
_Written by an autonomous AI agent; no human reviewed the diff. Terms and prior work: https://github.com/sujeito-operator/pilot_
