### PR TITLE
fix(predict): keep the Signature contract on ReActV2 failure exits

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -164,6 +164,26 @@ class ReActV2(Module):
             event["tool_calls"] = tool_calls
         return event
 
+    def _unsuccessful_outputs(
+        self,
+        history: dspy.History,
+        termination_reason: str,
+    ) -> Prediction:
+        """Build the return value for a loop that ended without a successful submit.
+
+        The declared output fields are included with ``None`` values so the
+        ``Signature`` contract holds on every return path: a module declaring
+        ``-> answer`` always yields a ``Prediction`` with ``answer``, and
+        callers branch on ``termination_reason`` instead of catching an
+        ``AttributeError``. Without this, ``dspy.Evaluate`` scores such runs
+        as zero through its per-example error handling, which reads as a
+        model-quality problem rather than a framework one.
+        """
+        outputs = {name: None for name in self.signature.output_fields}
+        outputs["history"] = history
+        outputs["termination_reason"] = termination_reason
+        return Prediction(**outputs)
+
     def _forced_submit(
         self,
         history: dspy.History,
@@ -184,11 +204,11 @@ class ReActV2(Module):
             tool_calls = _ensure_tool_call_ids(_coerce_tool_calls(getattr(pred, "tool_calls", None)), turn_index)
         except (AdapterParseError, ValueError, ContextWindowExceededError) as err:
             logger.warning("Forced submit failed: %s", format_error_for_lm(err, traceback_frames=5))
-            return Prediction(history=history, termination_reason=break_reason or "failed")
+            return self._unsuccessful_outputs(history, break_reason or "failed")
 
         submit_calls = ToolCalls(tool_calls=[call for call in tool_calls.tool_calls if call.name == "submit"])
         if not submit_calls.tool_calls:
-            return Prediction(history=history, termination_reason=break_reason or "failed")
+            return self._unsuccessful_outputs(history, break_reason or "failed")
 
         tool_call_results, final_outputs = self._execute_tool_calls(submit_calls)
         event = self._history_event(pending_inputs, pred, submit_calls, tool_call_results)
@@ -199,7 +219,7 @@ class ReActV2(Module):
         if final_outputs is not None:
             return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
 
-        return Prediction(history=history, termination_reason=break_reason or "failed")
+        return self._unsuccessful_outputs(history, break_reason or "failed")
 
 
 def _json_schema_for_annotation(annotation: Any) -> dict[str, Any]:

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -324,3 +324,67 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
         "call_provider_1",
         "call_provider_2",
     ]
+
+def test_react_v2_unsuccessful_loop_still_returns_declared_output_fields():
+    """The Signature contract holds on every return path.
+
+    A loop that ends without a successful submit used to return a
+    Prediction carrying only the framework fields, so reading a declared
+    output raised AttributeError -- silently scored as zero under
+    dspy.Evaluate instead of surfacing as an unsuccessful termination.
+    """
+    stalling = [
+        {
+            "next_thought": "stalling",
+            "tool_calls": dspy.ToolCalls.from_dict_list(
+                [{"name": "noop", "args": {"x": "a"}}]
+            ),
+        }
+    ] * 30
+
+    def noop(x: str) -> str:
+        return "noop"
+
+    with dspy.context(lm=ReasoningDummyLM(stalling), adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2("question -> answer", tools=[noop], max_iters=2)(question="q")
+
+    assert pred.termination_reason == "max_iters"
+    assert pred.answer is None
+    assert "answer" in pred.keys()
+
+
+def test_react_v2_empty_tool_calls_still_returns_declared_output_fields():
+    lm = ReasoningDummyLM(
+        [
+            {"next_thought": "No action.", "tool_calls": dspy.ToolCalls(tool_calls=[])},
+            {"next_thought": "Still no action.", "tool_calls": dspy.ToolCalls(tool_calls=[])},
+        ]
+    )
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2("question -> answer", tools=[])(question="cats")
+
+    assert pred.termination_reason == "empty_tool_calls"
+    assert pred.answer is None
+    assert "answer" in pred.keys()
+
+
+def test_react_v2_failed_submit_still_returns_declared_output_fields():
+    lm = ReasoningDummyLM(
+        [
+            {
+                "next_thought": "Submitting too early.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [{"name": "submit", "args": {}}]
+                ),
+            },
+        ]
+        * 30
+    )
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = dspy.ReActV2("question -> answer", tools=[], max_iters=2)(question="q")
+
+    assert pred.termination_reason == "max_iters"
+    assert pred.answer is None
+    assert "answer" in pred.keys()


### PR DESCRIPTION
## Summary

`ReActV2("question -> answer")` could return a `Prediction` with no `answer` key whenever the loop ended without a successful `submit` — the three unsuccessful-termination exits in `_forced_submit` built the `Prediction` from the two framework fields only (#10243). Reading `pred.answer` raised `AttributeError`, and under `dspy.Evaluate` that is caught per example and scored as zero, so an agent that exhausted `max_iters` printed a number that looked like a model-quality problem.

Implements option 1 from the issue, as discussed there: the declared output fields are always present.

## Implementation

The three exits (`parse/forced-submit failure`, `no submit calls`, `submit produced no final outputs`) now route through one `_unsuccessful_outputs` helper that includes every declared output field with a `None` value alongside `history` / `termination_reason`. Callers branch on `termination_reason` instead of catching `AttributeError`. The successful `submit` / `forced_submit` paths are untouched.

## Testing

- 3 new tests using `DummyLM`, one per reported scenario: `max_iters` with a tool-stalling model, `empty_tool_calls` where the forced submit also stalls, and a `submit` call missing a required field so the tool executor raises. Each asserts `termination_reason`, `answer is None`, and `answer in pred.keys()`.
- Differential: all 3 fail on unpatched main (`AttributeError: 'Prediction' object has no attribute 'answer'`); the file's full suite is 13/13 with the fix.

Fixes #10243
