### PR TITLE
fix(dspy): accept int where float is annotated in Predict type checks

### DIFF
--- a/dspy/predict/predict.py
+++ b/dspy/predict/predict.py
@@ -376,6 +376,12 @@ def _check_type(value: Any, expected: type) -> bool:
 
     # Plain type (int, str, BaseModel subclass, etc.)
     if isinstance(expected, type):
+        # PEP 484 numeric tower: `int` is acceptable where `float` is expected, and both are
+        # acceptable where `complex` is expected.
+        if expected is float and isinstance(value, int):
+            return True
+        if expected is complex and isinstance(value, (int, float)):
+            return True
         return isinstance(value, expected)
 
     return False

--- a/tests/predict/test_predict.py
+++ b/tests/predict/test_predict.py
@@ -1197,6 +1197,34 @@ def test_correct_types_no_warning(caplog):
     assert "Type mismatch" not in caplog.text
 
 
+def test_numeric_tower_no_warning(caplog):
+    """Test that ints are accepted where floats are expected, per the PEP 484 numeric tower."""
+    log_test_helper()
+
+    class NumericSignature(dspy.Signature):
+        temperature: float = dspy.InputField()
+        readings: list[float] = dspy.InputField()
+        count: int = dspy.InputField()
+        result: str = dspy.OutputField()
+
+    predict_instance = Predict(NumericSignature)
+    lm = DummyLM([{"result": "test output 1"}, {"result": "test output 2"}])
+    dspy.configure(lm=lm)
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(temperature=20, readings=[1, 2.5], count=3)
+
+    assert "Type mismatch" not in caplog.text
+
+    # The numeric tower only goes one way: floats are not acceptable where an int is expected.
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="dspy.predict.predict"):
+        predict_instance(temperature=20.5, readings=[1.0], count=1.5)
+
+    assert "Type mismatch for field 'count': expected int" in caplog.text
+
+
 def test_list_type_validation(caplog):
     """Test type validation with list[str] types."""
     log_test_helper()


### PR DESCRIPTION
settings.warn_on_type_mismatch is on by default. After #9735 replaced typeguard with a hand-rolled _check_type, int is no longer accepted where float is expected (PEP 484 numeric tower), so Predict(temperature=20) on a float field warns every call. list[float] with [1, 2.5] also warns.

Accept int for float and int/float for complex. One-way: float in an int field still warns. Tests: uv run pytest tests/predict/test_predict.py tests/signatures -> 195 passed. Distinct from #10215 (TypedDict) and #10221-#10223.