### PR TITLE
fix(dspy): empty Completions no longer raise StopIteration

### DIFF
--- a/dspy/primitives/prediction.py
+++ b/dspy/primitives/prediction.py
@@ -41,7 +41,7 @@ class Prediction(Example):
     def __repr__(self):
         store_repr = ",\n    ".join(f"{k}={v!r}" for k, v in self._store.items())
 
-        if self._completions is None or len(self._completions) == 1:
+        if self._completions is None or len(self._completions) <= 1:
             return f"Prediction(\n    {store_repr}\n)"
 
         num_completions = len(self._completions)
@@ -159,6 +159,8 @@ class Completions:
     def __len__(self):
         # Return the length of the list for one of the keys
         # It assumes all lists have the same length
+        if not self._completions:
+            return 0
         return len(next(iter(self._completions.values())))
 
     def __contains__(self, key):

--- a/tests/primitives/test_prediction.py
+++ b/tests/primitives/test_prediction.py
@@ -1,0 +1,31 @@
+import pytest
+
+from dspy.primitives.prediction import Completions, Prediction
+
+
+def test_completions_len():
+    completions = Completions([{"answer": "2"}, {"answer": "3"}])
+    assert len(completions) == 2
+
+
+def test_empty_completions_len_is_zero():
+    assert len(Completions([])) == 0
+    assert len(Completions({})) == 0
+
+
+def test_empty_completions_is_falsy_and_iterates_empty():
+    completions = Completions([])
+    assert not completions
+    assert list(completions) == []
+    with pytest.raises(IndexError):
+        completions[0]
+
+
+def test_prediction_repr_with_empty_completions():
+    prediction = Prediction.from_completions([])
+    assert repr(prediction) == "Prediction(\n    \n)"
+
+
+def test_prediction_repr_with_multiple_completions():
+    prediction = Prediction.from_completions([{"answer": "2"}, {"answer": "3"}])
+    assert "1 completions omitted" in repr(prediction)


### PR DESCRIPTION
Completions.__len__ did len(next(iter(self._completions.values()))). Completions([]) stores {}, so next() raises StopIteration. That escapes into generators as a silent early stop. Empty Prediction repr also printed (-1 completions omitted).

Empty Completions now have length 0. Distinct from #10221-#10225. Signature.load_state is already covered by #9949.

Tests: uv run pytest tests/primitives/test_prediction.py -q — 5 passed. CI-style: 1224 passed, 253 skipped, 2 xfailed.