### PR TITLE
Fix ReActV2 missing output fields on failed termination

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -24,6 +24,13 @@ class ReActV2(Module):
     def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
         super().__init__()
         self.signature = ensure_signature(signature)
+
+        reserved_output_names = {"history", "termination_reason"}
+        conflicting_outputs = reserved_output_names.intersection(self.signature.output_fields)
+        if conflicting_outputs:
+            names = ", ".join(sorted(conflicting_outputs))
+            raise ValueError(f"The following output field(s) are reserved by ReActV2: {names}")
+
         self.max_iters = max_iters
 
         user_tools = [tool if isinstance(tool, Tool) else Tool(tool) for tool in tools]
@@ -173,11 +180,11 @@ class ReActV2(Module):
         termination_reason: str,
     ) -> Prediction:
         outputs = self._default_output_fields()
-        outputs.update(
+        return Prediction(
+            **outputs,
             history=history,
             termination_reason=termination_reason,
         )
-        return Prediction(**outputs)
 
     def _forced_submit(
         self,

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -164,6 +164,9 @@ class ReActV2(Module):
             event["tool_calls"] = tool_calls
         return event
 
+    def _default_output_fields(self) -> dict[str, None]:
+        return {name: None for name in self.signature.output_fields}
+
     def _forced_submit(
         self,
         history: dspy.History,
@@ -184,11 +187,19 @@ class ReActV2(Module):
             tool_calls = _ensure_tool_call_ids(_coerce_tool_calls(getattr(pred, "tool_calls", None)), turn_index)
         except (AdapterParseError, ValueError, ContextWindowExceededError) as err:
             logger.warning("Forced submit failed: %s", format_error_for_lm(err, traceback_frames=5))
-            return Prediction(history=history, termination_reason=break_reason or "failed")
+            return Prediction(
+                **self._default_output_fields(),
+                history=history,
+                termination_reason=break_reason or "failed",
+            )
 
         submit_calls = ToolCalls(tool_calls=[call for call in tool_calls.tool_calls if call.name == "submit"])
         if not submit_calls.tool_calls:
-            return Prediction(history=history, termination_reason=break_reason or "failed")
+            return Prediction(
+                **self._default_output_fields(),
+                history=history,
+                termination_reason=break_reason or "failed",
+            )
 
         tool_call_results, final_outputs = self._execute_tool_calls(submit_calls)
         event = self._history_event(pending_inputs, pred, submit_calls, tool_call_results)
@@ -199,7 +210,11 @@ class ReActV2(Module):
         if final_outputs is not None:
             return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
 
-        return Prediction(history=history, termination_reason=break_reason or "failed")
+        return Prediction(
+            **self._default_output_fields(),
+            history=history,
+            termination_reason=break_reason or "failed",
+        )
 
 
 def _json_schema_for_annotation(annotation: Any) -> dict[str, Any]:

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -167,6 +167,18 @@ class ReActV2(Module):
     def _default_output_fields(self) -> dict[str, None]:
         return {name: None for name in self.signature.output_fields}
 
+    def _failed_prediction(
+        self,
+        history: dspy.History,
+        termination_reason: str,
+    ) -> Prediction:
+        outputs = self._default_output_fields()
+        outputs.update(
+            history=history,
+            termination_reason=termination_reason,
+        )
+        return Prediction(**outputs)
+
     def _forced_submit(
         self,
         history: dspy.History,
@@ -187,19 +199,11 @@ class ReActV2(Module):
             tool_calls = _ensure_tool_call_ids(_coerce_tool_calls(getattr(pred, "tool_calls", None)), turn_index)
         except (AdapterParseError, ValueError, ContextWindowExceededError) as err:
             logger.warning("Forced submit failed: %s", format_error_for_lm(err, traceback_frames=5))
-            return Prediction(
-                **self._default_output_fields(),
-                history=history,
-                termination_reason=break_reason or "failed",
-            )
+            return self._failed_prediction(history, break_reason or "failed")
 
         submit_calls = ToolCalls(tool_calls=[call for call in tool_calls.tool_calls if call.name == "submit"])
         if not submit_calls.tool_calls:
-            return Prediction(
-                **self._default_output_fields(),
-                history=history,
-                termination_reason=break_reason or "failed",
-            )
+            return self._failed_prediction(history, break_reason or "failed")
 
         tool_call_results, final_outputs = self._execute_tool_calls(submit_calls)
         event = self._history_event(pending_inputs, pred, submit_calls, tool_call_results)
@@ -210,11 +214,7 @@ class ReActV2(Module):
         if final_outputs is not None:
             return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
 
-        return Prediction(
-            **self._default_output_fields(),
-            history=history,
-            termination_reason=break_reason or "failed",
-        )
+        return self._failed_prediction(history, break_reason or "failed")
 
 
 def _json_schema_for_annotation(annotation: Any) -> dict[str, Any]:

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -194,6 +194,34 @@ def test_react_v2_forced_submit_on_empty_tool_calls():
     assert lm.history[1]["kwargs"].get("reasoning_effort") is None
 
 
+def test_react_v2_failed_forced_submit_preserves_output_fields():
+    def noop(x: str) -> str:
+        return "noop"
+
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "Stalling.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [{"name": "noop", "args": {"x": "a"}}]
+                ),
+            }
+        ]
+        * 3
+    )
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2(
+            "question -> answer",
+            tools=[noop],
+            max_iters=1,
+        )(question="q")
+
+    assert pred.termination_reason == "max_iters"
+    assert "answer" in pred
+    assert pred.answer is None
+
+
 class NativeToolLM(dspy.BaseLM):
     def __init__(self):
         super().__init__("native-tool-lm", "chat", 0.0, 1000, True)

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -1,3 +1,5 @@
+import pytest
+
 import dspy
 from dspy.dsp.utils.utils import dotdict
 
@@ -13,6 +15,16 @@ def test_react_v2_submit_tool_returns_original_output_fields():
 
     assert react.tools["submit"](answer="Paris") == {"answer": "Paris"}
     assert "tool_call_results" not in react.react.signature.input_fields
+
+
+def test_react_v2_rejects_reserved_history_output():
+    with pytest.raises(ValueError, match="reserved by ReActV2: history"):
+        dspy.ReActV2("question -> answer, history", tools=[])
+
+
+def test_react_v2_rejects_reserved_termination_reason_output():
+    with pytest.raises(ValueError, match="reserved by ReActV2: termination_reason"):
+        dspy.ReActV2("question -> answer, termination_reason", tools=[])
 
 
 def test_react_v2_text_mock_lm_loop_records_inputs_once():
@@ -352,3 +364,30 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
         "call_provider_1",
         "call_provider_2",
     ]
+
+def test_react_v2_failed_forced_submit_preserves_output_fields():
+    def noop(x: str) -> str:
+        return "noop"
+
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "Stalling.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [{"name": "noop", "args": {"x": "a"}}]
+                ),
+            }
+        ]
+        * 3
+    )
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2(
+            "question -> answer",
+            tools=[noop],
+            max_iters=1,
+        )(question="q")
+
+    assert pred.termination_reason == "max_iters"
+    assert "answer" in pred
+    assert pred.answer is None


### PR DESCRIPTION
## Summary

Fixes ReActV2 predictions so failed termination paths preserve the signature's output fields with None values.

## Changes

- Preserve all signature output fields on failed termination.
- Reserve `history` and `termination_reason` as internal ReActV2 output names.
- Add regression coverage for failed forced-submit behavior.
- Add regression coverage for reserved output names.

## Testing

pytest tests/predict/test_react_v2.py -q
13 passed

Fixes #10243