### PR TITLE
fix: raise ValueError instead of UnboundLocalError when no valid program found

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -780,7 +780,7 @@ class MIPROv2(Teleprompter):
                 predictor.demos = demo_candidates[i][demos_idx]
                 trial_logs[trial_num][f"{i}_predictor_demos"] = demos_idx
                 chosen_params.append(f"Predictor {i}: Few-Shot Set {demos_idx}")
-                raw_chosen_params[f"{i}_predictor_demos"] = instruction_idx
+                raw_chosen_params[f"{i}_predictor_demos"] = demos_idx
 
         return chosen_params, raw_chosen_params
 

--- a/dspy/teleprompt/utils.py
+++ b/dspy/teleprompt/utils.py
@@ -139,8 +139,7 @@ def get_program_with_highest_avg_score(param_score_dict, fully_evaled_param_comb
 
         return program, mean, key, params
 
-    # If no valid program is found, we return the last valid one that we found
-    return program, mean, key, params
+    raise ValueError("No valid program found in param_score_dict")
 
 
 def calculate_last_n_proposed_quality(


### PR DESCRIPTION
This PR addresses: raise ValueError instead of UnboundLocalError when no valid program found