### PR TITLE
Add trusted in-process LocalInterpreter

### DIFF
--- a/docs/docs/api/modules/Flex.md
+++ b/docs/docs/api/modules/Flex.md
@@ -27,7 +27,7 @@ print(result.total_cents)
 
 Out of the box, `solve` is just a `dspy.Predict` over the signature, wrapped in a module (with `tools`, it starts as a `dspy.RLM` instead — see [Tools](#tools)). The point of `Flex` is what happens when you optimize it (see [Optimizing with GEPA](#optimizing-with-gepa)): GEPA can replace that baseline with, say, a predictor that only extracts quantities and unit prices, and a line of Python that multiplies and sums them.
 
-The generated code always runs in a sandbox (`interpreter_factory` defaults to `dspy.PythonInterpreter`), so the example above needs [Deno](https://deno.land/) installed — see [Sandboxed Execution](#sandboxed-execution).
+By default, generated code runs in a sandbox (`interpreter_factory` defaults to `dspy.PythonInterpreter`), so the example above needs [Deno](https://deno.land/) installed — see [Sandboxed Execution](#sandboxed-execution).
 
 ## How Optimization Works
 
@@ -84,7 +84,7 @@ The `program_trace` parameter is opt-in *by declaration*: only metrics that name
 
 ## Sandboxed Execution
 
-`Flex` always runs its generated code in a sandbox — never in the host Python process. `interpreter_factory` defaults to `dspy.PythonInterpreter` (Deno/Pyodide) and must be a **zero-argument factory** returning a fresh `CodeInterpreter`; a bare instance is not accepted, so parallel evaluations receive isolated sessions. The factory is called once per sandbox session, including separate sessions requested by nested code-executing modules. The code is authored by the reflection model, so isolating it keeps it from running with your host's full permissions. With the default interpreter, optimizer-authored control flow, string work, arithmetic, and supported imports run inside the sandbox, and only provided-tool calls, predictor construction, and predictor calls bridge back to the host, which makes the real LM calls.
+`Flex` defaults to running generated code in `dspy.PythonInterpreter`'s Deno/Pyodide sandbox. `interpreter_factory` must be a **zero-argument factory** returning a fresh `CodeInterpreter`; a bare instance is not accepted, so parallel evaluations receive isolated sessions. The factory is called once per interpreter session, including separate sessions requested by nested code-executing modules. The code is authored by the reflection model, so custom factories should preserve an appropriate isolation boundary. In particular, opting into `dspy.LocalInterpreter` executes optimizer-authored code with the host process's full authority. With the default interpreter, optimizer-authored control flow, string work, arithmetic, and supported imports run inside the sandbox, and only provided-tool calls, predictor construction, and predictor calls bridge back to the host, which makes the real LM calls.
 
 Because the default builds a `PythonInterpreter`, *running* a `Flex` needs [Deno](https://deno.land/) installed; without it, the call raises.
 

--- a/docs/docs/api/modules/RLM.md
+++ b/docs/docs/api/modules/RLM.md
@@ -270,6 +270,8 @@ RLM returns a `Prediction` with:
 
 !!! note "Interpreter Requirements"
     The default `PythonInterpreter` requires [Deno](https://deno.land/) to be installed for the Pyodide WASM sandbox.
+    `LocalInterpreter` requires no additional runtime, but executes model-generated code with the DSPy host process's
+    full authority and should only be used when that code is trusted.
 
 ## API Reference
 

--- a/docs/docs/api/tools/LocalInterpreter.md
+++ b/docs/docs/api/tools/LocalInterpreter.md
@@ -1,0 +1,43 @@
+# dspy.LocalInterpreter
+
+`LocalInterpreter` executes Python directly in the DSPy host process. It starts immediately, preserves Python state
+between calls, can import the host environment's installed packages, and requires no Deno runtime.
+
+!!! danger "Trusted code only"
+
+    `LocalInterpreter` is **not a sandbox**. Executed code has the same filesystem, environment, credential, network,
+    and process access as the DSPy application. Do not use it for untrusted or model-generated code unless that code
+    is already trusted to run with full host authority. Use [`PythonInterpreter`](PythonInterpreter.md) for local
+    sandboxed execution.
+
+```python
+import dspy
+
+with dspy.LocalInterpreter() as interpreter:
+    interpreter.execute("import math\nvalue = math.sqrt(1764)")
+    assert interpreter.execute("value") == 42
+```
+
+`LocalInterpreter.execution_instructions` describes its persistent host-Python environment. Passing
+`interpreter_factory=dspy.LocalInterpreter` to `RLM` therefore adds that description to the action prompt, but it
+does not create a security boundary around generated actions. Executions are serialized across `LocalInterpreter`
+instances because Python's standard-output redirection is process-global.
+
+<!-- START_API_REF -->
+::: dspy.LocalInterpreter
+    handler: python
+    options:
+        members:
+            - __call__
+            - execute
+            - shutdown
+            - start
+        show_source: true
+        show_root_heading: true
+        heading_level: 2
+        docstring_style: google
+        show_root_full_path: true
+        show_object_full_path: false
+        separate_signature: false
+        inherited_members: true
+<!-- END_API_REF -->

--- a/docs/docs/api/tools/index.md
+++ b/docs/docs/api/tools/index.md
@@ -5,5 +5,6 @@ API reference for DSPy tools. Select a page below.
 <!-- START_API_INDEX -->
 - [ColBERTv2](ColBERTv2.md)
 - [Embeddings](Embeddings.md)
+- [LocalInterpreter](LocalInterpreter.md)
 - [PythonInterpreter](PythonInterpreter.md)
 <!-- END_API_INDEX -->

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -177,6 +177,7 @@ nav:
             - api/tools/index.md
             - ColBERTv2: api/tools/ColBERTv2.md
             - Embeddings: api/tools/Embeddings.md
+            - LocalInterpreter: api/tools/LocalInterpreter.md
             - PythonInterpreter: api/tools/PythonInterpreter.md
         - Utils:
             - api/utils/index.md

--- a/docs/scripts/generate_api_docs.py
+++ b/docs/scripts/generate_api_docs.py
@@ -47,6 +47,7 @@ API_MAPPING = {
     "tools": [
         dspy.ColBERTv2,
         dspy.retrievers.Embeddings,
+        dspy.LocalInterpreter,
         dspy.PythonInterpreter,
     ],
     "utils": [

--- a/dspy/primitives/__init__.py
+++ b/dspy/primitives/__init__.py
@@ -1,6 +1,7 @@
 from dspy.primitives.base_module import BaseModule
 from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreter, CodeInterpreterError, FinalOutput
 from dspy.primitives.example import Example
+from dspy.primitives.local_interpreter import LocalInterpreter
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Completions, Prediction
 from dspy.primitives.python_interpreter import PythonInterpreter
@@ -14,6 +15,7 @@ __all__ = [
     "Example",
     "FinalOutput",
     "CodeInterpreterError",
+    "LocalInterpreter",
     "Module",
     "Prediction",
     "PythonInterpreter",

--- a/dspy/primitives/code_interpreter.py
+++ b/dspy/primitives/code_interpreter.py
@@ -3,7 +3,8 @@ Abstract interpreter interface for code execution environments.
 
 This module defines the CodeInterpreter protocol that allows RLM and other
 code-executing modules to work with different interpreter implementations:
-- PythonInterpreter: Local Deno/Pyodide WASM interpreter
+- LocalInterpreter: Trusted execution in the host Python process
+- PythonInterpreter: Sandboxed Deno/Pyodide WASM interpreter
 - MockInterpreter: Scriptable responses for testing
 """
 
@@ -67,7 +68,8 @@ class CodeInterpreter(Protocol):
         4. shutdown() - Release resources
 
     Example implementations:
-        - LocalInterpreter: Deno/Pyodide WASM interpreter (local)
+        - LocalInterpreter: Trusted in-process Python interpreter
+        - PythonInterpreter: Deno/Pyodide WASM interpreter
         - MockInterpreter: Scriptable responses for testing
 
     Pooling:

--- a/dspy/primitives/local_interpreter.py
+++ b/dspy/primitives/local_interpreter.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import ast
+import contextlib
+import inspect
+import io
+import keyword
+import sys
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreterError, FinalOutput
+
+
+class _Submission(BaseException):
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+
+class LocalInterpreter:
+    """Execute trusted Python code in the DSPy host process.
+
+    This interpreter is fast and supports the host's installed Python packages,
+    but it is not a security sandbox. Executed code has the same filesystem,
+    network, environment, process, and credential access as the DSPy process.
+    Use :class:`PythonInterpreter` for sandboxed model-generated code.
+
+    Args:
+        tools: Host functions exposed to executed code by name.
+        output_fields: Optional field definitions for typed ``SUBMIT`` calls.
+    """
+
+    execution_instructions = (
+        "Code runs as trusted Python in the host process. State, imports, functions, and variables persist "
+        "for this session. Host tools and SUBMIT are available as global functions."
+    )
+    _execution_lock = threading.RLock()
+
+    def __init__(
+        self,
+        tools: dict[str, Callable[..., Any]] | None = None,
+        output_fields: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.tools = dict(tools or {})
+        self.output_fields = None if output_fields is None else [dict(field) for field in output_fields]
+        self._namespace: dict[str, Any] = {"__builtins__": __builtins__}
+        self._ended = False
+
+    def start(self) -> None:
+        """Validate that the in-process session is still active."""
+        if self._ended:
+            raise CodeInterpreterError("LocalInterpreter session has been shut down.")
+
+    def _submit(self, *args: Any, **kwargs: Any) -> None:
+        if self.output_fields is None:
+            signature = inspect.Signature([inspect.Parameter("value", inspect.Parameter.POSITIONAL_OR_KEYWORD)])
+            value = signature.bind(*args, **kwargs).arguments["value"]
+            raise _Submission({"output": value})
+
+        names = [field["name"] for field in self.output_fields]
+        signature = inspect.Signature(
+            [inspect.Parameter(name, inspect.Parameter.POSITIONAL_OR_KEYWORD) for name in names]
+        )
+        values = signature.bind(*args, **kwargs).arguments
+        raise _Submission(dict(values))
+
+    def execute(self, code: str, variables: dict[str, Any] | None = None) -> Any:
+        """Execute Python code in a persistent in-process namespace."""
+        with self._execution_lock:
+            self.start()
+            if variables:
+                if any(
+                    not isinstance(name, str) or not name.isidentifier() or keyword.iskeyword(name)
+                    for name in variables
+                ):
+                    raise CodeInterpreterError("Variable names must be valid Python identifiers.")
+                self._namespace.update(variables)
+
+            old_capabilities = self._namespace.pop("__dspy_capabilities__", set())
+            for name in old_capabilities:
+                self._namespace.pop(name, None)
+            capabilities = set(self.tools) | {"SUBMIT"}
+            self._namespace.update(self.tools)
+            self._namespace["SUBMIT"] = self._submit
+            self._namespace["__dspy_capabilities__"] = capabilities
+
+            tree = ast.parse(code, mode="exec")
+            stdout = io.StringIO()
+            host_dspy_module = sys.modules.get("dspy")
+            try:
+                with contextlib.redirect_stdout(stdout):
+                    value = None
+                    if tree.body and isinstance(tree.body[-1], ast.Expr):
+                        prefix = ast.Module(body=tree.body[:-1], type_ignores=[])
+                        exec(compile(prefix, "<local-interpreter>", "exec"), self._namespace)
+                        value = eval(
+                            compile(ast.Expression(tree.body[-1].value), "<local-interpreter>", "eval"),
+                            self._namespace,
+                        )
+                    else:
+                        exec(compile(tree, "<local-interpreter>", "exec"), self._namespace)
+            except _Submission as submission:
+                return FinalOutput(submission.value)
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception as exc:
+                raise CodeExecutionError(f"{type(exc).__name__}: {exc}") from exc
+            finally:
+                if host_dspy_module is None:
+                    sys.modules.pop("dspy", None)
+                else:
+                    sys.modules["dspy"] = host_dspy_module
+
+        output = stdout.getvalue().rstrip("\n")
+        return value if value is not None else (output or None)
+
+    def __enter__(self) -> LocalInterpreter:
+        self.start()
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.shutdown()
+
+    def __call__(self, code: str, variables: dict[str, Any] | None = None) -> Any:
+        return self.execute(code, variables)
+
+    def shutdown(self) -> None:
+        """End the session and discard its namespace."""
+        with self._execution_lock:
+            self._ended = True
+            self._namespace.clear()

--- a/tests/primitives/test_local_interpreter.py
+++ b/tests/primitives/test_local_interpreter.py
@@ -1,0 +1,118 @@
+import sys
+
+import pytest
+
+import dspy
+from dspy.primitives.code_interpreter import CodeExecutionError, CodeInterpreter, CodeInterpreterError, FinalOutput
+
+
+def test_public_protocol_and_execution_instructions():
+    interpreter = dspy.LocalInterpreter()
+    try:
+        assert isinstance(interpreter, CodeInterpreter)
+        assert dspy.LocalInterpreter.execution_instructions
+    finally:
+        interpreter.shutdown()
+
+
+def test_persistent_state_variables_and_output():
+    with dspy.LocalInterpreter() as interpreter:
+        assert interpreter.execute("value = 40") is None
+        assert interpreter.execute("value + increment", {"increment": 2}) == 42
+        assert interpreter.execute("print('hello')") == "hello"
+
+
+def test_rejects_invalid_variable_names():
+    with dspy.LocalInterpreter() as interpreter:
+        with pytest.raises(CodeInterpreterError, match="valid Python identifiers"):
+            interpreter.execute("pass", {"for": 1})
+
+
+def test_syntax_and_runtime_errors_are_recoverable():
+    with dspy.LocalInterpreter() as interpreter:
+        with pytest.raises(SyntaxError):
+            interpreter.execute("if")
+        with pytest.raises(CodeExecutionError, match="ZeroDivisionError"):
+            interpreter.execute("1 / 0")
+        assert interpreter.execute("6 * 7") == 42
+
+
+def test_tools_refresh_between_executions():
+    with dspy.LocalInterpreter(tools={"old_tool": lambda: 1}) as interpreter:
+        assert interpreter.execute("old_tool()") == 1
+        interpreter.tools.clear()
+        interpreter.tools["new_tool"] = lambda: 2
+        assert interpreter.execute("new_tool()") == 2
+        with pytest.raises(CodeExecutionError, match="old_tool"):
+            interpreter.execute("old_tool()")
+
+
+def test_untyped_and_typed_submit():
+    with dspy.LocalInterpreter() as interpreter:
+        result = interpreter.execute("SUBMIT(42)")
+        assert result == FinalOutput({"output": 42})
+
+    fields = [{"name": "answer", "type": "str"}, {"name": "score", "type": "int"}]
+    with dspy.LocalInterpreter(output_fields=fields) as interpreter:
+        result = interpreter.execute("SUBMIT(answer='yes', score=42)")
+        assert result == FinalOutput({"answer": "yes", "score": 42})
+        with pytest.raises(CodeExecutionError, match="missing"):
+            interpreter.execute("SUBMIT(answer='no')")
+
+
+def test_submit_stops_execution():
+    calls = []
+
+    def after_submit():
+        calls.append(True)
+
+    with dspy.LocalInterpreter(tools={"after_submit": after_submit}) as interpreter:
+        assert interpreter.execute("SUBMIT(42)\nafter_submit()") == FinalOutput({"output": 42})
+        assert calls == []
+
+
+def test_shutdown_is_terminal_and_idempotent():
+    interpreter = dspy.LocalInterpreter()
+    interpreter.start()
+    interpreter.start()
+    interpreter.shutdown()
+    interpreter.shutdown()
+    with pytest.raises(CodeInterpreterError, match="shut down"):
+        interpreter.start()
+    with pytest.raises(CodeInterpreterError, match="shut down"):
+        interpreter.execute("1")
+
+
+def test_execution_restores_host_dspy_module():
+    host_module = sys.modules["dspy"]
+    with dspy.LocalInterpreter() as interpreter:
+        interpreter.execute("import sys, types\nsys.modules['dspy'] = types.ModuleType('dspy')")
+    assert sys.modules["dspy"] is host_module
+
+
+def test_rlm_uses_local_interpreter_factory():
+    calls = []
+
+    def add(*, left: int, right: int) -> int:
+        calls.append((left, right))
+        return left + right
+
+    class Actions(dspy.Predict):
+        def __init__(self, signature):
+            super().__init__(signature)
+            self.responses = iter(
+                [
+                    dspy.Prediction(reasoning="compute", code="answer = add(left=20, right=22)"),
+                    dspy.Prediction(reasoning="submit", code="SUBMIT(answer=str(answer))"),
+                ]
+            )
+
+        def forward(self, **kwargs):
+            return next(self.responses)
+
+    rlm = dspy.RLM("question: str -> answer: str", max_iters=2, tools=[add], interpreter_factory=dspy.LocalInterpreter)
+    rlm.generate_action = Actions(rlm.generate_action.signature)
+
+    assert rlm(question="What is 20 + 22?").answer == "42"
+    assert calls == [(20, 22)]
+    assert dspy.LocalInterpreter.execution_instructions in rlm.generate_action.signature.instructions


### PR DESCRIPTION
## Summary

- port the trusted in-process `LocalInterpreter` from `dspy-interpreters` into DSPy
- expose it as `dspy.LocalInterpreter` with persistent state, host tools, typed `SUBMIT`, recoverable execution errors, terminal shutdown, and execution-environment metadata
- verify it through a deterministic real `dspy.RLM` flow and the external interpreter conformance suites, including Flex
- document its full host authority and correct Flex's categorical sandbox wording for custom interpreter factories

This intentionally does **not** port the abandoned invocation-scoped binding extension or the speculative subprocess mode. `LocalInterpreter` is opt-in; `PythonInterpreter` remains the sandboxed default for RLM and Flex.

## Usage with Flex

```python
import dspy

lm = dspy.LM("openai/gpt-5-mini", temperature=1.0, max_tokens=16000)
dspy.configure(lm=lm)

solve = dspy.Flex(
    "question: str -> answer: int",
    interpreter_factory=dspy.LocalInterpreter,
)
result = solve(question="What is 19 + 23? Return only the integer answer.")

print(result.answer)  # 42
```

This exact example was run against the real `openai/gpt-5-mini` provider. It returned integer `42`, and `lm.history` recorded exactly one real LM call through Flex's host-side predictor bridge.

## Security model

`LocalInterpreter` is not a sandbox. Executed code has the DSPy process's filesystem, environment, credential, network, package, and process authority. The API docs and RLM/Flex docs warn users explicitly. Executions are serialized across LocalInterpreter instances because stdout redirection is process-global.

## Verification

- real-LM Flex example above — `answer: 42`, `answer_type: int`, `real_lm_calls: 1`
- `uv run pytest -q -o addopts='' tests/primitives/test_local_interpreter.py tests/predict/test_rlm.py -m 'not deno'` — 116 passed, 2 skipped, 37 deselected
- external `dspy-interpreters` checks — core interpreter, execution instructions, real RLM, RLM prompt integration, and Flex facade all passed
- focused Ruff check and `git diff --check` — passed
- docs build — completed successfully
- `uv build` — wheel and sdist built; wheel contains `dspy/primitives/local_interpreter.py`
