### PR TITLE
Add sort_keys=True to tool call/result JSON serialization

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -764,7 +764,7 @@ def _tool_result_content(value: Any) -> str:
     if isinstance(value, str):
         return value
 
-    return json.dumps(serialize_for_json(value), ensure_ascii=False)
+    return json.dumps(serialize_for_json(value), ensure_ascii=False, sort_keys=True)
 
 
 def _tool_call_as_openai_message_tool_call(tool_call: ToolCalls.ToolCall) -> dict[str, Any]:
@@ -773,6 +773,6 @@ def _tool_call_as_openai_message_tool_call(tool_call: ToolCalls.ToolCall) -> dic
         "type": "function",
         "function": {
             "name": tool_call.name,
-            "arguments": json.dumps(serialize_for_json(tool_call.args), ensure_ascii=False),
+            "arguments": json.dumps(serialize_for_json(tool_call.args), ensure_ascii=False, sort_keys=True),
         },
     }

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -98,7 +98,7 @@ def format_field_value(field_info: FieldInfo, value: Any, assume_text=True) -> s
     else:
         jsonable_value = serialize_for_json(value)
         if isinstance(jsonable_value, dict) or isinstance(jsonable_value, list):
-            string_value = json.dumps(jsonable_value, ensure_ascii=False)
+            string_value = json.dumps(jsonable_value, ensure_ascii=False, sort_keys=True)
         else:
             # If the value is not a Python representation of a JSON object or Array
             # (e.g. the value is a JSON string), just use the string representation of the value

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -766,3 +766,54 @@ def test_tool_call_execute_with_local_functions():
             globals().pop("local_add", None)
 
     main()
+
+
+class TestSortKeysPromptCache:
+    """Regression tests for sort_keys in tool call/result serialization (issue #10216).
+
+    Without sort_keys, dict key order depends on insertion order, which can vary
+    after a round trip through stores that normalize key order (e.g. Postgres jsonb).
+    This breaks byte-exact prompt caching on Anthropic and OpenAI.
+    """
+
+    def test_tool_call_args_sorted(self):
+        from dspy.adapters.base import _tool_call_as_openai_message_tool_call
+
+        call = ToolCalls.ToolCall(id="c1", name="search", args={"zeta": 1, "alpha": 2, "mid": 3})
+        result = _tool_call_as_openai_message_tool_call(call)
+        assert result["function"]["arguments"] == '{"alpha": 2, "mid": 3, "zeta": 1}'
+
+    def test_tool_call_args_stable_after_key_reorder(self):
+        from dspy.adapters.base import _tool_call_as_openai_message_tool_call
+
+        args = {"zeta": 1, "alpha": 2, "mid": 3}
+        call_a = ToolCalls.ToolCall(id="c1", name="search", args=args)
+        reordered = {k: args[k] for k in sorted(args, key=lambda k: (len(k), k))}
+        call_b = ToolCalls.ToolCall(id="c1", name="search", args=reordered)
+
+        a_out = _tool_call_as_openai_message_tool_call(call_a)["function"]["arguments"]
+        b_out = _tool_call_as_openai_message_tool_call(call_b)["function"]["arguments"]
+        assert a_out == b_out
+
+    def test_tool_result_dict_sorted(self):
+        from dspy.adapters.base import _tool_result_content
+
+        result = _tool_result_content({"zeta": 1, "alpha": 2})
+        assert result == '{"alpha": 2, "zeta": 1}'
+
+    def test_tool_result_nested_dict_sorted(self):
+        from dspy.adapters.base import _tool_result_content
+
+        result = _tool_result_content({"b": {"y": 1, "a": 2}, "a": 3})
+        assert result == '{"a": 3, "b": {"a": 2, "y": 1}}'
+
+    def test_format_field_value_dict_sorted(self):
+        import json
+        from pydantic.fields import FieldInfo
+        from dspy.adapters.utils import format_field_value
+
+        fi = FieldInfo(annotation=dict)
+        value = {"zeta": 1, "alpha": 2, "mid": 3}
+        result = format_field_value(fi, value)
+        parsed = json.loads(result)
+        assert list(parsed.keys()) == ["alpha", "mid", "zeta"]


### PR DESCRIPTION
## Summary

Tool call arguments and tool results were serialized with `json.dumps` without `sort_keys`, so key order depended on insertion order. After a round trip through stores that normalize key order (e.g. Postgres jsonb), the same tool call could produce byte-different JSON, breaking prompt caching on Anthropic and OpenAI.

## Changes

Added `sort_keys=True` at three call sites:
- `dspy/adapters/base.py` — `_tool_result_content` (dict tool results)
- `dspy/adapters/base.py` — `_tool_call_as_openai_message_tool_call` (native function-calling path)
- `dspy/adapters/utils.py` — `format_field_value` (text rendering path)

## Tests

5 regression tests in `tests/adapters/test_tool.py::TestSortKeysPromptCache`:
- Sorted args output
- Stability after key reorder (simulates jsonb round trip)
- Sorted tool results (flat and nested dicts)
- Sorted `format_field_value` output

Fixes #10216