### PR TITLE
fix(gepa): align GEPA auto budget with evaluation costs

### DIFF
--- a/docs/docs/diving-deeper/gepa-in-depth.md
+++ b/docs/docs/diving-deeper/gepa-in-depth.md
@@ -54,7 +54,7 @@ When `track_stats=True`, the compiled program’s `detailed_results` carries eve
 
 ### 12. Reflection LM cost dominates if you’re not careful
 
-A `medium` budget on a 2-predictor / 100-example task means ~12 mutations, each spawning 1–3 reflection calls depending on minibatch size and number of components — so ~12–36 calls to `reflection_lm`. With `gpt-4o` reflecting and `gpt-4o-mini` running the program, reflection often costs more than evaluation. Budget accordingly.
+A `medium` budget reserves full-validation capacity for 12 accepted candidates, but the actual number of mutations depends on how often proposals pass the minibatch acceptance check. Each mutation invokes the reflection model for the selected components. With `gpt-4o` reflecting and `gpt-4o-mini` running the program, reflection often costs more than evaluation. Budget accordingly.
 
 ## API walkthrough
 
@@ -74,7 +74,7 @@ Runs the search. `valset` defaults to `trainset` when not provided. Returns a fr
 How a budget number turns into LM calls.
 
 **`auto`** — light / medium / heavy preset
-Maps to `num_candidates = 6 / 12 / 18` and derives the metric-call budget from your valset size. The conversion accounts for the initial full eval, bootstrapping (`5 × num_candidates`), per-candidate minibatch evals, and periodic full evals every 5 steps. On a 2-predictor / 100-example task: light ≈ 1330 calls, medium ≈ 1740, heavy ≈ 2045.
+Maps to `num_candidates = 6 / 12 / 18` and derives the metric-call budget from the validation-set size, `reflection_minibatch_size`, number of program components, and enabled merge attempts. The conversion accounts for the initial full validation, both parent and child minibatch evaluations in each reflective trial, full validation of accepted candidates, and merge screening plus validation. It is an allocation rather than an exact prediction: rejected proposals are cheaper because they skip full validation. With the defaults on a 2-predictor / 100-example task: light ≈ 1345 calls, medium ≈ 1993, heavy ≈ 2623.
 
 **`max_full_evals`** — pass-count budget
 Each “full eval” is one walk through the union of trainset and valset. GEPA computes `max_metric_calls = max_full_evals × (len(trainset) + len(valset))` internally.

--- a/docs/docs/diving-deeper/gepa-in-depth.md
+++ b/docs/docs/diving-deeper/gepa-in-depth.md
@@ -74,7 +74,7 @@ Runs the search. `valset` defaults to `trainset` when not provided. Returns a fr
 How a budget number turns into LM calls.
 
 **`auto`** — light / medium / heavy preset
-Maps to `num_candidates = 6 / 12 / 18` and derives the metric-call budget from the validation-set size, `reflection_minibatch_size`, number of program components, and enabled merge attempts. The conversion accounts for the initial full validation, both parent and child minibatch evaluations in each reflective trial, full validation of accepted candidates, and merge screening plus validation. It is an allocation rather than an exact prediction: rejected proposals are cheaper because they skip full validation. With the defaults on a 2-predictor / 100-example task: light ≈ 1345 calls, medium ≈ 1993, heavy ≈ 2623.
+Maps to `num_candidates = 6 / 12 / 18` and derives the metric-call budget from the validation-set size, `reflection_minibatch_size`, number of program components, and enabled merge attempts. The conversion accounts for the initial full validation, both parent and child minibatch evaluations in each reflective trial, full validation of accepted candidates, and merge screening plus validation. It is an allocation rather than an exact prediction: rejected proposals are cheaper because they skip full validation. With a custom batch sampler, auto mode uses its `minibatch_size` attribute when available; otherwise it falls back to the legacy estimate of 35 and logs a warning. With the defaults on a 2-predictor / 100-example task: light ≈ 1345 calls, medium ≈ 1993, heavy ≈ 2623.
 
 **`max_full_evals`** — pass-count budget
 Each “full eval” is one walk through the union of trainset and valset. GEPA computes `max_metric_calls = max_full_evals × (len(trainset) + len(valset))` internally.

--- a/docs/docs/getting-started/gepa-optimization.md
+++ b/docs/docs/getting-started/gepa-optimization.md
@@ -78,7 +78,7 @@ When optimizing smaller models, it’s worthwhile to use a larger model as the `
 
 In addition to a `reflection_lm`, we set our metric and number of threads. For now we’re using two, but depending on your inference provider you may have to tweak this to avoid any rate limits.
 
-The `auto` argument sets our budget. `auto="light"` evaluates around six candidate prompts before stopping. `"medium"` and `"heavy"` options go further, and our GEPA deep dive covers additional levers we can set.
+The `auto` argument sets our budget. `auto="light"` reserves full-validation capacity for around six accepted candidate prompts. Rejected proposals are cheaper and may allow additional exploration. `"medium"` and `"heavy"` options go further, and our GEPA deep dive covers additional levers we can set.
 
 Finally, we compile our optimized program:
 

--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -507,8 +507,8 @@ class GEPA(Teleprompter):
         num_preds: int,
         num_candidates: int,
         valset_size: int,
-        reflection_minibatch_size: int,
-        max_merge_invocations: int = 0,
+        minibatch_size: int | None = None,
+        full_eval_steps: int = 5,
     ) -> int:
         """Estimate a metric-call budget for the current GEPA optimization loop.
 
@@ -524,7 +524,18 @@ class GEPA(Teleprompter):
         proposals do not consume a full validation evaluation, while custom GEPA
         sampling or evaluation policies passed through ``gepa_kwargs`` can have
         different costs.
+
+        ``minibatch_size`` retains the name used by the original public API. If
+        omitted, the effective reflection minibatch size is resolved from this
+        optimizer's configuration. ``full_eval_steps`` is retained and validated
+        for backward compatibility, but no longer affects the budget because GEPA
+        does not perform periodic full evaluations.
         """
+        reflection_minibatch_size = (
+            minibatch_size if minibatch_size is not None else self._resolve_auto_budget_minibatch_size()
+        )
+        max_merge_invocations = self.max_merge_invocations if self.use_merge else 0
+
         if num_preds < 1:
             raise ValueError("num_preds must be >= 1.")
         if num_candidates < 1:
@@ -532,7 +543,14 @@ class GEPA(Teleprompter):
         if valset_size < 0:
             raise ValueError("valset_size must be >= 0.")
         if reflection_minibatch_size < 1:
-            raise ValueError("reflection_minibatch_size must be >= 1.")
+            raise ValueError("minibatch_size must be >= 1.")
+        if full_eval_steps < 1:
+            raise ValueError("full_eval_steps must be >= 1.")
+        if max_merge_invocations is None:
+            raise ValueError(
+                "auto budget requires a concrete max_merge_invocations when merge is enabled. "
+                "Set max_merge_invocations, disable merge, or set max_metric_calls instead."
+            )
         if max_merge_invocations < 0:
             raise ValueError("max_merge_invocations must be >= 0.")
 
@@ -587,13 +605,10 @@ class GEPA(Teleprompter):
                     "auto budget requires a concrete max_merge_invocations when merge is enabled. "
                     "Set max_merge_invocations, disable merge, or set max_metric_calls instead."
                 )
-            auto_budget_minibatch_size = self._resolve_auto_budget_minibatch_size()
             self.max_metric_calls = self.auto_budget(
                 num_preds=max(num_components, 1),
                 num_candidates=AUTO_RUN_SETTINGS[self.auto]["n"],
                 valset_size=len(valset) if valset is not None else len(trainset),
-                reflection_minibatch_size=auto_budget_minibatch_size,
-                max_merge_invocations=self.max_merge_invocations if self.use_merge else 0,
             )
         elif self.max_full_evals is not None:
             self.max_metric_calls = self.max_full_evals * (len(trainset) + (len(valset) if valset is not None else 0))

--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -23,6 +23,9 @@ AUTO_RUN_SETTINGS = {
     "heavy": {"n": 18},
 }
 
+DEFAULT_REFLECTION_MINIBATCH_SIZE = 3
+LEGACY_AUTO_BUDGET_MINIBATCH_SIZE = 35
+
 # GEPA evaluates a merge candidate on up to five validation examples before
 # deciding whether to run its full validation evaluation.
 MERGE_MINIBATCH_SIZE = 5
@@ -310,6 +313,8 @@ class GEPA(Teleprompter):
             Available parameters:
             - batch_sampler: Strategy for selecting training examples. Can be a [BatchSampler](https://github.com/gepa-ai/gepa/blob/main/src/gepa/strategies/batch_sampler.py) instance or a string
               ('epoch_shuffled'). Defaults to 'epoch_shuffled'. Only valid when reflection_minibatch_size is None.
+              In auto mode, DSPy uses the sampler's `minibatch_size` attribute for budget estimation when
+              available. Otherwise, it uses the legacy estimate of 35 and logs a warning.
             - merge_val_overlap_floor: Minimum number of shared validation ids required between parents before
               attempting a merge subsample. Only relevant when using `val_evaluation_policy` other than 'full_eval'.
               Default is 5.
@@ -371,7 +376,7 @@ class GEPA(Teleprompter):
         max_full_evals: int | None = None,
         max_metric_calls: int | None = None,
         # Reflection configuration
-        reflection_minibatch_size: int = 3,
+        reflection_minibatch_size: int = DEFAULT_REFLECTION_MINIBATCH_SIZE,
         candidate_selection_strategy: Literal["pareto", "current_best"] = "pareto",
         reflection_lm: LM | None = None,
         skip_perfect_score: bool = True,
@@ -473,6 +478,30 @@ class GEPA(Teleprompter):
                 "To customize reflection behavior, pass a custom ProposalFn via the instruction_proposer parameter instead."
             )
 
+    def _resolve_auto_budget_minibatch_size(self) -> int:
+        """Resolve the minibatch-size estimate used by the automatic budget."""
+        if self.reflection_minibatch_size is not None:
+            return self.reflection_minibatch_size
+
+        batch_sampler = self.gepa_kwargs.get("batch_sampler", "epoch_shuffled")
+        if isinstance(batch_sampler, str) and batch_sampler == "epoch_shuffled":
+            return DEFAULT_REFLECTION_MINIBATCH_SIZE
+
+        sampler_minibatch_size = getattr(batch_sampler, "minibatch_size", None)
+        if (
+            isinstance(sampler_minibatch_size, int)
+            and not isinstance(sampler_minibatch_size, bool)
+            and sampler_minibatch_size > 0
+        ):
+            return sampler_minibatch_size
+
+        logger.warning(
+            "Could not infer the minibatch size from the custom GEPA batch sampler. "
+            f"Using the legacy auto-budget estimate of {LEGACY_AUTO_BUDGET_MINIBATCH_SIZE}. "
+            "Set max_metric_calls explicitly for precise budget control."
+        )
+        return LEGACY_AUTO_BUDGET_MINIBATCH_SIZE
+
     def auto_budget(
         self,
         num_preds: int,
@@ -553,21 +582,17 @@ class GEPA(Teleprompter):
 
         num_components = len(instruction_predictors) + len(flex_submodules)
         if self.auto is not None:
-            if self.reflection_minibatch_size is None:
-                raise ValueError(
-                    "auto budget requires a concrete reflection_minibatch_size. "
-                    "When using a custom batch_sampler, set max_metric_calls instead."
-                )
             if self.use_merge and self.max_merge_invocations is None:
                 raise ValueError(
                     "auto budget requires a concrete max_merge_invocations when merge is enabled. "
                     "Set max_merge_invocations, disable merge, or set max_metric_calls instead."
                 )
+            auto_budget_minibatch_size = self._resolve_auto_budget_minibatch_size()
             self.max_metric_calls = self.auto_budget(
                 num_preds=max(num_components, 1),
                 num_candidates=AUTO_RUN_SETTINGS[self.auto]["n"],
                 valset_size=len(valset) if valset is not None else len(trainset),
-                reflection_minibatch_size=self.reflection_minibatch_size,
+                reflection_minibatch_size=auto_budget_minibatch_size,
                 max_merge_invocations=self.max_merge_invocations if self.use_merge else 0,
             )
         elif self.max_full_evals is not None:

--- a/dspy/teleprompt/gepa/gepa.py
+++ b/dspy/teleprompt/gepa/gepa.py
@@ -23,6 +23,10 @@ AUTO_RUN_SETTINGS = {
     "heavy": {"n": 18},
 }
 
+# GEPA evaluates a merge candidate on up to five validation examples before
+# deciding whether to run its full validation evaluation.
+MERGE_MINIBATCH_SIZE = 5
+
 
 @experimental(version="3.0.0")
 class GEPAFeedbackMetric(Protocol):
@@ -470,35 +474,52 @@ class GEPA(Teleprompter):
             )
 
     def auto_budget(
-        self, num_preds, num_candidates, valset_size: int, minibatch_size: int = 35, full_eval_steps: int = 5
+        self,
+        num_preds: int,
+        num_candidates: int,
+        valset_size: int,
+        reflection_minibatch_size: int,
+        max_merge_invocations: int = 0,
     ) -> int:
+        """Estimate a metric-call budget for the current GEPA optimization loop.
+
+        Each reflective proposal evaluates both its parent and child on the
+        reflection minibatch. Candidates that pass the minibatch acceptance
+        check are then evaluated on the full validation set. The auto modes use
+        ``num_candidates`` as the number of such full evaluations to reserve and
+        retain the existing component-aware heuristic for the number of proposal
+        trials. Enabled merge invocations reserve their five-example screening
+        evaluation and a full validation evaluation as well.
+
+        The result is an allocation rather than an exact prediction: rejected
+        proposals do not consume a full validation evaluation, while custom GEPA
+        sampling or evaluation policies passed through ``gepa_kwargs`` can have
+        different costs.
+        """
+        if num_preds < 1:
+            raise ValueError("num_preds must be >= 1.")
+        if num_candidates < 1:
+            raise ValueError("num_candidates must be >= 1.")
+        if valset_size < 0:
+            raise ValueError("valset_size must be >= 0.")
+        if reflection_minibatch_size < 1:
+            raise ValueError("reflection_minibatch_size must be >= 1.")
+        if max_merge_invocations < 0:
+            raise ValueError("max_merge_invocations must be >= 0.")
+
         num_trials = int(max(2 * (num_preds * 2) * math.log2(num_candidates), 1.5 * num_candidates))
-        if num_trials < 0 or valset_size < 0 or minibatch_size < 0:
-            raise ValueError("num_trials, valset_size, and minibatch_size must be >= 0.")
-        if full_eval_steps < 1:
-            raise ValueError("full_eval_steps must be >= 1.")
 
-        V = valset_size
-        N = num_trials
-        M = minibatch_size
-        m = full_eval_steps
+        # The seed candidate is evaluated once on the full validation set.
+        total = valset_size
 
-        # Initial full evaluation on the default program
-        total = V
+        # A reflective proposal evaluates the parent and child on the same minibatch.
+        total += num_trials * 2 * reflection_minibatch_size
 
-        # Assume upto 5 trials for bootstrapping each candidate
-        total += num_candidates * 5
+        # Reserve full validation evaluations for the target number of accepted candidates.
+        total += num_candidates * valset_size
 
-        # N minibatch evaluations
-        total += N * M
-        if N == 0:
-            return total  # no periodic/full evals inside the loop
-        # Periodic full evals occur when trial_num % (m+1) == 0, where trial_num runs 2..N+1
-        periodic_fulls = (N + 1) // (m) + 1
-        # If 1 <= N < m, the code triggers one final full eval at the end
-        extra_final = 1 if N < m else 0
-
-        total += (periodic_fulls + extra_final) * V
+        # Each accepted merge uses a five-example screening evaluation followed by full validation.
+        total += max_merge_invocations * (MERGE_MINIBATCH_SIZE + valset_size)
         return total
 
     def compile(
@@ -532,10 +553,22 @@ class GEPA(Teleprompter):
 
         num_components = len(instruction_predictors) + len(flex_submodules)
         if self.auto is not None:
+            if self.reflection_minibatch_size is None:
+                raise ValueError(
+                    "auto budget requires a concrete reflection_minibatch_size. "
+                    "When using a custom batch_sampler, set max_metric_calls instead."
+                )
+            if self.use_merge and self.max_merge_invocations is None:
+                raise ValueError(
+                    "auto budget requires a concrete max_merge_invocations when merge is enabled. "
+                    "Set max_merge_invocations, disable merge, or set max_metric_calls instead."
+                )
             self.max_metric_calls = self.auto_budget(
                 num_preds=max(num_components, 1),
                 num_candidates=AUTO_RUN_SETTINGS[self.auto]["n"],
                 valset_size=len(valset) if valset is not None else len(trainset),
+                reflection_minibatch_size=self.reflection_minibatch_size,
+                max_merge_invocations=self.max_merge_invocations if self.use_merge else 0,
             )
         elif self.max_full_evals is not None:
             self.max_metric_calls = self.max_full_evals * (len(trainset) + (len(valset) if valset is not None else 0))
@@ -551,12 +584,9 @@ class GEPA(Teleprompter):
                 "No valset provided; Using trainset as valset. This is useful as an inference-time scaling strategy where you want GEPA to find the best solutions for the provided tasks in the trainset, as it makes GEPA overfit prompts to the provided trainset. In order to ensure generalization and perform well on unseen tasks, please provide separate trainset and valset. Provide the smallest valset that is just large enough to match the downstream task distribution, while keeping trainset as large as possible."
             )
         valset = valset or trainset
-        # 35 matches the default minibatch_size in auto_budget(); when the valset is
-        # at or below this size, suggesting further reduction is unhelpful since GEPA
-        # would already evaluate the full valset per step.
-        if len(valset) > 35:
+        if self.reflection_minibatch_size is None or len(valset) > self.reflection_minibatch_size:
             logger.info(
-                f"Using {len(valset)} examples for tracking Pareto scores. You can consider using a smaller sample of the valset to allow GEPA to explore more diverse solutions within the same budget. GEPA requires you to provide the smallest valset that is just large enough to match your downstream task distribution, while providing as large trainset as possible."
+                f"Using {len(valset)} examples for tracking Pareto scores. Each accepted candidate is evaluated on the full valset, so you can consider using a smaller representative sample to allow GEPA to explore more diverse solutions within the same budget."
             )
         else:
             logger.info(f"Using {len(valset)} examples for tracking Pareto scores.")

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -83,14 +83,34 @@ def test_gepa_auto_budget_matches_reflective_loop(reflection_minibatch_size, max
             num_preds=2,
             num_candidates=6,
             valset_size=100,
-            reflection_minibatch_size=reflection_minibatch_size,
-            max_merge_invocations=max_merge_invocations,
         )
         == expected_budget
     )
 
 
-def test_gepa_compile_passes_runtime_settings_to_auto_budget():
+def test_gepa_auto_budget_accepts_legacy_direct_call_and_keywords():
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=DummyLM([]),
+        auto="light",
+        reflection_minibatch_size=3,
+        use_merge=False,
+    )
+
+    assert optimizer.auto_budget(num_preds=2, num_candidates=6, valset_size=100) == 820
+    assert (
+        optimizer.auto_budget(
+            num_preds=2,
+            num_candidates=6,
+            valset_size=100,
+            minibatch_size=7,
+            full_eval_steps=5,
+        )
+        == 980
+    )
+
+
+def test_gepa_compile_calls_auto_budget_with_legacy_keywords():
     student = SimpleModule("input -> output")
     trainset = [Example(input="question", output="answer").with_inputs("input")]
     optimizer = dspy.GEPA(
@@ -112,9 +132,36 @@ def test_gepa_compile_passes_runtime_settings_to_auto_budget():
         num_preds=1,
         num_candidates=6,
         valset_size=1,
-        reflection_minibatch_size=7,
-        max_merge_invocations=0,
     )
+    assert optimize.call_args.kwargs["max_metric_calls"] == 123
+
+
+def test_gepa_compile_supports_legacy_auto_budget_override():
+    class LegacyAutoBudgetGEPA(dspy.GEPA):
+        def auto_budget(
+            self,
+            num_preds,
+            num_candidates,
+            valset_size,
+            minibatch_size=35,
+            full_eval_steps=5,
+        ):
+            return 123
+
+    student = SimpleModule("input -> output")
+    trainset = [Example(input="question", output="answer").with_inputs("input")]
+    optimizer = LegacyAutoBudgetGEPA(
+        metric=simple_metric,
+        reflection_lm=DummyLM([]),
+        auto="light",
+        reflection_minibatch_size=7,
+        use_merge=False,
+    )
+    result = mock.Mock(best_candidate={"predictor": student.predictor.signature.instructions})
+
+    with mock.patch("gepa.optimize", return_value=result) as optimize:
+        optimizer.compile(student, trainset=trainset, valset=trainset)
+
     assert optimize.call_args.kwargs["max_metric_calls"] == 123
 
 
@@ -154,7 +201,7 @@ def test_gepa_compile_auto_budget_falls_back_for_opaque_custom_sampler(caplog):
     result = mock.Mock(best_candidate={"predictor": student.predictor.signature.instructions})
 
     with (
-        mock.patch.object(optimizer, "auto_budget", return_value=123) as auto_budget,
+        mock.patch.object(optimizer, "auto_budget", wraps=optimizer.auto_budget) as auto_budget,
         mock.patch("gepa.optimize", return_value=result) as optimize,
     ):
         optimizer.compile(student, trainset=trainset, valset=trainset)
@@ -163,10 +210,9 @@ def test_gepa_compile_auto_budget_falls_back_for_opaque_custom_sampler(caplog):
         num_preds=1,
         num_candidates=6,
         valset_size=1,
-        reflection_minibatch_size=35,
-        max_merge_invocations=0,
     )
-    assert optimize.call_args.kwargs["max_metric_calls"] == 123
+    # V + 2RT + CV = 1 + 2 * 35 * 10 + 6 * 1.
+    assert optimize.call_args.kwargs["max_metric_calls"] == 707
     assert optimize.call_args.kwargs["batch_sampler"] is batch_sampler
     assert optimize.call_args.kwargs["reflection_minibatch_size"] is None
     assert "Using the legacy auto-budget estimate of 35" in caplog.text
@@ -178,8 +224,8 @@ def test_gepa_compile_auto_budget_falls_back_for_opaque_custom_sampler(caplog):
         ({"num_preds": 0}, "num_preds"),
         ({"num_candidates": 0}, "num_candidates"),
         ({"valset_size": -1}, "valset_size"),
-        ({"reflection_minibatch_size": 0}, "reflection_minibatch_size"),
-        ({"max_merge_invocations": -1}, "max_merge_invocations"),
+        ({"minibatch_size": 0}, "minibatch_size"),
+        ({"full_eval_steps": 0}, "full_eval_steps"),
     ],
 )
 def test_gepa_auto_budget_rejects_invalid_inputs(kwargs, error):
@@ -188,13 +234,24 @@ def test_gepa_auto_budget_rejects_invalid_inputs(kwargs, error):
         "num_preds": 1,
         "num_candidates": 6,
         "valset_size": 100,
-        "reflection_minibatch_size": 3,
-        "max_merge_invocations": 0,
     }
     inputs.update(kwargs)
 
     with pytest.raises(ValueError, match=error):
         optimizer.auto_budget(**inputs)
+
+
+def test_gepa_auto_budget_rejects_invalid_merge_cap():
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=DummyLM([]),
+        auto="light",
+        use_merge=True,
+        max_merge_invocations=-1,
+    )
+
+    with pytest.raises(ValueError, match="max_merge_invocations"):
+        optimizer.auto_budget(num_preds=1, num_candidates=6, valset_size=100)
 
 
 @pytest.mark.parametrize("reflection_minibatch_size, batch, expected_callback_metadata", [

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -44,6 +44,19 @@ def bad_metric(example, prediction):
     return 0.0
 
 
+class SizedBatchSampler:
+    def __init__(self, minibatch_size):
+        self.minibatch_size = minibatch_size
+
+    def next_minibatch_ids(self, loader, state):
+        return list(loader.all_ids())[: self.minibatch_size]
+
+
+class OpaqueBatchSampler:
+    def next_minibatch_ids(self, loader, state):
+        return list(loader.all_ids())[:1]
+
+
 @pytest.mark.parametrize(
     "reflection_minibatch_size, max_merge_invocations, expected_budget",
     [
@@ -103,6 +116,60 @@ def test_gepa_compile_passes_runtime_settings_to_auto_budget():
         max_merge_invocations=0,
     )
     assert optimize.call_args.kwargs["max_metric_calls"] == 123
+
+
+@pytest.mark.parametrize(
+    "gepa_kwargs, expected_minibatch_size",
+    [
+        ({}, 3),
+        ({"batch_sampler": SizedBatchSampler(7)}, 7),
+    ],
+)
+def test_gepa_auto_budget_resolves_minibatch_size_when_reflection_size_is_none(
+    gepa_kwargs, expected_minibatch_size
+):
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=DummyLM([]),
+        auto="light",
+        reflection_minibatch_size=None,
+        gepa_kwargs=gepa_kwargs,
+    )
+
+    assert optimizer._resolve_auto_budget_minibatch_size() == expected_minibatch_size
+
+
+def test_gepa_compile_auto_budget_falls_back_for_opaque_custom_sampler(caplog):
+    student = SimpleModule("input -> output")
+    trainset = [Example(input="question", output="answer").with_inputs("input")]
+    batch_sampler = OpaqueBatchSampler()
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=DummyLM([]),
+        auto="light",
+        reflection_minibatch_size=None,
+        use_merge=False,
+        gepa_kwargs={"batch_sampler": batch_sampler},
+    )
+    result = mock.Mock(best_candidate={"predictor": student.predictor.signature.instructions})
+
+    with (
+        mock.patch.object(optimizer, "auto_budget", return_value=123) as auto_budget,
+        mock.patch("gepa.optimize", return_value=result) as optimize,
+    ):
+        optimizer.compile(student, trainset=trainset, valset=trainset)
+
+    auto_budget.assert_called_once_with(
+        num_preds=1,
+        num_candidates=6,
+        valset_size=1,
+        reflection_minibatch_size=35,
+        max_merge_invocations=0,
+    )
+    assert optimize.call_args.kwargs["max_metric_calls"] == 123
+    assert optimize.call_args.kwargs["batch_sampler"] is batch_sampler
+    assert optimize.call_args.kwargs["reflection_minibatch_size"] is None
+    assert "Using the legacy auto-budget estimate of 35" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -44,6 +44,92 @@ def bad_metric(example, prediction):
     return 0.0
 
 
+@pytest.mark.parametrize(
+    "reflection_minibatch_size, max_merge_invocations, expected_budget",
+    [
+        (3, 0, 820),
+        (7, 0, 980),
+        (3, 5, 1345),
+    ],
+)
+def test_gepa_auto_budget_matches_reflective_loop(reflection_minibatch_size, max_merge_invocations, expected_budget):
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=DummyLM([]),
+        auto="light",
+        reflection_minibatch_size=reflection_minibatch_size,
+        use_merge=max_merge_invocations > 0,
+        max_merge_invocations=max_merge_invocations,
+    )
+
+    # With two components and six target candidates, the existing exploration
+    # heuristic yields 20 reflective trials. Each trial evaluates both the
+    # parent and child on the configured reflection minibatch.
+    assert (
+        optimizer.auto_budget(
+            num_preds=2,
+            num_candidates=6,
+            valset_size=100,
+            reflection_minibatch_size=reflection_minibatch_size,
+            max_merge_invocations=max_merge_invocations,
+        )
+        == expected_budget
+    )
+
+
+def test_gepa_compile_passes_runtime_settings_to_auto_budget():
+    student = SimpleModule("input -> output")
+    trainset = [Example(input="question", output="answer").with_inputs("input")]
+    optimizer = dspy.GEPA(
+        metric=simple_metric,
+        reflection_lm=DummyLM([]),
+        auto="light",
+        reflection_minibatch_size=7,
+        use_merge=False,
+    )
+    result = mock.Mock(best_candidate={"predictor": student.predictor.signature.instructions})
+
+    with (
+        mock.patch.object(optimizer, "auto_budget", return_value=123) as auto_budget,
+        mock.patch("gepa.optimize", return_value=result) as optimize,
+    ):
+        optimizer.compile(student, trainset=trainset, valset=trainset)
+
+    auto_budget.assert_called_once_with(
+        num_preds=1,
+        num_candidates=6,
+        valset_size=1,
+        reflection_minibatch_size=7,
+        max_merge_invocations=0,
+    )
+    assert optimize.call_args.kwargs["max_metric_calls"] == 123
+
+
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        ({"num_preds": 0}, "num_preds"),
+        ({"num_candidates": 0}, "num_candidates"),
+        ({"valset_size": -1}, "valset_size"),
+        ({"reflection_minibatch_size": 0}, "reflection_minibatch_size"),
+        ({"max_merge_invocations": -1}, "max_merge_invocations"),
+    ],
+)
+def test_gepa_auto_budget_rejects_invalid_inputs(kwargs, error):
+    optimizer = dspy.GEPA(metric=simple_metric, reflection_lm=DummyLM([]), auto="light")
+    inputs = {
+        "num_preds": 1,
+        "num_candidates": 6,
+        "valset_size": 100,
+        "reflection_minibatch_size": 3,
+        "max_merge_invocations": 0,
+    }
+    inputs.update(kwargs)
+
+    with pytest.raises(ValueError, match=error):
+        optimizer.auto_budget(**inputs)
+
+
 @pytest.mark.parametrize("reflection_minibatch_size, batch, expected_callback_metadata", [
     (None, [], {"metric_key": "eval_full"}),
     (None, [Example(input="What is the color of the sky?", output="blue")], {"metric_key": "eval_full"}),


### PR DESCRIPTION
Fixes #10245.

This PR updates `GEPA.auto_budget()` to reflect the current GEPA evaluation flow.

### The bug

Before this change, the auto budget was calculated approximately as:

```text
budget = V + 5C + 35T + FV

where:

F = floor((T + 1) / 5) + 1 + indicator(T < 5)
```

where `V` is the validation-set size, `C` is the candidate count, `T` is the estimated number of trials, and `F` is the assumed number of periodic full evaluations.

This calculation had three stale assumptions:

* the reflection minibatch size was always 35
* each candidate required five bootstrapping evaluations
* full validation occurred periodically every five trials

The current GEPA loop instead evaluates both the parent and child on the configured reflection minibatch and performs full validation only when a proposal passes minibatch acceptance.

Consequently, changing `reflection_minibatch_size` changed the actual metric-call cost but did not change the calculated auto budget.

### The fix

The updated budget calculation is:

```text
budget = V + 2RT + AV + K(5 + V)
```

where:

* `V` is the validation-set size
* `R` is the effective reflection minibatch size
* `T` is the estimated number of reflective trials
* `A` is the number of accepted-candidate validations reserved by auto mode
* `K` is the maximum number of merge attempts

The `2RT` term accounts for evaluating both the parent and child on each reflection minibatch. `AV` reserves full-validation cost for accepted candidates. Each merge attempt reserves five metric calls for merge screening plus one full validation, represented by `K(5 + V)`.

For custom batch samplers, the effective minibatch size is resolved from the sampler's `minibatch_size` attribute when available. Otherwise, the legacy value of 35 is used with a warning.

To preserve backward compatibility, `auto_budget()` continues to accept the legacy `minibatch_size` and `full_eval_steps` parameters. `full_eval_steps` is retained for compatibility but no longer affects the calculation.

`compile()` also calls `auto_budget()` using the original three-keyword form, so subclasses overriding the legacy signature continue to work.

The result remains a budget allocation rather than an exact prediction because rejected proposals skip full validation and custom GEPA policies may have different evaluation costs.

### Verification

Added regression tests covering:

* minibatch-aware budget calculation
* merge-related evaluation costs
* propagation of `reflection_minibatch_size` through `compile()`
* default and custom batch samplers, including fallback behavior
* legacy three-argument `auto_budget()` calls
* legacy `minibatch_size` and `full_eval_steps` keywords
* subclasses overriding the previous `auto_budget()` signature

All focused GEPA tests and pre-commit checks pass.