### PR TITLE
fix(utils): don't materialize lazy modules from import-machinery setattr

### DIFF
--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -145,12 +145,14 @@ class _LazyModule(types.ModuleType):
             # submodule's init and corrupting it. Bind locally instead; _load()
             # replays these bindings onto the real module once it materializes.
             super().__setattr__(attr, value)
-            # A caller can retain the proxy past first use; once the real module has
-            # materialized, sys.modules no longer routes through this object, so a
-            # module-valued assignment must also be forwarded to the canonical module
-            # or the two views of the package diverge.
+            # A caller can retain the proxy past first use. Once the real module has
+            # materialized, sys.modules no longer routes through this object, so the
+            # import system binds submodules onto the real module directly — any
+            # module-valued assignment reaching the retained proxy from here on can
+            # only be caller code and must replace the canonical module's binding,
+            # exactly like a non-module configuration write.
             loaded = sys.modules.get(self.__name__)
-            if loaded is not None and loaded is not self and not hasattr(loaded, attr):
+            if loaded is not None and loaded is not self:
                 setattr(loaded, attr, value)
         else:
             setattr(self._load(), attr, value)

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -145,6 +145,13 @@ class _LazyModule(types.ModuleType):
             # submodule's init and corrupting it. Bind locally instead; _load()
             # replays these bindings onto the real module once it materializes.
             super().__setattr__(attr, value)
+            # A caller can retain the proxy past first use; once the real module has
+            # materialized, sys.modules no longer routes through this object, so a
+            # module-valued assignment must also be forwarded to the canonical module
+            # or the two views of the package diverge.
+            loaded = sys.modules.get(self.__name__)
+            if loaded is not None and loaded is not self and not hasattr(loaded, attr):
+                setattr(loaded, attr, value)
         else:
             setattr(self._load(), attr, value)
 

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -83,6 +83,9 @@ class _LazyModule(types.ModuleType):
     """Module proxy that imports the real module on first attribute access.
 
     Attribute assignment also materializes the real module so configuration writes apply to the real dependency.
+    Assigning a *module* value is treated as the import system binding a submodule onto
+    this (parent) proxy and never triggers a load; the binding is replayed onto the real
+    module once it materializes.
     """
 
     def __init__(self, module: str, spec: importlib.machinery.ModuleSpec, lock: threading.RLock):
@@ -113,13 +116,34 @@ class _LazyModule(types.ModuleType):
             except Exception:
                 sys.modules[module_name] = self
                 raise
-            return sys.modules.get(module_name, module)
+            real = sys.modules.get(module_name, module)
+            self._replay_deferred_submodules(real)
+            return real
+
+    def _replay_deferred_submodules(self, real: types.ModuleType) -> None:
+        # Submodules the import system bound onto the proxy before the real module
+        # materialized (see __setattr__). The real module's own imports found those
+        # submodules already in sys.modules, so the import system never re-bound them
+        # onto it; copy the bindings over so `real.<submodule>` resolves the same way
+        # it would have without the proxy in the middle.
+        for attr, value in list(self.__dict__.items()):
+            if isinstance(value, types.ModuleType) and not hasattr(real, attr):
+                setattr(real, attr, value)
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self._load(), attr)
 
     def __setattr__(self, attr: str, value: Any) -> None:
         if attr.startswith("_dspy_lazy_") or attr in {"__spec__", "__loader__", "__package__", "__path__"}:
+            super().__setattr__(attr, value)
+        elif isinstance(value, types.ModuleType):
+            # The import system binds submodules onto their parent package with
+            # setattr(). Materializing the real module from here would re-enter the
+            # import machinery while this package's submodule can still be
+            # mid-initialization (e.g. `import numpy._core` while sys.modules still
+            # holds this proxy), nesting a full exec of the parent inside the
+            # submodule's init and corrupting it. Bind locally instead; _load()
+            # replays these bindings onto the real module once it materializes.
             super().__setattr__(attr, value)
         else:
             setattr(self._load(), attr, value)

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -100,6 +100,30 @@ def test_require_module_valued_assignment_does_not_materialize(tmp_path, monkeyp
     assert sys.modules[module_name].plugged_in is other
 
 
+def test_require_module_valued_assignment_after_materialization_forwards(tmp_path, monkeypatch):
+    """A retained proxy must forward module-valued assignments to the canonical module.
+
+    Callers keep the object returned by require() past first use; after
+    materialization sys.modules holds the real module, so a module-valued
+    assignment through the retained proxy has to reach both views.
+    """
+    module_name = "dspy_lazy_module_assignment_after_load_module"
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    (tmp_path / f"{module_name}.py").write_text("value = 1\n")
+
+    mod = require(module_name)
+    assert mod.value == 1  # materialize
+    real = sys.modules[module_name]
+    assert real is not mod
+
+    other = types.ModuleType("a_late_external_module")
+    mod.late_binding = other
+
+    assert mod.late_binding is other
+    assert real.late_binding is other
+
+
 def test_require_submodule_import_does_not_reenter_parent_init(tmp_path, monkeypatch):
     """Importing a submodule while the parent slot still holds the lazy proxy must not
     nest a full exec of the parent inside the submodule's initialization.

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -1,5 +1,7 @@
 import sys
 import threading
+import importlib
+import types
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -76,6 +78,74 @@ def test_require_assignment_updates_materialized_module(tmp_path, monkeypatch):
     mod.value = 2
 
     assert sys.modules[module_name].value == 2
+
+
+def test_require_module_valued_assignment_does_not_materialize(tmp_path, monkeypatch):
+    module_name = "dspy_lazy_module_assignment_module"
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    (tmp_path / f"{module_name}.py").write_text("value = 1\n")
+
+    mod = require(module_name)
+    other = types.ModuleType("an_external_module")
+    mod.plugged_in = other
+
+    # Module-valued assignment is treated as the import system binding a submodule
+    # onto its parent package: it must not trigger materialization.
+    assert sys.modules[module_name] is mod
+    assert mod.plugged_in is other
+
+    # Materializing later replays the binding onto the real module.
+    assert mod.value == 1
+    assert sys.modules[module_name].plugged_in is other
+
+
+def test_require_submodule_import_does_not_reenter_parent_init(tmp_path, monkeypatch):
+    """Importing a submodule while the parent slot still holds the lazy proxy must not
+    nest a full exec of the parent inside the submodule's initialization.
+
+    The import system binds submodules onto their parent with ``setattr``; the proxy
+    used to treat that as an attribute assignment, materialized the parent from inside
+    the import machinery, and the parent's own imports then found the submodule
+    mid-initialization. With numpy this surfaces as ``TypeError: data type 'bool' not
+    understood`` when ``import numpy._core`` races the lazy parent (e.g. a C extension
+    importing ``numpy._core`` directly after ``import dspy``).
+    """
+    pkg = "dspy_lazy_reentrant_pkg"
+    pkg_dir = tmp_path / pkg
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(
+        "from .sub import marker\n"
+        "parent_value = 1\n"
+    )
+    (pkg_dir / "sub.py").write_text(
+        f"from {pkg}.version import version as __version__\n"
+        "marker = 'ok'\n"
+    )
+    (pkg_dir / "version.py").write_text("version = '1.0'\n")
+    monkeypatch.syspath_prepend(tmp_path)
+    for suffix in ("", ".sub", ".version"):
+        monkeypatch.delitem(sys.modules, pkg + suffix, raising=False)
+
+    proxy = require(pkg)
+    assert sys.modules[pkg] is proxy
+
+    # Used to raise ImportError: cannot import name 'marker' from partially
+    # initialized module (nested parent exec inside the submodule's init).
+    sub = importlib.import_module(f"{pkg}.sub")
+    assert sub.marker == "ok"
+
+    # The import system's submodule bindings are visible through the proxy
+    # without materializing the parent.
+    assert proxy.version.version == "1.0"
+    assert sys.modules[pkg] is proxy
+
+    # Materializing the parent afterwards keeps every binding consistent.
+    assert proxy.parent_value == 1
+    real = sys.modules[pkg]
+    assert real is not proxy
+    assert real.sub.marker == "ok"
+    assert real.version.version == "1.0"
 
 
 def test_require_returns_stub_when_missing():

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -123,6 +123,15 @@ def test_require_module_valued_assignment_after_materialization_forwards(tmp_pat
     assert mod.late_binding is other
     assert real.late_binding is other
 
+    # Replacing an existing binding through the retained proxy must also reach
+    # the canonical module: post-materialization assignments can only come from
+    # caller code, so they replace like any configuration write.
+    replacement = types.ModuleType("a_replacement_module")
+    mod.late_binding = replacement
+
+    assert mod.late_binding is replacement
+    assert real.late_binding is replacement
+
 
 def test_require_submodule_import_does_not_reenter_parent_init(tmp_path, monkeypatch):
     """Importing a submodule while the parent slot still holds the lazy proxy must not


### PR DESCRIPTION
## Summary

Fixes #10220.

`_LazyModule.__setattr__` treated every assignment as a configuration write and materialized the real module. But the import system also uses `setattr(parent, child, submodule)` to bind submodules onto their parent package — and answering *that* binding with a full load means executing the parent from inside the import machinery while one of its submodules is still mid-initialization.

## Root cause

Deterministic repro on plain CPython (no onnxruntime needed):

```python
import sys
sys.path.insert(0, "<repo>")                     # standalone dspy/utils/lazy_import.py
from dspy.utils.lazy_import import require

np = require("numpy")        # proxy now holds sys.modules["numpy"]
import numpy._core           # what the onnxruntime C extension effectively does
```

1. `import numpy._core` starts executing `numpy/_core/__init__.py` (the import system sees `sys.modules["numpy"]` occupied by the proxy and skips importing the parent).
2. `_core/__init__.py:11` runs `from numpy.version import version as __version__`. The import machinery loads `numpy.version`, then binds it onto the parent with `setattr(sys.modules["numpy"], "version", <module>)` — which lands on the **proxy**.
3. The old `__setattr__` calls `_load()`, so `numpy/__init__.py` executes *nested inside the submodule's import*, while `numpy._core` is half-initialized.
4. `numpy/__init__.py`'s own `from ._core import (...)` finds the mid-init `_core` module, mixing module generations inside `_core` — ending in `TypeError: data type 'bool' not understood`, exactly as reported.

## Fix

Module-valued assignment on the proxy no longer triggers a load:

- the binding lands on the proxy itself (import-system submodule binding), and
- `_load()` replays those bindings onto the real module once it materializes, for names the real module does not already provide.

This mirrors how `importlib.util.LazyLoader` behaves for the same edge case (a stdlib `LazyLoader`-wrapped numpy fails `import numpy._core` identically *without* the re-entrancy corruption). Plain (non-module) configuration writes still materialize the real module immediately — `mod.value = 2` behavior is unchanged and covered by an existing test.

## Tests

Numpy-free regression tests added to `tests/utils/test_lazy_import.py`:

- `test_require_submodule_import_does_not_reenter_parent_init` — imports a submodule while the lazy parent proxy holds `sys.modules`; on the old code this raises `ImportError: cannot import name 'marker' from partially initialized module` (the synthetic equivalent of the reported crash), and it additionally asserts the deferred bindings are replayed consistently after materialization.
- `test_require_module_valued_assignment_does_not_materialize` — module-valued assignment defers, non-module writes still apply to the materialized module.

Verified locally: new tests fail on `main` and pass with this change; all 12 pre-existing tests in the file remain green.
