### PR TITLE
feat: add async support to ReActV2

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -44,10 +44,7 @@ class ReActV2(Module):
                 raise ValueError(f"Missing required final output field(s): {', '.join(missing)}")
             return {name: kwargs[name] for name in output_names}
 
-        args = {
-            name: _json_schema_for_annotation(field.annotation)
-            for name, field in output_fields.items()
-        }
+        args = {name: _json_schema_for_annotation(field.annotation) for name, field in output_fields.items()}
         arg_types = {name: field.annotation for name, field in output_fields.items()}
         return Tool(
             submit,
@@ -100,7 +97,9 @@ class ReActV2(Module):
                 )
                 tool_calls = _coerce_tool_calls(getattr(pred, "tool_calls", None))
             except (AdapterParseError, ValueError) as err:
-                logger.warning("Ending ReActV2 loop after parse failure: %s", format_error_for_lm(err, traceback_frames=5))
+                logger.warning(
+                    "Ending ReActV2 loop after parse failure: %s", format_error_for_lm(err, traceback_frames=5)
+                )
                 break_reason = "parse_error"
                 break
             except ContextWindowExceededError:
@@ -147,6 +146,92 @@ class ReActV2(Module):
                 is_errors.append(True)
 
         return ToolCallResults.from_tool_calls_and_values(tool_calls, values, is_errors), final_outputs
+
+    async def aforward(self, **input_args):
+        max_iters = input_args.pop("max_iters", self.max_iters)
+        history = _coerce_history(input_args.pop("history", None))
+        pending_inputs = {name: input_args[name] for name in self.signature.input_fields if name in input_args}
+
+        break_reason = "max_iters"
+        for turn_index in range(max_iters):
+            try:
+                pred = await self.react.acall(
+                    history=history,
+                    tools=list(self.tools.values()),
+                    **pending_inputs,
+                )
+                tool_calls = _coerce_tool_calls(getattr(pred, "tool_calls", None))
+            except (AdapterParseError, ValueError) as err:
+                logger.warning(
+                    "Ending ReActV2 loop after parse failure: %s", format_error_for_lm(err, traceback_frames=5)
+                )
+                break_reason = "parse_error"
+                break
+            except ContextWindowExceededError:
+                logger.warning("Ending ReActV2 loop after context window exceeded.")
+                break_reason = "context_window_exceeded"
+                break
+
+            if not tool_calls.tool_calls:
+                break_reason = "empty_tool_calls"
+                break
+
+            tool_calls = _ensure_tool_call_ids(tool_calls, turn_index)
+            tool_call_results, final_outputs = await self._aexecute_tool_calls(tool_calls)
+            event = self._history_event(pending_inputs, pred, tool_calls, tool_call_results)
+            if final_outputs is not None:
+                event.update(final_outputs)
+            _append_history_event(history, event)
+            pending_inputs = {}
+
+            if final_outputs is not None:
+                return Prediction(**final_outputs, history=history, termination_reason="submit")
+
+        return await self._aforced_submit(history, pending_inputs, break_reason, max_iters)
+
+    async def _aexecute_tool_calls(self, tool_calls: ToolCalls) -> tuple[ToolCallResults, dict[str, Any] | None]:
+        values = []
+        is_errors = []
+        final_outputs = None
+        for tool_call in tool_calls.tool_calls:
+            if tool_call.name not in self.tools:
+                values.append(f"Unknown tool: {tool_call.name}")
+                is_errors.append(True)
+                continue
+            try:
+                value = await self.tools[tool_call.name].acall(**(tool_call.args or {}))
+                values.append(value)
+                is_errors.append(False)
+                if tool_call.name == "submit" and isinstance(value, dict):
+                    final_outputs = value
+            except Exception as err:
+                values.append(f"Execution error in {tool_call.name}: {format_error_for_lm(err, traceback_frames=5)}")
+                is_errors.append(True)
+        return ToolCallResults.from_tool_calls_and_values(tool_calls, values, is_errors), final_outputs
+
+    async def _aforced_submit(self, history, pending_inputs, break_reason, turn_index):
+        try:
+            pred = await self.react.acall(
+                history=history,
+                tools=list(self.tools.values()),
+                config={"tool_choice": {"type": "function", "function": {"name": "submit"}}, "reasoning_effort": None},
+                **pending_inputs,
+            )
+            tool_calls = _ensure_tool_call_ids(_coerce_tool_calls(getattr(pred, "tool_calls", None)), turn_index)
+        except (AdapterParseError, ValueError, ContextWindowExceededError) as err:
+            logger.warning("Forced submit failed: %s", format_error_for_lm(err, traceback_frames=5))
+            return Prediction(history=history, termination_reason=break_reason or "failed")
+        submit_calls = ToolCalls(tool_calls=[call for call in tool_calls.tool_calls if call.name == "submit"])
+        if not submit_calls.tool_calls:
+            return Prediction(history=history, termination_reason=break_reason or "failed")
+        tool_call_results, final_outputs = await self._aexecute_tool_calls(submit_calls)
+        event = self._history_event(pending_inputs, pred, submit_calls, tool_call_results)
+        if final_outputs is not None:
+            event.update(final_outputs)
+        _append_history_event(history, event)
+        if final_outputs is not None:
+            return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
+        return Prediction(history=history, termination_reason=break_reason or "failed")
 
     def _history_event(
         self,

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -1,3 +1,5 @@
+import pytest
+
 import dspy
 from dspy.dsp.utils.utils import dotdict
 
@@ -15,6 +17,35 @@ def test_react_v2_submit_tool_returns_original_output_fields():
     assert "tool_call_results" not in react.react.signature.input_fields
 
 
+@pytest.mark.asyncio
+async def test_react_v2_async_path_awaits_tools_and_submits():
+    calls = []
+
+    async def lookup(query: str) -> str:
+        calls.append(query)
+        return f"found {query}"
+
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "Look it up.",
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "lookup", "args": {"query": "cats"}}]),
+            },
+            {
+                "next_thought": "Answer.",
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "found cats"}}]),
+            },
+        ]
+    )
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        pred = await dspy.ReActV2("question -> answer", tools=[lookup]).acall(question="cats")
+
+    assert calls == ["cats"]
+    assert pred.answer == "found cats"
+    assert pred.termination_reason == "submit"
+
+
 def test_react_v2_text_mock_lm_loop_records_inputs_once():
     def lookup(query: str) -> str:
         return f"found {query}"
@@ -23,15 +54,11 @@ def test_react_v2_text_mock_lm_loop_records_inputs_once():
         [
             {
                 "next_thought": "I should look this up.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "lookup", "args": {"query": "cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "lookup", "args": {"query": "cats"}}]),
             },
             {
                 "next_thought": "I can answer now.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "found cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "found cats"}}]),
             },
         ]
     )
@@ -55,15 +82,11 @@ def test_react_v2_continuation_omits_missing_original_inputs():
         [
             {
                 "next_thought": "I should look this up.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "lookup", "args": {"query": "cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "lookup", "args": {"query": "cats"}}]),
             },
             {
                 "next_thought": "I can answer now.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "found cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "found cats"}}]),
             },
         ]
     )
@@ -91,9 +114,7 @@ def test_react_v2_text_mode_accepts_top_level_tool_arguments():
             },
             {
                 "next_thought": "I can answer now.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "found cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "found cats"}}]),
             },
         ]
     )
@@ -128,15 +149,11 @@ def test_react_v2_unknown_tool_observation_can_continue():
         [
             {
                 "next_thought": "Try a missing tool.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "missing_tool", "args": {"query": "cats"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "missing_tool", "args": {"query": "cats"}}]),
             },
             {
                 "next_thought": "Recover with a final answer.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "done"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "done"}}]),
             },
         ]
     )
@@ -156,9 +173,7 @@ def test_react_v2_accepts_serialized_history_input():
         [
             {
                 "next_thought": "I can answer.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "done"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "done"}}]),
             }
         ]
     )
@@ -177,9 +192,7 @@ def test_react_v2_forced_submit_on_empty_tool_calls():
             {"next_thought": "No action.", "tool_calls": dspy.ToolCalls(tool_calls=[])},
             {
                 "next_thought": "Forced final.",
-                "tool_calls": dspy.ToolCalls.from_dict_list(
-                    [{"name": "submit", "args": {"answer": "forced"}}]
-                ),
+                "tool_calls": dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "forced"}}]),
             },
         ]
     )
@@ -310,17 +323,12 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
         "call_provider_2",
     ]
     assert [
-        result.call_id
-        for result in pred.history.messages[0]["tool_calls"].tool_call_results.tool_call_results
+        result.call_id for result in pred.history.messages[0]["tool_calls"].tool_call_results.tool_call_results
     ] == [
         "call_provider_1",
         "call_provider_2",
     ]
-    assert [
-        message["tool_call_id"]
-        for message in lm.calls[1]["messages"]
-        if message["role"] == "tool"
-    ] == [
+    assert [message["tool_call_id"] for message in lm.calls[1]["messages"] if message["role"] == "tool"] == [
         "call_provider_1",
         "call_provider_2",
     ]


### PR DESCRIPTION
Fixes #10256.\n\nReActV2 exposed Module.acall() but had no aforward() implementation, so async callers fell back to the synchronous path. This prevented async MCP tools from being awaited.\n\nThis PR adds the async ReActV2 loop, async tool execution, and the forced-submit recovery path. The synchronous path is unchanged.\n\nVerification:\n- uv run pytest tests/predict/test_react_v2.py -q — 11 passed\n- uv run ruff check dspy/predict/react_v2.py tests/predict/test_react_v2.py — passed\n- uv run ruff format --check dspy/predict/react_v2.py tests/predict/test_react_v2.py — passed\n- git diff --check — passed\n- uv run ty check dspy/predict/react_v2.py — reports 10 existing typing diagnostics in this module; the new async path adds no distinct diagnostic beyond the existing self.signature typing issue.\n\nThe regression test uses a deterministic DummyLM and an async tool, with no API key or external service.