### PR TITLE
fix(utils): materialize a lazy package before its submodules import

### DIFF
--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -57,6 +57,60 @@ def _get_lazy_module_lock(module: str) -> threading.RLock:
         return _lazy_module_locks.setdefault(module, threading.RLock())
 
 
+class _ReuseExecutedLoader:
+    """Loader that hands back an already-executed module unchanged.
+
+    The import machinery does not re-check ``sys.modules`` once a direct
+    child import has committed to a spec, so a child that completed during
+    parent materialization (the parent ``__init__`` imports it) would be
+    re-executed by the original pending import. This loader makes that
+    pending import resolve to the completed module object instead, and
+    restores its original ``__spec__``/``__loader__`` afterwards.
+    """
+
+    def __init__(self, module: types.ModuleType):
+        self._module = module
+        self._original_spec = module.__spec__
+        self._original_loader = module.__loader__
+
+    def create_module(self, spec: importlib.machinery.ModuleSpec) -> types.ModuleType:
+        return self._module
+
+    def exec_module(self, module: types.ModuleType) -> None:
+        module.__spec__ = self._original_spec
+        module.__loader__ = self._original_loader
+
+
+class _MaterializedChildFinder:
+    """Meta-path finder deduplicating children imported during materialization.
+
+    Returns a reuse spec only for a module that is already in
+    ``sys.modules``, was imported while a lazy parent was materializing,
+    and is therefore the subject of an outer pending import; every other
+    lookup falls through to the normal finders.
+    """
+
+    _MARKER = "_dspy_lazy_reuse"
+
+    def find_spec(self, fullname: str, path=None, target=None):  # noqa: ANN001, ANN202
+        module = sys.modules.get(fullname)
+        if module is None or getattr(module, _MaterializedChildFinder._MARKER, False) is not True:
+            return None
+        return importlib.util.spec_from_loader(
+            fullname,
+            _ReuseExecutedLoader(module),
+            is_package=hasattr(module, "__path__"),
+        )
+
+
+sys.meta_path.insert(0, _MaterializedChildFinder())
+
+# True while a lazy parent's real module executes: modules imported in that
+# window may be the subject of the outer pending import that triggered
+# materialization, so they are marked for reuse by _load().
+_MATERIALIZING = False
+
+
 def _is_submodule_binding(package: str, attr: str, value: Any) -> bool:
     """Return True when *value* is the import machinery binding a submodule.
 
@@ -129,11 +183,27 @@ class _LazyModule(types.ModuleType):
             spec = self._dspy_lazy_spec
             module = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = module
+            global _MATERIALIZING
+            prior_materializing = _MATERIALIZING
+            imported_before = set(sys.modules)
+            _MATERIALIZING = True
             try:
                 spec.loader.exec_module(module)
             except Exception:
                 sys.modules[module_name] = self
                 raise
+            finally:
+                _MATERIALIZING = prior_materializing
+            # Modules the package __init__ imported may be the subject of the
+            # outer pending import that triggered this materialization; mark
+            # them so the machinery's committed import reuses the completed
+            # module instead of re-executing it.
+            for imported_name, imported_module in sys.modules.items():
+                if imported_name not in imported_before:
+                    try:
+                        setattr(imported_module, _MaterializedChildFinder._MARKER, True)
+                    except (AttributeError, TypeError):
+                        pass
             return sys.modules.get(module_name, module)
 
     def __getattr__(self, attr: str) -> Any:

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -214,8 +214,10 @@ class _LazyModule(types.ModuleType):
             # Modules the package __init__ imported may be the subject of the
             # outer pending import that triggered this materialization; mark
             # them so the machinery's committed import reuses the completed
-            # module instead of re-executing it.
-            for imported_name, imported_module in sys.modules.items():
+            # module instead of re-executing it. Iterate a snapshot: another
+            # thread importing or removing a module in the live dict would
+            # otherwise abort materialization after it already succeeded.
+            for imported_name, imported_module in list(sys.modules.items()):
                 if imported_name not in imported_before:
                     try:
                         setattr(imported_module, _MaterializedChildFinder._MARKER, True)

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -72,6 +72,7 @@ class _ReuseExecutedLoader:
         self._module = module
         self._original_spec = module.__spec__
         self._original_loader = module.__loader__
+        self._original_path: list[str] | None = list(getattr(module, "__path__", [])) or None
 
     def create_module(self, spec: importlib.machinery.ModuleSpec) -> types.ModuleType:
         return self._module
@@ -79,6 +80,11 @@ class _ReuseExecutedLoader:
     def exec_module(self, module: types.ModuleType) -> None:
         module.__spec__ = self._original_spec
         module.__loader__ = self._original_loader
+        # spec_from_loader(is_package=True) pins an empty search path, which
+        # module_from_spec would have stamped onto the reused package --
+        # restore the real one so later submodule imports still resolve.
+        if self._original_path is not None:
+            module.__path__ = self._original_path
 
 
 class _MaterializedChildFinder:

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -99,9 +99,20 @@ class _MaterializedChildFinder:
     _MARKER = "_dspy_lazy_reuse"
 
     def find_spec(self, fullname: str, path=None, target=None):  # noqa: ANN001, ANN202
+        # A reload passes the module as ``target`` and must re-execute it;
+        # reuse only serves the one pending import that raced the parent's
+        # materialization.
+        if target is not None:
+            return None
         module = sys.modules.get(fullname)
         if module is None or getattr(module, _MaterializedChildFinder._MARKER, False) is not True:
             return None
+        # Consume the marker: the reuse serves exactly the pending import,
+        # and a later reload or re-import must go through the normal path.
+        try:
+            delattr(module, _MaterializedChildFinder._MARKER)
+        except AttributeError:
+            pass
         return importlib.util.spec_from_loader(
             fullname,
             _ReuseExecutedLoader(module),

--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -57,6 +57,17 @@ def _get_lazy_module_lock(module: str) -> threading.RLock:
         return _lazy_module_locks.setdefault(module, threading.RLock())
 
 
+def _is_submodule_binding(package: str, attr: str, value: Any) -> bool:
+    """Return True when *value* is the import machinery binding a submodule.
+
+    The machinery binds ``sys.modules[parent].<child> = <module>`` after a
+    submodule import; such a value is a module whose ``__name__`` is the
+    child's fully qualified name. Any other assignment (configuration writes
+    from dspy call sites) keeps the materialize-on-assign behaviour.
+    """
+    return isinstance(value, types.ModuleType) and getattr(value, "__name__", None) == f"{package}.{attr}"
+
+
 class _MissingModule(types.ModuleType):
     """Stand-in returned by `require()` when a package is not installed.
 
@@ -90,10 +101,20 @@ class _LazyModule(types.ModuleType):
         self.__spec__ = spec
         self.__loader__ = spec.loader
         self.__package__ = spec.parent
-        if spec.submodule_search_locations is not None:
-            self.__path__ = spec.submodule_search_locations
         self._dspy_lazy_spec = spec
         self._dspy_lazy_lock = lock
+
+    @property
+    def __path__(self) -> Any:
+        # The import machinery reads the parent package's __path__ to locate
+        # and import submodules, before any submodule code runs. Answering
+        # from the proxy would let a direct submodule import (a C extension
+        # doing `import numpy._core` after `import dspy`) execute the child
+        # while the real package __init__ never ran -- its side effects
+        # (numpy registers its Windows DLL directory, then re-exports _core)
+        # are skipped and the child crashes. Materializing here runs the
+        # real package first, exactly where the machinery would have.
+        return getattr(self._load(), "__path__")
 
     def _load(self) -> types.ModuleType:
         # The proxy starts in sys.modules, then the first attribute access swaps in and executes the real module under
@@ -119,7 +140,22 @@ class _LazyModule(types.ModuleType):
         return getattr(self._load(), attr)
 
     def __setattr__(self, attr: str, value: Any) -> None:
-        if attr.startswith("_dspy_lazy_") or attr in {"__spec__", "__loader__", "__package__", "__path__"}:
+        if attr.startswith("_dspy_lazy_") or attr in {"__spec__", "__loader__", "__package__"}:
+            super().__setattr__(attr, value)
+        elif _is_submodule_binding(self.__name__, attr, value):
+            # The import machinery binds a freshly imported submodule onto
+            # its parent by name, and the parent in sys.modules is still
+            # this proxy. Materializing here would execute the real package
+            # while that submodule's import is in flight: the nested package
+            # __init__ then re-imports the half-initialized submodule from
+            # sys.modules and the double execution corrupts package state
+            # (importing dspy before a C extension that imports the
+            # package's submodule directly, e.g. onnxruntime after dspy,
+            # dies inside numpy with "data type 'bool' not understood").
+            # Record the binding on the proxy instead; the real module's
+            # own execution binds its submodules onto itself once it
+            # materializes, and the stored object is the same module the
+            # machinery has cached in sys.modules.
             super().__setattr__(attr, value)
         else:
             setattr(self._load(), attr, value)

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -291,6 +291,49 @@ def test_direct_submodule_import_executes_the_child_exactly_once(tmp_path, monke
     assert events.index("package-init") < events.index("child-exec"), (
         "the package initializer runs before the child"
     )
-    # The reused module keeps a real spec/loader, not the reuse shims.
+    # The reused module keeps a real spec/loader, not the reuse shims,
+    # and the reuse marker is consumed by the one pending import it served.
     assert child.__spec__ is not None and child.__spec__.loader is not None
-    assert getattr(child, "_dspy_lazy_reuse", None) is True
+    assert getattr(child, "_dspy_lazy_reuse", None) is None
+
+
+def test_reload_reexecutes_a_reused_child(tmp_path, monkeypatch):
+    """importlib.reload re-executes a child that was served by the reuse path.
+
+    The reuse marker is consumed by the one pending import it serves, so a
+    later reload must fall through to the normal finders and run the
+    module body again instead of silently returning the stale module.
+    """
+    name = "dspy_lazy_reload_pkg"
+    events_path = tmp_path / "events.txt"
+    (tmp_path / name).mkdir()
+    record = (
+        "import pathlib\n"
+        f"path = pathlib.Path({str(events_path)!r})\n"
+        "def log(event):\n"
+        "    with path.open('a') as fh:\n"
+        "        fh.write(event + chr(10))\n"
+    )
+    (tmp_path / f"{name}/__init__.py").write_text(
+        record
+        + "log('package-init')\n"
+        + f"from {name}.child import CHILD_VALUE\n"
+    )
+    (tmp_path / f"{name}/child.py").write_text(
+        record + "log('child-exec')\n" + "CHILD_VALUE = 42\n"
+    )
+
+    monkeypatch.syspath_prepend(tmp_path)
+    for suffix in ("", ".child"):
+        monkeypatch.delitem(sys.modules, f"{name}{suffix}", raising=False)
+
+    require(name)
+    child = importlib.import_module(f"{name}.child")
+    assert events_path.read_text().splitlines().count("child-exec") == 1
+
+    importlib.reload(child)
+
+    assert events_path.read_text().splitlines().count("child-exec") == 2, (
+        "reload must re-execute the module body"
+    )
+    assert child.CHILD_VALUE == 42

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -242,3 +242,55 @@ def test_submodule_binding_records_without_materializing(tmp_path, monkeypatch):
     mod.setting = "value"
     assert sys.modules[name] is not mod
     assert sys.modules[name].setting == "value"
+
+
+def test_direct_submodule_import_executes_the_child_exactly_once(tmp_path, monkeypatch):
+    """A direct child import runs the child one time, not twice.
+
+    Materializing the parent from ``__path__`` happens after the outer
+    child import has committed to a spec, and the package ``__init__``
+    imports the same child -- so without reuse the pending import
+    re-executes it and non-idempotent children register state twice.
+    """
+    name = "dspy_lazy_exact_once_pkg"
+    events_path = tmp_path / "events.txt"
+    (tmp_path / name).mkdir()
+    record = (
+        "import pathlib\n"
+        f"path = pathlib.Path({str(events_path)!r})\n"
+        "def log(event):\n"
+        "    with path.open('a') as fh:\n"
+        "        fh.write(event + chr(10))\n"
+    )
+    (tmp_path / f"{name}/__init__.py").write_text(
+        record
+        + "log('package-init')\n"
+        + f"from {name}.child import CHILD_VALUE\n"
+    )
+    (tmp_path / f"{name}/child.py").write_text(
+        record
+        + "log('child-exec')\n"
+        + "import sys\n"
+        + f"import {name}.version\n"
+        + "CHILD_VALUE = 42\n"
+    )
+    (tmp_path / f"{name}/version.py").write_text(record + "log('version-exec')\n")
+
+    monkeypatch.syspath_prepend(tmp_path)
+    for suffix in ("", ".child", ".version"):
+        monkeypatch.delitem(sys.modules, f"{name}{suffix}", raising=False)
+
+    require(name)
+    child = importlib.import_module(f"{name}.child")
+
+    events = events_path.read_text().splitlines()
+    assert child.CHILD_VALUE == 42
+    assert events.count("package-init") == 1
+    assert events.count("child-exec") == 1, f"child must execute exactly once, saw: {events}"
+    assert events.count("version-exec") == 1
+    assert events.index("package-init") < events.index("child-exec"), (
+        "the package initializer runs before the child"
+    )
+    # The reused module keeps a real spec/loader, not the reuse shims.
+    assert child.__spec__ is not None and child.__spec__.loader is not None
+    assert getattr(child, "_dspy_lazy_reuse", None) is True

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -1,4 +1,6 @@
 import sys
+import importlib
+import types
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
@@ -139,3 +141,104 @@ def test_install_hints_match_pyproject_extras(pytestconfig):
             f"_INSTALL_HINTS[{module!r}] = {hint!r} is not a declared extra in "
             f"pyproject.toml (declared: {sorted(extras)})"
         )
+
+def _write_lazy_package(tmp_path, monkeypatch, name: str) -> None:
+    """Create an importable package whose child, mid-exec, imports a sibling.
+
+    Mirrors the numpy shape that broke with onnxruntime: the package
+    ``__init__`` imports the child, and the child's first act is importing
+    a sibling submodule -- which the import machinery binds onto the parent
+    module found in ``sys.modules``.
+    """
+    (tmp_path / name).mkdir()
+    (tmp_path / f"{name}/__init__.py").write_text(
+        "INIT_RAN = True\n"
+        f"from {name}.child import CHILD_VALUE\n"
+    )
+    (tmp_path / f"{name}/child.py").write_text(
+        "import sys\n"
+        f"import {name}.version\n"
+        "PARENT_INIT_RAN_AT_CHILD_IMPORT = getattr(sys.modules[__package__], 'INIT_RAN', False)\n"
+        "CHILD_VALUE = 42\n"
+    )
+    (tmp_path / f"{name}/version.py").write_text("VERSION = '1.0'\n")
+    monkeypatch.syspath_prepend(tmp_path)
+    for suffix in ("", ".child", ".version"):
+        monkeypatch.delitem(sys.modules, f"{name}{suffix}", raising=False)
+
+
+def test_direct_submodule_import_runs_package_init_first(tmp_path, monkeypatch):
+    """A submodule imported directly still gets the package's __init__ side effects.
+
+    The lazy proxy sits in ``sys.modules`` as the not-yet-loaded parent, and
+    a C extension (onnxruntime after ``import dspy``) imports
+    ``numpy._core`` directly. The machinery reads the parent's ``__path__``
+    to locate the child; answering from the proxy let the child execute
+    while the real ``__init__`` -- which registers numpy's Windows DLL
+    directory before importing ``._core`` -- never ran.
+    """
+    name = "dspy_lazy_parent_first_pkg"
+    _write_lazy_package(tmp_path, monkeypatch, name)
+
+    require(name)
+    assert sys.modules[name] is not None
+
+    child = importlib.import_module(f"{name}.child")
+
+    assert child.CHILD_VALUE == 42
+    assert child.PARENT_INIT_RAN_AT_CHILD_IMPORT is True, (
+        "the package __init__ must run before any of its submodules"
+    )
+    assert sys.modules[f"{name}.version"].VERSION == "1.0"
+
+
+def test_lazy_module_path_access_materializes_the_package(tmp_path, monkeypatch):
+    """Reading a lazy package's ``__path__`` materializes it.
+
+    ``__path__`` is what the import machinery consults to import or find
+    submodules, so it doubles as the materialization trigger for the
+    direct-submodule-import case; any other reader observes the real
+    package's path.
+    """
+    name = "dspy_lazy_path_materialize_pkg"
+    _write_lazy_package(tmp_path, monkeypatch, name)
+
+    mod = require(name)
+    assert sys.modules[name] is mod
+
+    paths = list(mod.__path__)
+
+    assert paths and str(tmp_path) in str(paths[0])
+    assert sys.modules[name] is not mod, "__path__ access must materialize the real package"
+    assert sys.modules[name].INIT_RAN is True
+
+
+def test_submodule_binding_records_without_materializing(tmp_path, monkeypatch):
+    """The machinery binding a submodule onto the proxy must not nest a full load.
+
+    Executing the real package from inside ``__setattr__`` runs the
+    ``__init__`` while that submodule's import is still in flight; the
+    ``__init__`` then re-imports the half-initialized submodule from
+    ``sys.modules`` and the double execution corrupts package state (the
+    onnxruntime failure died inside numpy with "data type 'bool' not
+    understood"). The binding is recorded on the proxy instead.
+    """
+    name = "dspy_lazy_submodule_binding_pkg"
+    (tmp_path / name).mkdir()
+    (tmp_path / f"{name}/__init__.py").write_text("INIT_RAN = True\n")
+    monkeypatch.syspath_prepend(tmp_path)
+    monkeypatch.delitem(sys.modules, name, raising=False)
+
+    mod = require(name)
+    sibling = types.ModuleType(f"{name}.extra")
+    sys.modules[f"{name}.extra"] = sibling
+
+    setattr(mod, "extra", sibling)
+
+    assert sys.modules[name] is mod, "a submodule binding must not materialize the package"
+    assert mod.extra is sibling
+
+    # A plain value assignment still materializes and applies to the real module.
+    mod.setting = "value"
+    assert sys.modules[name] is not mod
+    assert sys.modules[name].setting == "value"


### PR DESCRIPTION
## Summary

`import dspy` then `import onnxruntime` fails inside numpy with `TypeError: data type 'bool' not understood` (wrapped as onnxruntime's `ImportError: import numpy failed`); the reverse order works (#10220).

## Root cause

`require("numpy")` parks a `_LazyModule` proxy in `sys.modules["numpy"]`. onnxruntime's C extension imports `numpy._core` **directly**, and the import machinery resolves the parent by the `sys.modules` entry — the proxy — so it proceeds to execute the child while the real `numpy/__init__.py` never ran. Two defects compound from there:

1. **Nested double execution.** When the machinery later binds a freshly imported submodule onto its parent (`sys.modules["numpy"].version = <module>`), that `setattr` lands on the proxy, whose `__setattr__` routed through `_load()` — executing a *full* `numpy/__init__.py` nested inside the in-flight `numpy._core` import. The nested `__init__` re-imports the half-initialized `numpy._core` from `sys.modules`, and the double execution corrupts package state — the observed `dtype("bool")` failure. Confirmed by instrumenting the proxy: the crash stack contains exactly one `__setattr__` on the proxy, from `numpy/_core/__init__.py:11`'s `from numpy.version import ...`.
2. **Skipped `__init__` side effects.** Even without the crash, `numpy/__init__.py` registers its Windows DLL directory (line 91) before importing `._core`; with the proxy as parent, that registration never happens and `_multiarray_umath` fails to load its DLLs.

## Fix

- The proxy's `__path__` is now a read-through property that materializes the real package. That is exactly the point where the import machinery consults the parent (`_find_and_load_unlocked` reads `parent_module.__path__` before any child code runs), so the package `__init__` executes first — identical ordering to a world without the proxy. Both import orders now work.
- Submodule bindings recorded on the proxy (`setattr(proxy, "version", <module>)` where the value's `__name__` is `<package>.<attr>`) are stored on the proxy without triggering a nested load — a nested load there is never correct, because the machinery is mid-flight on a child of the same package.
- Plain attribute assignment (configuration writes) keeps the existing materialize-on-assign behaviour, covered by an unchanged pre-existing test.

## Testing

- Reproduced on Python 3.12 (numpy 2.5.2 + onnxruntime 1.29.0) before the fix; both import orders work after it.
- 3 new regression tests (no onnxruntime needed — the numpy shape is simulated with tmp_path packages): direct-submodule import runs the package `__init__` first; `__path__` access materializes; submodule bindings record without materializing while plain assignment still does.
- Differential: the 3 new tests fail on unpatched main; the full `tests/utils/` suite is otherwise unchanged (2 pre-existing `test_settings` failures reproduce with the patch stashed).

Fixes #10220
