### PR TITLE
fix(dspy): preserve Field constraints in JSONAdapter structured outputs

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -26,6 +26,42 @@ from dspy.utils.exceptions import AdapterParseError, LMError
 logger = logging.getLogger(__name__)
 
 
+# Keywords whose values map user-controlled names to subschemas, so their own keys must never be treated as
+# schema keywords (a field may legitimately be named `ge`).
+_SUBSCHEMA_MAP_KEYWORDS = ("properties", "patternProperties", "$defs", "definitions")
+# Keywords whose values are literal data rather than subschemas.
+_LITERAL_KEYWORDS = ("const", "default", "enum", "examples")
+
+
+def _strip_unsupported_constraint_kwargs(node: Any) -> None:
+    """
+    Recursively drop raw Pydantic constraint kwargs from a JSON schema.
+
+    Pydantic emits a constraint kwarg verbatim when it cannot express it for the annotated type (e.g. `ge` on a
+    string field). Those keys are not valid JSON Schema, and they can appear anywhere the annotation is expanded,
+    including inside `anyOf` branches and `$defs`, so every subschema has to be visited.
+    """
+    if isinstance(node, list):
+        for item in node:
+            _strip_unsupported_constraint_kwargs(item)
+        return
+    if not isinstance(node, dict):
+        return
+
+    for constraint in PYDANTIC_CONSTRAINT_MAP:
+        node.pop(constraint, None)
+
+    for keyword, value in node.items():
+        if keyword in _LITERAL_KEYWORDS:
+            continue
+        if keyword in _SUBSCHEMA_MAP_KEYWORDS:
+            if isinstance(value, dict):
+                for subschema in value.values():
+                    _strip_unsupported_constraint_kwargs(subschema)
+        else:
+            _strip_unsupported_constraint_kwargs(value)
+
+
 def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
     """
     Check whether any output field in the signature has an open-ended mapping type,
@@ -279,10 +315,8 @@ def _get_structured_outputs_response_format(
     # Remove any DSPy-specific metadata.
     for prop in schema.get("properties", {}).values():
         prop.pop("json_schema_extra", None)
-        # Pydantic emits a constraint kwarg verbatim when it cannot express it for the field's type (e.g. `ge` on a
-        # string field). Those keys are not valid JSON Schema, so drop them rather than sending them to a provider.
-        for constraint in PYDANTIC_CONSTRAINT_MAP:
-            prop.pop(constraint, None)
+
+    _strip_unsupported_constraint_kwargs(schema)
 
     def enforce_required(schema_part: dict):
         """

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, get_origin
+from typing import Annotated, Any, get_origin
 
 import json_repair
 import pydantic
@@ -18,6 +18,7 @@ from dspy.adapters.utils import (
     translate_field_type,
 )
 from dspy.clients.base_lm import BaseLM
+from dspy.signatures.field import PYDANTIC_CONSTRAINT_MAP
 from dspy.signatures.signature import Signature, SignatureMeta
 from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import AdapterParseError, LMError
@@ -258,6 +259,11 @@ def _get_structured_outputs_response_format(
             # Skip ToolCalls field if native function calling is enabled.
             continue
         default = field.default if hasattr(field, "default") else ...
+        if field.metadata:
+            # Constraints declared as `dspy.OutputField(ge=..., pattern=..., ...)` live in `FieldInfo.metadata`,
+            # so re-attach them to the annotation to keep them in the schema. Only the constraint metadata is
+            # carried over; DSPy's `json_schema_extra` stays out so no DSPy-specific keys reach the provider.
+            annotation = Annotated[(annotation, *field.metadata)]
         fields[name] = (annotation, default)
 
     # Build the model with extra fields forbidden.
@@ -273,6 +279,10 @@ def _get_structured_outputs_response_format(
     # Remove any DSPy-specific metadata.
     for prop in schema.get("properties", {}).values():
         prop.pop("json_schema_extra", None)
+        # Pydantic emits a constraint kwarg verbatim when it cannot express it for the field's type (e.g. `ge` on a
+        # string field). Those keys are not valid JSON Schema, so drop them rather than sending them to a provider.
+        for constraint in PYDANTIC_CONSTRAINT_MAP:
+            prop.pop(constraint, None)
 
     def enforce_required(schema_part: dict):
         """

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -9,6 +9,7 @@ from litellm.utils import ChatCompletionMessageToolCall, Choices, Function, Mess
 from openai.types.responses import ResponseOutputMessage
 
 import dspy
+from dspy.adapters.json_adapter import _get_structured_outputs_response_format
 from tests.adapters.conftest import format_messages_and_lm_kwargs
 
 
@@ -757,6 +758,43 @@ def test_json_adapter_passes_structured_output_when_supported_by_model():
     assert response_format is not None
     assert issubclass(response_format, pydantic.BaseModel)
     assert response_format.model_fields.keys() == {"output1", "output2", "output3", "output4_unannotated"}
+
+
+def test_json_adapter_structured_outputs_preserve_output_field_constraints():
+    class TestSignature(dspy.Signature):
+        input1: str = dspy.InputField()
+        score: float = dspy.OutputField(ge=0.0, le=1.0, multiple_of=0.25)
+        tag: str = dspy.OutputField(pattern="^[a-z]+$")
+        labels: list[str] = dspy.OutputField(min_length=1, max_length=3)
+        unconstrained: str = dspy.OutputField()
+
+    response_format = _get_structured_outputs_response_format(TestSignature)
+    properties = response_format.model_json_schema()["properties"]
+
+    assert properties["score"]["minimum"] == 0.0
+    assert properties["score"]["maximum"] == 1.0
+    assert properties["score"]["multipleOf"] == 0.25
+    assert properties["tag"]["pattern"] == "^[a-z]+$"
+    assert properties["labels"]["minItems"] == 1
+    assert properties["labels"]["maxItems"] == 3
+    assert properties["unconstrained"] == {"title": "Unconstrained", "type": "string"}
+
+    # DSPy-specific field metadata must not leak into the schema sent to the provider.
+    for prop in properties.values():
+        assert "desc" not in prop
+        assert "prefix" not in prop
+        assert "constraints" not in prop
+        assert "__dspy_field_type" not in prop
+
+
+def test_json_adapter_structured_outputs_drops_constraints_that_do_not_apply_to_the_field_type():
+    class TestSignature(dspy.Signature):
+        input1: str = dspy.InputField()
+        output1: str = dspy.OutputField(ge=0)
+
+    properties = _get_structured_outputs_response_format(TestSignature).model_json_schema()["properties"]
+
+    assert properties["output1"] == {"title": "Output1", "type": "string"}
 
 
 def test_json_adapter_not_using_structured_outputs_when_not_supported_by_model():

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -797,6 +797,27 @@ def test_json_adapter_structured_outputs_drops_constraints_that_do_not_apply_to_
     assert properties["output1"] == {"title": "Output1", "type": "string"}
 
 
+def test_json_adapter_structured_outputs_drops_inapplicable_constraints_from_nested_schemas():
+    class Detail(pydantic.BaseModel):
+        note: str = pydantic.Field(ge=0)
+        # A field may legitimately be named like a constraint kwarg.
+        ge: int
+
+    class TestSignature(dspy.Signature):
+        input1: str = dspy.InputField()
+        maybe_text: str | None = dspy.OutputField(ge=0)
+        detail: Detail | None = dspy.OutputField(min_length=2)
+
+    schema = _get_structured_outputs_response_format(TestSignature).model_json_schema()
+
+    for branch in schema["properties"]["maybe_text"]["anyOf"]:
+        assert "ge" not in branch
+    for branch in schema["properties"]["detail"]["anyOf"]:
+        assert "min_length" not in branch
+    assert schema["$defs"]["Detail"]["properties"]["note"] == {"title": "Note", "type": "string"}
+    assert schema["$defs"]["Detail"]["properties"]["ge"] == {"title": "Ge", "type": "integer"}
+
+
 def test_json_adapter_not_using_structured_outputs_when_not_supported_by_model():
     class TestSignature(dspy.Signature):
         input1: str = dspy.InputField()


### PR DESCRIPTION
## 📝 Changes Description

This MR/PR contains the following changes:
`JSONAdapter._get_structured_outputs_response_format` rebuilt each output field as `(annotation, default)`, so `Field(ge=..., le=..., multiple_of=..., pattern=...)` metadata was dropped. Constraints now ride on `Annotated[(annotation, *field.metadata)]`. Constraint kwargs pydantic cannot express for a type (e.g. `ge` on `str`) are stripped so they do not become invalid JSON Schema keys.

Fixes #10195

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

Fine-tuned OpenAI models still have a smaller Structured Outputs subset; this does not add provider-aware sanitization. Nearby #10114 is the *parsing* side (`parse_value`) and does not overlap.

`uv run pytest tests/adapters/test_json_adapter.py -q` → 41 passed. The new test fails on current main (`KeyError: 'minimum'`) and passes after the change.