### PR TITLE
fix(dspy): keep lazy-import proxies out of sys.modules

### DIFF
--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -82,7 +82,8 @@ class _MissingModule(types.ModuleType):
 class _LazyModule(types.ModuleType):
     """Module proxy that imports the real module on first attribute access.
 
-    Attribute assignment also materializes the real module so configuration writes apply to the real dependency.
+    Attribute assignment also materializes the real module so configuration writes apply to the real dependency,
+    except for the submodule bindings the import system writes while a submodule is still initializing.
     """
 
     def __init__(self, module: str, spec: importlib.machinery.ModuleSpec, lock: threading.RLock):
@@ -120,6 +121,10 @@ class _LazyModule(types.ModuleType):
 
     def __setattr__(self, attr: str, value: Any) -> None:
         if attr.startswith("_dspy_lazy_") or attr in {"__spec__", "__loader__", "__package__", "__path__"}:
+            super().__setattr__(attr, value)
+        elif isinstance(value, types.ModuleType) and getattr(value, "__name__", None) == f"{self.__name__}.{attr}":
+            # `import pkg.sub` binds the submodule on the parent package. Materializing the real module here would
+            # execute it while `pkg.sub` is still initializing, so record the binding on the proxy instead.
             super().__setattr__(attr, value)
         else:
             setattr(self._load(), attr, value)

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -48,6 +48,7 @@ _INSTALL_HINTS: dict[str, str] = {
 }
 
 
+_lazy_modules: dict[str, "_LazyModule"] = {}
 _lazy_module_locks: dict[str, threading.RLock] = {}
 _lazy_module_locks_lock = threading.Lock()
 
@@ -82,8 +83,7 @@ class _MissingModule(types.ModuleType):
 class _LazyModule(types.ModuleType):
     """Module proxy that imports the real module on first attribute access.
 
-    Attribute assignment also materializes the real module so configuration writes apply to the real dependency,
-    except for the submodule bindings the import system writes while a submodule is still initializing.
+    Attribute assignment also materializes the real module so configuration writes apply to the real dependency.
     """
 
     def __init__(self, module: str, spec: importlib.machinery.ModuleSpec, lock: threading.RLock):
@@ -93,38 +93,20 @@ class _LazyModule(types.ModuleType):
         self.__package__ = spec.parent
         if spec.submodule_search_locations is not None:
             self.__path__ = spec.submodule_search_locations
-        self._dspy_lazy_spec = spec
         self._dspy_lazy_lock = lock
 
     def _load(self) -> types.ModuleType:
-        # The proxy starts in sys.modules, then the first attribute access swaps in and executes the real module under
-        # the per-module lock. If import fails, restore the proxy so later accesses can retry and still share the lock.
-        # Return sys.modules after execution because a module may replace itself while importing.
-        module_name = self.__name__
+        # The proxy stays out of sys.modules and defers to the regular import machinery, so the real module is the only
+        # entry other importers can see. A proxy sitting in sys.modules would shadow the package: `import pkg.sub` would
+        # then skip `pkg`'s own initialization and execute `pkg.sub` against an unexecuted parent.
         with self._dspy_lazy_lock:
-            loaded = sys.modules.get(module_name)
-            if loaded is not None and loaded is not self:
-                return loaded
-
-            spec = self._dspy_lazy_spec
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = module
-            try:
-                spec.loader.exec_module(module)
-            except Exception:
-                sys.modules[module_name] = self
-                raise
-            return sys.modules.get(module_name, module)
+            return importlib.import_module(self.__name__)
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self._load(), attr)
 
     def __setattr__(self, attr: str, value: Any) -> None:
         if attr.startswith("_dspy_lazy_") or attr in {"__spec__", "__loader__", "__package__", "__path__"}:
-            super().__setattr__(attr, value)
-        elif isinstance(value, types.ModuleType) and getattr(value, "__name__", None) == f"{self.__name__}.{attr}":
-            # `import pkg.sub` binds the submodule on the parent package. Materializing the real module here would
-            # execute it while `pkg.sub` is still initializing, so record the binding on the proxy instead.
             super().__setattr__(attr, value)
         else:
             setattr(self._load(), attr, value)
@@ -190,6 +172,4 @@ def require(module: str, *, extra: str | None = None, feature: str | None = None
         if module in sys.modules:
             return sys.modules[module]
 
-        mod = _LazyModule(module, spec, lock)
-        sys.modules[module] = mod
-        return mod
+        return _lazy_modules.setdefault(module, _LazyModule(module, spec, lock))

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -79,7 +79,37 @@ def test_require_assignment_updates_materialized_module(tmp_path, monkeypatch):
     assert sys.modules[module_name].value == 2
 
 
-def test_require_keeps_parent_lazy_while_submodule_imports(tmp_path, monkeypatch):
+def test_require_leaves_sys_modules_untouched(tmp_path, monkeypatch):
+    # A proxy parked in sys.modules would shadow the real module for every other importer.
+    module_name = "dspy_lazy_unshadowed_module"
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    (tmp_path / f"{module_name}.py").write_text("value = 7\n")
+
+    mod = require(module_name)
+
+    assert module_name not in sys.modules
+    assert mod.value == 7
+    assert sys.modules[module_name].value == 7
+
+
+def test_require_retries_after_a_failed_import(tmp_path, monkeypatch):
+    module_name = "dspy_lazy_failing_module"
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    (tmp_path / f"{module_name}.py").write_text("raise RuntimeError('boom')\n")
+
+    mod = require(module_name)
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="boom"):
+            _ = mod.value
+    assert module_name not in sys.modules
+
+
+def test_require_does_not_break_submodule_imports(tmp_path, monkeypatch):
+    # A shadowed package is skipped when one of its submodules is imported, so the package ends up
+    # executing from an attribute access made while that submodule is still initializing.
     package_name = "dspy_lazy_submodule_package"
     monkeypatch.syspath_prepend(tmp_path)
     for name in (package_name, f"{package_name}.sub", f"{package_name}.version"):
@@ -88,8 +118,6 @@ def test_require_keeps_parent_lazy_while_submodule_imports(tmp_path, monkeypatch
     package = tmp_path / package_name
     package.mkdir()
     (package / "__init__.py").write_text(f"from {package_name}.sub import LATE\n\nvalue = 42\n")
-    # Importing a submodule makes the import system bind it on the parent package, which must not
-    # materialize the lazy parent while the submodule is still initializing.
     (package / "sub.py").write_text(f"from {package_name}.version import VERSION\n\nLATE = VERSION\n")
     (package / "version.py").write_text("VERSION = '1.0'\n")
 

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -76,6 +77,28 @@ def test_require_assignment_updates_materialized_module(tmp_path, monkeypatch):
     mod.value = 2
 
     assert sys.modules[module_name].value == 2
+
+
+def test_require_keeps_parent_lazy_while_submodule_imports(tmp_path, monkeypatch):
+    package_name = "dspy_lazy_submodule_package"
+    monkeypatch.syspath_prepend(tmp_path)
+    for name in (package_name, f"{package_name}.sub", f"{package_name}.version"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    package = tmp_path / package_name
+    package.mkdir()
+    (package / "__init__.py").write_text(f"from {package_name}.sub import LATE\n\nvalue = 42\n")
+    # Importing a submodule makes the import system bind it on the parent package, which must not
+    # materialize the lazy parent while the submodule is still initializing.
+    (package / "sub.py").write_text(f"from {package_name}.version import VERSION\n\nLATE = VERSION\n")
+    (package / "version.py").write_text("VERSION = '1.0'\n")
+
+    require(package_name)
+    submodule = importlib.import_module(f"{package_name}.sub")
+
+    assert submodule.LATE == "1.0"
+    assert sys.modules[package_name].sub is submodule
+    assert require(package_name).value == 42
 
 
 def test_require_returns_stub_when_missing():


### PR DESCRIPTION
Fixes #10220. require() parked a _LazyModule proxy in sys.modules, so later importers saw the proxy instead of the real package. Importing a submodule then ran against a parent that never executed (e.g. import dspy then import onnxruntime / numpy._core.fromnumeric).

The proxy stays out of sys.modules; the real module is materialized via importlib.import_module on first use.

Tests: uv run pytest tests/utils/test_lazy_import.py -q — 16 passed. CI-style suite: 1222 passed, 253 skipped, 2 xfailed. Distinct from #10221-#10224.