### PR TITLE
feat(dspy): support portable and provider-native compaction

### DIFF
--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -641,12 +641,20 @@ class Adapter:
         Returns:
             A list of multiturn messages as expected by the LM.
         """
-        conversation_history = inputs[history_field_name].messages if history_field_name in inputs else None
+        history = inputs.get(history_field_name)
+        conversation_history = history.messages if history is not None else None
 
         if conversation_history is None:
             return []
 
         messages = []
+        if history.summary is not None:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": f"Here is a summary of the conversation to date:\n\n{history.summary}",
+                }
+            )
         for message in conversation_history:
             tool_call_field_name, tool_calls = _tool_calls_from_message(message)
             tool_call_results = (

--- a/dspy/adapters/base.py
+++ b/dspy/adapters/base.py
@@ -18,7 +18,7 @@ from dspy.clients.openai_format import (
     lm_response_from_legacy_outputs,
     to_openai_chat_request,
 )
-from dspy.core.types import LMMessage, LMRequest, LMResponse
+from dspy.core.types import LMCompactionPart, LMMessage, LMRequest, LMResponse
 from dspy.experimental import Citations
 from dspy.signatures.field import InputField
 from dspy.signatures.signature import Signature
@@ -233,7 +233,7 @@ class Adapter:
         entry point directly. The OpenAI-shaped compatibility kwargs should live
         only inside concrete LM backends.
         """
-        data = self._legacy_call_kwargs(request)
+        data = self._legacy_call_kwargs(lm, request)
         outputs = lm(messages=data.pop("messages"), **data)
         return self._normalize_legacy_outputs(outputs, request)
 
@@ -243,16 +243,19 @@ class Adapter:
         TODO(language-models): Same transitional boundary as `_call_lm()`; this
         should eventually call a normalized async LM method directly.
         """
-        data = self._legacy_call_kwargs(request)
+        data = self._legacy_call_kwargs(lm, request)
         outputs = await lm.acall(messages=data.pop("messages"), **data)
         return self._normalize_legacy_outputs(outputs, request)
 
-    def _legacy_call_kwargs(self, request: LMRequest) -> dict[str, Any]:
+    def _legacy_call_kwargs(self, lm: BaseLM, request: LMRequest) -> dict[str, Any]:
         # TODO(language-models): Current `BaseLM` expects OpenAI/LiteLLM-shaped
         # chat kwargs. We intentionally use `dspy.clients.openai_format` here so
         # the conversion code lives in the future LM/client layer, not in
         # adapters. Remove this adapter helper once `BaseLM` accepts `LMRequest`.
-        data = to_openai_chat_request(request)
+        data = to_openai_chat_request(
+            request,
+            _allow_responses_compaction=lm.model_type == "responses",
+        )
         data.pop("model", None)
         # TODO(language-models): `cache` and `rollout_id` are DSPy BaseLM
         # execution controls, not provider request fields. The future
@@ -648,13 +651,15 @@ class Adapter:
             return []
 
         messages = []
-        if history.summary is not None:
+        if isinstance(history.compaction, str):
             messages.append(
                 {
                     "role": "user",
-                    "content": f"Here is a summary of the conversation to date:\n\n{history.summary}",
+                    "content": f"Here is a summary of the conversation to date:\n\n{history.compaction}",
                 }
             )
+        elif isinstance(history.compaction, LMCompactionPart):
+            messages.append({"role": "assistant", "content": [history.compaction]})
         for message in conversation_history:
             tool_call_field_name, tool_calls = _tool_calls_from_message(message)
             tool_call_results = (

--- a/dspy/adapters/types/history.py
+++ b/dspy/adapters/types/history.py
@@ -2,14 +2,17 @@ from typing import Any
 
 import pydantic
 
+from dspy.core.types import LMCompactionPart
+
 
 class History(pydantic.BaseModel):
     """Class representing the conversation history.
 
-    The conversation history contains an optional summary of compacted earlier
-    messages followed by a list of recent messages. Each message entity should
-    have keys from the associated signature. For example, if you have the
-    following signature:
+    The conversation history contains optional compacted context followed by a
+    list of recent messages. Compacted context can be a portable text summary
+    or provider-native state in an ``LMCompactionPart``. Each message entity
+    should have keys from the associated signature. For example, if you have
+    the following signature:
 
     ```
     class MySignature(dspy.Signature):
@@ -19,9 +22,9 @@ class History(pydantic.BaseModel):
     ```
 
     Then the history messages should be dictionaries with keys "question" and
-    "answer". When ``summary`` is set, adapters place it before the recent
-    messages as ordinary user context. The summary is not filtered against the
-    signature fields.
+    "answer". A string ``compaction`` is placed before the recent messages as
+    ordinary user context. An ``LMCompactionPart`` is replayed in its provider's
+    native format. Compacted context is not filtered against signature fields.
 
     Examples:
         ```
@@ -35,7 +38,7 @@ class History(pydantic.BaseModel):
             answer: str = dspy.OutputField()
 
         history = dspy.History(
-            summary="The user is comparing European capitals.",
+            compaction="The user is comparing European capitals.",
             messages=[
                 {"question": "What is the capital of France?", "answer": "Paris"},
                 {"question": "What is the capital of Germany?", "answer": "Berlin"},
@@ -65,7 +68,7 @@ class History(pydantic.BaseModel):
     """
 
     messages: list[dict[str, Any]]
-    summary: str | None = pydantic.Field(default=None, exclude_if=lambda value: value is None)
+    compaction: str | LMCompactionPart | None = pydantic.Field(default=None, exclude_if=lambda value: value is None)
 
     model_config = pydantic.ConfigDict(
         frozen=True,

--- a/dspy/adapters/types/history.py
+++ b/dspy/adapters/types/history.py
@@ -6,8 +6,10 @@ import pydantic
 class History(pydantic.BaseModel):
     """Class representing the conversation history.
 
-    The conversation history is a list of messages, each message entity should have keys from the associated signature.
-    For example, if you have the following signature:
+    The conversation history contains an optional summary of compacted earlier
+    messages followed by a list of recent messages. Each message entity should
+    have keys from the associated signature. For example, if you have the
+    following signature:
 
     ```
     class MySignature(dspy.Signature):
@@ -16,7 +18,10 @@ class History(pydantic.BaseModel):
         answer: str = dspy.OutputField()
     ```
 
-    Then the history should be a list of dictionaries with keys "question" and "answer".
+    Then the history messages should be dictionaries with keys "question" and
+    "answer". When ``summary`` is set, adapters place it before the recent
+    messages as ordinary user context. The summary is not filtered against the
+    signature fields.
 
     Examples:
         ```
@@ -30,6 +35,7 @@ class History(pydantic.BaseModel):
             answer: str = dspy.OutputField()
 
         history = dspy.History(
+            summary="The user is comparing European capitals.",
             messages=[
                 {"question": "What is the capital of France?", "answer": "Paris"},
                 {"question": "What is the capital of Germany?", "answer": "Berlin"},
@@ -59,6 +65,7 @@ class History(pydantic.BaseModel):
     """
 
     messages: list[dict[str, Any]]
+    summary: str | None = pydantic.Field(default=None, exclude_if=lambda value: value is None)
 
     model_config = pydantic.ConfigDict(
         frozen=True,

--- a/dspy/clients/base_lm.py
+++ b/dspy/clients/base_lm.py
@@ -566,7 +566,8 @@ class BaseLM:
 
     def _legacy_forward_kwargs(self, request: LMRequest) -> dict[str, Any]:
         """Convert a normalized request into kwargs for legacy `forward()` implementations."""
-        data = to_openai_chat_request(request)
+        # The legacy Responses path re-normalizes these chat-shaped kwargs in LM.forward.
+        data = to_openai_chat_request(request, _allow_responses_compaction=self.model_type == "responses")
         data.pop("model", None)
         if request.config.cache is not None:
             if request.config.cache.enabled is not None:

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -65,6 +65,21 @@ __all__ = [
 ]
 
 
+def provider_name_from_model(model: str) -> str:
+    """Return the provider prefix used by DSPy and LiteLLM model names."""
+    provider_name, separator, _ = model.partition("/")
+    return provider_name if separator else "openai"
+
+
+def validate_compaction_provider(compactions: list[LMCompactionPart], provider_name: str) -> None:
+    """Reject replay of provider-owned compaction state through another provider."""
+    for compaction in compactions:
+        if compaction.provider_name != provider_name:
+            raise ValueError(
+                f"Compaction state from provider {compaction.provider_name!r} cannot be sent to {provider_name!r}."
+            )
+
+
 # ---------------------------------------------------------------------------
 # DSPy request -> OpenAI Chat Completions
 #
@@ -77,10 +92,15 @@ __all__ = [
 
 def to_openai_chat_request(request: LMRequest, *, _allow_responses_compaction: bool = False) -> dict[str, Any]:
     """Convert a normalized DSPy request into Chat Completions kwargs."""
+    provider_name = provider_name_from_model(request.model)
     data = {
         "model": request.model,
         "messages": [
-            message_to_openai_chat(message, _allow_responses_compaction=_allow_responses_compaction)
+            message_to_openai_chat(
+                message,
+                provider_name=provider_name,
+                _allow_responses_compaction=_allow_responses_compaction,
+            )
             for message in request.messages
         ],
     }
@@ -92,7 +112,12 @@ def to_openai_chat_request(request: LMRequest, *, _allow_responses_compaction: b
     return data
 
 
-def message_to_openai_chat(message: LMMessage, *, _allow_responses_compaction: bool = False) -> dict[str, Any]:
+def message_to_openai_chat(
+    message: LMMessage,
+    *,
+    provider_name: str,
+    _allow_responses_compaction: bool = False,
+) -> dict[str, Any]:
     """Convert one DSPy message into one Chat Completions message."""
     output: dict[str, Any] = {"role": message.role}
     if message.name is not None:
@@ -101,15 +126,16 @@ def message_to_openai_chat(message: LMMessage, *, _allow_responses_compaction: b
     compactions = [part for part in message.parts if isinstance(part, LMCompactionPart)]
     if compactions and message.role != "assistant":
         raise ValueError("Compaction parts can only appear in assistant messages.")
+    validate_compaction_provider(compactions, provider_name)
 
     if message.role == "assistant":
         tool_calls = [part for part in message.parts if isinstance(part, LMToolCallPart)]
         if _allow_responses_compaction:
-            if any(not part.encrypted for part in compactions):
-                raise ValueError("Textual compaction blocks cannot be sent to the OpenAI Responses API.")
+            if any(not isinstance(part.provider_data.get("encrypted_content"), str) for part in compactions):
+                raise ValueError("Only encrypted compaction items can be sent to the OpenAI Responses API.")
             content_parts = [part for part in message.parts if not isinstance(part, LMToolCallPart)]
         else:
-            if any(part.encrypted for part in compactions):
+            if any("content" not in part.provider_data for part in compactions):
                 raise ValueError("Encrypted compaction items can only be sent to the OpenAI Responses API.")
             content_parts = [part for part in message.parts if not isinstance(part, (LMToolCallPart, LMCompactionPart))]
         output["content"] = (
@@ -148,9 +174,14 @@ def message_to_openai_chat(message: LMMessage, *, _allow_responses_compaction: b
 def to_openai_responses_request(request: LMRequest, *, enforce_reasoning_temperature: bool = True) -> dict[str, Any]:
     """Convert a normalized DSPy request into Responses API kwargs."""
     config = request.config
+    provider_name = provider_name_from_model(request.model)
     data: dict[str, Any] = {
         "model": request.model,
-        "input": [item for message in request.messages for item in message_to_responses_input_items(message)],
+        "input": [
+            item
+            for message in request.messages
+            for item in message_to_responses_input_items(message, provider_name=provider_name)
+        ],
     }
     data.update(
         responses_config_kwargs(config, model=request.model, enforce_reasoning_temperature=enforce_reasoning_temperature)
@@ -162,10 +193,12 @@ def to_openai_responses_request(request: LMRequest, *, enforce_reasoning_tempera
     return data
 
 
-def message_to_responses_input_items(message: LMMessage) -> list[dict[str, Any]]:
+def message_to_responses_input_items(message: LMMessage, *, provider_name: str) -> list[dict[str, Any]]:
     """Convert one DSPy message into one or more Responses input items."""
-    if message.role != "assistant" and any(isinstance(part, LMCompactionPart) for part in message.parts):
+    compactions = [part for part in message.parts if isinstance(part, LMCompactionPart)]
+    if message.role != "assistant" and compactions:
         raise ValueError("Compaction parts can only appear in assistant messages.")
+    validate_compaction_provider(compactions, provider_name)
 
     if message.role == "tool" and len(message.parts) == 1 and isinstance(message.parts[0], LMToolResultPart):
         result = message.parts[0]
@@ -228,21 +261,24 @@ def tool_call_to_responses_input(tool_call_part: LMToolCallPart) -> dict[str, An
 
 def compaction_to_responses_input(compaction: LMCompactionPart) -> dict[str, Any]:
     """Restore an opaque compaction part to its standalone Responses item."""
-    if not compaction.encrypted:
-        raise ValueError("Textual compaction blocks cannot be sent to the OpenAI Responses API.")
+    encrypted_content = compaction.provider_data.get("encrypted_content")
+    if not isinstance(encrypted_content, str):
+        raise ValueError("Only encrypted compaction items can be sent to the OpenAI Responses API.")
     item = dict(compaction.provider_data)
     item.pop("content", None)
+    item.pop("provider_name", None)
     item["type"] = "compaction"
-    item["encrypted_content"] = compaction.content
+    item["encrypted_content"] = encrypted_content
     return item
 
 
 def compaction_to_anthropic_block(compaction: LMCompactionPart) -> dict[str, Any]:
     """Restore textual compaction for LiteLLM to replay as an Anthropic block."""
-    if compaction.encrypted:
+    if "content" not in compaction.provider_data:
         raise ValueError("Encrypted compaction items can only be sent to the OpenAI Responses API.")
     block = dict(compaction.provider_data)
     block.pop("encrypted_content", None)
+    block.pop("provider_name", None)
     block["type"] = "compaction"
     block["content"] = compaction.content
     return block
@@ -343,10 +379,13 @@ def part_to_openai_blocks(part: Any) -> list[dict[str, Any]]:
         return [{"type": "text", "text": part.text}]
     if isinstance(part, LMCompactionPart):
         block = dict(part.provider_data)
-        field = "encrypted_content" if part.encrypted else "content"
-        block.pop("content" if part.encrypted else "encrypted_content", None)
         block["type"] = "compaction"
-        block[field] = part.content
+        block["provider_name"] = part.provider_name
+        if part.content is None:
+            block.pop("content", None)
+        else:
+            block.pop("encrypted_content", None)
+            block["content"] = part.content
         return [block]
     if isinstance(part, LMCitationPart):
         citation = " ".join(value for value in (part.title, part.text, part.url) if value)
@@ -695,7 +734,9 @@ def completion_to_lm_response(response: Any, request: LMRequest) -> LMResponse:
     choices = get_value(response, "choices", []) or []
     return LMResponse(
         model=get_value(response, "model") or request.model,
-        outputs=[choice_to_lm_output(choice) for choice in choices],
+        outputs=[
+            choice_to_lm_output(choice, provider_name=provider_name_from_model(request.model)) for choice in choices
+        ],
         usage=usage_from_response(response),
         cache_hit=bool(get_value(response, "cache_hit", False)),
         response_id=get_value(response, "id"),
@@ -703,12 +744,12 @@ def completion_to_lm_response(response: Any, request: LMRequest) -> LMResponse:
     )
 
 
-def choice_to_lm_output(choice: Any) -> LMOutput:
+def choice_to_lm_output(choice: Any, *, provider_name: str) -> LMOutput:
     """Convert one completion choice into one DSPy output candidate."""
     message = get_value(choice, "message")
     parts = []
     if message is not None:
-        parts.extend(extract_compactions_from_choice(choice))
+        parts.extend(extract_compactions_from_choice(choice, provider_name=provider_name))
         reasoning = get_value(message, "reasoning_content")
         if reasoning:
             parts.append(LMThinkingPart(text=str(reasoning)))
@@ -762,7 +803,7 @@ def responses_to_lm_response(response: Any, request: LMRequest) -> LMResponse:
                 if text:
                     parts.append(LMThinkingPart(text=text))
         elif output_type == "compaction":
-            parts.append(compaction_to_part(output_item, encrypted=True))
+            parts.append(compaction_to_part(output_item, provider_name=provider_name_from_model(request.model)))
     return LMResponse(
         model=get_value(response, "model") or request.model,
         outputs=[LMOutput(parts=parts, provider_output=response)],
@@ -861,22 +902,26 @@ def extract_citations_from_choice(choice: Any) -> list[LMCitationPart]:
     return []
 
 
-def extract_compactions_from_choice(choice: Any) -> list[LMCompactionPart]:
+def extract_compactions_from_choice(choice: Any, *, provider_name: str) -> list[LMCompactionPart]:
     """Extract Anthropic compaction blocks retained by LiteLLM."""
     message = get_value(choice, "message")
     provider_specific_fields = get_value(message, "provider_specific_fields", {}) or {}
     blocks = provider_specific_fields.get("compaction_blocks") or []
-    return [compaction_to_part(block, encrypted=False) for block in blocks]
+    return [compaction_to_part(block, provider_name=provider_name) for block in blocks]
 
 
-def compaction_to_part(value: Any, *, encrypted: bool) -> LMCompactionPart:
+def compaction_to_part(value: Any, *, provider_name: str) -> LMCompactionPart:
     """Normalize an OpenAI or Anthropic provider compaction item."""
     provider_data = model_dump(value)
-    field = "encrypted_content" if encrypted else "content"
-    content = provider_data.get(field)
-    if not isinstance(content, str):
-        raise ValueError(f"Provider compaction item requires a string {field!r} field.")
-    return LMCompactionPart(content=content, encrypted=encrypted, provider_data=provider_data)
+    encrypted_content = provider_data.get("encrypted_content")
+    if encrypted_content is not None and not isinstance(encrypted_content, str):
+        raise ValueError("Provider compaction item requires a string 'encrypted_content' field.")
+    content = provider_data.get("content")
+    if content is not None and not isinstance(content, str):
+        raise ValueError("Provider compaction item requires a string or null 'content' field.")
+    if encrypted_content is None and "content" not in provider_data:
+        raise ValueError("Provider compaction item requires 'encrypted_content' or 'content'.")
+    return LMCompactionPart(content=content, provider_name=provider_name, provider_data=provider_data)
 
 
 def responses_annotations_to_citations(content_item: Any) -> list[LMCitationPart]:

--- a/dspy/clients/openai_format.py
+++ b/dspy/clients/openai_format.py
@@ -33,6 +33,7 @@ from dspy.core.types import (
     LMAudioPart,
     LMBinaryPart,
     LMCitationPart,
+    LMCompactionPart,
     LMConfig,
     LMDocumentPart,
     LMImagePart,
@@ -74,9 +75,15 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 
-def to_openai_chat_request(request: LMRequest) -> dict[str, Any]:
+def to_openai_chat_request(request: LMRequest, *, _allow_responses_compaction: bool = False) -> dict[str, Any]:
     """Convert a normalized DSPy request into Chat Completions kwargs."""
-    data = {"model": request.model, "messages": [message_to_openai_chat(message) for message in request.messages]}
+    data = {
+        "model": request.model,
+        "messages": [
+            message_to_openai_chat(message, _allow_responses_compaction=_allow_responses_compaction)
+            for message in request.messages
+        ],
+    }
     data.update(common_config_kwargs(request.config, model=request.model, endpoint="chat"))
     if request.config.tool_choice is not None:
         data.update(tool_choice_to_openai(request.config.tool_choice))
@@ -85,18 +92,35 @@ def to_openai_chat_request(request: LMRequest) -> dict[str, Any]:
     return data
 
 
-def message_to_openai_chat(message: LMMessage) -> dict[str, Any]:
+def message_to_openai_chat(message: LMMessage, *, _allow_responses_compaction: bool = False) -> dict[str, Any]:
     """Convert one DSPy message into one Chat Completions message."""
     output: dict[str, Any] = {"role": message.role}
     if message.name is not None:
         output["name"] = message.name
 
+    compactions = [part for part in message.parts if isinstance(part, LMCompactionPart)]
+    if compactions and message.role != "assistant":
+        raise ValueError("Compaction parts can only appear in assistant messages.")
+
     if message.role == "assistant":
         tool_calls = [part for part in message.parts if isinstance(part, LMToolCallPart)]
-        content_parts = [part for part in message.parts if not isinstance(part, LMToolCallPart)]
-        output["content"] = None if tool_calls and not content_parts else parts_to_openai_content(content_parts)
+        if _allow_responses_compaction:
+            if any(not part.encrypted for part in compactions):
+                raise ValueError("Textual compaction blocks cannot be sent to the OpenAI Responses API.")
+            content_parts = [part for part in message.parts if not isinstance(part, LMToolCallPart)]
+        else:
+            if any(part.encrypted for part in compactions):
+                raise ValueError("Encrypted compaction items can only be sent to the OpenAI Responses API.")
+            content_parts = [part for part in message.parts if not isinstance(part, (LMToolCallPart, LMCompactionPart))]
+        output["content"] = (
+            None if (tool_calls or compactions) and not content_parts else parts_to_openai_content(content_parts)
+        )
         if tool_calls:
             output["tool_calls"] = [assistant_tool_call_to_openai(part) for part in tool_calls]
+        if compactions and not _allow_responses_compaction:
+            output["provider_specific_fields"] = {
+                "compaction_blocks": [compaction_to_anthropic_block(part) for part in compactions]
+            }
         return output
 
     if message.role == "tool" and len(message.parts) == 1 and isinstance(message.parts[0], LMToolResultPart):
@@ -140,6 +164,9 @@ def to_openai_responses_request(request: LMRequest, *, enforce_reasoning_tempera
 
 def message_to_responses_input_items(message: LMMessage) -> list[dict[str, Any]]:
     """Convert one DSPy message into one or more Responses input items."""
+    if message.role != "assistant" and any(isinstance(part, LMCompactionPart) for part in message.parts):
+        raise ValueError("Compaction parts can only appear in assistant messages.")
+
     if message.role == "tool" and len(message.parts) == 1 and isinstance(message.parts[0], LMToolResultPart):
         result = message.parts[0]
         item = {"type": "function_call_output", "output": responses_tool_output_text(tool_result_to_openai(result)["content"])}
@@ -147,19 +174,31 @@ def message_to_responses_input_items(message: LMMessage) -> list[dict[str, Any]]
             item["call_id"] = result.call_id
         return [item]
 
-    tool_calls = [part for part in message.parts if isinstance(part, LMToolCallPart)]
-    content_parts = [part for part in message.parts if not isinstance(part, LMToolCallPart)]
-    content = parts_to_responses_content(content_parts, role=message.role)
     items: list[dict[str, Any]] = []
+    content_parts = []
+    for part in message.parts:
+        if message.role == "assistant" and isinstance(part, (LMToolCallPart, LMCompactionPart)):
+            if content_parts:
+                item: dict[str, Any] = {
+                    "role": message.role,
+                    "content": parts_to_responses_content(content_parts, role=message.role),
+                }
+                if message.name is not None:
+                    item["name"] = message.name
+                items.append(item)
+                content_parts = []
+            if isinstance(part, LMToolCallPart):
+                items.append(tool_call_to_responses_input(part))
+            else:
+                items.append(compaction_to_responses_input(part))
+        else:
+            content_parts.append(part)
 
-    if content or message.role != "assistant" or not tool_calls:
-        item: dict[str, Any] = {"role": message.role, "content": content}
+    if content_parts or message.role != "assistant" or not items:
+        item = {"role": message.role, "content": parts_to_responses_content(content_parts, role=message.role)}
         if message.name is not None:
             item["name"] = message.name
         items.append(item)
-
-    if message.role == "assistant":
-        items.extend(tool_call_to_responses_input(tool_call) for tool_call in tool_calls)
     return items
 
 
@@ -185,6 +224,28 @@ def tool_call_to_responses_input(tool_call_part: LMToolCallPart) -> dict[str, An
     if call_id is not None:
         item["call_id"] = call_id
     return item
+
+
+def compaction_to_responses_input(compaction: LMCompactionPart) -> dict[str, Any]:
+    """Restore an opaque compaction part to its standalone Responses item."""
+    if not compaction.encrypted:
+        raise ValueError("Textual compaction blocks cannot be sent to the OpenAI Responses API.")
+    item = dict(compaction.provider_data)
+    item.pop("content", None)
+    item["type"] = "compaction"
+    item["encrypted_content"] = compaction.content
+    return item
+
+
+def compaction_to_anthropic_block(compaction: LMCompactionPart) -> dict[str, Any]:
+    """Restore textual compaction for LiteLLM to replay as an Anthropic block."""
+    if compaction.encrypted:
+        raise ValueError("Encrypted compaction items can only be sent to the OpenAI Responses API.")
+    block = dict(compaction.provider_data)
+    block.pop("encrypted_content", None)
+    block["type"] = "compaction"
+    block["content"] = compaction.content
+    return block
 
 
 def content_block_to_responses(block: dict[str, Any], role: str = "user") -> dict[str, Any]:
@@ -280,6 +341,13 @@ def part_to_openai_blocks(part: Any) -> list[dict[str, Any]]:
         return [binary_to_openai(part)]
     if isinstance(part, LMThinkingPart):
         return [{"type": "text", "text": part.text}]
+    if isinstance(part, LMCompactionPart):
+        block = dict(part.provider_data)
+        field = "encrypted_content" if part.encrypted else "content"
+        block.pop("content" if part.encrypted else "encrypted_content", None)
+        block["type"] = "compaction"
+        block[field] = part.content
+        return [block]
     if isinstance(part, LMCitationPart):
         citation = " ".join(value for value in (part.title, part.text, part.url) if value)
         return [{"type": "text", "text": citation}]
@@ -640,6 +708,7 @@ def choice_to_lm_output(choice: Any) -> LMOutput:
     message = get_value(choice, "message")
     parts = []
     if message is not None:
+        parts.extend(extract_compactions_from_choice(choice))
         reasoning = get_value(message, "reasoning_content")
         if reasoning:
             parts.append(LMThinkingPart(text=str(reasoning)))
@@ -692,6 +761,8 @@ def responses_to_lm_response(response: Any, request: LMRequest) -> LMResponse:
                 text = get_value(item, "text")
                 if text:
                     parts.append(LMThinkingPart(text=text))
+        elif output_type == "compaction":
+            parts.append(compaction_to_part(output_item, encrypted=True))
     return LMResponse(
         model=get_value(response, "model") or request.model,
         outputs=[LMOutput(parts=parts, provider_output=response)],
@@ -788,6 +859,24 @@ def extract_citations_from_choice(choice: Any) -> list[LMCitationPart]:
     except Exception:
         return []
     return []
+
+
+def extract_compactions_from_choice(choice: Any) -> list[LMCompactionPart]:
+    """Extract Anthropic compaction blocks retained by LiteLLM."""
+    message = get_value(choice, "message")
+    provider_specific_fields = get_value(message, "provider_specific_fields", {}) or {}
+    blocks = provider_specific_fields.get("compaction_blocks") or []
+    return [compaction_to_part(block, encrypted=False) for block in blocks]
+
+
+def compaction_to_part(value: Any, *, encrypted: bool) -> LMCompactionPart:
+    """Normalize an OpenAI or Anthropic provider compaction item."""
+    provider_data = model_dump(value)
+    field = "encrypted_content" if encrypted else "content"
+    content = provider_data.get(field)
+    if not isinstance(content, str):
+        raise ValueError(f"Provider compaction item requires a string {field!r} field.")
+    return LMCompactionPart(content=content, encrypted=encrypted, provider_data=provider_data)
 
 
 def responses_annotations_to_citations(content_item: Any) -> list[LMCitationPart]:
@@ -967,7 +1056,24 @@ def model_dump(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
         return dict(value)
     data = {}
-    for key in ("id", "call_id", "type", "name", "arguments", "status", "text", "refusal", "url", "data", "file_id", "filename", "media_type", "mime_type"):
+    for key in (
+        "id",
+        "call_id",
+        "type",
+        "name",
+        "arguments",
+        "status",
+        "text",
+        "content",
+        "encrypted_content",
+        "refusal",
+        "url",
+        "data",
+        "file_id",
+        "filename",
+        "media_type",
+        "mime_type",
+    ):
         item = getattr(value, key, None)
         if item is not None:
             data[key] = item

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -21,6 +21,7 @@ __all__ = [
     "LMBinaryPart",
     "LMCacheConfig",
     "LMCitationPart",
+    "LMCompactionPart",
     "LMConfig",
     "LMDocumentPart",
     "LMImagePart",
@@ -228,6 +229,27 @@ class LMRefusalPart(LMBasePart):
     text: str
 
 
+class LMCompactionPart(LMBasePart):
+    """Provider-generated state that replaces earlier conversation context.
+
+    OpenAI returns opaque encrypted state as a standalone Responses item, while
+    Anthropic returns a textual compaction block inside an assistant message.
+    DSPy keeps both as assistant-originated parts and restores each provider's
+    native wire shape when the response is used in a subsequent request.
+
+    Args:
+        content: The provider-returned compaction state. This is opaque when
+            `encrypted=True` and must not be interpreted as text.
+        encrypted: Whether `content` is opaque encrypted provider state.
+        provider_data: Raw provider fields retained for lossless replay.
+    """
+
+    type: Literal["compaction"] = "compaction"
+    content: str
+    encrypted: bool = False
+    provider_data: dict[str, Any] = Field(default_factory=dict)
+
+
 LMPart = Annotated[
     LMTextPart
     | LMImagePart
@@ -239,7 +261,8 @@ LMPart = Annotated[
     | LMToolResultPart
     | LMThinkingPart
     | LMCitationPart
-    | LMRefusalPart,
+    | LMRefusalPart
+    | LMCompactionPart,
     Field(discriminator="type"),
 ]
 
@@ -782,6 +805,10 @@ class LMOutput(BaseModel):
         return [part for part in self.parts if isinstance(part, LMBinaryPart)]
 
     @property
+    def compactions(self) -> list[LMCompactionPart]:
+        return [part for part in self.parts if isinstance(part, LMCompactionPart)]
+
+    @property
     def refusal(self) -> str | None:
         refusals = [part.text for part in self.parts if isinstance(part, LMRefusalPart)]
         return "".join(refusals) if refusals else None
@@ -901,6 +928,10 @@ class LMResponse(BaseModel):
     @property
     def binaries(self) -> list[LMBinaryPart]:
         return self.output.binaries
+
+    @property
+    def compactions(self) -> list[LMCompactionPart]:
+        return self.output.compactions
 
     def to_values(self) -> list[Any]:
         return [output.to_value() for output in self.outputs]
@@ -1779,6 +1810,7 @@ def _coerce_part(value: Any) -> LMPart:
             LMThinkingPart,
             LMCitationPart,
             LMRefusalPart,
+            LMCompactionPart,
         ),
     ):
         return value
@@ -1820,6 +1852,13 @@ def _parts_from_openai_content(content: Any) -> list[LMPart]:
         elif item_type == "video":
             video = item.get("video", {})
             parts.append(_media_dict_to_video_part(video))
+        elif item_type == "compaction":
+            encrypted = "encrypted_content" in item
+            field = "encrypted_content" if encrypted else "content"
+            content = item.get(field)
+            if not isinstance(content, str):
+                raise ValueError(f"Compaction content block requires a string {field!r} field.")
+            parts.append(LMCompactionPart(content=content, encrypted=encrypted, provider_data=dict(item)))
         else:
             parts.append(_coerce_part(item))
     return parts

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -238,15 +238,16 @@ class LMCompactionPart(LMBasePart):
     native wire shape when the response is used in a subsequent request.
 
     Args:
-        content: The provider-returned compaction state. This is opaque when
-            `encrypted=True` and must not be interpreted as text.
-        encrypted: Whether `content` is opaque encrypted provider state.
+        provider_name: The provider that generated the compaction. Compaction
+            state can only be replayed to the same provider.
+        content: A readable summary when the provider exposes one. OpenAI's
+            encrypted state is retained in ``provider_data`` instead.
         provider_data: Raw provider fields retained for lossless replay.
     """
 
     type: Literal["compaction"] = "compaction"
-    content: str
-    encrypted: bool = False
+    provider_name: str
+    content: str | None = None
     provider_data: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -1667,6 +1668,16 @@ def _history_message_parts_as_openai_content(parts: list[LMPart]) -> str | list[
 def _history_part_as_openai_content(part: LMPart) -> dict[str, Any]:
     if isinstance(part, LMTextPart):
         return {"type": "text", "text": part.text}
+    if isinstance(part, LMCompactionPart):
+        block = dict(part.provider_data)
+        block["type"] = "compaction"
+        block["provider_name"] = part.provider_name
+        if part.content is None:
+            block.pop("content", None)
+        else:
+            block.pop("encrypted_content", None)
+            block["content"] = part.content
+        return block
     if isinstance(part, LMImagePart):
         return {"type": "image_url", "image_url": {"url": _history_part_source(part)}}
     if isinstance(part, LMAudioPart):
@@ -1853,12 +1864,14 @@ def _parts_from_openai_content(content: Any) -> list[LMPart]:
             video = item.get("video", {})
             parts.append(_media_dict_to_video_part(video))
         elif item_type == "compaction":
-            encrypted = "encrypted_content" in item
-            field = "encrypted_content" if encrypted else "content"
-            content = item.get(field)
-            if not isinstance(content, str):
-                raise ValueError(f"Compaction content block requires a string {field!r} field.")
-            parts.append(LMCompactionPart(content=content, encrypted=encrypted, provider_data=dict(item)))
+            provider_name = item.get("provider_name")
+            if not isinstance(provider_name, str):
+                raise ValueError("Compaction content block requires a string 'provider_name' field.")
+            content = item.get("content")
+            if content is not None and not isinstance(content, str):
+                raise ValueError("Compaction content block requires a string or null 'content' field.")
+            provider_data = {key: value for key, value in item.items() if key != "provider_name"}
+            parts.append(LMCompactionPart(content=content, provider_name=provider_name, provider_data=provider_data))
         else:
             parts.append(_coerce_part(item))
     return parts
@@ -2058,6 +2071,8 @@ def _part_to_value(part: LMPart) -> Any:
         return part
     if isinstance(part, LMRefusalPart):
         return part.text
+    if isinstance(part, LMCompactionPart):
+        return None
     return part
 
 

--- a/dspy/utils/inspect_history.py
+++ b/dspy/utils/inspect_history.py
@@ -47,6 +47,15 @@ def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO
             with suppress(json.JSONDecodeError):
                 arguments = json.loads(arguments) if isinstance(arguments, str) else arguments
             print(_green(f"{function.get('name') or tool_call.get('name', '<unknown>')}: {json.dumps(arguments, ensure_ascii=False) if isinstance(arguments, (dict, list)) else str(arguments)}", use_colors=use_colors), file=out)
+
+    def print_compaction(provider_name: str, content: str | None, *, opaque: bool) -> None:
+        print(_red(f"Provider compaction ({provider_name}):", use_colors=use_colors), file=out)
+        if content is None:
+            label = "<opaque provider state>" if opaque else "<empty compaction>"
+            print(_blue(label, use_colors=use_colors), file=out)
+        else:
+            print(_green(content.strip(), use_colors=use_colors), file=out)
+
     for item in history[-n:]:
         messages = item["messages"] or [{"role": "user", "content": item["prompt"]}]
         outputs = item["outputs"]
@@ -87,18 +96,39 @@ def pretty_print_history(history: list[dict[str, Any]], n: int = 1, file: TextIO
                             file_data = file_info.get("file_data", "")
                             file_str = f"<file: name:{filename}, id:{file_id}, data_length:{len(file_data)}>"
                             print(_blue(file_str.strip(), use_colors=use_colors), file=out)
+                        elif c["type"] == "compaction":
+                            print_compaction(
+                                c.get("provider_name", "unknown"),
+                                c.get("content"),
+                                opaque="encrypted_content" in c,
+                            )
             print_tool_calls(msg.get("tool_calls"))
             print("\n", file=out)
 
-        if isinstance(outputs[0], dict):
-            if outputs[0].get("text"):
+        first_output = outputs[0]
+        if isinstance(first_output, dict):
+            if first_output.get("text"):
                 print(_red("Response:", use_colors=use_colors), file=out)
-                print(_green(outputs[0]["text"].strip(), use_colors=use_colors), file=out)
+                print(_green(first_output["text"].strip(), use_colors=use_colors), file=out)
 
-            print_tool_calls(outputs[0].get("tool_calls"))
-        else:
+            print_tool_calls(first_output.get("tool_calls"))
+        elif isinstance(first_output, str):
             print(_red("Response:", use_colors=use_colors), file=out)
-            print(_green(outputs[0].strip(), use_colors=use_colors), file=out)
+            print(_green(first_output.strip(), use_colors=use_colors), file=out)
+        elif isinstance(first_output, list):
+            text = "".join(value for value in first_output if isinstance(value, str))
+            if text:
+                print(_red("Response:", use_colors=use_colors), file=out)
+                print(_green(text.strip(), use_colors=use_colors), file=out)
+
+        response = getattr(item, "response", None)
+        if response is not None:
+            for compaction in response.compactions:
+                print_compaction(
+                    compaction.provider_name,
+                    compaction.content,
+                    opaque="encrypted_content" in compaction.provider_data,
+                )
 
         if len(outputs) > 1:
             choices_text = f" \t (and {len(outputs) - 1} other completions)"

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -385,6 +385,44 @@ def test_chat_adapter_format_exact_messages_with_history():
     assert lm_kwargs == expected_lm_kwargs
 
 
+def test_chat_adapter_formats_compacted_history_summary_before_recent_messages():
+    class HistorySignature(dspy.Signature):
+        history: dspy.History = dspy.InputField()
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    history = dspy.History(
+        summary="The user established that 1+1 is 2.",
+        messages=[{"question": "What is 2+2?", "answer": "4"}],
+    )
+    lm = dspy.utils.DummyLM([{"answer": "6"}])
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        prediction = dspy.Predict(HistorySignature)(history=history, question="What is 3+3?")
+
+    messages = lm.history[0]["messages"]
+    assert prediction.answer == "6"
+    assert messages[1] == {
+        "role": "user",
+        "content": "Here is a summary of the conversation to date:\n\nThe user established that 1+1 is 2.",
+    }
+    assert [message["role"] for message in messages[2:]] == ["user", "assistant", "user"]
+    assert "What is 2+2?" in messages[2]["content"]
+    assert "What is 3+3?" in messages[4]["content"]
+
+
+def test_compacted_history_round_trip_preserves_summary_and_recent_messages():
+    history = dspy.History(
+        summary="Earlier conversation summary.",
+        messages=[{"question": "Recent question", "answer": "Recent answer"}],
+    )
+
+    restored = dspy.History.model_validate(history.model_dump())
+
+    assert restored == history
+    assert dspy.History(messages=[]).model_dump() == {"messages": []}
+
+
 def test_chat_adapter_format_exact_messages_with_list_value_for_string_input():
     class ListAsStringSignature(dspy.Signature):
         context: str = dspy.InputField()

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -8,6 +8,7 @@ import pytest
 from litellm.utils import ChatCompletionMessageToolCall, Choices, Function, Message, ModelResponse
 
 import dspy
+from dspy.core.types import LMCompactionPart
 from dspy.experimental import Citations, Document
 from tests.adapters.conftest import format_messages_and_lm_kwargs
 
@@ -385,14 +386,14 @@ def test_chat_adapter_format_exact_messages_with_history():
     assert lm_kwargs == expected_lm_kwargs
 
 
-def test_chat_adapter_formats_compacted_history_summary_before_recent_messages():
+def test_chat_adapter_formats_text_compaction_before_recent_history_messages():
     class HistorySignature(dspy.Signature):
         history: dspy.History = dspy.InputField()
         question: str = dspy.InputField()
         answer: str = dspy.OutputField()
 
     history = dspy.History(
-        summary="The user established that 1+1 is 2.",
+        compaction="The user established that 1+1 is 2.",
         messages=[{"question": "What is 2+2?", "answer": "4"}],
     )
     lm = dspy.utils.DummyLM([{"answer": "6"}])
@@ -411,9 +412,19 @@ def test_chat_adapter_formats_compacted_history_summary_before_recent_messages()
     assert "What is 3+3?" in messages[4]["content"]
 
 
-def test_compacted_history_round_trip_preserves_summary_and_recent_messages():
+@pytest.mark.parametrize(
+    "compaction",
+    [
+        "Earlier conversation summary.",
+        LMCompactionPart(
+            provider_name="openai",
+            provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+        ),
+    ],
+)
+def test_compacted_history_round_trip_preserves_compaction_and_recent_messages(compaction):
     history = dspy.History(
-        summary="Earlier conversation summary.",
+        compaction=compaction,
         messages=[{"question": "Recent question", "answer": "Recent answer"}],
     )
 
@@ -421,6 +432,94 @@ def test_compacted_history_round_trip_preserves_summary_and_recent_messages():
 
     assert restored == history
     assert dspy.History(messages=[]).model_dump() == {"messages": []}
+
+
+@pytest.mark.parametrize(
+    ("lm", "compaction", "expected_message"),
+    [
+        (
+            dspy.LM("openai/gpt-5.3-codex", model_type="responses"),
+            LMCompactionPart(
+                provider_name="openai",
+                provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+            ),
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "compaction",
+                        "id": "cmp_1",
+                        "encrypted_content": "opaque",
+                        "provider_name": "openai",
+                    }
+                ],
+            },
+        ),
+        (
+            dspy.LM("anthropic/claude-opus-4-6"),
+            LMCompactionPart(
+                provider_name="anthropic",
+                content="Earlier conversation summary.",
+                provider_data={"type": "compaction", "content": "Earlier conversation summary."},
+            ),
+            {
+                "role": "assistant",
+                "content": None,
+                "provider_specific_fields": {
+                    "compaction_blocks": [
+                        {"type": "compaction", "content": "Earlier conversation summary."}
+                    ]
+                },
+            },
+        ),
+    ],
+)
+def test_chat_adapter_replays_provider_compaction_before_recent_history(lm, compaction, expected_message):
+    class HistorySignature(dspy.Signature):
+        history: dspy.History = dspy.InputField()
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    history = dspy.History(
+        compaction=compaction,
+        messages=[{"question": "What is 2+2?", "answer": "4"}],
+    )
+
+    messages, lm_kwargs = format_messages_and_lm_kwargs(
+        dspy.ChatAdapter(),
+        HistorySignature,
+        [],
+        {"history": history, "question": "What is 3+3?"},
+        lm=lm,
+    )
+
+    assert messages[1] == expected_message
+    assert [message["role"] for message in messages[2:]] == ["user", "assistant", "user"]
+    assert lm_kwargs == {}
+
+
+def test_chat_adapter_rejects_history_compaction_from_another_provider():
+    class HistorySignature(dspy.Signature):
+        history: dspy.History = dspy.InputField()
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    history = dspy.History(
+        compaction=LMCompactionPart(
+            provider_name="openai",
+            provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+        ),
+        messages=[],
+    )
+
+    with pytest.raises(ValueError, match="cannot be sent"):
+        format_messages_and_lm_kwargs(
+            dspy.ChatAdapter(),
+            HistorySignature,
+            [],
+            {"history": history, "question": "Continue."},
+            lm=dspy.LM("anthropic/claude-opus-4-6"),
+        )
 
 
 def test_chat_adapter_format_exact_messages_with_list_value_for_string_input():

--- a/tests/adapters/test_two_step_adapter.py
+++ b/tests/adapters/test_two_step_adapter.py
@@ -69,6 +69,7 @@ def test_two_step_adapter_call():
     mock_main_lm.return_value = ["text from main LM"]
     mock_main_lm.kwargs = {"temperature": 1.0}
     mock_main_lm.model = "openai/gpt-4o-mini"
+    mock_main_lm.model_type = "chat"
 
     mock_extraction_lm = mock.MagicMock(spec=dspy.LM)
     mock_extraction_lm.return_value = [
@@ -80,6 +81,7 @@ def test_two_step_adapter_call():
     ]
     mock_extraction_lm.kwargs = {"temperature": 1.0}
     mock_extraction_lm.model = "openai/gpt-4o"
+    mock_extraction_lm.model_type = "chat"
 
     dspy.configure(lm=mock_main_lm, adapter=dspy.TwoStepAdapter(extraction_model=mock_extraction_lm))
 
@@ -136,6 +138,7 @@ async def test_two_step_adapter_async_call():
     mock_main_lm.acall.return_value = ["text from main LM"]
     mock_main_lm.kwargs = {"temperature": 1.0}
     mock_main_lm.model = "openai/gpt-4o-mini"
+    mock_main_lm.model_type = "chat"
 
     mock_extraction_lm = mock.MagicMock(spec=dspy.LM)
     mock_extraction_lm.acall.return_value = [
@@ -147,6 +150,7 @@ async def test_two_step_adapter_async_call():
     ]
     mock_extraction_lm.kwargs = {"temperature": 1.0}
     mock_extraction_lm.model = "openai/gpt-4o"
+    mock_extraction_lm.model_type = "chat"
 
     with dspy.context(lm=mock_main_lm, adapter=dspy.TwoStepAdapter(extraction_model=mock_extraction_lm)):
         result = await program.acall(question="What is 5 + 7?")
@@ -208,6 +212,7 @@ def test_two_step_adapter_parse():
     ]
     mock_extraction_lm.kwargs = {"temperature": 1.0}
     mock_extraction_lm.model = "openai/gpt-4o"
+    mock_extraction_lm.model_type = "chat"
     adapter = dspy.TwoStepAdapter(mock_extraction_lm)
     dspy.configure(adapter=adapter, lm=mock_extraction_lm)
 

--- a/tests/clients/test_inspect_global_history.py
+++ b/tests/clients/test_inspect_global_history.py
@@ -4,6 +4,7 @@ import pytest
 
 import dspy
 from dspy.clients.base_lm import GLOBAL_HISTORY
+from dspy.core.types import LMCompactionPart, LMHistoryEntry, LMOutput, LMRequest, LMResponse
 from dspy.utils.dummies import DummyLM
 from dspy.utils.inspect_history import pretty_print_history
 
@@ -90,6 +91,62 @@ def test_inspect_history_renders_output_tool_calls_without_text():
     assert "Tool calls:" in text
     assert 'lookup: {"query": "cats"}' in text
     assert 'search: {"query": "dogs"}' in text
+
+
+def test_inspect_history_renders_provider_compaction_without_exposing_opaque_state():
+    out = StringIO()
+    entry = LMHistoryEntry(
+        request=LMRequest.from_call(model="openai/gpt-5", prompt="hello"),
+        response=LMResponse(
+            outputs=[
+                LMOutput(
+                    parts=[
+                        LMCompactionPart(
+                            provider_name="openai",
+                            provider_data={"type": "compaction", "encrypted_content": "secret-state"},
+                        )
+                    ]
+                )
+            ]
+        ),
+        timestamp="now",
+        uuid="uuid",
+    )
+
+    pretty_print_history([entry], n=1, file=out)
+
+    text = out.getvalue()
+    assert "Provider compaction (openai):" in text
+    assert "<opaque provider state>" in text
+    assert "secret-state" not in text
+
+
+def test_inspect_history_renders_readable_provider_compaction():
+    out = StringIO()
+    entry = LMHistoryEntry(
+        request=LMRequest.from_call(model="anthropic/claude", prompt="hello"),
+        response=LMResponse(
+            outputs=[
+                LMOutput(
+                    parts=[
+                        LMCompactionPart(
+                            provider_name="anthropic",
+                            content="Conversation summary.",
+                            provider_data={"type": "compaction", "content": "Conversation summary."},
+                        )
+                    ]
+                )
+            ]
+        ),
+        timestamp="now",
+        uuid="uuid",
+    )
+
+    pretty_print_history([entry], n=1, file=out)
+
+    text = out.getvalue()
+    assert "Provider compaction (anthropic):" in text
+    assert "Conversation summary." in text
 
 
 def test_inspect_history_with_n(capsys):

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -2172,3 +2172,107 @@ def test_responses_to_lm_response_normalizes_mixed_text_reasoning_and_tool_calls
     assert output.tool_calls[0].provider_data["raw_arguments"] == '{"city": "Paris",}'
     assert "arguments_parse_error" in output.tool_calls[0].provider_data
     assert lm_response.usage.total_tokens == 2
+
+
+def test_typed_lm_replays_openai_native_compaction_state():
+    first_provider_response = make_response(
+        [
+            {"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+            ResponseOutputMessage(
+                id="msg_1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "First answer.", "annotations": []}],
+            ),
+        ]
+    )
+    second_provider_response = make_response(
+        [
+            ResponseOutputMessage(
+                id="msg_2",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[{"type": "output_text", "text": "Second answer.", "annotations": []}],
+            )
+        ]
+    )
+
+    with mock.patch(
+        "litellm.responses", autospec=True, side_effect=[first_provider_response, second_provider_response]
+    ) as responses:
+        lm = dspy.LM(
+            "openai/gpt-5.3-codex",
+            model_type="responses",
+            cache=False,
+            context_management=[{"type": "compaction", "compact_threshold": 200_000}],
+        )
+        with dspy.context(experimental=True):
+            first = lm(dspy.User("Start the task."))
+            second = lm(dspy.User("Start the task."), first, dspy.User("Continue."))
+
+    assert first.compactions[0].content == "opaque"
+    assert first.compactions[0].encrypted is True
+    assert second.text == "Second answer."
+    assert responses.call_args_list[1].kwargs["input"] == [
+        {"role": "user", "content": [{"type": "input_text", "text": "Start the task."}]},
+        {"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+        {"role": "assistant", "content": [{"type": "output_text", "text": "First answer."}]},
+        {"role": "user", "content": [{"type": "input_text", "text": "Continue."}]},
+    ]
+    assert responses.call_args_list[1].kwargs["context_management"] == [
+        {"type": "compaction", "compact_threshold": 200_000}
+    ]
+
+
+def test_typed_lm_replays_anthropic_native_compaction_block():
+    first_provider_response = ModelResponse(
+        model="claude-opus-4-6",
+        choices=[
+            Choices(
+                index=0,
+                finish_reason="stop",
+                message=Message(
+                    content="First answer.",
+                    provider_specific_fields={
+                        "compaction_blocks": [{"type": "compaction", "content": "Conversation summary."}]
+                    },
+                ),
+            )
+        ],
+    )
+    second_provider_response = ModelResponse(
+        model="claude-opus-4-6",
+        choices=[Choices(index=0, finish_reason="stop", message=Message(content="Second answer."))],
+    )
+
+    with mock.patch(
+        "litellm.completion", autospec=True, side_effect=[first_provider_response, second_provider_response]
+    ) as completion:
+        lm = dspy.LM(
+            "anthropic/claude-opus-4-6",
+            cache=False,
+            context_management=[{"type": "compaction", "compact_threshold": 150_000}],
+        )
+        with dspy.context(experimental=True):
+            first = lm(dspy.User("Start the task."))
+            second = lm(dspy.User("Start the task."), first, dspy.User("Continue."))
+
+    assert first.compactions[0].content == "Conversation summary."
+    assert first.compactions[0].encrypted is False
+    assert second.text == "Second answer."
+    assert completion.call_args_list[1].kwargs["messages"] == [
+        {"role": "user", "content": "Start the task."},
+        {
+            "role": "assistant",
+            "content": "First answer.",
+            "provider_specific_fields": {
+                "compaction_blocks": [{"type": "compaction", "content": "Conversation summary."}]
+            },
+        },
+        {"role": "user", "content": "Continue."},
+    ]
+    assert completion.call_args_list[1].kwargs["context_management"] == [
+        {"type": "compaction", "compact_threshold": 150_000}
+    ]

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -16,6 +16,7 @@ from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response_reasoning_item import Summary
 
 import dspy
+from dspy.core.types import LMCompactionPart, LMOutput, LMResponse
 from dspy.utils.usage_tracker import track_usage
 
 
@@ -2212,8 +2213,9 @@ def test_typed_lm_replays_openai_native_compaction_state():
             first = lm(dspy.User("Start the task."))
             second = lm(dspy.User("Start the task."), first, dspy.User("Continue."))
 
-    assert first.compactions[0].content == "opaque"
-    assert first.compactions[0].encrypted is True
+    assert first.compactions[0].content is None
+    assert first.compactions[0].provider_name == "openai"
+    assert first.compactions[0].provider_data["encrypted_content"] == "opaque"
     assert second.text == "Second answer."
     assert responses.call_args_list[1].kwargs["input"] == [
         {"role": "user", "content": [{"type": "input_text", "text": "Start the task."}]},
@@ -2260,7 +2262,7 @@ def test_typed_lm_replays_anthropic_native_compaction_block():
             second = lm(dspy.User("Start the task."), first, dspy.User("Continue."))
 
     assert first.compactions[0].content == "Conversation summary."
-    assert first.compactions[0].encrypted is False
+    assert first.compactions[0].provider_name == "anthropic"
     assert second.text == "Second answer."
     assert completion.call_args_list[1].kwargs["messages"] == [
         {"role": "user", "content": "Start the task."},
@@ -2276,3 +2278,38 @@ def test_typed_lm_replays_anthropic_native_compaction_block():
     assert completion.call_args_list[1].kwargs["context_management"] == [
         {"type": "compaction", "compact_threshold": 150_000}
     ]
+
+
+@pytest.mark.parametrize(
+    ("model", "model_type", "transport", "compaction"),
+    [
+        (
+            "openai/gpt-5.3-codex",
+            "responses",
+            "litellm.responses",
+            LMCompactionPart(
+                provider_name="anthropic",
+                content="Conversation summary.",
+                provider_data={"type": "compaction", "content": "Conversation summary."},
+            ),
+        ),
+        (
+            "anthropic/claude-opus-4-6",
+            "chat",
+            "litellm.completion",
+            LMCompactionPart(
+                provider_name="openai",
+                provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+            ),
+        ),
+    ],
+)
+def test_typed_lm_rejects_compaction_from_another_provider(model, model_type, transport, compaction):
+    response = LMResponse(outputs=[LMOutput(parts=[compaction])])
+    lm = dspy.LM(model, model_type=model_type, cache=False)
+
+    with mock.patch(transport, autospec=True) as completion:
+        with dspy.context(experimental=True), pytest.raises(ValueError, match="cannot be sent"):
+            lm(dspy.User("Start the task."), response, dspy.User("Continue."))
+
+    completion.assert_not_called()

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -451,17 +451,64 @@ def test_output_to_value_preserves_redacted_thinking_part():
     assert output.to_value() == [thinking]
 
 
-def test_response_serialization_preserves_native_compaction_state():
-    compaction = LMCompactionPart(
-        content="opaque",
-        encrypted=True,
-        provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
-    )
+@pytest.mark.parametrize(
+    "compaction",
+    [
+        LMCompactionPart(
+            provider_name="openai",
+            provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+        ),
+        LMCompactionPart(
+            provider_name="anthropic",
+            content="Conversation summary.",
+            provider_data={"type": "compaction", "content": "Conversation summary."},
+        ),
+    ],
+)
+def test_response_serialization_preserves_native_compaction_state(compaction):
     response = LMResponse(model="model", outputs=[LMOutput(parts=[compaction])])
 
     restored = LMResponse.model_validate(response.model_dump())
 
     assert restored.compactions == [compaction]
+
+
+@pytest.mark.parametrize(
+    "compaction",
+    [
+        LMCompactionPart(
+            provider_name="openai",
+            provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+        ),
+        LMCompactionPart(
+            provider_name="anthropic",
+            content="Conversation summary.",
+            provider_data={"type": "compaction", "content": "Conversation summary."},
+        ),
+    ],
+)
+def test_response_legacy_outputs_omit_provider_compaction_state(compaction):
+    response = LMResponse(outputs=[LMOutput(parts=[compaction, LMTextPart(text="answer")])])
+
+    assert response.to_outputs() == ["answer"]
+
+
+def test_provider_compaction_round_trips_through_history_messages():
+    compaction = LMCompactionPart(
+        provider_name="openai",
+        provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+    )
+    content = _history_entry(LMMessage(role="assistant", parts=[compaction])).messages[0]["content"][0]
+
+    restored = LMMessage(role="assistant", content=[content]).parts[0]
+
+    assert content == {
+        "type": "compaction",
+        "id": "cmp_1",
+        "encrypted_content": "opaque",
+        "provider_name": "openai",
+    }
+    assert restored == compaction
 
 
 def test_stream_event_indices_must_be_non_negative():

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -6,6 +6,7 @@ import pytest
 from dspy.core.types import (
     LMAudioPart,
     LMBinaryPart,
+    LMCompactionPart,
     LMConfig,
     LMDocumentPart,
     LMHistoryEntry,
@@ -448,6 +449,19 @@ def test_output_to_value_preserves_redacted_thinking_part():
     output = LMOutput(parts=[thinking])
 
     assert output.to_value() == [thinking]
+
+
+def test_response_serialization_preserves_native_compaction_state():
+    compaction = LMCompactionPart(
+        content="opaque",
+        encrypted=True,
+        provider_data={"type": "compaction", "id": "cmp_1", "encrypted_content": "opaque"},
+    )
+    response = LMResponse(model="model", outputs=[LMOutput(parts=[compaction])])
+
+    restored = LMResponse.model_validate(response.model_dump())
+
+    assert restored.compactions == [compaction]
 
 
 def test_stream_event_indices_must_be_non_negative():


### PR DESCRIPTION
## 📝 Changes Description

This PR gives DSPy one compacted-history shape:

```python
History(
    compaction: str | LMCompactionPart | None,
    messages=[...recent signature-shaped turns...],
)
```

`compaction` is top-level state, so `History`'s normal signature-field filtering cannot discard it. Its two values preserve the distinction between portable summaries and provider-owned continuation state:

### Portable text compaction

```python
history = dspy.History(
    compaction="The user chose PostgreSQL and migrations are pending.",
    messages=[...recent signature-shaped turns...],
)
```

Adapters render a string before retained turns as ordinary user context:

```text
Here is a summary of the conversation to date:

{compaction}
```

This follows the common non-native scheme of replacing an old prefix with a user summary and retaining a recent suffix. It can produce adjacent user messages when the retained suffix begins with a user turn; providers and frameworks normally merge or accept that shape.

### Provider-native compaction

Provider compaction is returned as `LMCompactionPart` on typed LM responses and can be placed directly into `History`:

```python
lm = dspy.LM(
    "openai/gpt-5.3-codex",
    model_type="responses",
    context_management=[
        {"type": "compaction", "compact_threshold": 200_000},
    ],
)

with dspy.context(experimental=True):
    first = lm(dspy.User("Start the task."))

history = dspy.History(
    compaction=first.compactions[-1],
    messages=[...recent signature-shaped turns...],
)
```

The adapter inserts the typed part at the compacted-history boundary. The LM client then restores the provider's actual wire representation:

- OpenAI's opaque, role-less Responses compaction item remains encrypted provider data.
- Anthropic's readable compaction block remains assistant content.
- Cross-provider replay is rejected rather than silently converting provider state to text.

The same OpenAI-shaped `context_management=[...]` setting works for both providers: LiteLLM maps it to Anthropic's native `compact_20260112` edit.

Additional behavior:

- Typed responses, serialized `LMResponse`s, `History`, and `LMHistoryEntry.messages` preserve provider compaction losslessly.
- Legacy string outputs omit provider-only compaction parts.
- `inspect_history()` displays readable summaries and labels opaque state without printing encrypted content.
- `History(compaction=None, messages=...)` keeps the previous serialized shape.
- This PR defines representation and replay, not an automatic `_compact_if_needed` policy.

## Why one union field?

Both values occupy the same semantic slot: a replacement for the omitted history prefix. A union makes it impossible to set a portable summary and native state simultaneously.

They intentionally render differently. A string is model-readable, provider-independent application context. An `LMCompactionPart` is provider-owned state and may be opaque. Converting a string into `LMCompactionPart` would invent a provider identity; flattening native state into a string would lose or leak OpenAI's encrypted payload.

Ownership remains separated:

- `History` stores the compacted prefix and retained signature-shaped suffix.
- Adapters place the compacted prefix relative to recent turns.
- LM clients serialize native parts and enforce provider/endpoint compatibility.

## References

- [OpenAI compaction guide](https://developers.openai.com/api/docs/guides/compaction): compaction is an opaque standalone Responses item; append it as provider output or use the compacted output as the next canonical context window.
- [Anthropic compaction guide](https://platform.claude.com/docs/en/build-with-claude/compaction): compaction is a readable block at the start of an assistant response and must be passed back in that assistant content.
- [LiteLLM context-management guide](https://docs.litellm.ai/docs/claude_code_context_management): maps the common OpenAI compaction setting to Anthropic's edit shape and preserves returned compaction blocks for subsequent turns.
- [LangChain summarization middleware](https://github.com/langchain-ai/langchain/blob/master/libs/langchain_v1/langchain/agents/middleware/summarization.py): replaces the summarized prefix with `HumanMessage("Here is a summary...")` followed by preserved recent messages.
- [Pydantic AI message history](https://ai.pydantic.dev/message-history/): history processors replace old history with summarized messages plus a retained suffix; provider-valid history remains typed and serializable.
- [Pydantic AI `CompactionPart`](https://github.com/pydantic/pydantic-ai/blob/main/pydantic_ai_slim/pydantic_ai/messages.py#L1981-L2029): precedent for retaining provider-specific compaction as a typed history part rather than flattening it into ordinary text.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing locally
- [x] Title follows the required format
- [x] Commit messages follow `{label}(dspy): {message}`

## 🧪 Validation

- Live OpenAI Responses smoke test with `openai/gpt-5.3-codex`: the first call emitted opaque native compaction, the latest `LMCompactionPart` was assigned to `History.compaction`, and a subsequent `Predict` call recovered the compacted codeword `COBALT`. The encrypted payload's SHA-256 matched between the first response and second provider request, proving lossless replay.
- `uv run --frozen pytest --deno tests/adapters -q` — 280 passed
- `uv run --frozen pytest --deno tests/core/test_types.py tests/clients/test_inspect_global_history.py tests/clients/test_disk_serialization.py -q` — 62 passed
- `uv run --frozen pytest --deno tests/clients/test_lm.py -q` — 83 passed, 8 skipped
- Ruff lint on all touched files
- `git diff --check`

## ⚠️ Warnings

The typed direct-call API used to obtain and continue an `LMResponse` is experimental. Provider compaction is enabled through the upstream `context_management` API.

