### PR TITLE
Add opt-in structured results for MCP tools

### DIFF
--- a/docs/docs/diving-deeper/tools.md
+++ b/docs/docs/diving-deeper/tools.md
@@ -90,23 +90,12 @@ MCP servers publish tools with JSON schemas. `dspy.Tool.from_mcp_tool(session, t
 
 ```python
 dspy_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
-
 structured_tool = dspy.Tool.from_mcp_tool(
-    session,
-    mcp_tool,
-    result_mode="structured",
+    session, mcp_tool, result_mode="structured"
 )
 ```
 
-The bridge:
-
-1. Converts the MCP input schema into DSPy's `args`, `arg_types`, and `arg_desc`.
-2. Creates an async callable that invokes `session.call_tool(...)`.
-3. By default, unpacks MCP text content into a string or list and preserves the existing non-text fallback.
-4. With `result_mode="structured"`, returns `structuredContent` exactly when present and otherwise uses the default conversion.
-5. Raises an execution error when the MCP response has `isError=True`.
-
-The bridge supports both the camelCase result fields in MCP SDK v1 and their snake_case replacements in v2. Structured mode does not parse values or unwrap a single `result` field, because MCP structured content can be any JSON value and a `result` field may belong to the application.
+The default preserves DSPy's existing `content` conversion. Structured mode returns `structuredContent` exactly when present, without parsing or unwrapping it, and otherwise falls back to the default. The bridge supports MCP SDK v1 and v2 field names and raises on tool errors.
 
 MCP tools are asynchronous because `mcp.ClientSession` is asynchronous. Use a module's async entry point, such as `acall`, or explicitly enable async-to-sync conversion when appropriate.
 

--- a/docs/docs/diving-deeper/tools.md
+++ b/docs/docs/diving-deeper/tools.md
@@ -90,16 +90,23 @@ MCP servers publish tools with JSON schemas. `dspy.Tool.from_mcp_tool(session, t
 
 ```python
 dspy_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
+
+structured_tool = dspy.Tool.from_mcp_tool(
+    session,
+    mcp_tool,
+    result_mode="structured",
+)
 ```
 
 The bridge:
 
 1. Converts the MCP input schema into DSPy's `args`, `arg_types`, and `arg_desc`.
 2. Creates an async callable that invokes `session.call_tool(...)`.
-3. Unpacks MCP text content into a string or list and preserves non-text content.
-4. Raises an execution error when the MCP response has `isError=True`.
+3. By default, unpacks MCP text content into a string or list and preserves the existing non-text fallback.
+4. With `result_mode="structured"`, returns `structuredContent` exactly when present and otherwise uses the default conversion.
+5. Raises an execution error when the MCP response has `isError=True`.
 
-The bridge supports both the camelCase result fields in MCP SDK v1 and their snake_case replacements in v2 without changing text or non-text result behavior.
+The bridge supports both the camelCase result fields in MCP SDK v1 and their snake_case replacements in v2. Structured mode does not parse values or unwrap a single `result` field, because MCP structured content can be any JSON value and a `result` field may belong to the application.
 
 MCP tools are asynchronous because `mcp.ClientSession` is asynchronous. Use a module's async entry point, such as `acall`, or explicitly enable async-to-sync conversion when appropriate.
 
@@ -116,8 +123,8 @@ Validates, coerces, and executes tool arguments through synchronous or asynchron
 **`Tool.format_as_litellm_function_call()`** → `dict`
 Returns the OpenAI/LiteLLM-style function descriptor used by adapters for native calling.
 
-**`Tool.from_mcp_tool(session, tool)`** → `Tool`
-Wraps a remote MCP tool as an asynchronous DSPy tool.
+**`Tool.from_mcp_tool(session, tool, *, result_mode="text")`** → `Tool`
+Wraps a remote MCP tool as an asynchronous DSPy tool. Set `result_mode="structured"` for exact machine-readable MCP results; the default keeps the model-facing content behavior.
 
 **`Tool.from_langchain(tool)`** → `Tool`
 Wraps a LangChain tool in the same DSPy interface.

--- a/docs/docs/diving-deeper/tools.md
+++ b/docs/docs/diving-deeper/tools.md
@@ -90,12 +90,16 @@ MCP servers publish tools with JSON schemas. `dspy.Tool.from_mcp_tool(session, t
 
 ```python
 dspy_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
-structured_tool = dspy.Tool.from_mcp_tool(
-    session, mcp_tool, result_mode="structured"
-)
 ```
 
-The default preserves DSPy's existing `content` conversion. Structured mode returns `structuredContent` exactly when present, without parsing or unwrapping it, and otherwise falls back to the default. The bridge supports MCP SDK v1 and v2 field names and raises on tool errors.
+The bridge:
+
+1. Converts the MCP input schema into DSPy's `args`, `arg_types`, and `arg_desc`.
+2. Creates an async callable that invokes `session.call_tool(...)`.
+3. Unpacks MCP text content into a string or list and preserves non-text content.
+4. Raises an execution error when the MCP response has `isError=True`.
+
+The bridge supports both the camelCase result fields in MCP SDK v1 and their snake_case replacements in v2 without changing text or non-text result behavior. Pass `result_mode="structured"` to return `structuredContent` when available, falling back to the default conversion when it is absent.
 
 MCP tools are asynchronous because `mcp.ClientSession` is asynchronous. Use a module's async entry point, such as `acall`, or explicitly enable async-to-sync conversion when appropriate.
 
@@ -113,7 +117,7 @@ Validates, coerces, and executes tool arguments through synchronous or asynchron
 Returns the OpenAI/LiteLLM-style function descriptor used by adapters for native calling.
 
 **`Tool.from_mcp_tool(session, tool, *, result_mode="text")`** → `Tool`
-Wraps a remote MCP tool as an asynchronous DSPy tool. Set `result_mode="structured"` for exact machine-readable MCP results; the default keeps the model-facing content behavior.
+Wraps a remote MCP tool as an asynchronous DSPy tool. Set `result_mode="structured"` to return structured MCP results when available.
 
 **`Tool.from_langchain(tool)`** → `Tool`
 Wraps a LangChain tool in the same DSPy interface.

--- a/docs/docs/learn/programming/mcp.md
+++ b/docs/docs/learn/programming/mcp.md
@@ -158,6 +158,26 @@ dspy_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
 result = await dspy_tool.acall(param1="value", param2=123)
 ```
 
+### Choosing the result representation
+
+By default, DSPy uses the MCP result's model-facing `content` field. This preserves the existing behavior: one text block becomes a string, multiple text blocks become a list, and results without text fall back to their non-text content.
+
+For programmatic workflows that need the MCP result's machine-readable JSON value, opt into structured content when converting the tool:
+
+```python
+structured_tool = dspy.Tool.from_mcp_tool(
+    session,
+    mcp_tool,
+    result_mode="structured",
+)
+
+result = await structured_tool.acall(param1="value", param2=123)
+```
+
+Structured mode returns `structuredContent` exactly as the server sent it. Objects, arrays, strings, numbers, booleans, JSON `null`, and empty values are preserved without parsing or unwrapping. For example, the official MCP Python SDK may represent a tool annotated `-> int` as `{"result": 3}`; DSPy returns that entire object rather than guessing that the `result` field is an SDK-generated envelope. If a result has no structured content, DSPy falls back to the default content conversion.
+
+Use the default mode for tools primarily observed by a ReAct agent or another language model, since MCP `content` is the server's model-facing representation. Use structured mode when application code needs native JSON values for validation, indexing, or explicit tool chaining. In both modes, treat tool results as untrusted server data and validate them before passing them to sensitive operations.
+
 ## Learn More
 
 - [MCP Official Documentation](https://modelcontextprotocol.io/)

--- a/docs/docs/learn/programming/mcp.md
+++ b/docs/docs/learn/programming/mcp.md
@@ -160,98 +160,33 @@ result = await dspy_tool.acall(param1="value", param2=123)
 
 ### Choosing the result representation
 
-By default, DSPy uses the MCP result's model-facing `content` field. This preserves the existing behavior: one text block becomes a string, multiple text blocks become a list, and results without text fall back to their non-text content.
-
-For programmatic workflows that need the MCP result's machine-readable JSON value, opt into structured content when converting the tool:
+DSPy uses the model-facing `content` field by default. Opt into the machine-readable `structuredContent` field for programmatic use:
 
 ```python
 structured_tool = dspy.Tool.from_mcp_tool(
-    session,
-    mcp_tool,
-    result_mode="structured",
+    session, mcp_tool, result_mode="structured"
 )
-
-result = await structured_tool.acall(param1="value", param2=123)
 ```
 
-Structured mode returns `structuredContent` exactly as the server sent it. Objects, arrays, strings, numbers, booleans, JSON `null`, and empty values are preserved without parsing or unwrapping. For example, the official MCP Python SDK may represent a tool annotated `-> int` as `{"result": 3}`; DSPy returns that entire object rather than guessing that the `result` field is an SDK-generated envelope. If a result has no structured content, DSPy falls back to the default content conversion.
+Structured mode returns the value exactly, including scalars, `null`, and empty values. It does not parse text or unwrap `{"result": ...}`; if structured content is absent, it falls back to the default conversion. Use the default for model observations and structured mode for validation, indexing, or tool chaining.
 
-Use the default mode for tools primarily observed by a ReAct agent or another language model, since MCP `content` is the server's model-facing representation. Use structured mode when application code needs native JSON values for validation, indexing, or explicit tool chaining. In both modes, treat tool results as untrusted server data and validate them before passing them to sensitive operations.
+### Example with a reference MCP server
 
-### Running against maintained MCP servers
-
-The following complete example uses two maintained [MCP reference servers](https://github.com/modelcontextprotocol/servers): Everything, which returns a domain-shaped weather object, and Filesystem, which returns file content in an object. Neither requires API credentials. The package versions are pinned to the versions used to verify these outputs; Node.js and `npx` must be installed.
+Use the maintained [Everything server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) in the stdio example above:
 
 ```python
-import asyncio
-import tempfile
-from pathlib import Path
-
-import dspy
-from mcp import ClientSession, StdioServerParameters
-from mcp.client.stdio import stdio_client
-
-
-async def call_in_both_modes(server, tool_name, arguments):
-    async with stdio_client(server) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            tools = (await session.list_tools()).tools
-            mcp_tool = next(tool for tool in tools if tool.name == tool_name)
-
-            text_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
-            structured_tool = dspy.Tool.from_mcp_tool(
-                session,
-                mcp_tool,
-                result_mode="structured",
-            )
-            return (
-                await text_tool.acall(**arguments),
-                await structured_tool.acall(**arguments),
-            )
-
-
-async def main():
-    everything = StdioServerParameters(
-        command="npx",
-        args=["-y", "@modelcontextprotocol/server-everything@2026.7.4"],
-    )
-    text, structured = await call_in_both_modes(
-        everything,
-        "get-structured-content",
-        {"location": "New York"},
-    )
-    print(repr(text))
-    # '{"temperature":33,"conditions":"Cloudy","humidity":82}'
-    print(structured)
-    # {'temperature': 33, 'conditions': 'Cloudy', 'humidity': 82}
-
-    with tempfile.TemporaryDirectory() as directory:
-        path = Path(directory, "example.txt")
-        path.write_text("alpha\nbeta\ngamma\n")
-        filesystem = StdioServerParameters(
-            command="npx",
-            args=[
-                "-y",
-                "@modelcontextprotocol/server-filesystem@2026.7.10",
-                directory,
-            ],
-        )
-        text, structured = await call_in_both_modes(
-            filesystem,
-            "read_text_file",
-            {"path": str(path), "head": 2},
-        )
-        print(repr(text))
-        # 'alpha\nbeta'
-        print(structured)
-        # {'content': 'alpha\nbeta'}
-
-
-asyncio.run(main())
+server_params = StdioServerParameters(
+    command="npx",
+    args=["-y", "@modelcontextprotocol/server-everything@2026.7.4"],
+)
+# After initializing the session:
+mcp_tool = next(t for t in response.tools if t.name == "get-structured-content")
+weather = dspy.Tool.from_mcp_tool(session, mcp_tool, result_mode="structured")
+print(await weather.acall(location="New York"))
+# {'temperature': 33, 'conditions': 'Cloudy', 'humidity': 82}
 ```
 
-These results illustrate why DSPy keeps the representations separate: model-facing `content` is already useful text, while `structuredContent` preserves the native object for indexing and validation. The Filesystem server limits access to the directory passed on its command line. Review and pin any server package before using it with sensitive data.
+The same code was verified against the maintained [Filesystem server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem): `read_text_file(..., head=2)` returned `{"content": "alpha\nbeta"}`. Review and pin MCP server packages before giving them access to sensitive data.
 
 ## Learn More
 

--- a/docs/docs/learn/programming/mcp.md
+++ b/docs/docs/learn/programming/mcp.md
@@ -178,6 +178,81 @@ Structured mode returns `structuredContent` exactly as the server sent it. Objec
 
 Use the default mode for tools primarily observed by a ReAct agent or another language model, since MCP `content` is the server's model-facing representation. Use structured mode when application code needs native JSON values for validation, indexing, or explicit tool chaining. In both modes, treat tool results as untrusted server data and validate them before passing them to sensitive operations.
 
+### Running against maintained MCP servers
+
+The following complete example uses two maintained [MCP reference servers](https://github.com/modelcontextprotocol/servers): Everything, which returns a domain-shaped weather object, and Filesystem, which returns file content in an object. Neither requires API credentials. The package versions are pinned to the versions used to verify these outputs; Node.js and `npx` must be installed.
+
+```python
+import asyncio
+import tempfile
+from pathlib import Path
+
+import dspy
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+async def call_in_both_modes(server, tool_name, arguments):
+    async with stdio_client(server) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            tools = (await session.list_tools()).tools
+            mcp_tool = next(tool for tool in tools if tool.name == tool_name)
+
+            text_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
+            structured_tool = dspy.Tool.from_mcp_tool(
+                session,
+                mcp_tool,
+                result_mode="structured",
+            )
+            return (
+                await text_tool.acall(**arguments),
+                await structured_tool.acall(**arguments),
+            )
+
+
+async def main():
+    everything = StdioServerParameters(
+        command="npx",
+        args=["-y", "@modelcontextprotocol/server-everything@2026.7.4"],
+    )
+    text, structured = await call_in_both_modes(
+        everything,
+        "get-structured-content",
+        {"location": "New York"},
+    )
+    print(repr(text))
+    # '{"temperature":33,"conditions":"Cloudy","humidity":82}'
+    print(structured)
+    # {'temperature': 33, 'conditions': 'Cloudy', 'humidity': 82}
+
+    with tempfile.TemporaryDirectory() as directory:
+        path = Path(directory, "example.txt")
+        path.write_text("alpha\nbeta\ngamma\n")
+        filesystem = StdioServerParameters(
+            command="npx",
+            args=[
+                "-y",
+                "@modelcontextprotocol/server-filesystem@2026.7.10",
+                directory,
+            ],
+        )
+        text, structured = await call_in_both_modes(
+            filesystem,
+            "read_text_file",
+            {"path": str(path), "head": 2},
+        )
+        print(repr(text))
+        # 'alpha\nbeta'
+        print(structured)
+        # {'content': 'alpha\nbeta'}
+
+
+asyncio.run(main())
+```
+
+These results illustrate why DSPy keeps the representations separate: model-facing `content` is already useful text, while `structuredContent` preserves the native object for indexing and validation. The Filesystem server limits access to the directory passed on its command line. Review and pin any server package before using it with sensitive data.
+
 ## Learn More
 
 - [MCP Official Documentation](https://modelcontextprotocol.io/)

--- a/docs/docs/learn/programming/mcp.md
+++ b/docs/docs/learn/programming/mcp.md
@@ -158,33 +158,7 @@ dspy_tool = dspy.Tool.from_mcp_tool(session, mcp_tool)
 result = await dspy_tool.acall(param1="value", param2=123)
 ```
 
-### Choosing the result representation
-
-DSPy uses the model-facing `content` field by default. Opt into the machine-readable `structuredContent` field for programmatic use:
-
-```python
-structured_tool = dspy.Tool.from_mcp_tool(
-    session, mcp_tool, result_mode="structured"
-)
-```
-
-Structured mode returns the value exactly, including scalars, `null`, and empty values. It does not parse text or unwrap `{"result": ...}`; if structured content is absent, it falls back to the default conversion. Use the default for model observations and structured mode for validation, indexing, or tool chaining.
-
-### Example with a reference MCP server
-
-Use the maintained [Everything server](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) in the stdio example above:
-
-```python
-server_params = StdioServerParameters(
-    command="npx",
-    args=["-y", "@modelcontextprotocol/server-everything@2026.7.4"],
-)
-# After initializing the session:
-mcp_tool = next(t for t in response.tools if t.name == "get-structured-content")
-weather = dspy.Tool.from_mcp_tool(session, mcp_tool, result_mode="structured")
-print(await weather.acall(location="New York"))
-# {'temperature': 33, 'conditions': 'Cloudy', 'humidity': 82}
-```
+By default, MCP tools return the `content` field. Pass `result_mode="structured"` to `dspy.Tool.from_mcp_tool` to return `structuredContent` when available; if it is absent, DSPy falls back to the default conversion.
 
 ## Learn More
 

--- a/docs/docs/learn/programming/mcp.md
+++ b/docs/docs/learn/programming/mcp.md
@@ -186,8 +186,6 @@ print(await weather.acall(location="New York"))
 # {'temperature': 33, 'conditions': 'Cloudy', 'humidity': 82}
 ```
 
-The same code was verified against the maintained [Filesystem server](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem): `read_text_file(..., head=2)` returned `{"content": "alpha\nbeta"}`. Review and pin MCP server packages before giving them access to sensitive data.
-
 ## Learn More
 
 - [MCP Official Documentation](https://modelcontextprotocol.io/)

--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -1,6 +1,6 @@
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, Protocol, get_origin, get_type_hints
+from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol, get_origin, get_type_hints
 
 import json_repair
 import pydantic
@@ -204,20 +204,29 @@ class Tool(Type):
             return result
 
     @classmethod
-    def from_mcp_tool(cls, session: _MCPToolClient, tool: "mcp.types.Tool") -> "Tool":
+    def from_mcp_tool(
+        cls,
+        session: _MCPToolClient,
+        tool: "mcp.types.Tool",
+        *,
+        result_mode: Literal["text", "structured"] = "text",
+    ) -> "Tool":
         """
         Build a DSPy tool from an MCP tool and a compatible MCP client.
 
         Args:
             session: An MCP client or session with an async ``call_tool`` method.
             tool: The MCP tool to convert.
+            result_mode: ``"text"`` preserves DSPy's existing text/non-text
+                conversion. ``"structured"`` returns MCP structured content
+                exactly when present, with the existing conversion as fallback.
 
         Returns:
             A Tool object.
         """
         from dspy.utils.mcp import convert_mcp_tool
 
-        return convert_mcp_tool(session, tool)
+        return convert_mcp_tool(session, tool, result_mode=result_mode)
 
     @classmethod
     def from_langchain(cls, tool: "BaseTool") -> "Tool":

--- a/dspy/utils/mcp.py
+++ b/dspy/utils/mcp.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from dspy.adapters.types.tool import Tool, _MCPToolClient, convert_input_schema_to_tool_args
 
@@ -14,7 +14,20 @@ def _get_field(obj: Any, snake_name: str, camel_name: str, default: Any = None) 
     return default
 
 
-def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> str | list[Any]:
+def _field_is_set(obj: Any, snake_name: str, camel_name: str) -> bool:
+    """Check whether an optional field was explicitly set, including to null."""
+    fields_set = getattr(obj, "model_fields_set", None)
+    if fields_set is None:
+        fields_set = getattr(obj, "__fields_set__", None)
+    if fields_set is not None:
+        return snake_name in fields_set or camel_name in fields_set
+    return hasattr(obj, snake_name) or hasattr(obj, camel_name)
+
+
+def _convert_mcp_tool_result(
+    call_tool_result: "mcp.types.CallToolResult",
+    result_mode: Literal["text", "structured"] = "text",
+) -> Any:
     from mcp.types import TextContent
 
     text_contents: list[TextContent] = []
@@ -32,10 +45,18 @@ def _convert_mcp_tool_result(call_tool_result: "mcp.types.CallToolResult") -> st
     if _get_field(call_tool_result, "is_error", "isError", default=False):
         raise RuntimeError(f"Failed to call a MCP tool: {tool_content}")
 
+    if result_mode == "structured" and _field_is_set(call_tool_result, "structured_content", "structuredContent"):
+        return _get_field(call_tool_result, "structured_content", "structuredContent")
+
     return tool_content or non_text_contents
 
 
-def convert_mcp_tool(session: _MCPToolClient, tool: "mcp.types.Tool") -> Tool:
+def convert_mcp_tool(
+    session: _MCPToolClient,
+    tool: "mcp.types.Tool",
+    *,
+    result_mode: Literal["text", "structured"] = "text",
+) -> Tool:
     """Build a DSPy tool from an MCP tool.
 
     Both mcp SDK v1's ``ClientSession`` and v2's high-level ``Client`` satisfy
@@ -44,16 +65,22 @@ def convert_mcp_tool(session: _MCPToolClient, tool: "mcp.types.Tool") -> Tool:
     Args:
         session: An MCP client or session with an async ``call_tool`` method.
         tool: The MCP tool to convert.
+        result_mode: ``"text"`` preserves DSPy's existing text/non-text
+            conversion. ``"structured"`` returns MCP structured content
+            exactly when present, with the existing conversion as fallback.
 
     Returns:
         A dspy Tool object.
     """
+    if result_mode not in ("text", "structured"):
+        raise ValueError(f"Unsupported MCP result mode: {result_mode!r}")
+
     input_schema = _get_field(tool, "input_schema", "inputSchema", default={})
     args, arg_types, arg_desc = convert_input_schema_to_tool_args(input_schema)
 
     # Convert the MCP tool and Session to a single async method
     async def func(*args, **kwargs):
         result = await session.call_tool(tool.name, arguments=kwargs)
-        return _convert_mcp_tool_result(result)
+        return _convert_mcp_tool_result(result, result_mode=result_mode)
 
     return Tool(func=func, name=tool.name, desc=tool.description, args=args, arg_types=arg_types, arg_desc=arg_desc)

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -12,30 +12,99 @@ from dspy.utils.mcp import _convert_mcp_tool_result, convert_mcp_tool
 if importlib.util.find_spec("mcp") is None:
     pytest.skip(reason="mcp is not installed", allow_module_level=True)
 
+_UNSET = object()
 
-def make_call_tool_result(field_style, texts=(), is_error=False):
+
+def make_call_tool_result(field_style, texts=(), structured=_UNSET, is_error=False):
     from mcp.types import TextContent
 
     fields = {
         "content": [TextContent(type="text", text=text) for text in texts],
-        "structured_content" if field_style == "snake" else "structuredContent": {"result": "ignored"},
         "is_error" if field_style == "snake" else "isError": is_error,
     }
+    if structured is not _UNSET:
+        fields["structured_content" if field_style == "snake" else "structuredContent"] = structured
     return SimpleNamespace(**fields)
 
 
 @pytest.mark.extra
 def test_convert_mcp_tool_result_supports_both_field_styles_without_changing_results():
-    assert _convert_mcp_tool_result(make_call_tool_result("camel", texts=["hi"])) == "hi"
-    assert _convert_mcp_tool_result(make_call_tool_result("snake", texts=["a", "b"])) == ["a", "b"]
+    camel_result = make_call_tool_result("camel", texts=["hi"], structured={"result": "ignored"})
+    snake_result = make_call_tool_result("snake", texts=["a", "b"], structured={"result": "ignored"})
+
+    assert _convert_mcp_tool_result(camel_result) == "hi"
+    assert _convert_mcp_tool_result(snake_result) == ["a", "b"]
 
 
 @pytest.mark.extra
 @pytest.mark.parametrize("field_style", ["camel", "snake"])
-def test_error_result_raises(field_style):
-    result = make_call_tool_result(field_style, texts=["boom"], is_error=True)
+@pytest.mark.parametrize(
+    "structured",
+    [
+        pytest.param({"answer": 42}, id="object"),
+        pytest.param([1, 2], id="array"),
+        pytest.param("answer", id="string"),
+        pytest.param(3.5, id="number"),
+        pytest.param(False, id="boolean"),
+        pytest.param(None, id="null"),
+        pytest.param({}, id="empty-object"),
+        pytest.param([], id="empty-array"),
+        pytest.param("", id="empty-string"),
+        pytest.param(0, id="zero"),
+    ],
+)
+def test_structured_result_mode_returns_every_json_value_exactly(field_style, structured):
+    result = make_call_tool_result(field_style, texts=["fallback"], structured=structured)
+
+    converted = _convert_mcp_tool_result(result, result_mode="structured")
+    assert converted == structured
+    assert type(converted) is type(structured)
+
+
+@pytest.mark.extra
+@pytest.mark.parametrize("field_style", ["camel", "snake"])
+def test_structured_result_mode_falls_back_when_field_is_absent(field_style):
+    result = make_call_tool_result(field_style, texts=["fallback"])
+
+    assert _convert_mcp_tool_result(result, result_mode="structured") == "fallback"
+
+
+@pytest.mark.extra
+def test_structured_result_mode_distinguishes_explicit_null_from_omission():
+    from mcp.types import CallToolResult
+
+    model_fields = getattr(CallToolResult, "model_fields", None)
+    if model_fields is None:
+        model_fields = getattr(CallToolResult, "__fields__", {})
+    field_name = next(
+        (name for name in ("structured_content", "structuredContent") if name in model_fields),
+        None,
+    )
+    if field_name is None:
+        pytest.skip("This MCP version predates structured content")
+
+    omitted = CallToolResult(content=[])
+    explicit_null = CallToolResult(content=[], **{field_name: None})
+
+    assert _convert_mcp_tool_result(omitted, result_mode="structured") == []
+    assert _convert_mcp_tool_result(explicit_null, result_mode="structured") is None
+
+
+@pytest.mark.extra
+@pytest.mark.parametrize("field_style", ["camel", "snake"])
+@pytest.mark.parametrize("result_mode", ["text", "structured"])
+def test_error_result_raises_before_conversion(field_style, result_mode):
+    result = make_call_tool_result(field_style, texts=["boom"], structured={"result": "ignored"}, is_error=True)
     with pytest.raises(RuntimeError, match="Failed to call a MCP tool: boom"):
-        _convert_mcp_tool_result(result)
+        _convert_mcp_tool_result(result, result_mode=result_mode)
+
+
+@pytest.mark.extra
+def test_convert_mcp_tool_rejects_unknown_result_mode():
+    tool = SimpleNamespace(name="test", description="test", input_schema={})
+
+    with pytest.raises(ValueError, match="Unsupported MCP result mode: 'invalid'"):
+        convert_mcp_tool(SimpleNamespace(), tool, result_mode="invalid")
 
 
 @pytest.mark.asyncio
@@ -56,7 +125,10 @@ async def test_convert_mcp_tool_with_v2_client():
     async with Client(server) as client:
         response = await client.list_tools()
         increment_tool = Tool.from_mcp_tool(client, response.tools[0])
+        structured_increment_tool = Tool.from_mcp_tool(client, response.tools[0], result_mode="structured")
+
         assert await increment_tool.acall(value=1) == "2"
+        assert await structured_increment_tool.acall(value=1) == {"result": 2}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add an explicit, backward-compatible way to consume MCP's machine-readable `structuredContent` through `dspy.Tool`.

```python
structured_tool = dspy.Tool.from_mcp_tool(
    client,
    mcp_tool,
    result_mode="structured",
)
```

- Keep `result_mode="text"` as the default, preserving the result behavior established before and during #10188.
- In structured mode, return `structuredContent` / `structured_content` exactly when the field is present.
- Preserve every JSON root type and falsy/empty value, including objects, arrays, strings, numbers, booleans, `null`, `{}`, `[]`, `""`, and `0`.
- Distinguish an omitted structured field from an explicitly present JSON `null` using the SDK model's field-presence metadata.
- Fall back to the existing text/non-text conversion when a server does not provide structured content.
- Keep tool errors ahead of normal result conversion.
- Document when model-facing content is preferable (for example ReAct observations) versus when structured data is preferable (programmatic validation, indexing, and explicit tool chaining).
- Include a concise user example against the maintained Everything MCP reference server.

## Result contract

DSPy returns structured content exactly as the server sent it. It does not parse text, infer provenance, or unwrap a single `result` field.

| MCP result | Default `text` mode | `structured` mode |
| --- | --- | --- |
| `content="3"`, `structuredContent={"result":3}` | `"3"` | `{"result":3}` |
| structured object | existing content conversion | exact object |
| structured array/scalar/boolean/null | existing content conversion | exact JSON value |
| no structured field | existing content conversion | existing content conversion |
| `isError=true` | raises `RuntimeError` | raises `RuntimeError` |

Keeping the envelope is deliberate: in an application-defined object, `result` may be real domain data rather than an SDK wrapper.

## Deliberate scope

This PR builds on the transport compatibility merged in #10188. It does **not**:

- change the default result mode;
- automatically unwrap Python SDK `{"result": ...}` envelopes;
- parse JSON strings from `content`;
- change MCP connection or multi-round-trip lifecycle handling;
- add a DSPy output-schema abstraction.

**Separate DSPy issue / follow-up: #10236.** Mixed MCP content blocks need their own contract. The existing converter favors text when a result also contains images, audio, embedded resources, or resource links. Preserving those mixed blocks is useful, but it is independent of structured JSON selection and should be addressed in a separate issue and PR.

## Verification

Focused MCP suite:

- `mcp==1.5.0`: 29 passed, 2 skipped
- `mcp==1.10.0`: 30 passed, 1 skipped
- `mcp==2.0.0`: 31 passed
- Real `@modelcontextprotocol/server-everything@2026.7.4` stdio call: text and native weather object observed
- Real `@modelcontextprotocol/server-filesystem@2026.7.10` stdio call: text and exact structured file-content object observed
- `tests/adapters/test_tool.py`: 38 passed
- Ruff check and format checks on touched Python files: passed
- `git diff --check`: passed