### PR TITLE
fix(dspy): do not advertise *args/**kwargs as required tool params

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -85,13 +85,19 @@ class Tool(Type):
         args = {}
         arg_types = {}
 
-        # Use inspect.signature to get all arg names
+        # Use inspect.signature to get all arg names. `*args` and `**kwargs` are not addressable by
+        # name in a tool call, so they must not be advertised as parameters of the tool.
         sig = inspect.signature(annotations_func)
+        named_params = {
+            param_name: param
+            for param_name, param in sig.parameters.items()
+            if param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
+        }
         # Get available type hints
         available_hints = get_type_hints(annotations_func)
         # Build a dictionary of arg name -> type (defaulting to Any when missing)
-        hints = {param_name: available_hints.get(param_name, Any) for param_name in sig.parameters.keys()}
-        default_values = {param_name: sig.parameters[param_name].default for param_name in sig.parameters.keys()}
+        hints = {param_name: available_hints.get(param_name, Any) for param_name in named_params}
+        default_values = {param_name: named_params[param_name].default for param_name in named_params}
 
         # Process each argument's type to generate its JSON schema.
         for k, v in hints.items():

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -284,6 +284,35 @@ def test_tool_call_kwarg():
     assert tool(x=1, y=2, z=3) == {"y": 2, "z": 3}
 
 
+def test_tool_excludes_var_keyword_from_args():
+    def fn(x: int, **kwargs):
+        """A function with keyword varargs."""
+        return kwargs
+
+    tool = Tool(fn)
+
+    assert tool.args == {"x": {"type": "integer"}}
+    assert tool.arg_types == {"x": int}
+    assert tool.has_kwargs
+    assert tool.format_as_litellm_function_call()["function"]["parameters"] == {
+        "type": "object",
+        "properties": {"x": {"type": "integer"}},
+        "required": ["x"],
+    }
+
+
+def test_tool_excludes_var_positional_from_args():
+    def fn(x: int, *args):
+        """A function with positional varargs."""
+        return x
+
+    tool = Tool(fn)
+
+    assert tool.args == {"x": {"type": "integer"}}
+    assert tool.arg_types == {"x": int}
+    assert not tool.has_kwargs
+
+
 def test_tool_str():
     def add(x: int, y: int = 0) -> int:
         """Add two integers."""


### PR DESCRIPTION
## Summary
`Tool._parse_function` built the JSON schema from every `inspect.signature` parameter, including `*args` and `**kwargs`. A tool wrapping `def fn(x: int, **kwargs)` advertised a required `kwargs` field; `*args` was worse — the model then hit `TypeError: unexpected keyword argument 'args'`.

Skip `VAR_POSITIONAL` and `VAR_KEYWORD` when inferring `args`/`arg_types`. `has_kwargs` still reads the unfiltered signature, so extra keywords keep working. Explicit `args`/`arg_types` (MCP/LangChain) are unchanged.

Distinct from #10221/#10222.

## Test plan
- [x] New tests fail on current main (`{'kwargs': {}}` / `{'args': {}}` in `tool.args`) and pass after
- [x] `uv run pytest tests/adapters/test_tool.py -q` → 40 passed