### PR TITLE
fix(signatures): raise clear error for field names that shadow SignatureMeta properties

### DIFF
--- a/dspy/signatures/signature.py
+++ b/dspy/signatures/signature.py
@@ -184,6 +184,14 @@ class SignatureMeta(type(BaseModel)):
         # Let Pydantic do its thing
         cls = super().__new__(mcs, signature_name, bases, namespace, **kwargs)
 
+        # Ensure all fields are declared with InputField or OutputField. This must run before
+        # any code below that reads `field.json_schema_extra` (e.g. via input_fields/output_fields),
+        # since a field whose name collides with a SignatureMeta property (e.g. `instructions`)
+        # gets a plain pydantic FieldInfo with json_schema_extra=None instead of the one from
+        # InputField()/OutputField() - which would otherwise surface as an opaque internal
+        # TypeError instead of this validation's clear message.
+        cls._validate_fields()
+
         # If we don't have instructions, it might be because we are a derived generic type.
         # In that case, we should inherit the instructions from the base class.
         if cls.__doc__ is None:
@@ -197,9 +205,6 @@ class SignatureMeta(type(BaseModel)):
         # In that case, we should default to the input/output format.
         if cls.__doc__ is None:
             cls.__doc__ = _default_instructions(cls)
-
-        # Ensure all fields are declared with InputField or OutputField
-        cls._validate_fields()
 
         # Ensure all fields have a prefix
         for name, field in cls.model_fields.items():

--- a/tests/signatures/test_signature.py
+++ b/tests/signatures/test_signature.py
@@ -41,6 +41,21 @@ def test_no_input_output2():
             input1: str = pydantic.Field()
 
 
+def test_field_name_shadowing_signaturemeta_property_raises_clear_error():
+    """
+    Regression test for https://github.com/stanfordnlp/dspy/issues/1710
+
+    A field name that collides with a SignatureMeta property (e.g. `instructions`) must raise
+    the existing `_validate_fields` TypeError, not crash with an opaque internal TypeError from
+    `_get_fields_with_type` deep inside `input_fields`/`output_fields`.
+    """
+    with pytest.raises(TypeError, match="must be declared with InputField or OutputField"):
+
+        class TestSignature(Signature):
+            instructions: str = InputField()
+            answer: str = OutputField()
+
+
 def test_all_fields_have_prefix():
     class TestSignature(Signature):
         input = InputField(prefix="Modified:")


### PR DESCRIPTION
## 📝 Changes Description

Declaring a `Signature` field whose name collides with a `SignatureMeta` property (e.g. `instructions`, the metaclass property used to read/write the docstring) crashes signature class construction with an opaque internal error instead of a clear validation message:

```python
class MySig(dspy.Signature):
    instructions: str = dspy.InputField()
    answer: str = dspy.OutputField()
# TypeError: 'NoneType' object is not subscriptable
```

**Root cause**: Pydantic detects the name collision itself (it emits its own `UserWarning: Field name "instructions" ... shadows an attribute in parent "Signature"`) and, for that field only, produces a plain `FieldInfo` with `json_schema_extra=None` instead of preserving the `InputField()`/`OutputField()` instance from the class body. `SignatureMeta` already has validation for exactly this shape of problem — `_validate_fields()` raises a clear `TypeError` when a field's `json_schema_extra` doesn't carry the expected `__dspy_field_type` key — but it ran too late in `__new__`: when no docstring is given, `_default_instructions(cls)` runs first, which calls `cls.input_fields` → `_get_fields_with_type()`, which indexes `json_schema_extra` directly and crashes before `_validate_fields()` ever gets a chance to run.

**Fix**: move the existing `_validate_fields()` call to run immediately after Pydantic builds the class, before anything reads `json_schema_extra`. No new validation logic — just correct ordering of what was already there. After the fix:

```
TypeError: Field `instructions` in `MySig` must be declared with InputField or OutputField, but field `instructions` has `field.json_schema_extra=None`
```

Fixes #1710.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format `fix(signatures): ...`

## ⚠️ Warnings

None — this only changes the order of two pre-existing steps in `SignatureMeta.__new__`; no new validation logic was added, so behavior for non-colliding field names (the common case) is unchanged.

## Testing

- Reverted the fix locally and reproduced the exact reported `TypeError: 'NoneType' object is not subscriptable` before reapplying it.
- Added a regression test asserting the clear `_validate_fields` error is now raised instead.
- `uv run pytest tests/signatures/ tests/primitives/ -q`: 172 passed (6 deselected pre-existing Windows temp-file-permission failures, confirmed present on unmodified `main` too and unrelated to signature construction).
- `uv run pytest tests/ -q` (full suite, minus pre-existing environment failures — see companion PR #10241 for the same three confirmed-pre-existing exclusions): all passing.