### PR TITLE
fix(dspy): keep lazy-import proxies out of sys.modules

### DIFF
--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -50,6 +50,7 @@ _INSTALL_HINTS: dict[str, str] = {
 
 _lazy_module_locks: dict[str, threading.RLock] = {}
 _lazy_module_locks_lock = threading.Lock()
+_lazy_modules: dict[str, "_LazyModule"] = {}
 
 
 def _get_lazy_module_lock(module: str) -> threading.RLock:
@@ -92,28 +93,18 @@ class _LazyModule(types.ModuleType):
         self.__package__ = spec.parent
         if spec.submodule_search_locations is not None:
             self.__path__ = spec.submodule_search_locations
-        self._dspy_lazy_spec = spec
         self._dspy_lazy_lock = lock
 
     def _load(self) -> types.ModuleType:
-        # The proxy starts in sys.modules, then the first attribute access swaps in and executes the real module under
-        # the per-module lock. If import fails, restore the proxy so later accesses can retry and still share the lock.
-        # Return sys.modules after execution because a module may replace itself while importing.
+        # The proxy never sits in sys.modules: parking it there would shadow the real module for every other
+        # importer, so `import numpy` from onnxruntime would receive a half-initialized proxy and crash. Defer to
+        # the regular import machinery so the real module is the only entry other importers can see.
         module_name = self.__name__
         with self._dspy_lazy_lock:
             loaded = sys.modules.get(module_name)
             if loaded is not None and loaded is not self:
                 return loaded
-
-            spec = self._dspy_lazy_spec
-            module = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = module
-            try:
-                spec.loader.exec_module(module)
-            except Exception:
-                sys.modules[module_name] = self
-                raise
-            return sys.modules.get(module_name, module)
+            return importlib.import_module(module_name)
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self._load(), attr)
@@ -185,6 +176,4 @@ def require(module: str, *, extra: str | None = None, feature: str | None = None
         if module in sys.modules:
             return sys.modules[module]
 
-        mod = _LazyModule(module, spec, lock)
-        sys.modules[module] = mod
-        return mod
+        return _lazy_modules.setdefault(module, _LazyModule(module, spec, lock))

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -76,6 +77,58 @@ def test_require_assignment_updates_materialized_module(tmp_path, monkeypatch):
     mod.value = 2
 
     assert sys.modules[module_name].value == 2
+
+
+def test_require_leaves_sys_modules_untouched(tmp_path, monkeypatch):
+    """A proxy parked in sys.modules would shadow the real module for every other importer."""
+    module_name = "dspy_lazy_unshadowed_module"
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    (tmp_path / f"{module_name}.py").write_text("value = 7\n")
+
+    mod = require(module_name)
+
+    # The proxy is returned but never inserted into sys.modules.
+    assert module_name not in sys.modules
+    assert mod.value == 7
+    assert sys.modules[module_name].value == 7
+
+
+def test_require_retries_after_a_failed_import(tmp_path, monkeypatch):
+    module_name = "dspy_lazy_failing_module"
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.delitem(sys.modules, module_name, raising=False)
+    (tmp_path / f"{module_name}.py").write_text("raise RuntimeError('boom')\n")
+
+    mod = require(module_name)
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="boom"):
+            _ = mod.value
+    assert module_name not in sys.modules
+
+
+def test_require_does_not_break_submodule_imports(tmp_path, monkeypatch):
+    """A shadowed package is skipped when one of its submodules is imported, so the package ends up
+    executing from an attribute access made while that submodule is still initializing.
+    """
+    package_name = "dspy_lazy_submodule_package"
+    monkeypatch.syspath_prepend(tmp_path)
+    for name in (package_name, f"{package_name}.sub", f"{package_name}.version"):
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+    package = tmp_path / package_name
+    package.mkdir()
+    (package / "__init__.py").write_text(f"from {package_name}.sub import LATE\n\nvalue = 42\n")
+    (package / "sub.py").write_text(f"from {package_name}.version import VERSION\n\nLATE = VERSION\n")
+    (package / "version.py").write_text("VERSION = '1.0'\n")
+
+    require(package_name)
+    submodule = importlib.import_module(f"{package_name}.sub")
+
+    assert submodule.LATE == "1.0"
+    assert sys.modules[package_name].sub is submodule
+    assert require(package_name).value == 42
 
 
 def test_require_returns_stub_when_missing():


### PR DESCRIPTION
##  Changes Description

Fixes #10220. `dspy.utils.lazy_import.require()` registered a `_LazyModule`
proxy directly in `sys.modules`, so a later `import numpy` (triggered here by
onnxruntime) received the half-initialized proxy instead of the real module
and crashed numpy's C-extension init with
`TypeError: data type 'bool' not understood`.

The proxies are now kept out of `sys.modules` entirely: they are cached in a
private dict and resolved through the normal import machinery on first
attribute access, so other importers always see the real module. Added
regression tests covering a clean `sys.modules`, retrying after a failed
import, and importing a submodule.

##  Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

##  Warnings

None.

---

### AI assistance disclosure

Prepared with AI assistance (Codebuff): I reproduced the bug locally first,
then the tool helped me test the fix. I reviewed and verified the change
myself and ran the repro and the `tests/utils/test_lazy_import.py` suite.

Prompt shared:

> In `dspy/utils/lazy_import.py`, keep the `_LazyModule` proxies out of
> `sys.modules` so `import dspy` followed by `import onnxruntime` works, and
> help me test the fix with regression tests.