### PR TITLE
feat(adapter): support nested XML data

### DIFF
--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -122,7 +122,7 @@ In adhering to this structure, your objective is:
 Ada, 36, lives in London, UK and likes math and machines.
 </text>
 
-Respond with the corresponding output fields wrapped in XML tags `<person>`.
+Respond with the corresponding output fields wrapped in XML tags `<person>`. Use this nested XML structure: <person><name>...</name><age>...</age><address><city>...</city><country>...</country></address><interests>...</interests> <interests>...</interests></person>
 ```
 
 A matching LM response looks like this:

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -67,6 +67,81 @@ Outputs structured JSON. Internally extends ChatAdapter — formatting is simila
 **`dspy.XMLAdapter(callbacks=None)`**  
 `<field_name>value</field_name>` tags. Structured values use nested elements and lists use repeated elements. The parser validates the response as XML and casts the resulting tree to the signature's field types. JSON inside a field is still accepted for compatibility with older prompts. Literal `&` and `<` in text values must be escaped as `&amp;` and `&lt;`; DSPy does this automatically when formatting examples.
 
+For example, define a nested output type and select `XMLAdapter`:
+
+```python
+from pydantic import BaseModel
+
+import dspy
+
+
+class Address(BaseModel):
+    city: str
+    country: str
+
+
+class Person(BaseModel):
+    name: str
+    age: int
+    address: Address
+    interests: list[str]
+
+
+class ExtractPerson(dspy.Signature):
+    """Extract the person's details."""
+
+    text: str = dspy.InputField()
+    person: Person = dspy.OutputField()
+
+
+extract = dspy.Predict(ExtractPerson)
+with dspy.context(adapter=dspy.XMLAdapter()):
+    result = extract(text="Ada, 36, lives in London, UK and likes math and machines.")
+```
+
+The final prompt sent to the LM shows the exact nested structure, including repeated tags for lists:
+
+```text
+[system]
+Your input fields are:
+1. `text` (str):
+Your output fields are:
+1. `person` (Person):
+All interactions will be structured in the following way, with the appropriate values filled in.
+
+<text>
+{text}
+</text>
+
+<person><name>...</name><age>...</age><address><city>...</city><country>...</country></address><interests>...</interests> <interests>...</interests></person>
+In adhering to this structure, your objective is:
+        Extract the person's details.
+
+[user]
+<text>
+Ada, 36, lives in London, UK and likes math and machines.
+</text>
+
+Respond with the corresponding output fields wrapped in XML tags `<person>`. Use this nested XML structure: <person><name>...</name><age>...</age><address><city>...</city><country>...</country></address><interests>...</interests> <interests>...</interests></person>
+```
+
+A matching LM response looks like this:
+
+```xml
+<person>
+  <name>Ada</name>
+  <age>36</age>
+  <address>
+    <city>London</city>
+    <country>UK</country>
+  </address>
+  <interests>math</interests>
+  <interests>machines</interests>
+</person>
+```
+
+DSPy parses it into the declared types, so `result.person` is a `Person`, `result.person.address` is an `Address`, and `result.person.interests` is `['math', 'machines']`.
+
 **`dspy.TwoStepAdapter(extraction_model: BaseLM, **kwargs)`**  
 Two LM calls per inference. Use it when the main LM is a reasoning model that’s bad at formatting — the extractor is usually a cheap general-purpose LM with ChatAdapter. Doesn’t support finetuning yet.
 

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -65,7 +65,7 @@ The default. Builds a chat-style prompt with field markers, parses the response 
 Outputs structured JSON. Internally extends ChatAdapter — formatting is similar, but the output instruction asks for JSON and parsing uses `json_repair`. The constructor’s `use_native_function_calling=True` default flips when tool calling is wired in.
 
 **`dspy.XMLAdapter(callbacks=None)`**  
-`<field_name>value</field_name>` tags. The parser is a regex (`r"<(\w+)>(.*?)</\1>"` with `DOTALL`); it’s robust to whitespace but doesn’t tolerate nested tags of the same name.
+`<field_name>value</field_name>` tags. Structured values use nested elements and lists use repeated elements. The parser validates the response as XML and casts the resulting tree to the signature's field types. JSON inside a field is still accepted for compatibility with older prompts. Literal `&` and `<` in text values must be escaped as `&amp;` and `&lt;`; DSPy does this automatically when formatting examples.
 
 **`dspy.TwoStepAdapter(extraction_model: BaseLM, **kwargs)`**  
 Two LM calls per inference. Use it when the main LM is a reasoning model that’s bad at formatting — the extractor is usually a cheap general-purpose LM with ChatAdapter. Doesn’t support finetuning yet.

--- a/docs/docs/diving-deeper/adapters.md
+++ b/docs/docs/diving-deeper/adapters.md
@@ -122,7 +122,7 @@ In adhering to this structure, your objective is:
 Ada, 36, lives in London, UK and likes math and machines.
 </text>
 
-Respond with the corresponding output fields wrapped in XML tags `<person>`. Use this nested XML structure: <person><name>...</name><age>...</age><address><city>...</city><country>...</country></address><interests>...</interests> <interests>...</interests></person>
+Respond with the corresponding output fields wrapped in XML tags `<person>`.
 ```
 
 A matching LM response looks like this:

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -1,37 +1,58 @@
 import re
-from typing import Any
+import types
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from typing import Any, Union, get_args, get_origin
 
+import pydantic
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
-from dspy.adapters.utils import apply_output_field_defaults, format_field_value, translate_field_type
+from dspy.adapters.types.base_type import CUSTOM_TYPE_END_IDENTIFIER, CUSTOM_TYPE_START_IDENTIFIER
+from dspy.adapters.utils import (
+    apply_output_field_defaults,
+    format_field_value,
+    parse_value,
+    serialize_for_json,
+    translate_field_type,
+)
 from dspy.signatures.signature import Signature
+from dspy.utils.exceptions import AdapterParseError
 
 
 class XMLAdapter(ChatAdapter):
-    field_pattern = re.compile(r"<(?P<name>\w+)>((?P<content>.*?))</\1>", re.DOTALL)
+    """Format and parse signature fields as XML.
+
+    Structured values use nested elements, with repeated elements representing lists. JSON values
+    inside a field remain accepted for backwards compatibility. XML text is escaped when DSPy
+    formats examples, and malformed model output raises ``AdapterParseError`` instead of returning
+    a silently truncated value.
+    """
 
     def format_field_with_value(self, fields_with_values: dict[FieldInfoWithName, Any]) -> str:
         output = []
         for field, field_value in fields_with_values.items():
-            formatted = format_field_value(field_info=field.info, value=field_value)
-            output.append(f"<{field.name}>\n{formatted}\n</{field.name}>")
+            serialized = serialize_for_json(field_value)
+            is_output = (field.info.json_schema_extra or {}).get("__dspy_field_type") == "output"
+            if is_output and self._uses_nested_xml(field.info.annotation) and isinstance(serialized, (dict, list)):
+                output.append(self._value_to_xml(serialized, field.name))
+            else:
+                formatted = format_field_value(field_info=field.info, value=field_value)
+                if field.info.annotation is str:
+                    formatted = self._escape_text(formatted)
+                output.append(f"<{field.name}>\n{formatted}\n</{field.name}>")
         return "\n\n".join(output).strip()
 
     def format_field_structure(self, signature: type[Signature]) -> str:
-        """
-        XMLAdapter requires input and output fields to be wrapped in XML tags like `<field_name>`.
-        """
-
-        parts = []
-        parts.append("All interactions will be structured in the following way, with the appropriate values filled in.")
+        """XMLAdapter requires signature fields to be wrapped in XML tags."""
+        parts = ["All interactions will be structured in the following way, with the appropriate values filled in."]
 
         def format_signature_fields_for_instructions(fields: dict[str, FieldInfo]):
             return self.format_field_with_value(
-                fields_with_values={
+                {
                     FieldInfoWithName(name=field_name, info=field_info): translate_field_type(field_name, field_info)
                     for field_name, field_info in fields.items()
-                },
+                }
             )
 
         parts.append(format_signature_fields_for_instructions(signature.input_fields))
@@ -48,12 +69,15 @@ class XMLAdapter(ChatAdapter):
     ) -> str:
         messages = [prefix]
 
-        messages.append(self.format_field_with_value(
-            {
-                FieldInfoWithName(name=k, info=v): inputs.get(k)
-                for k, v in signature.input_fields.items() if k in inputs
-            },
-        ))
+        messages.append(
+            self.format_field_with_value(
+                {
+                    FieldInfoWithName(name=k, info=v): inputs.get(k)
+                    for k, v in signature.input_fields.items()
+                    if k in inputs
+                },
+            )
+        )
 
         if main_request:
             output_requirements = self.user_message_output_requirements(signature)
@@ -80,22 +104,50 @@ class XMLAdapter(ChatAdapter):
         message = "Respond with the corresponding output fields wrapped in XML tags "
         message += ", then ".join(f"`<{f}>`" for f in signature.output_fields)
         message += "."
+        nested_fields = [
+            self._xml_schema(name, field.annotation)
+            for name, field in signature.output_fields.items()
+            if self._uses_nested_xml(field.annotation)
+        ]
+        if nested_fields:
+            message += f" Use this nested XML structure: {' '.join(nested_fields)}"
         return message
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
+        try:
+            root = ET.fromstring(f"<dspy_root>{completion}</dspy_root>")
+        except ET.ParseError as e:
+            raise AdapterParseError(
+                adapter_name="XMLAdapter",
+                signature=signature,
+                lm_response=completion,
+                message=f"Failed to parse XML: {e}",
+            ) from e
+
+        elements_by_name: dict[str, list[ET.Element]] = defaultdict(list)
+        for element in root:
+            if element.tag in signature.output_fields:
+                elements_by_name[element.tag].append(element)
+
         fields = {}
-        for match in self.field_pattern.finditer(completion):
-            name = match.group("name")
-            content = match.group("content").strip()
-            if name in signature.output_fields and name not in fields:
-                fields[name] = content
-        # Cast values using base class parse_value helper
-        for k, v in fields.items():
-            fields[k] = self._parse_field_value(signature.output_fields[k], v, completion, signature)
+        for name, field_info in signature.output_fields.items():
+            elements = elements_by_name.get(name)
+            if not elements:
+                continue
+            value: Any = None
+            try:
+                value = self._elements_to_value(elements, field_info.annotation)
+                fields[name] = parse_value(value, field_info.annotation)
+            except Exception as e:
+                raise AdapterParseError(
+                    adapter_name="XMLAdapter",
+                    signature=signature,
+                    lm_response=completion,
+                    message=f"Failed to parse field {field_info} with value {value}: {e}",
+                ) from e
+
         fields = apply_output_field_defaults(signature, fields)
         if fields.keys() != signature.output_fields.keys():
-            from dspy.utils.exceptions import AdapterParseError
-
             raise AdapterParseError(
                 adapter_name="XMLAdapter",
                 signature=signature,
@@ -104,17 +156,151 @@ class XMLAdapter(ChatAdapter):
             )
         return fields
 
-    def _parse_field_value(self, field_info, raw, completion, signature):
-        from dspy.adapters.utils import parse_value
+    @classmethod
+    def _value_to_xml(cls, value: Any, tag: str) -> str:
+        if isinstance(value, list):
+            if not value:
+                return f"<{tag} />"
+            return "".join(cls._value_to_xml(item, tag) for item in value)
 
-        try:
-            return parse_value(raw, field_info.annotation)
-        except Exception as e:
-            from dspy.utils.exceptions import AdapterParseError
+        if isinstance(value, dict):
+            inner = "".join(cls._value_to_xml(child, str(name)) for name, child in value.items())
+            return f"<{tag}>{inner}</{tag}>"
 
-            raise AdapterParseError(
-                adapter_name="XMLAdapter",
-                signature=signature,
-                lm_response=completion,
-                message=f"Failed to parse field {field_info} with value {raw}: {e}",
+        if value is None:
+            return f"<{tag} />"
+        return f"<{tag}>{cls._escape_text(str(value))}</{tag}>"
+
+    @classmethod
+    def _xml_schema(cls, tag: str, annotation: Any) -> str:
+        annotation = cls._unwrap_optional(annotation)
+        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+            inner = "".join(cls._xml_schema(name, field.annotation) for name, field in annotation.model_fields.items())
+            return f"<{tag}>{inner}</{tag}>"
+        if get_origin(annotation) is list:
+            item_annotation = get_args(annotation)[0] if get_args(annotation) else Any
+            item = cls._xml_schema(tag, item_annotation)
+            return f"{item} {item}"
+        return f"<{tag}>...</{tag}>"
+
+    @staticmethod
+    def _escape_text(value: str) -> str:
+        """Escape XML text while retaining DSPy's private multimodal markers."""
+        marker_pattern = re.compile(
+            f"({re.escape(CUSTOM_TYPE_START_IDENTIFIER)}.*?{re.escape(CUSTOM_TYPE_END_IDENTIFIER)})",
+            re.DOTALL,
+        )
+        parts = marker_pattern.split(value)
+        for index in range(0, len(parts), 2):
+            parts[index] = parts[index].replace("&", "&amp;").replace("<", "&lt;")
+        return "".join(parts)
+
+    @classmethod
+    def _elements_to_value(cls, elements: list[ET.Element], annotation: Any) -> Any:
+        annotation = cls._unwrap_optional(annotation)
+        origin = get_origin(annotation)
+
+        if origin is list:
+            item_annotation = get_args(annotation)[0] if get_args(annotation) else Any
+            if len(elements) == 1 and not list(elements[0]):
+                text = (elements[0].text or "").strip()
+                if not text:
+                    return []
+                if text.startswith("["):
+                    return text
+            return [cls._element_to_value(element, item_annotation) for element in elements]
+        if annotation is Any and len(elements) > 1:
+            return [cls._element_to_value(element, Any) for element in elements]
+
+        # Preserve the historical first-field-wins behavior for duplicate scalar fields.
+        return cls._element_to_value(elements[0], annotation)
+
+    @classmethod
+    def _element_to_value(cls, element: ET.Element, annotation: Any) -> Any:
+        annotation = cls._unwrap_optional(annotation)
+
+        if annotation is str:
+            if not list(element):
+                return (element.text or "").strip()
+            return cls._inner_xml(element).strip()
+
+        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+            if not list(element):
+                return (element.text or "").strip()
+            children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
+            for child in element:
+                children_by_name[child.tag].append(child)
+            return {
+                name: cls._elements_to_value(children_by_name[name], field.annotation)
+                for name, field in annotation.model_fields.items()
+                if name in children_by_name
+            }
+
+        origin = get_origin(annotation)
+        if origin is list:
+            return cls._elements_to_value([element], annotation)
+        if origin is dict:
+            args = get_args(annotation)
+            value_annotation = args[1] if len(args) == 2 else Any
+            children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
+            for child in element:
+                children_by_name[child.tag].append(child)
+            return {
+                name: cls._elements_to_value(children, value_annotation) for name, children in children_by_name.items()
+            }
+
+        if list(element):
+            return cls._element_to_dict(element)
+        return (element.text or "").strip()
+
+    @classmethod
+    def _element_to_dict(cls, element: ET.Element) -> dict[str, Any]:
+        values: dict[str, Any] = {}
+        for child in element:
+            value = cls._element_to_dict(child) if list(child) else (child.text or "").strip()
+            if child.tag in values:
+                if not isinstance(values[child.tag], list):
+                    values[child.tag] = [values[child.tag]]
+                values[child.tag].append(value)
+            else:
+                values[child.tag] = value
+        return values
+
+    @staticmethod
+    def _inner_xml(element: ET.Element) -> str:
+        content = element.text or ""
+        for child in element:
+            content += ET.tostring(child, encoding="unicode")
+        return content
+
+    @staticmethod
+    def _unwrap_optional(annotation: Any) -> Any:
+        origin = get_origin(annotation)
+        if origin in (Union, types.UnionType):
+            args = [arg for arg in get_args(annotation) if arg is not type(None)]
+            if len(args) == 1:
+                return args[0]
+        return annotation
+
+    @classmethod
+    def _uses_nested_xml(cls, annotation: Any) -> bool:
+        """Keep DSPy's transport models on their established marker/JSON representation."""
+        annotation = cls._unwrap_optional(annotation)
+        origin = get_origin(annotation)
+        if origin is list:
+            args = get_args(annotation)
+            if not args:
+                return True
+            item_annotation = cls._unwrap_optional(args[0])
+            return not (
+                isinstance(item_annotation, type)
+                and issubclass(item_annotation, pydantic.BaseModel)
+                and item_annotation.__module__.startswith("dspy.")
             )
+        if origin is dict:
+            return True
+        return (
+            isinstance(annotation, type)
+            and issubclass(annotation, pydantic.BaseModel)
+            and not annotation.__module__.startswith("dspy.")
+        )

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -115,13 +115,6 @@ class XMLAdapter(ChatAdapter):
         message = "Respond with the corresponding output fields wrapped in XML tags "
         message += ", then ".join(f"`<{f}>`" for f in signature.output_fields)
         message += "."
-        nested_fields = [
-            self._xml_schema(name, field.annotation)
-            for name, field in signature.output_fields.items()
-            if self._uses_nested_xml(field.annotation)
-        ]
-        if nested_fields:
-            message += f" Use this nested XML structure: {' '.join(nested_fields)}"
         return message
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
@@ -135,10 +128,7 @@ class XMLAdapter(ChatAdapter):
                 message=f"Failed to parse XML: {e}",
             ) from e
 
-        elements_by_name: dict[str, list[ET.Element]] = defaultdict(list)
-        for element in root:
-            if element.tag in signature.output_fields:
-                elements_by_name[element.tag].append(element)
+        elements_by_name = self._group_children(root)
 
         fields = {}
         for name, field_info in signature.output_fields.items():
@@ -242,13 +232,12 @@ class XMLAdapter(ChatAdapter):
                 return (element.text or "").strip()
             return cls._inner_xml(element).strip()
 
+        children_by_name = cls._group_children(element)
+        if not children_by_name:
+            return (element.text or "").strip()
+
         field_annotations = cls._structured_field_annotations(annotation)
         if field_annotations is not None:
-            if not list(element):
-                return (element.text or "").strip()
-            children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
-            for child in element:
-                children_by_name[child.tag].append(child)
             return {
                 name: cls._elements_to_value(children_by_name[name], field_annotation)
                 for name, field_annotation in field_annotations.items()
@@ -258,29 +247,20 @@ class XMLAdapter(ChatAdapter):
         origin = get_origin(annotation)
         if origin is list:
             return cls._elements_to_value([element], annotation)
-        if origin is dict:
-            args = get_args(annotation)
-            value_annotation = args[1] if len(args) == 2 else Any
-            children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
-            for child in element:
-                children_by_name[child.tag].append(child)
-            return {
-                name: cls._elements_to_value(children, value_annotation) for name, children in children_by_name.items()
-            }
+        args = get_args(annotation)
+        child_annotation = args[1] if origin is dict and len(args) == 2 else Any
+        return {name: cls._elements_to_value(children, child_annotation) for name, children in children_by_name.items()}
 
+    @staticmethod
+    def _group_children(element: ET.Element) -> dict[str, list[ET.Element]]:
         children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
         for child in element:
             children_by_name[child.tag].append(child)
-        if children_by_name:
-            return {name: cls._elements_to_value(children, Any) for name, children in children_by_name.items()}
-        return (element.text or "").strip()
+        return children_by_name
 
     @staticmethod
     def _inner_xml(element: ET.Element) -> str:
-        content = element.text or ""
-        for child in element:
-            content += ET.tostring(child, encoding="unicode")
-        return content
+        return (element.text or "") + "".join(ET.tostring(child, encoding="unicode") for child in element)
 
     @staticmethod
     def _unwrap_optional(annotation: Any) -> Any:

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -48,12 +48,22 @@ class XMLAdapter(ChatAdapter):
         parts = ["All interactions will be structured in the following way, with the appropriate values filled in."]
 
         def format_signature_fields_for_instructions(fields: dict[str, FieldInfo]):
-            return self.format_field_with_value(
-                {
-                    FieldInfoWithName(name=field_name, info=field_info): translate_field_type(field_name, field_info)
-                    for field_name, field_info in fields.items()
-                }
-            )
+            formatted_fields = []
+            for field_name, field_info in fields.items():
+                is_output = (field_info.json_schema_extra or {}).get("__dspy_field_type") == "output"
+                if is_output and self._uses_nested_xml(field_info.annotation):
+                    formatted_fields.append(self._xml_schema(field_name, field_info.annotation))
+                else:
+                    formatted_fields.append(
+                        self.format_field_with_value(
+                            {
+                                FieldInfoWithName(name=field_name, info=field_info): translate_field_type(
+                                    field_name, field_info
+                                )
+                            }
+                        )
+                    )
+            return "\n\n".join(formatted_fields)
 
         parts.append(format_signature_fields_for_instructions(signature.input_fields))
         parts.append(format_signature_fields_for_instructions(signature.output_fields))

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -1,15 +1,13 @@
-import re
 import types
 import xml.etree.ElementTree as ET
 from collections import defaultdict
-from typing import Any, Union, get_args, get_origin, get_type_hints
+from typing import Any, Union, get_args, get_origin
 
 import pydantic
-from pydantic.fields import FieldInfo
+from pydantic import TypeAdapter
 from typing_extensions import is_typeddict
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
-from dspy.adapters.types.base_type import CUSTOM_TYPE_END_IDENTIFIER, CUSTOM_TYPE_START_IDENTIFIER
 from dspy.adapters.utils import (
     apply_output_field_defaults,
     format_field_value,
@@ -22,284 +20,150 @@ from dspy.utils.exceptions import AdapterParseError
 
 
 class XMLAdapter(ChatAdapter):
-    """Format and parse signature fields as XML.
-
-    Structured values use nested elements, with repeated elements representing lists. JSON values
-    inside a field remain accepted for backwards compatibility. XML text is escaped when DSPy
-    formats examples, and malformed model output raises ``AdapterParseError`` instead of returning
-    a silently truncated value.
-    """
-
     def format_field_with_value(self, fields_with_values: dict[FieldInfoWithName, Any]) -> str:
         output = []
-        for field, field_value in fields_with_values.items():
-            serialized = serialize_for_json(field_value)
+        for field, value in fields_with_values.items():
+            serialized = serialize_for_json(value)
             is_output = (field.info.json_schema_extra or {}).get("__dspy_field_type") == "output"
             if is_output and self._uses_nested_xml(field.info.annotation) and isinstance(serialized, (dict, list)):
                 output.append(self._value_to_xml(serialized, field.name))
-            else:
-                formatted = format_field_value(field_info=field.info, value=field_value)
-                if field.info.annotation is str:
-                    formatted = self._escape_text(formatted)
-                output.append(f"<{field.name}>\n{formatted}\n</{field.name}>")
+                continue
+            formatted = format_field_value(field_info=field.info, value=value)
+            if is_output and field.info.annotation is str:
+                formatted = formatted.replace("&", "&amp;").replace("<", "&lt;")
+            output.append(f"<{field.name}>\n{formatted}\n</{field.name}>")
         return "\n\n".join(output).strip()
 
     def format_field_structure(self, signature: type[Signature]) -> str:
-        """XMLAdapter requires signature fields to be wrapped in XML tags."""
-        parts = ["All interactions will be structured in the following way, with the appropriate values filled in."]
-
-        def format_signature_fields_for_instructions(fields: dict[str, FieldInfo]):
-            formatted_fields = []
-            for field_name, field_info in fields.items():
-                is_output = (field_info.json_schema_extra or {}).get("__dspy_field_type") == "output"
-                if is_output and self._uses_nested_xml(field_info.annotation):
-                    formatted_fields.append(self._xml_schema(field_name, field_info.annotation))
-                else:
-                    formatted_fields.append(
-                        self.format_field_with_value(
-                            {
-                                FieldInfoWithName(name=field_name, info=field_info): translate_field_type(
-                                    field_name, field_info
-                                )
-                            }
-                        )
-                    )
-            return "\n\n".join(formatted_fields)
-
-        parts.append(format_signature_fields_for_instructions(signature.input_fields))
-        parts.append(format_signature_fields_for_instructions(signature.output_fields))
-        return "\n\n".join(parts).strip()
-
-    def format_user_message_content(
-        self,
-        signature: type[Signature],
-        inputs: dict[str, Any],
-        prefix: str = "",
-        suffix: str = "",
-        main_request: bool = False,
-    ) -> str:
-        messages = [prefix]
-
-        messages.append(
-            self.format_field_with_value(
-                {
-                    FieldInfoWithName(name=k, info=v): inputs.get(k)
-                    for k, v in signature.input_fields.items()
-                    if k in inputs
-                },
+        def format_field(name, field):
+            if (field.json_schema_extra or {}).get("__dspy_field_type") == "output" and self._uses_nested_xml(
+                field.annotation
+            ):
+                return self._xml_schema(name, field.annotation)
+            return self.format_field_with_value(
+                {FieldInfoWithName(name=name, info=field): translate_field_type(name, field)}
             )
-        )
 
+        fields = ("\n\n".join(format_field(name, field) for name, field in group.items()) for group in (signature.input_fields, signature.output_fields))
+        return "\n\n".join(("All interactions will be structured in the following way, with the appropriate values filled in.", *fields))
+
+    def format_user_message_content(self, signature: type[Signature], inputs: dict[str, Any], prefix: str = "", suffix: str = "", main_request: bool = False) -> str:
+        fields = {FieldInfoWithName(name=k, info=v): inputs[k] for k, v in signature.input_fields.items() if k in inputs}
+        messages = [prefix, self.format_field_with_value(fields)]
         if main_request:
-            output_requirements = self.user_message_output_requirements(signature)
-            if output_requirements is not None:
-                messages.append(output_requirements)
+            messages.append(self.user_message_output_requirements(signature))
+        return "\n\n".join((*messages, suffix)).strip()
 
-        messages.append(suffix)
-        return "\n\n".join(messages).strip()
-
-    def format_assistant_message_content(
-        self,
-        signature: type[Signature],
-        outputs: dict[str, Any],
-        missing_field_message=None,
-    ) -> str:
-        return self.format_field_with_value(
-            {
-                FieldInfoWithName(name=k, info=v): outputs.get(k, missing_field_message)
-                for k, v in signature.output_fields.items()
-            },
-        )
+    def format_assistant_message_content(self, signature: type[Signature], outputs: dict[str, Any], missing_field_message=None) -> str:
+        fields = {FieldInfoWithName(name=k, info=v): outputs.get(k, missing_field_message) for k, v in signature.output_fields.items()}
+        return self.format_field_with_value(fields)
 
     def user_message_output_requirements(self, signature: type[Signature]) -> str:
-        message = "Respond with the corresponding output fields wrapped in XML tags "
-        message += ", then ".join(f"`<{f}>`" for f in signature.output_fields)
-        message += "."
-        return message
+        fields = ", then ".join(f"`<{name}>`" for name in signature.output_fields)
+        schemas = [self._xml_schema(name, field.annotation) for name, field in signature.output_fields.items() if self._uses_nested_xml(field.annotation)]
+        return f"Respond with the corresponding output fields wrapped in XML tags {fields}." + (f" Use this nested XML structure: {' '.join(schemas)}" if schemas else "")
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
         try:
             root = ET.fromstring(f"<dspy_root>{completion}</dspy_root>")
         except ET.ParseError as e:
-            raise AdapterParseError(
-                adapter_name="XMLAdapter",
-                signature=signature,
-                lm_response=completion,
-                message=f"Failed to parse XML: {e}",
-            ) from e
-
-        elements_by_name = self._group_children(root)
-
+            raise AdapterParseError(adapter_name="XMLAdapter", signature=signature, lm_response=completion, message=f"Failed to parse XML: {e}") from e
+        elements = self._group_children(root)
         fields = {}
-        for name, field_info in signature.output_fields.items():
-            elements = elements_by_name.get(name)
-            if not elements:
+        for name, field in signature.output_fields.items():
+            if name not in elements:
                 continue
-            value: Any = None
+            value = None
             try:
-                value = self._elements_to_value(elements, field_info.annotation)
-                fields[name] = parse_value(value, field_info.annotation)
+                schema = TypeAdapter(field.annotation).json_schema()
+                value = self._elements_to_value(elements[name], schema, schema.get("$defs", {}))
+                fields[name] = parse_value(value, field.annotation)
             except Exception as e:
                 raise AdapterParseError(
                     adapter_name="XMLAdapter",
                     signature=signature,
                     lm_response=completion,
-                    message=f"Failed to parse field {field_info} with value {value}: {e}",
+                    message=f"Failed to parse field {field} with value {value}: {e}",
                 ) from e
-
         fields = apply_output_field_defaults(signature, fields)
         if fields.keys() != signature.output_fields.keys():
-            raise AdapterParseError(
-                adapter_name="XMLAdapter",
-                signature=signature,
-                lm_response=completion,
-                parsed_result=fields,
-            )
+            raise AdapterParseError(adapter_name="XMLAdapter", signature=signature, lm_response=completion, parsed_result=fields)
         return fields
 
     @classmethod
     def _value_to_xml(cls, value: Any, tag: str) -> str:
         if isinstance(value, list):
-            if not value:
-                return f"<{tag} />"
-            return "".join(cls._value_to_xml(item, tag) for item in value)
-
+            return "".join(cls._value_to_xml(item, tag) for item in value) if value else f"<{tag} />"
         if isinstance(value, dict):
-            inner = "".join(cls._value_to_xml(child, str(name)) for name, child in value.items())
-            return f"<{tag}>{inner}</{tag}>"
-
-        if value is None:
-            return f"<{tag} />"
-        return f"<{tag}>{cls._escape_text(str(value))}</{tag}>"
+            return f"<{tag}>{''.join(cls._value_to_xml(child, str(name)) for name, child in value.items())}</{tag}>"
+        return f"<{tag}>{str(value).replace('&', '&amp;').replace('<', '&lt;')}</{tag}>" if value is not None else f"<{tag} />"
 
     @classmethod
-    def _xml_schema(cls, tag: str, annotation: Any, expanded_types: frozenset[type] = frozenset()) -> str:
-        annotation = cls._unwrap_optional(annotation)
-        field_annotations = cls._structured_field_annotations(annotation)
-        if field_annotations is not None:
-            if annotation in expanded_types:
-                return f"<{tag}>...</{tag}>"
-            expanded_types |= {annotation}
-            inner = "".join(
-                cls._xml_schema(name, field_annotation, expanded_types)
-                for name, field_annotation in field_annotations.items()
+    def _xml_schema(cls, tag: str, annotation: Any) -> str:
+        schema = TypeAdapter(annotation).json_schema()
+        return cls._schema_to_xml(tag, schema, schema.get("$defs", {}), frozenset())
+
+    @classmethod
+    def _schema_to_xml(cls, tag: str, schema: dict, definitions: dict, seen: frozenset[str]) -> str:
+        if ref := schema.get("$ref"):
+            name = ref.rsplit("/", 1)[-1]
+            return f"<{tag}>...</{tag}>" if name in seen else cls._schema_to_xml(tag, definitions[name], definitions, seen | {name})
+        if choices := schema.get("anyOf"):
+            return cls._schema_to_xml(
+                tag, next((s for s in choices if s.get("type") != "null"), choices[0]), definitions, seen
             )
-            return f"<{tag}>{inner}</{tag}>"
-        if get_origin(annotation) is list:
-            item_annotation = get_args(annotation)[0] if get_args(annotation) else Any
-            item = cls._xml_schema(tag, item_annotation, expanded_types)
+        if schema.get("type") == "array":
+            item = cls._schema_to_xml(tag, schema.get("items", {}), definitions, seen)
             return f"{item} {item}"
-        return f"<{tag}>...</{tag}>"
-
-    @staticmethod
-    def _escape_text(value: str) -> str:
-        """Escape XML text while retaining DSPy's private multimodal markers."""
-        marker_pattern = re.compile(
-            f"({re.escape(CUSTOM_TYPE_START_IDENTIFIER)}.*?{re.escape(CUSTOM_TYPE_END_IDENTIFIER)})",
-            re.DOTALL,
+        children = "".join(
+            cls._schema_to_xml(name, child, definitions, seen) for name, child in schema.get("properties", {}).items()
         )
-        parts = marker_pattern.split(value)
-        for index in range(0, len(parts), 2):
-            parts[index] = parts[index].replace("&", "&amp;").replace("<", "&lt;")
-        return "".join(parts)
+        return f"<{tag}>{children}</{tag}>" if children else f"<{tag}>...</{tag}>"
 
     @classmethod
-    def _elements_to_value(cls, elements: list[ET.Element], annotation: Any) -> Any:
-        annotation = cls._unwrap_optional(annotation)
-        origin = get_origin(annotation)
-
-        if origin is list:
-            item_annotation = get_args(annotation)[0] if get_args(annotation) else Any
+    def _elements_to_value(cls, elements: list[ET.Element], schema: dict, definitions: dict) -> Any:
+        if ref := schema.get("$ref"):
+            schema = definitions[ref.rsplit("/", 1)[-1]]
+        if choices := schema.get("anyOf"):
+            return cls._elements_to_value(elements, next((s for s in choices if s.get("type") != "null"), choices[0]), definitions)
+        if schema.get("type") == "array":
             if len(elements) == 1 and not list(elements[0]):
                 text = (elements[0].text or "").strip()
-                if not text:
-                    return []
-                if text.startswith("["):
-                    return text
-            return [cls._element_to_value(element, item_annotation) for element in elements]
-        if annotation is Any and len(elements) > 1:
-            return [cls._element_to_value(element, Any) for element in elements]
-
-        # Preserve the historical first-field-wins behavior for duplicate scalar fields.
-        return cls._element_to_value(elements[0], annotation)
-
-    @classmethod
-    def _element_to_value(cls, element: ET.Element, annotation: Any) -> Any:
-        annotation = cls._unwrap_optional(annotation)
-
-        if annotation is str:
-            if not list(element):
-                return (element.text or "").strip()
-            return cls._inner_xml(element).strip()
-
-        children_by_name = cls._group_children(element)
-        if not children_by_name:
+                if not text or text.startswith("["):
+                    return [] if not text else text
+            return [cls._elements_to_value([element], schema.get("items", {}), definitions) for element in elements]
+        element = elements[0]
+        if schema.get("type") == "string" and list(element):
+            return (element.text or "") + "".join(ET.tostring(child, encoding="unicode") for child in element)
+        children = cls._group_children(element)
+        if not children:
             return (element.text or "").strip()
-
-        field_annotations = cls._structured_field_annotations(annotation)
-        if field_annotations is not None:
-            return {
-                name: cls._elements_to_value(children_by_name[name], field_annotation)
-                for name, field_annotation in field_annotations.items()
-                if name in children_by_name
-            }
-
-        origin = get_origin(annotation)
-        if origin is list:
-            return cls._elements_to_value([element], annotation)
-        args = get_args(annotation)
-        child_annotation = args[1] if origin is dict and len(args) == 2 else Any
-        return {name: cls._elements_to_value(children, child_annotation) for name, children in children_by_name.items()}
+        properties, child_schema = schema.get("properties", {}), schema.get("additionalProperties", {})
+        child_schema = child_schema if isinstance(child_schema, dict) else {}
+        return {
+            name: cls._elements_to_value(items, properties.get(name, child_schema), definitions)
+            for name, items in children.items()
+            if not properties or name in properties
+        }
 
     @staticmethod
     def _group_children(element: ET.Element) -> dict[str, list[ET.Element]]:
-        children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
+        children = defaultdict(list)
         for child in element:
-            children_by_name[child.tag].append(child)
-        return children_by_name
+            children[child.tag].append(child)
+        return children
 
     @staticmethod
-    def _inner_xml(element: ET.Element) -> str:
-        return (element.text or "") + "".join(ET.tostring(child, encoding="unicode") for child in element)
-
-    @staticmethod
-    def _unwrap_optional(annotation: Any) -> Any:
+    def _uses_nested_xml(annotation: Any) -> bool:
+        args = [arg for arg in get_args(annotation) if arg is not type(None)]
+        annotation = args[0] if len(args) == 1 and get_origin(annotation) in (Union, types.UnionType) else annotation
         origin = get_origin(annotation)
-        if origin in (Union, types.UnionType):
-            args = [arg for arg in get_args(annotation) if arg is not type(None)]
-            if len(args) == 1:
-                return args[0]
-        return annotation
-
-    @staticmethod
-    def _structured_field_annotations(annotation: Any) -> dict[str, Any] | None:
-        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
-            return {name: field.annotation for name, field in annotation.model_fields.items()}
-        if is_typeddict(annotation):
-            return get_type_hints(annotation)
-        return None
-
-    @classmethod
-    def _uses_nested_xml(cls, annotation: Any) -> bool:
-        """Keep DSPy's transport models on their established marker/JSON representation."""
-        annotation = cls._unwrap_optional(annotation)
-        origin = get_origin(annotation)
-        if origin is list:
-            args = get_args(annotation)
-            if not args:
-                return True
-            item_annotation = cls._unwrap_optional(args[0])
-            return not (
-                isinstance(item_annotation, type)
-                and issubclass(item_annotation, pydantic.BaseModel)
-                and item_annotation.__module__.startswith("dspy.")
-            )
-        if origin is dict:
-            return True
-        if is_typeddict(annotation):
-            return True
-        return (
-            isinstance(annotation, type)
-            and issubclass(annotation, pydantic.BaseModel)
-            and not annotation.__module__.startswith("dspy.")
+        item = get_args(annotation)[0] if origin is list and get_args(annotation) else annotation
+        is_dspy_model = (
+            isinstance(item, type) and issubclass(item, pydantic.BaseModel) and item.__module__.startswith("dspy.")
+        )
+        return not is_dspy_model and (
+            origin in (list, dict)
+            or is_typeddict(annotation)
+            or (isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel))
         )

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -2,10 +2,11 @@ import re
 import types
 import xml.etree.ElementTree as ET
 from collections import defaultdict
-from typing import Any, Union, get_args, get_origin
+from typing import Any, Union, get_args, get_origin, get_type_hints
 
 import pydantic
 from pydantic.fields import FieldInfo
+from typing_extensions import is_typeddict
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
 from dspy.adapters.types.base_type import CUSTOM_TYPE_END_IDENTIFIER, CUSTOM_TYPE_START_IDENTIFIER
@@ -182,14 +183,29 @@ class XMLAdapter(ChatAdapter):
         return f"<{tag}>{cls._escape_text(str(value))}</{tag}>"
 
     @classmethod
-    def _xml_schema(cls, tag: str, annotation: Any) -> str:
+    def _xml_schema(cls, tag: str, annotation: Any, expanded_types: frozenset[type] = frozenset()) -> str:
         annotation = cls._unwrap_optional(annotation)
         if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
-            inner = "".join(cls._xml_schema(name, field.annotation) for name, field in annotation.model_fields.items())
+            if annotation in expanded_types:
+                return f"<{tag}>...</{tag}>"
+            expanded_types |= {annotation}
+            inner = "".join(
+                cls._xml_schema(name, field.annotation, expanded_types)
+                for name, field in annotation.model_fields.items()
+            )
+            return f"<{tag}>{inner}</{tag}>"
+        if is_typeddict(annotation):
+            if annotation in expanded_types:
+                return f"<{tag}>...</{tag}>"
+            expanded_types |= {annotation}
+            inner = "".join(
+                cls._xml_schema(name, field_annotation, expanded_types)
+                for name, field_annotation in get_type_hints(annotation).items()
+            )
             return f"<{tag}>{inner}</{tag}>"
         if get_origin(annotation) is list:
             item_annotation = get_args(annotation)[0] if get_args(annotation) else Any
-            item = cls._xml_schema(tag, item_annotation)
+            item = cls._xml_schema(tag, item_annotation, expanded_types)
             return f"{item} {item}"
         return f"<{tag}>...</{tag}>"
 
@@ -243,6 +259,16 @@ class XMLAdapter(ChatAdapter):
             return {
                 name: cls._elements_to_value(children_by_name[name], field.annotation)
                 for name, field in annotation.model_fields.items()
+                if name in children_by_name
+            }
+
+        if is_typeddict(annotation):
+            children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
+            for child in element:
+                children_by_name[child.tag].append(child)
+            return {
+                name: cls._elements_to_value(children_by_name[name], field_annotation)
+                for name, field_annotation in get_type_hints(annotation).items()
                 if name in children_by_name
             }
 
@@ -308,6 +334,8 @@ class XMLAdapter(ChatAdapter):
                 and item_annotation.__module__.startswith("dspy.")
             )
         if origin is dict:
+            return True
+        if is_typeddict(annotation):
             return True
         return (
             isinstance(annotation, type)

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -185,22 +185,14 @@ class XMLAdapter(ChatAdapter):
     @classmethod
     def _xml_schema(cls, tag: str, annotation: Any, expanded_types: frozenset[type] = frozenset()) -> str:
         annotation = cls._unwrap_optional(annotation)
-        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
-            if annotation in expanded_types:
-                return f"<{tag}>...</{tag}>"
-            expanded_types |= {annotation}
-            inner = "".join(
-                cls._xml_schema(name, field.annotation, expanded_types)
-                for name, field in annotation.model_fields.items()
-            )
-            return f"<{tag}>{inner}</{tag}>"
-        if is_typeddict(annotation):
+        field_annotations = cls._structured_field_annotations(annotation)
+        if field_annotations is not None:
             if annotation in expanded_types:
                 return f"<{tag}>...</{tag}>"
             expanded_types |= {annotation}
             inner = "".join(
                 cls._xml_schema(name, field_annotation, expanded_types)
-                for name, field_annotation in get_type_hints(annotation).items()
+                for name, field_annotation in field_annotations.items()
             )
             return f"<{tag}>{inner}</{tag}>"
         if get_origin(annotation) is list:
@@ -250,25 +242,16 @@ class XMLAdapter(ChatAdapter):
                 return (element.text or "").strip()
             return cls._inner_xml(element).strip()
 
-        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+        field_annotations = cls._structured_field_annotations(annotation)
+        if field_annotations is not None:
             if not list(element):
                 return (element.text or "").strip()
             children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
             for child in element:
                 children_by_name[child.tag].append(child)
             return {
-                name: cls._elements_to_value(children_by_name[name], field.annotation)
-                for name, field in annotation.model_fields.items()
-                if name in children_by_name
-            }
-
-        if is_typeddict(annotation):
-            children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
-            for child in element:
-                children_by_name[child.tag].append(child)
-            return {
                 name: cls._elements_to_value(children_by_name[name], field_annotation)
-                for name, field_annotation in get_type_hints(annotation).items()
+                for name, field_annotation in field_annotations.items()
                 if name in children_by_name
             }
 
@@ -285,22 +268,12 @@ class XMLAdapter(ChatAdapter):
                 name: cls._elements_to_value(children, value_annotation) for name, children in children_by_name.items()
             }
 
-        if list(element):
-            return cls._element_to_dict(element)
-        return (element.text or "").strip()
-
-    @classmethod
-    def _element_to_dict(cls, element: ET.Element) -> dict[str, Any]:
-        values: dict[str, Any] = {}
+        children_by_name: dict[str, list[ET.Element]] = defaultdict(list)
         for child in element:
-            value = cls._element_to_dict(child) if list(child) else (child.text or "").strip()
-            if child.tag in values:
-                if not isinstance(values[child.tag], list):
-                    values[child.tag] = [values[child.tag]]
-                values[child.tag].append(value)
-            else:
-                values[child.tag] = value
-        return values
+            children_by_name[child.tag].append(child)
+        if children_by_name:
+            return {name: cls._elements_to_value(children, Any) for name, children in children_by_name.items()}
+        return (element.text or "").strip()
 
     @staticmethod
     def _inner_xml(element: ET.Element) -> str:
@@ -317,6 +290,14 @@ class XMLAdapter(ChatAdapter):
             if len(args) == 1:
                 return args[0]
         return annotation
+
+    @staticmethod
+    def _structured_field_annotations(annotation: Any) -> dict[str, Any] | None:
+        if isinstance(annotation, type) and issubclass(annotation, pydantic.BaseModel):
+            return {name: field.annotation for name, field in annotation.model_fields.items()}
+        if is_typeddict(annotation):
+            return get_type_hints(annotation)
+        return None
 
     @classmethod
     def _uses_nested_xml(cls, annotation: Any) -> bool:

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -84,6 +84,72 @@ def test_xml_adapter_parse_raises_on_type_error():
     assert "Failed to parse field" in str(e.value)
 
 
+def test_xml_adapter_nested_xml_round_trip_and_legacy_json():
+    class Address(pydantic.BaseModel):
+        city: str
+
+    class Person(pydantic.BaseModel):
+        name: str
+        address: Address
+
+    class TestSignature(dspy.Signature):
+        person: Person = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    person = Person(name="Ada", address=Address(city="London"))
+    field = FieldInfoWithName(name="person", info=TestSignature.output_fields["person"])
+    xml = adapter.format_field_with_value({field: person})
+
+    assert xml == "<person><name>Ada</name><address><city>London</city></address></person>"
+    assert adapter.parse(TestSignature, xml) == {"person": person}
+    assert adapter.user_message_output_requirements(TestSignature).endswith(
+        "Use this nested XML structure: <person><name>...</name><address><city>...</city></address></person>"
+    )
+    assert adapter.parse(TestSignature, '<person>{"name":"Ada","address":{"city":"London"}}</person>') == {
+        "person": person
+    }
+
+
+def test_xml_adapter_repeated_elements_empty_lists_and_nested_typed_dicts():
+    class Item(pydantic.BaseModel):
+        value: int
+
+    class TestSignature(dspy.Signature):
+        items: list[Item] = dspy.OutputField()
+        counts: dict[str, list[int]] = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    completion = (
+        "<items><value>1</value></items><items><value>2</value></items>"
+        "<counts><first>3</first><first>4</first><second>5</second></counts>"
+    )
+    assert adapter.parse(TestSignature, completion) == {
+        "items": [Item(value=1), Item(value=2)],
+        "counts": {"first": [3, 4], "second": [5]},
+    }
+
+    class EmptySignature(dspy.Signature):
+        items: list[str] = dspy.OutputField()
+
+    field = FieldInfoWithName(name="items", info=EmptySignature.output_fields["items"])
+    assert adapter.format_field_with_value({field: []}) == "<items />"
+    assert adapter.parse(EmptySignature, "<items />") == {"items": []}
+
+
+def test_xml_adapter_escapes_closing_tags_and_rejects_malformed_xml():
+    class TestSignature(dspy.Signature):
+        code: str = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    value = "print('</code> & done')"
+    formatted = adapter.format_assistant_message_content(TestSignature, {"code": value})
+    assert "&lt;/code> &amp; done" in formatted
+    assert adapter.parse(TestSignature, formatted) == {"code": value}
+
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError, match="Failed to parse XML"):
+        adapter.parse(TestSignature, "<code>print('</code>')</code>")
+
+
 def test_xml_adapter_format_and_parse_nested_model():
     class InnerModel(pydantic.BaseModel):
         value: int
@@ -99,11 +165,7 @@ def test_xml_adapter_format_and_parse_nested_model():
         FieldInfoWithName(name="result", info=TestSignature.output_fields["result"]): InnerModel(value=5, label="foo")
     }
     xml = adapter.format_field_with_value(fields_with_values)
-    # The output will be a JSON string inside the XML tag
-    assert xml.strip().startswith("<result>")
-    assert '"value": 5' in xml
-    assert '"label": "foo"' in xml
-    assert xml.strip().endswith("</result>")
+    assert xml == "<result><value>5</value><label>foo</label></result>"
 
     # Parse XML output (should parse as string, not as model)
     completion = '<result>{"value": 5, "label": "foo"}</result>'
@@ -126,10 +188,7 @@ def test_xml_adapter_format_and_parse_list_of_models():
     items = [Item(name="a", score=1.1), Item(name="b", score=2.2)]
     fields_with_values = {FieldInfoWithName(name="items", info=TestSignature.output_fields["items"]): items}
     xml = adapter.format_field_with_value(fields_with_values)
-    assert xml.strip().startswith("<items>")
-    assert '"name": "a"' in xml
-    assert '"score": 2.2' in xml
-    assert xml.strip().endswith("</items>")
+    assert xml == ("<items><name>a</name><score>1.1</score></items><items><name>b</name><score>2.2</score></items>")
 
     # Parse XML output
     import json
@@ -167,8 +226,8 @@ def test_xml_adapter_with_tool_like_output():
     }
     xml = adapter.format_field_with_value(fields_with_values)
     assert xml.strip().startswith("<tool_calls>")
-    assert '"name": "get_weather"' in xml
-    assert '"result": "125M"' in xml
+    assert "<name>get_weather</name>" in xml
+    assert "<result>125M</result>" in xml
     assert xml.strip().endswith("</answer>")
 
     import json
@@ -649,7 +708,7 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
                            'What should we mention?\n'
                            '</question>'}]},
      {"role": "assistant",
-      "content": '<answer>\n{"answer": "Mention analytical engines.", "sources": ["demo"]}\n</answer>'},
+      "content": "<answer><answer>Mention analytical engines.</answer><sources>demo</sources></answer>"},
      {"role": "user",
       "content": '<profile>\n'
                  '{"name": "Ada", "location": {"city": "London", "country": "UK"}, "interests": '
@@ -660,7 +719,7 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
                  'Who is Ada?\n'
                  '</question>'},
      {"role": "assistant",
-      "content": '<answer>\n{"answer": "Ada is a mathematician.", "sources": ["memory"]}\n</answer>'},
+      "content": "<answer><answer>Ada is a mathematician.</answer><sources>memory</sources></answer>"},
      {"role": "user",
       "content": [{"type": "text", "text": "<image>\n"},
                   {"type": "image_url", "image_url": {"url": "https://example.com/current.png"}},
@@ -684,7 +743,9 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
                            '</question>\n'
                            '\n'
                            'Respond with the corresponding output fields wrapped in XML tags '
-                           '`<answer>`.'}]}]
+                           '`<answer>`. Use this nested XML structure: '
+                               '<answer><answer>...</answer><sources>...</sources> '
+                               '<sources>...</sources></answer>'}]}]
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs
@@ -731,7 +792,10 @@ def test_xml_adapter_format_exact_messages_with_nested_pydantic_output():
                  "Summarize\n"
                  "</question>\n"
                  "\n"
-                 "Respond with the corresponding output fields wrapped in XML tags `<summary>`."}]
+                 "Respond with the corresponding output fields wrapped in XML tags `<summary>`. "
+                    "Use this nested XML structure: "
+                    "<summary><title>...</title><address><city>...</city><country>...</country>"
+                    "</address></summary>"}]
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -674,12 +674,8 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
                  '{question}\n'
                  '</question>\n'
                  '\n'
-                 '<answer>\n'
-                 '{answer}        # note: the value you produce must adhere to the JSON schema: '
-                 '{"type": "object", "properties": {"answer": {"type": "string", "title": "Answer"}, '
-                 '"sources": {"type": "array", "items": {"type": "string"}, "title": "Sources"}}, '
-                 '"required": ["answer", "sources"], "title": "AnswerCard"}\n'
-                 '</answer>\n'
+                 '<answer><answer>...</answer><sources>...</sources> '
+                 '<sources>...</sources></answer>\n'
                  'In adhering to this structure, your objective is: \n'
                  '        Answer using all supplied context.'},
      {"role": "user",
@@ -777,14 +773,8 @@ def test_xml_adapter_format_exact_messages_with_nested_pydantic_output():
                  '{question}\n'
                  '</question>\n'
                  '\n'
-                 '<summary>\n'
-                 '{summary}        # note: the value you produce must adhere to the JSON schema: '
-                 '{"type": "object", "$defs": {"XmlAddress": {"type": "object", "properties": {"city": '
-                 '{"type": "string", "title": "City"}, "country": {"type": "string", "title": '
-                 '"Country"}}, "required": ["city", "country"], "title": "XmlAddress"}}, "properties": '
-                 '{"address": {"$ref": "#/$defs/XmlAddress"}, "title": {"type": "string", "title": '
-                 '"Title"}}, "required": ["title", "address"], "title": "XmlSummary"}\n'
-                 '</summary>\n'
+                 '<summary><title>...</title><address><city>...</city><country>...</country>'
+                 '</address></summary>\n'
                  'In adhering to this structure, your objective is: \n'
                  '        Given the fields `question`, produce the fields `summary`.'},
      {"role": "user",
@@ -895,13 +885,9 @@ All interactions will be structured in the following way, with the appropriate v
 {question}
 </question>
 
-<answers>
-{answers}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "string"}}
-</answers>
+<answers>...</answers> <answers>...</answers>
 
-<scores>
-{scores}        # note: the value you produce must adhere to the JSON schema: {"type": "array", "items": {"type": "number"}}
-</scores>
+<scores>...</scores> <scores>...</scores>
 In adhering to this structure, your objective is:\x20
         Answer the question with multiple answers and scores"""
     assert system_message == expected_system_message

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -85,47 +85,13 @@ def test_xml_adapter_parse_raises_on_type_error():
     assert "Failed to parse field" in str(e.value)
 
 
-def test_xml_adapter_nested_xml_round_trip_and_legacy_json():
-    class Address(pydantic.BaseModel):
-        city: str
-
-    class Person(pydantic.BaseModel):
-        name: str
-        address: Address
-
+def test_xml_adapter_repeated_dict_elements_and_empty_lists():
     class TestSignature(dspy.Signature):
-        person: Person = dspy.OutputField()
-
-    adapter = XMLAdapter()
-    person = Person(name="Ada", address=Address(city="London"))
-    field = FieldInfoWithName(name="person", info=TestSignature.output_fields["person"])
-    xml = adapter.format_field_with_value({field: person})
-
-    assert xml == "<person><name>Ada</name><address><city>London</city></address></person>"
-    assert adapter.parse(TestSignature, xml) == {"person": person}
-    assert adapter.user_message_output_requirements(TestSignature).endswith(
-        "Use this nested XML structure: <person><name>...</name><address><city>...</city></address></person>"
-    )
-    assert adapter.parse(TestSignature, '<person>{"name":"Ada","address":{"city":"London"}}</person>') == {
-        "person": person
-    }
-
-
-def test_xml_adapter_repeated_elements_empty_lists_and_nested_typed_dicts():
-    class Item(pydantic.BaseModel):
-        value: int
-
-    class TestSignature(dspy.Signature):
-        items: list[Item] = dspy.OutputField()
         counts: dict[str, list[int]] = dspy.OutputField()
 
     adapter = XMLAdapter()
-    completion = (
-        "<items><value>1</value></items><items><value>2</value></items>"
-        "<counts><first>3</first><first>4</first><second>5</second></counts>"
-    )
+    completion = "<counts><first>3</first><first>4</first><second>5</second></counts>"
     assert adapter.parse(TestSignature, completion) == {
-        "items": [Item(value=1), Item(value=2)],
         "counts": {"first": [3, 4], "second": [5]},
     }
 
@@ -162,9 +128,6 @@ def test_xml_adapter_typed_dict_schema_and_parsing():
     system_instructions = adapter.format_field_structure(TestSignature)
     assert f"{order_schema}\n\n{orders_schema} {orders_schema}" in system_instructions
 
-    requirements = adapter.user_message_output_requirements(TestSignature)
-    assert f"Use this nested XML structure: {order_schema} {orders_schema} {orders_schema}" in requirements
-
     completion = (
         "<order><order_id>1</order_id><address><city>London</city></address><labels>new</labels></order>"
         "<orders><order_id>2</order_id><address><city>Paris</city></address><labels>paid</labels></orders>"
@@ -183,9 +146,8 @@ def test_xml_adapter_recursive_model_schema_terminates():
     class TestSignature(dspy.Signature):
         root: Node = dspy.OutputField()
 
-    assert XMLAdapter().user_message_output_requirements(TestSignature).endswith(
-        "Use this nested XML structure: "
-        "<root><value>...</value><children>...</children> <children>...</children></root>"
+    assert "<root><value>...</value><children>...</children> <children>...</children></root>" in (
+        XMLAdapter().format_field_structure(TestSignature)
     )
 
 
@@ -204,9 +166,13 @@ def test_xml_adapter_escapes_closing_tags_and_rejects_malformed_xml():
 
 
 def test_xml_adapter_format_and_parse_nested_model():
+    class Address(pydantic.BaseModel):
+        city: str
+
     class InnerModel(pydantic.BaseModel):
         value: int
         label: str
+        address: Address
 
     class TestSignature(dspy.Signature):
         question: str = dspy.InputField()
@@ -214,19 +180,16 @@ def test_xml_adapter_format_and_parse_nested_model():
 
     adapter = XMLAdapter()
     # Format output fields as XML
-    fields_with_values = {
-        FieldInfoWithName(name="result", info=TestSignature.output_fields["result"]): InnerModel(value=5, label="foo")
-    }
+    result = InnerModel(value=5, label="foo", address=Address(city="London"))
+    fields_with_values = {FieldInfoWithName(name="result", info=TestSignature.output_fields["result"]): result}
     xml = adapter.format_field_with_value(fields_with_values)
-    assert xml == "<result><value>5</value><label>foo</label></result>"
+    assert xml == "<result><value>5</value><label>foo</label><address><city>London</city></address></result>"
+    assert adapter.parse(TestSignature, xml) == {"result": result}
 
-    # Parse XML output (should parse as string, not as model)
-    completion = '<result>{"value": 5, "label": "foo"}</result>'
+    # Legacy JSON values inside the outer XML field remain supported.
+    completion = '<result>{"value": 5, "label": "foo", "address": {"city": "London"}}</result>'
     parsed = adapter.parse(TestSignature, completion)
-    # The parse_value helper will try to cast to InnerModel
-    assert isinstance(parsed["result"], InnerModel)
-    assert parsed["result"].value == 5
-    assert parsed["result"].label == "foo"
+    assert parsed == {"result": result}
 
 
 def test_xml_adapter_format_and_parse_list_of_models():
@@ -242,16 +205,13 @@ def test_xml_adapter_format_and_parse_list_of_models():
     fields_with_values = {FieldInfoWithName(name="items", info=TestSignature.output_fields["items"]): items}
     xml = adapter.format_field_with_value(fields_with_values)
     assert xml == ("<items><name>a</name><score>1.1</score></items><items><name>b</name><score>2.2</score></items>")
+    assert adapter.parse(TestSignature, xml) == {"items": items}
 
-    # Parse XML output
+    # Legacy JSON lists inside the outer XML field remain supported.
     import json
 
     completion = f"<items>{json.dumps([i.model_dump() for i in items])}</items>"
-    parsed = adapter.parse(TestSignature, completion)
-    assert isinstance(parsed["items"], list)
-    assert all(isinstance(i, Item) for i in parsed["items"])
-    assert parsed["items"][0].name == "a"
-    assert parsed["items"][1].score == 2.2
+    assert adapter.parse(TestSignature, completion) == {"items": items}
 
 
 def test_xml_adapter_with_tool_like_output():
@@ -792,9 +752,7 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
                            '</question>\n'
                            '\n'
                            'Respond with the corresponding output fields wrapped in XML tags '
-                           '`<answer>`. Use this nested XML structure: '
-                               '<answer><answer>...</answer><sources>...</sources> '
-                               '<sources>...</sources></answer>'}]}]
+                           '`<answer>`.'}]}]
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs
@@ -835,10 +793,7 @@ def test_xml_adapter_format_exact_messages_with_nested_pydantic_output():
                  "Summarize\n"
                  "</question>\n"
                  "\n"
-                 "Respond with the corresponding output fields wrapped in XML tags `<summary>`. "
-                    "Use this nested XML structure: "
-                    "<summary><title>...</title><address><city>...</city><country>...</country>"
-                    "</address></summary>"}]
+                 "Respond with the corresponding output fields wrapped in XML tags `<summary>`."}]
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pydantic
 import pytest
 from litellm import Choices, Message, ModelResponse
+from typing_extensions import TypedDict
 
 import dspy
 from dspy.adapters.chat_adapter import FieldInfoWithName
@@ -134,6 +135,58 @@ def test_xml_adapter_repeated_elements_empty_lists_and_nested_typed_dicts():
     field = FieldInfoWithName(name="items", info=EmptySignature.output_fields["items"])
     assert adapter.format_field_with_value({field: []}) == "<items />"
     assert adapter.parse(EmptySignature, "<items />") == {"items": []}
+
+
+def test_xml_adapter_typed_dict_schema_and_parsing():
+    class Address(TypedDict):
+        city: str
+
+    class Order(TypedDict):
+        order_id: int
+        address: Address
+        labels: list[str]
+
+    class TestSignature(dspy.Signature):
+        order: Order = dspy.OutputField()
+        orders: list[Order] = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    order_schema = (
+        "<order><order_id>...</order_id><address><city>...</city></address>"
+        "<labels>...</labels> <labels>...</labels></order>"
+    )
+    orders_schema = (
+        "<orders><order_id>...</order_id><address><city>...</city></address>"
+        "<labels>...</labels> <labels>...</labels></orders>"
+    )
+    system_instructions = adapter.format_field_structure(TestSignature)
+    assert f"{order_schema}\n\n{orders_schema} {orders_schema}" in system_instructions
+
+    requirements = adapter.user_message_output_requirements(TestSignature)
+    assert f"Use this nested XML structure: {order_schema} {orders_schema} {orders_schema}" in requirements
+
+    completion = (
+        "<order><order_id>1</order_id><address><city>London</city></address><labels>new</labels></order>"
+        "<orders><order_id>2</order_id><address><city>Paris</city></address><labels>paid</labels></orders>"
+    )
+    assert adapter.parse(TestSignature, completion) == {
+        "order": {"order_id": 1, "address": {"city": "London"}, "labels": ["new"]},
+        "orders": [{"order_id": 2, "address": {"city": "Paris"}, "labels": ["paid"]}],
+    }
+
+
+def test_xml_adapter_recursive_model_schema_terminates():
+    class Node(pydantic.BaseModel):
+        value: str
+        children: list["Node"]
+
+    class TestSignature(dspy.Signature):
+        root: Node = dspy.OutputField()
+
+    assert XMLAdapter().user_message_output_requirements(TestSignature).endswith(
+        "Use this nested XML structure: "
+        "<root><value>...</value><children>...</children> <children>...</children></root>"
+    )
 
 
 def test_xml_adapter_escapes_closing_tags_and_rejects_malformed_xml():
@@ -643,41 +696,41 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
     )
 
     expected_messages = [{"role": "system",
-      "content": 'Your input fields are:\n'
-                 '1. `history` (History): \n'
-                 '2. `image` (Image): \n'
-                 '3. `tools` (list[Tool]): \n'
-                 '4. `profile` (Profile): \n'
-                 '5. `question` (str):\n'
-                 'Your output fields are:\n'
-                 '1. `answer` (AnswerCard):\n'
-                 'All interactions will be structured in the following way, with the appropriate '
-                 'values filled in.\n'
-                 '\n'
-                 '<history>\n'
-                 '{history}\n'
-                 '</history>\n'
-                 '\n'
-                 '<image>\n'
-                 '{image}\n'
-                 '</image>\n'
-                 '\n'
-                 '<tools>\n'
-                 '{tools}\n'
-                 '</tools>\n'
-                 '\n'
-                 '<profile>\n'
-                 '{profile}\n'
-                 '</profile>\n'
-                 '\n'
-                 '<question>\n'
-                 '{question}\n'
-                 '</question>\n'
-                 '\n'
-                 '<answer><answer>...</answer><sources>...</sources> '
-                 '<sources>...</sources></answer>\n'
-                 'In adhering to this structure, your objective is: \n'
-                 '        Answer using all supplied context.'},
+      "content": "Your input fields are:\n"
+                 "1. `history` (History): \n"
+                 "2. `image` (Image): \n"
+                 "3. `tools` (list[Tool]): \n"
+                 "4. `profile` (Profile): \n"
+                 "5. `question` (str):\n"
+                 "Your output fields are:\n"
+                 "1. `answer` (AnswerCard):\n"
+                 "All interactions will be structured in the following way, with the appropriate "
+                 "values filled in.\n"
+                 "\n"
+                 "<history>\n"
+                 "{history}\n"
+                 "</history>\n"
+                 "\n"
+                 "<image>\n"
+                 "{image}\n"
+                 "</image>\n"
+                 "\n"
+                 "<tools>\n"
+                 "{tools}\n"
+                 "</tools>\n"
+                 "\n"
+                 "<profile>\n"
+                 "{profile}\n"
+                 "</profile>\n"
+                 "\n"
+                 "<question>\n"
+                 "{question}\n"
+                 "</question>\n"
+                 "\n"
+                 "<answer><answer>...</answer><sources>...</sources> "
+                 "<sources>...</sources></answer>\n"
+                 "In adhering to this structure, your objective is: \n"
+                 "        Answer using all supplied context."},
      {"role": "user",
       "content": [{"type": "text",
                    "text": "This is an example of the task, though some input or output fields are not "
@@ -762,21 +815,21 @@ def test_xml_adapter_format_exact_messages_with_nested_pydantic_output():
     messages, lm_kwargs = format_messages_and_lm_kwargs(dspy.XMLAdapter(), PydanticSignature, [], {"question": "Summarize"})
 
     expected_messages = [{"role": "system",
-      "content": 'Your input fields are:\n'
-                 '1. `question` (str):\n'
-                 'Your output fields are:\n'
-                 '1. `summary` (XmlSummary):\n'
-                 'All interactions will be structured in the following way, with the appropriate '
-                 'values filled in.\n'
-                 '\n'
-                 '<question>\n'
-                 '{question}\n'
-                 '</question>\n'
-                 '\n'
-                 '<summary><title>...</title><address><city>...</city><country>...</country>'
-                 '</address></summary>\n'
-                 'In adhering to this structure, your objective is: \n'
-                 '        Given the fields `question`, produce the fields `summary`.'},
+      "content": "Your input fields are:\n"
+                 "1. `question` (str):\n"
+                 "Your output fields are:\n"
+                 "1. `summary` (XmlSummary):\n"
+                 "All interactions will be structured in the following way, with the appropriate "
+                 "values filled in.\n"
+                 "\n"
+                 "<question>\n"
+                 "{question}\n"
+                 "</question>\n"
+                 "\n"
+                 "<summary><title>...</title><address><city>...</city><country>...</country>"
+                 "</address></summary>\n"
+                 "In adhering to this structure, your objective is: \n"
+                 "        Given the fields `question`, produce the fields `summary`."},
      {"role": "user",
       "content": "<question>\n"
                  "Summarize\n"

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -109,7 +109,7 @@ def test_xml_adapter_typed_dict_schema_and_parsing():
 
     class Order(TypedDict):
         order_id: int
-        address: Address
+        address: Address | None
         labels: list[str]
 
     class TestSignature(dspy.Signature):
@@ -127,6 +127,9 @@ def test_xml_adapter_typed_dict_schema_and_parsing():
     )
     system_instructions = adapter.format_field_structure(TestSignature)
     assert f"{order_schema}\n\n{orders_schema} {orders_schema}" in system_instructions
+    assert f"Use this nested XML structure: {order_schema} {orders_schema} {orders_schema}" in (
+        adapter.user_message_output_requirements(TestSignature)
+    )
 
     completion = (
         "<order><order_id>1</order_id><address><city>London</city></address><labels>new</labels></order>"
@@ -146,9 +149,14 @@ def test_xml_adapter_recursive_model_schema_terminates():
     class TestSignature(dspy.Signature):
         root: Node = dspy.OutputField()
 
+    adapter = XMLAdapter()
     assert "<root><value>...</value><children>...</children> <children>...</children></root>" in (
-        XMLAdapter().format_field_structure(TestSignature)
+        adapter.format_field_structure(TestSignature)
     )
+    completion = "<root><value>parent</value><children><value>child</value><children /></children></root>"
+    assert adapter.parse(TestSignature, completion) == {
+        "root": Node(value="parent", children=[Node(value="child", children=[])])
+    }
 
 
 def test_xml_adapter_escapes_closing_tags_and_rejects_malformed_xml():
@@ -752,7 +760,9 @@ def test_xml_adapter_format_exact_messages_with_history_demo_pydantic_tools_and_
                            '</question>\n'
                            '\n'
                            'Respond with the corresponding output fields wrapped in XML tags '
-                           '`<answer>`.'}]}]
+                           '`<answer>`. Use this nested XML structure: '
+                               '<answer><answer>...</answer><sources>...</sources> '
+                               '<sources>...</sources></answer>'}]}]
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs
@@ -793,7 +803,10 @@ def test_xml_adapter_format_exact_messages_with_nested_pydantic_output():
                  "Summarize\n"
                  "</question>\n"
                  "\n"
-                 "Respond with the corresponding output fields wrapped in XML tags `<summary>`."}]
+                 "Respond with the corresponding output fields wrapped in XML tags `<summary>`. "
+                    "Use this nested XML structure: "
+                    "<summary><title>...</title><address><city>...</city><country>...</country>"
+                    "</address></summary>"}]
     assert messages == expected_messages
     expected_lm_kwargs = {}
     assert lm_kwargs == expected_lm_kwargs


### PR DESCRIPTION
Closes #8481.
Closes #10102.
Supersedes #8482 with an implementation based on current `main`.

## Summary

- format nested Pydantic outputs, TypedDicts, and lists as nested XML
- show the nested XML schema consistently in system instructions and the final user reminder, including TypedDict child fields
- parse nested and repeated XML elements into signature field types\n- bound recursive Pydantic schema expansion so self-referential models format safely
- retain support for legacy JSON values inside outer XML field tags
- XML-escape string output values so embedded closing tags round-trip safely
- reject malformed XML with `AdapterParseError` instead of silently truncating values
- preserve existing DSPy transport and multimodal input formatting

## What the final prompt looks like

Given a `Person` output containing a nested `Address` and `list[str]` interests, the LM receives this schema in both the system instructions and final user request:

```xml
<person><name>...</name><age>...</age><address><city>...</city><country>...</country></address><interests>...</interests> <interests>...</interests></person>
```

The final user message looks like:

```text
<text>
Ada, 36, lives in London, UK and likes math and machines.
</text>

Respond with the corresponding output fields wrapped in XML tags `<person>`. Use this nested XML structure: <person><name>...</name><age>...</age><address><city>...</city><country>...</country></address><interests>...</interests> <interests>...</interests></person>
```

A matching response is parsed directly into the declared Pydantic types:

```xml
<person>
  <name>Ada</name>
  <age>36</age>
  <address><city>London</city><country>UK</country></address>
  <interests>math</interests>
  <interests>machines</interests>
</person>
```

The [XMLAdapter documentation](https://github.com/stanfordnlp/dspy/blob/feat/xml-adapter-nested-data/docs/docs/diving-deeper/adapters.md#adapter-types) includes the runnable example, complete system and user prompt, matching response, and parsed result types.

## Testing

- `pytest -q tests/adapters/test_xml_adapter.py` (24 passed)
- `pytest -q tests/adapters` (278 passed)
- `ruff check dspy/adapters/xml_adapter.py`
- `ruff format --check dspy/adapters/xml_adapter.py`
- `git diff --check`