### PR TITLE
fix(primitives): prevent named_parameters()/named_sub_modules() dict-key collisions

### DIFF
--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -20,9 +20,15 @@ class BaseModule:
     def __init__(self):
         pass
 
-    def named_parameters(self):
+    def _traverse_parameters(self, dict_key_name):
         """
-        Unlike PyTorch, handles (non-recursive) lists of parameters too.
+        Shared traversal behind named_parameters(): walks self.__dict__ collecting Parameters,
+        recursing into dspy.Module attributes and (non-recursive) lists/tuples/dicts.
+
+        `dict_key_name(name, key)` builds the parameter name for a dict-valued attribute's entry;
+        it's a hook so load_state() can re-run this traversal with the pre-#1302 naming scheme
+        (see https://github.com/stanfordnlp/dspy/issues/1302) to locate parameters in state files
+        saved by older DSPy versions.
         """
 
         import dspy
@@ -40,7 +46,7 @@ class BaseModule:
             elif isinstance(param_value, dspy.Module):
                 # When a sub-module is pre-compiled, keep it frozen.
                 if not getattr(param_value, "_compiled", False):
-                    for sub_name, param in param_value.named_parameters():
+                    for sub_name, param in param_value._traverse_parameters(dict_key_name):
                         add_parameter(f"{param_name}.{sub_name}", param)
 
         if isinstance(self, Parameter):
@@ -53,7 +59,7 @@ class BaseModule:
             elif isinstance(value, dspy.Module):
                 # When a sub-module is pre-compiled, keep it frozen.
                 if not getattr(value, "_compiled", False):
-                    for sub_name, param in value.named_parameters():
+                    for sub_name, param in value._traverse_parameters(dict_key_name):
                         add_parameter(f"{name}.{sub_name}", param)
 
             elif isinstance(value, (list, tuple)):
@@ -62,9 +68,15 @@ class BaseModule:
 
             elif isinstance(value, dict):
                 for key, item in value.items():
-                    add_parameter(f"{name}[{key!r}]", item)
+                    add_parameter(dict_key_name(name, key), item)
 
         return named_parameters
+
+    def named_parameters(self):
+        """
+        Unlike PyTorch, handles (non-recursive) lists of parameters too.
+        """
+        return self._traverse_parameters(lambda name, key: f"{name}[{key!r}]")
 
     def named_sub_modules(self, type_=None, skip_compiled=False) -> Generator[tuple[str, "BaseModule"], None, None]:
         """Find all sub-modules in the module, as well as their names.
@@ -160,16 +172,25 @@ class BaseModule:
         from dspy import Module
 
         def _apply(module):
-            for name, param in module.named_parameters():
-                try:
+            # Also traverse with the pre-#1302 dict-key naming (always-quoted, e.g. "d['0']" for both
+            # str and int keys) so state saved by an older DSPy version can still be loaded: only
+            # non-string dict keys ever differ between the two names, so this is a no-op fallback for
+            # everything else.
+            legacy_names = [
+                legacy_name for legacy_name, _ in module._traverse_parameters(lambda name, key: f"{name}['{key}']")
+            ]
+            for (name, param), legacy_name in zip(module.named_parameters(), legacy_names, strict=True):
+                if name in state:
                     param_state = state[name]
-                except KeyError as e:
+                elif legacy_name in state:
+                    param_state = state[legacy_name]
+                else:
                     raise KeyError(
-                        f"{e}. If this state was saved by a DSPy version older than the one that fixed "
+                        f"'{name}'. If this state was saved by a DSPy version older than the one that fixed "
                         "https://github.com/stanfordnlp/dspy/issues/1302, and a dict-valued module "
-                        "attribute uses a non-string key (e.g. an int or tuple), note the persisted "
-                        "parameter name for such keys changed there."
-                    ) from e
+                        "attribute uses a non-string key (e.g. an int or tuple), the pre-fix name "
+                        f"('{legacy_name}') was also not found in the saved state."
+                    )
                 if isinstance(param, Module):
                     param.load_state(param_state, allow_unsafe_lm_state=allow_unsafe_lm_state)
                 else:
@@ -177,6 +198,7 @@ class BaseModule:
 
         _apply(self.deepcopy())  # trial run raises before self is touched
         _apply(self)
+
     def save(self, path, save_program=False, modules_to_serialize=None):
         """Save the module.
 
@@ -219,8 +241,10 @@ class BaseModule:
             if not path.exists():
                 # Create the directory (and any parent directories)
                 path.mkdir(parents=True)
-            logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
-                          'this, prefer saving using json format using module.save("module.json").')
+            logger.warning(
+                "Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
+                'this, prefer saving using json format using module.save("module.json").'
+            )
             try:
                 modules_to_serialize = modules_to_serialize or []
                 for module in modules_to_serialize:
@@ -251,8 +275,10 @@ class BaseModule:
                     "with `.pkl`, or saving the whole program by setting `save_program=True`."
                 )
         elif path.suffix == ".pkl":
-            logger.warning("Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
-                          'this, prefer saving using json format using module.save("module.json").')
+            logger.warning(
+                "Loading untrusted .pkl files can run arbitrary code, which may be dangerous. To avoid "
+                'this, prefer saving using json format using module.save("module.json").'
+            )
             state = self.dump_state(json_mode=False)
             state["metadata"] = metadata
             with open(path, "wb") as f:
@@ -279,9 +305,11 @@ class BaseModule:
                 state = orjson.loads(f.read())
         elif path.suffix == ".pkl":
             if not allow_pickle:
-                raise ValueError("Loading .pkl files can run arbitrary code, which may be dangerous. Prefer "
-                                 "saving with .json files if possible. Set `allow_pickle=True` "
-                                 "if you are sure about the source of the file and in a trusted environment.")
+                raise ValueError(
+                    "Loading .pkl files can run arbitrary code, which may be dangerous. Prefer "
+                    "saving with .json files if possible. Set `allow_pickle=True` "
+                    "if you are sure about the source of the file and in a trusted environment."
+                )
             with open(path, "rb") as f:
                 state = cloudpickle.load(f)
         else:

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -62,7 +62,7 @@ class BaseModule:
 
             elif isinstance(value, dict):
                 for key, item in value.items():
-                    add_parameter(f"{name}['{key}']", item)
+                    add_parameter(f"{name}[{key!r}]", item)
 
         return named_parameters
 
@@ -102,7 +102,7 @@ class BaseModule:
 
             elif isinstance(item, dict):
                 for key, sub_item in item.items():
-                    add_to_queue(f"{name}[{key}]", sub_item)
+                    add_to_queue(f"{name}[{key!r}]", sub_item)
 
     def parameters(self):
         return [param for _, param in self.named_parameters()]

--- a/dspy/primitives/base_module.py
+++ b/dspy/primitives/base_module.py
@@ -161,10 +161,19 @@ class BaseModule:
 
         def _apply(module):
             for name, param in module.named_parameters():
+                try:
+                    param_state = state[name]
+                except KeyError as e:
+                    raise KeyError(
+                        f"{e}. If this state was saved by a DSPy version older than the one that fixed "
+                        "https://github.com/stanfordnlp/dspy/issues/1302, and a dict-valued module "
+                        "attribute uses a non-string key (e.g. an int or tuple), note the persisted "
+                        "parameter name for such keys changed there."
+                    ) from e
                 if isinstance(param, Module):
-                    param.load_state(state[name], allow_unsafe_lm_state=allow_unsafe_lm_state)
+                    param.load_state(param_state, allow_unsafe_lm_state=allow_unsafe_lm_state)
                 else:
-                    param.load_state(state[name])
+                    param.load_state(param_state)
 
         _apply(self.deepcopy())  # trial run raises before self is touched
         _apply(self)

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -201,12 +201,14 @@ def test_named_parameters_dict_keys_do_not_collide():
     assert "dict_a[0]" in names
 
 
-def test_load_state_raises_clear_error_for_pre_fix_dict_key_names():
+def test_load_state_accepts_pre_fix_dict_key_names():
     """
-    Loading a state saved by a DSPy version before the #1302 fix, for a dict-valued attribute with
-    a non-string key, must fail loudly with a clear message rather than a bare KeyError - matching
-    the existing "fail-fast, no partial corruption" design (see test_load_state_is_transactional,
-    regression test for #9589).
+    Backward-compatibility regression test for https://github.com/stanfordnlp/dspy/issues/1302.
+
+    State saved by a DSPy version before the #1302 fix quoted dict keys as if they were strings
+    (e.g. an int key 0 was persisted as "dict_a['0']" instead of the current "dict_a[0]").
+    load_state() must still restore such state after upgrading, not merely fail with a clearer
+    error - old save files must keep working.
     """
 
     class Prog(Module):
@@ -215,12 +217,28 @@ def test_load_state_raises_clear_error_for_pre_fix_dict_key_names():
             self.dict_a = {0: dspy.Predict("question -> answer")}
 
     prog = Prog()
-    # Simulate a pre-fix save: the old code always quoted dict keys, so an int key 0 was persisted
-    # as "dict_a['0']" instead of the current "dict_a[0]".
-    state = {"dict_a['0']": prog.dict_a[0].dump_state()}
+    legacy_state = {"dict_a['0']": prog.dict_a[0].dump_state()}
+
+    prog.load_state(legacy_state)  # must not raise
+
+
+def test_load_state_raises_clear_error_when_name_missing_in_both_formats():
+    """
+    A parameter missing under BOTH its current name and its pre-#1302 legacy name is a genuine
+    problem (not just an old save format) and must still fail loudly - matching the existing
+    "fail-fast, no partial corruption" design (see test_load_state_is_transactional, regression
+    test for #9589).
+    """
+
+    class Prog(Module):
+        def __init__(self):
+            super().__init__()
+            self.dict_a = {0: dspy.Predict("question -> answer")}
+
+    prog = Prog()
 
     with pytest.raises(KeyError, match="issues/1302"):
-        prog.load_state(state)
+        prog.load_state({})
 
 
 def test_named_sub_modules_dict_keys_do_not_collide():
@@ -253,6 +271,7 @@ def test_load_dspy_program_cross_version():
 
     assert len(loaded_react.react.demos) == 2
     assert len(loaded_react.extract.predict.demos) == 2
+
 
 def test_load_state_is_transactional():
     """
@@ -291,6 +310,4 @@ def test_load_state_is_transactional():
         with pytest.raises(KeyError):
             template.load(str(path))
 
-        assert template.a.predict.demos == [], (
-            "load_state partially mutated module before failing"
-        )
+        assert template.a.predict.demos == [], "load_state partially mutated module before failing"

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -114,7 +114,7 @@ def test_complex_module_traversal():
         "self",
         "self.sub_module",
         "self.sub_module.nested_list[0]",
-        "self.sub_module.nested_list[1][key]",
+        "self.sub_module.nested_list[1]['key']",
         "self.sub_module.nested_tuple[0]",
         "self.sub_module.nested_tuple[1][0]",
         "self.sub_module.nested_tuple[1][1]",
@@ -136,7 +136,7 @@ def test_complex_module_traversal_with_same_module():
         "self",
         "self.sub_module",
         "self.sub_module.nested_list[0]",
-        "self.sub_module.nested_list[1][key]",  # NOTE: named_sub_modules allows recursive structures
+        "self.sub_module.nested_list[1]['key']",  # NOTE: named_sub_modules allows recursive structures
         "self.sub_module.nested_tuple[0]",
         "self.sub_module.nested_tuple[1][0]",  # NEW: named_sub_modules allows recursive structures, but named_parameters does not
     }
@@ -181,6 +181,35 @@ def test_named_parameters_duplicate_references():
     # Only testing for whether exceptions are thrown or not
     # As Module.named_parameters() is recursive, this is mainly for catching infinite recursion
     module.named_parameters()
+
+
+def test_named_parameters_dict_keys_do_not_collide():
+    """
+    Regression test for https://github.com/stanfordnlp/dspy/issues/1302
+
+    Dict keys that stringify to the same text but differ in type/value (e.g. "0" vs 0) must not
+    be collapsed into the same parameter name, or distinct parameters silently merge/get lost.
+    """
+    from dspy.predict.parameter import Parameter
+
+    module = Module()
+    module.dict_a = {"0": Parameter(), 0: Parameter()}
+
+    names = [name for name, _ in module.named_parameters()]
+    assert len(names) == len(set(names)) == 2
+    assert "dict_a['0']" in names
+    assert "dict_a[0]" in names
+
+
+def test_named_sub_modules_dict_keys_do_not_collide():
+    """Regression test for https://github.com/stanfordnlp/dspy/issues/1302 (named_sub_modules side)."""
+    module = Module()
+    module.dict_b = {"0": Module(), 0: Module()}
+
+    names = [name for name, _ in module.named_sub_modules()]
+    assert len(names) == len(set(names))
+    assert "self.dict_b['0']" in names
+    assert "self.dict_b[0]" in names
 
 
 def test_load_dspy_program_cross_version():

--- a/tests/primitives/test_module.py
+++ b/tests/primitives/test_module.py
@@ -201,6 +201,28 @@ def test_named_parameters_dict_keys_do_not_collide():
     assert "dict_a[0]" in names
 
 
+def test_load_state_raises_clear_error_for_pre_fix_dict_key_names():
+    """
+    Loading a state saved by a DSPy version before the #1302 fix, for a dict-valued attribute with
+    a non-string key, must fail loudly with a clear message rather than a bare KeyError - matching
+    the existing "fail-fast, no partial corruption" design (see test_load_state_is_transactional,
+    regression test for #9589).
+    """
+
+    class Prog(Module):
+        def __init__(self):
+            super().__init__()
+            self.dict_a = {0: dspy.Predict("question -> answer")}
+
+    prog = Prog()
+    # Simulate a pre-fix save: the old code always quoted dict keys, so an int key 0 was persisted
+    # as "dict_a['0']" instead of the current "dict_a[0]".
+    state = {"dict_a['0']": prog.dict_a[0].dump_state()}
+
+    with pytest.raises(KeyError, match="issues/1302"):
+        prog.load_state(state)
+
+
 def test_named_sub_modules_dict_keys_do_not_collide():
     """Regression test for https://github.com/stanfordnlp/dspy/issues/1302 (named_sub_modules side)."""
     module = Module()


### PR DESCRIPTION
## 📝 Changes Description

`Module.named_parameters()` and `Module.named_sub_modules()` build dotted parameter/sub-module names for dict-valued attributes by interpolating the dict key directly into an f-string (`named_parameters` always wraps it in literal single-quotes; `named_sub_modules` doesn't quote it at all). Neither distinguishes key type, so keys that share a string representation but differ in type or value collide onto the same name:

```python
module.dict_a = {"0": Parameter(), 0: Parameter(), ("0", 0): Parameter()}
[name for name, _ in module.named_parameters()]
# ["dict_a['0']", "dict_a['0']", "dict_a['('0', 0)']"]   <- first two collide, third is unparseable
```

This is silent: two distinct parameters end up under the same name, which every optimizer that walks `named_parameters()` relies on to be unique.

**Fix**: use `repr(key)` in both functions instead of ad-hoc string interpolation. This:
- Distinguishes key type (`repr("0") == "'0'"` vs `repr(0) == "0"`), eliminating the collision.
- Produces valid Python literal syntax that `set_attribute_by_name`'s AST-based parser (`dspy/utils/magicattr.py`) can actually consume.
- Brings `named_sub_modules`'s dict-key formatting in line with `named_parameters`'s (previously inconsistent between the two) and with `named_sub_modules`'s own docstring, which already documented quoted string keys (`children[4]['key'].sub_module`).

Updated the two existing `named_sub_modules` tests whose expected names encoded the old unquoted format, and added regression tests for the collision itself in both functions.

Fixes #1302.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format `fix: ...`

## ⚠️ Warnings

Tuple-typed dict keys now produce syntactically valid output (e.g. `dict_a[('0', 0)]`) instead of the previous broken nested-quote string, but full round-trip support via `set_attribute_by_name`/`magicattr` for tuple-subscript keys is a separate, pre-existing limitation (its AST-based parser doesn't yet handle `ast.Tuple` subscripts) — out of scope here since it's a distinct concern from the collision this PR fixes, and not part of what #1302 reports.

## Testing

- Reverted the fix locally and reproduced the exact reported collision (`git stash` + rerun) before reapplying it.
- `uv run pytest tests/primitives/test_module.py -q`: 18 passed.
- `uv run pytest tests/ -q` (full suite, minus three unrelated pre-existing environment failures confirmed present on unmodified `main` too: a Windows temp-file permission issue, a `websockets`-dependent litellm-proxy test, and a Windows CRLF snapshot-fixture mismatch): all passing.