### PR TITLE
[Bug] ReActV2 marker instructions leak

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -106,6 +106,9 @@ class ReActV2(Module):
                 "Call tools when more information is needed.",
                 f"When the final answer is ready, call `submit` with {outputs}.",
                 f"The available tools are: {tool_names}.",
+                "The `[[ ## ... ## ]]` field markers only structure this response's own output fields "
+                "(e.g. `next_thought`); never include them inside a tool call's arguments. Tool arguments, "
+                "including `submit`'s, must contain plain final values, not planning text or markers.",
             ]
         ).strip()
 

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -45,10 +45,14 @@ def _recover_marker_wrapped_value(value: Any, field_name: str) -> Any:
     sections: dict[str, list[str]] = {}
     current = preamble
     for line in value.splitlines():
-        match = field_header_pattern.match(line.strip())
+        # Match and slice the same string: `match.end()` is an offset into the
+        # stripped line, so slicing the raw one drops part of an indented marker
+        # into the recovered value.
+        stripped = line.strip()
+        match = field_header_pattern.match(stripped)
         if match:
             current = sections.setdefault(match.group(1), [])
-            remaining = line[match.end() :].strip()
+            remaining = stripped[match.end() :].strip()
             if remaining:
                 current.append(remaining)
             continue

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, get_args
 import pydantic
 
 import dspy
+from dspy.adapters.chat_adapter import field_header_pattern
 from dspy.adapters.types.tool import Tool, ToolCallResults, ToolCalls
 from dspy.primitives.module import Module
 from dspy.primitives.prediction import Prediction
@@ -22,6 +23,49 @@ _RESERVED_PREDICTION_KEYS = frozenset({"history", "termination_reason"})
 
 if TYPE_CHECKING:
     from dspy.signatures.signature import Signature
+
+
+def _recover_marker_wrapped_value(value: Any, field_name: str) -> Any:
+    """Recover a final output value that the model wrapped in ChatAdapter field markers.
+
+    `ChatAdapter` asks for `[[ ## field ## ]]`-delimited text while ReActV2 asks for the
+    final answer through the native `submit` tool. Some models satisfy both at once and
+    pass the marker scaffold as the argument, so the submitted value carries the planning
+    text instead of the answer.
+
+    When the scaffold names the field being submitted, or carries the value ahead of any
+    marker, that is what the model meant and it is recovered. When it carries only other
+    fields' markers there is no answer in it, so a `ValueError` is raised; the tool-call
+    loop reports that back to the model, which can then retry with a plain value.
+    """
+    if not isinstance(value, str) or "[[ ##" not in value:
+        return value
+
+    preamble: list[str] = []
+    sections: dict[str, list[str]] = {}
+    current = preamble
+    for line in value.splitlines():
+        match = field_header_pattern.match(line.strip())
+        if match:
+            current = sections.setdefault(match.group(1), [])
+            remaining = line[match.end() :].strip()
+            if remaining:
+                current.append(remaining)
+            continue
+        current.append(line)
+
+    if field_name in sections:
+        return "\n".join(sections[field_name]).strip()
+
+    recovered = "\n".join(preamble).strip()
+    if recovered:
+        return recovered
+
+    raise ValueError(
+        f"`{field_name}` was submitted as `[[ ## ... ## ]]` field markers "
+        f"({', '.join(sorted(sections))}) instead of a value. Those markers structure the "
+        f"response's own output fields; call `submit` with the plain final value for `{field_name}`."
+    )
 
 
 @experimental
@@ -68,7 +112,7 @@ class ReActV2(Module):
             missing = [name for name in output_names if name not in kwargs]
             if missing:
                 raise ValueError(f"Missing required final output field(s): {', '.join(missing)}")
-            return {name: kwargs[name] for name in output_names}
+            return {name: _recover_marker_wrapped_value(kwargs[name], name) for name in output_names}
 
         args = {
             name: _json_schema_for_annotation(field.annotation)

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -20,13 +20,99 @@ def test_react_v2_submit_tool_returns_original_output_fields():
     assert "tool_call_results" not in react.react.signature.input_fields
 
 
-def test_react_v2_instructions_warn_against_markers_in_tool_arguments():
+def test_react_v2_submit_recovers_value_wrapped_in_its_own_marker():
     react = dspy.ReActV2("question -> answer", tools=[])
 
-    instructions = react.react.signature.instructions
-    assert "tool call" in instructions
-    assert "markers" in instructions
-    assert "submit" in instructions
+    submitted = "[[ ## answer ## ]]\nParis\n[[ ## completed ## ]]"
+
+    assert react.tools["submit"](answer=submitted) == {"answer": "Paris"}
+
+
+def test_react_v2_submit_recovers_value_emitted_before_a_marker():
+    react = dspy.ReActV2("question -> answer", tools=[])
+
+    assert react.tools["submit"](answer="Paris\n\n[[ ## completed ## ]]") == {"answer": "Paris"}
+
+
+def test_react_v2_submit_rejects_scaffold_with_no_value_in_it():
+    """The reported failure: the marker scaffold arrives carrying planning text only."""
+    react = dspy.ReActV2("question -> answer", tools=[])
+
+    leaked = "[[ ## next_thought ## ]]\nPreparing the answer...\n[[ ## completed ## ]]"
+
+    with pytest.raises(ValueError) as err:
+        react.tools["submit"](answer=leaked)
+
+    message = str(err.value)
+    assert "next_thought" in message
+    assert "answer" in message
+
+
+def test_react_v2_submit_leaves_ordinary_values_untouched():
+    react = dspy.ReActV2("question -> answer", tools=[])
+
+    assert react.tools["submit"](answer="Paris") == {"answer": "Paris"}
+    assert react.tools["submit"](answer="the [[ bracket ]] stays") == {"answer": "the [[ bracket ]] stays"}
+
+
+def test_react_v2_submit_leaves_non_string_values_untouched():
+    react = dspy.ReActV2("question -> count: int", tools=[])
+
+    assert react.tools["submit"](count=42) == {"count": 42}
+
+
+def test_react_v2_end_to_end_recovers_marker_wrapped_answer():
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "I can answer now.",
+                "tool_calls": {
+                    "tool_calls": [
+                        {
+                            "name": "submit",
+                            "arguments": {"answer": "[[ ## answer ## ]]\n42\n[[ ## completed ## ]]"},
+                        }
+                    ]
+                },
+            },
+        ]
+    )
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter(use_native_function_calling=False)):
+        pred = dspy.ReActV2("question -> answer", tools=[])(question="what is it")
+
+    assert pred.answer == "42"
+    assert pred.termination_reason == "submit"
+
+
+def test_react_v2_end_to_end_retries_after_a_leaked_scaffold():
+    """A scaffold with no value is reported back as a tool error, so the model can retry."""
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "Submitting.",
+                "tool_calls": {
+                    "tool_calls": [
+                        {
+                            "name": "submit",
+                            "arguments": {
+                                "answer": "[[ ## next_thought ## ]]\nPreparing...\n[[ ## completed ## ]]"
+                            },
+                        }
+                    ]
+                },
+            },
+            {
+                "next_thought": "Retrying with a plain value.",
+                "tool_calls": {"tool_calls": [{"name": "submit", "arguments": {"answer": "42"}}]},
+            },
+        ]
+    )
+
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter(use_native_function_calling=False)):
+        pred = dspy.ReActV2("question -> answer", tools=[])(question="what is it")
+
+    assert pred.answer == "42"
 
 
 def test_react_v2_text_mock_lm_loop_records_inputs_once():

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -20,6 +20,15 @@ def test_react_v2_submit_tool_returns_original_output_fields():
     assert "tool_call_results" not in react.react.signature.input_fields
 
 
+def test_react_v2_instructions_warn_against_markers_in_tool_arguments():
+    react = dspy.ReActV2("question -> answer", tools=[])
+
+    instructions = react.react.signature.instructions
+    assert "tool call" in instructions
+    assert "markers" in instructions
+    assert "submit" in instructions
+
+
 def test_react_v2_text_mock_lm_loop_records_inputs_once():
     def lookup(query: str) -> str:
         return f"found {query}"

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -28,6 +28,16 @@ def test_react_v2_submit_recovers_value_wrapped_in_its_own_marker():
     assert react.tools["submit"](answer=submitted) == {"answer": "Paris"}
 
 
+def test_react_v2_submit_recovers_value_from_an_indented_marker_line():
+    """An indented marker must not leave its own closing bracket in the value."""
+    react = dspy.ReActV2("question -> answer", tools=[])
+
+    assert react.tools["submit"](answer="  [[ ## answer ## ]] Paris") == {"answer": "Paris"}
+    assert react.tools["submit"](answer="\t[[ ## answer ## ]]\n  Paris\n[[ ## completed ## ]]") == {
+        "answer": "Paris"
+    }
+
+
 def test_react_v2_submit_recovers_value_emitted_before_a_marker():
     react = dspy.ReActV2("question -> answer", tools=[])
 


### PR DESCRIPTION
Fixes #10263.

## The problem

`ReActV2` builds a prompt that asks for `[[ ## ... ## ]]` marker-formatted output while also telling the model to return its final answer through the native `submit` tool. Some models satisfy both literally and pass the marker scaffold as the argument, so `submit(answer=...)` arrives carrying planning text instead of the answer. The call succeeds and the polluted value becomes the final output.

## What changed

Two parts, because the instruction alone is unenforceable.

**Prompt side.** One instruction added to the generated ReAct signature: the markers structure this response's own output fields only, and tool arguments including `submit`'s must carry plain final values.

**Enforcement.** `submit` now passes each final value through `_recover_marker_wrapped_value`, which reuses `field_header_pattern` from `ChatAdapter` rather than re-matching the markers here:

- a value under a marker naming the field being submitted is what the model meant, so it is returned with the scaffold removed
- a value emitted ahead of any marker, such as text followed by a trailing `[[ ## completed ## ]]`, is likewise returned
- a scaffold carrying only other fields' markers holds no answer, so it raises `ValueError`. `_execute_tool_calls` already reports tool errors back to the model, so it retries with a plain value rather than a planning-text answer being accepted silently

Values with no markers, and non-string values, are returned untouched.

## Verification

`pytest tests/predict/test_react_v2.py` passes (17 tests). The five new behavioural tests all fail when the source change is reverted and the tests are kept, so they exercise the fix rather than asserting that instruction text exists. `tests/predict/` and `tests/adapters/` are differential-clean: the one failure there, `test_in_memory_resource_construction`, is an ImportError from an optional image dependency that reproduces identically with this change reverted. `ruff check` is clean on both files.

## AI assistance

Disclosed per CONTRIBUTING. This patch was written with AI assistance (Claude, run
through a local pipeline of mine) and reviewed and submitted by me. Nothing here is
auto-opened; every PR goes through a manual review step before it is sent.
