### PR TITLE
fix(adapters): preserve XMLAdapter round-trip fidelity for `]]>` and empty optional containers

### DIFF
--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -30,9 +30,10 @@ class XMLAdapter(ChatAdapter):
                 output.append(self._value_to_xml(serialized, field.name))
                 continue
             formatted = format_field_value(field_info=field.info, value=value)
-            if is_output and field.info.annotation is str:
-                # `]]>` is illegal in XML character data (XML 1.0 §2.5), so escape just that
-                # sequence to keep the output parseable by this adapter's own XML parser.
+            if is_output and not isinstance(serialized, (dict, list)):
+                # Textual output values (str, Optional[str], enums, dates, ...) are re-parsed as
+                # XML character data, where `]]>` is illegal (XML 1.0 §2.5), so escape just that
+                # sequence to keep the emission parseable by this adapter's own XML parser.
                 formatted = formatted.replace("&", "&amp;").replace("<", "&lt;").replace("]]>", "]]&gt;")
             output.append(f"<{field.name}>\n{formatted}\n</{field.name}>")
         return "\n\n".join(output).strip()

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -31,7 +31,9 @@ class XMLAdapter(ChatAdapter):
                 continue
             formatted = format_field_value(field_info=field.info, value=value)
             if is_output and field.info.annotation is str:
-                formatted = formatted.replace("&", "&amp;").replace("<", "&lt;")
+                # `]]>` is illegal in XML character data (XML 1.0 §2.5), so escape just that
+                # sequence to keep the output parseable by this adapter's own XML parser.
+                formatted = formatted.replace("&", "&amp;").replace("<", "&lt;").replace("]]>", "]]&gt;")
             output.append(f"<{field.name}>\n{formatted}\n</{field.name}>")
         return "\n\n".join(output).strip()
 
@@ -150,7 +152,9 @@ class XMLAdapter(ChatAdapter):
                 )
             return f"<{tag}{attrs}>{''.join(children)}</{tag}>"
         return (
-            f"<{tag}{attrs}>{str(value).replace('&', '&amp;').replace('<', '&lt;')}</{tag}>"
+            # `]]>` is illegal in XML character data (XML 1.0 §2.5), so escape just that
+            # sequence to keep the output parseable by this adapter's own XML parser.
+            f"<{tag}{attrs}>{str(value).replace('&', '&amp;').replace('<', '&lt;').replace(']]>', ']]&gt;')}</{tag}>"
             if value is not None
             else f"<{tag}{attrs} />"
         )
@@ -184,9 +188,16 @@ class XMLAdapter(ChatAdapter):
     @classmethod
     def _elements_to_value(cls, elements: list[ET.Element], schema: dict, definitions: dict) -> Any:
         schema = definitions.get(schema.get("$ref", "").rsplit("/", 1)[-1], schema)
+        if schema.get("type") == "null" and not list(elements[0]) and not (elements[0].text or "").strip():
+            return None
         if choices := schema.get("anyOf"):
             if {"type": "null"} in choices and not list(elements[0]) and not (elements[0].text or "").strip():
-                return None
+                # An empty element is ambiguous between "no value" and "empty container". Format
+                # never encodes None as an empty element (it emits literal `None` text), so decode
+                # empty elements as empty containers when a non-null choice is an array or
+                # free-form object, and as None otherwise (scalars, models, TypedDicts).
+                if not any(cls._is_container_choice(choice, definitions) for choice in choices):
+                    return None
             choices = [choice for choice in choices if choice.get("type") != "null"]
             schema = choices[0]
             if list(elements[0]):
@@ -216,6 +227,17 @@ class XMLAdapter(ChatAdapter):
             name: cls._elements_to_value(items, properties.get(name, child_schema), definitions)
             for name, items in children.items()
         }
+
+    @staticmethod
+    def _is_container_choice(choice: dict, definitions: dict) -> bool:
+        if choice.get("type") == "null":
+            return False
+        resolved = definitions.get(choice.get("$ref", "").rsplit("/", 1)[-1], choice)
+        if resolved.get("type") == "array":
+            return True
+        # Free-form objects (e.g. `dict[str, int]`) have no `properties`; models and
+        # TypedDicts do, and keep decoding empty elements as None.
+        return resolved.get("type") == "object" and "properties" not in resolved
 
     @staticmethod
     def _group_children(element: ET.Element) -> dict[str, list[ET.Element]]:

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -266,6 +266,60 @@ def test_xml_adapter_escapes_closing_tags_and_rejects_malformed_xml():
         adapter.parse(TestSignature, "<code>print('</code>')</code>")
 
 
+def test_xml_adapter_round_trips_cdata_end_marker():
+    class TestSignature(dspy.Signature):
+        code: str = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    value = "while (arr[i]]>0): pass"
+    formatted = adapter.format_field_with_value(
+        {FieldInfoWithName(name="code", info=TestSignature.output_fields["code"]): value}
+    )
+    # `]]>` is illegal in XML character data and must be escaped to stay parseable.
+    assert adapter.parse(TestSignature, formatted) == {"code": value}
+
+
+def test_xml_adapter_round_trips_cdata_end_marker_inside_nested_values():
+    class TestSignature(dspy.Signature):
+        payload: dict[str, list[str]] = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    value = {"notes": ["a ]]> b", "plain"]}
+    formatted = adapter.format_field_with_value(
+        {FieldInfoWithName(name="payload", info=TestSignature.output_fields["payload"]): value}
+    )
+    assert adapter.parse(TestSignature, formatted) == {"payload": value}
+
+
+def test_xml_adapter_empty_optional_containers_survive_format_and_parse():
+    class TestSignature(dspy.Signature):
+        items: list[str] | None = dspy.OutputField()
+        mapping: dict[str, int] | None = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    fields = {
+        FieldInfoWithName(name="items", info=TestSignature.output_fields["items"]): [],
+        FieldInfoWithName(name="mapping", info=TestSignature.output_fields["mapping"]): {},
+    }
+    formatted = adapter.format_field_with_value(fields)
+    assert "<items />" in formatted
+    assert adapter.parse(TestSignature, formatted) == {"items": [], "mapping": {}}
+
+    fields[FieldInfoWithName(name="items", info=TestSignature.output_fields["items"])] = ["a"]
+    fields[FieldInfoWithName(name="mapping", info=TestSignature.output_fields["mapping"])] = {"a": 1}
+    formatted = adapter.format_field_with_value(fields)
+    assert adapter.parse(TestSignature, formatted) == {"items": ["a"], "mapping": {"a": 1}}
+
+
+def test_xml_adapter_parse_optional_containers_from_lm_output():
+    class TestSignature(dspy.Signature):
+        items: list[str] | None = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    # An LM that emits an empty element for "no results" gets an empty list.
+    assert adapter.parse(TestSignature, "<items />") == {"items": []}
+
+
 def test_xml_adapter_format_and_parse_nested_model():
     class Address(pydantic.BaseModel):
         city: str

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -279,6 +279,19 @@ def test_xml_adapter_round_trips_cdata_end_marker():
     assert adapter.parse(TestSignature, formatted) == {"code": value}
 
 
+def test_xml_adapter_round_trips_cdata_end_marker_for_nullable_strings():
+    class TestSignature(dspy.Signature):
+        note: str | None = dspy.OutputField()
+
+    adapter = XMLAdapter()
+    value = "a ]]> b"
+    formatted = adapter.format_field_with_value(
+        {FieldInfoWithName(name="note", info=TestSignature.output_fields["note"]): value}
+    )
+    # Nullable strings bypass the exact-`str` guard but still need CDATA-safe escaping.
+    assert adapter.parse(TestSignature, formatted) == {"note": value}
+
+
 def test_xml_adapter_round_trips_cdata_end_marker_inside_nested_values():
     class TestSignature(dspy.Signature):
         payload: dict[str, list[str]] = dspy.OutputField()


### PR DESCRIPTION
Fixes #10269

## Summary

Two round-trip fidelity defects in the nested-XML support added by #10239, where `XMLAdapter.format()` produced output that `XMLAdapter.parse()` rejected or decoded incorrectly.

### 1. `]]>` in text values crashed parsing (regression vs. the pre-#10239 regex parser)

Text escaping covered only `&` and `<`, so a value containing `]]>` was emitted as raw character data. That sequence is illegal in XML (XML 1.0 §2.5), and the adapter's own `ET.fromstring` rejected it:

```python
adapter.format_field_with_value({field: "array ]]> trap"})
# -> <text>\narray ]]> trap\n</text>
adapter.parse(Sig, formatted)
# -> AdapterParseError: Failed to parse XML: not well-formed (invalid token)
```

Any completion containing `]]>` — realistic for code-generation tasks (`arr[i]]>0`) — failed hard. All textual output emissions now escape `]]>` as `]]&gt;`, which decodes back losslessly. The guard covers every non dict/list serialized payload (plain `str`, `str | None`, enums, dates), not just exact-`str` annotations, so nullable strings can't bypass it. I chose the targeted sequence over escaping every `>` to keep prompt rendering unchanged apart from the illegal case.

### 2. Empty containers under nullable unions silently became `None`

`format` emits an empty list as `<items />`, but `parse` short-circuited any empty element with a null union choice to `None`:

```python
items: list[str] | None
# format([])      -> "<items />"
# parse("<items />") -> None   (data loss; also {} for Optional[dict])
```

The empty-element check in `_elements_to_value` now defers to container decoding when a non-null union choice is an array or a free-form object (JSON-schema object without `properties`, i.e. `dict[...]`). Scalars, pydantic models and TypedDicts keep decoding empty elements as `None`, exactly matching the existing expectations in `test_xml_adapter_parses_nullable_and_structured_union_fields`. This is consistent with the format side, which never encodes `None` as an empty element (it emits literal `None` text, which `parse_value` coerces back).

A bare null-schema candidate now also returns `None` for empty elements so `Optional[some_model]` still falls back to `None` when `{}` fails model validation.

## Known residual (unchanged by this PR, noted in the issue)

Inside *nested* user models, `None` and `[]` both serialize to `<tags />`, so the two remain indistinguishable in that position; after this PR they decode as `[]` (before, both decoded as `None`). Whitespace-only strings also continue to lose leading/trailing whitespace, as in all prior versions. Separately, formatting a `None` value for a `str | None` field emits literal `None` text that parses back as the string `"None"` — pre-existing since before #10239, and fixable only with a format-side change to `None` encoding.

## Testing

- 5 new tests in `tests/adapters/test_xml_adapter.py`: `]]>` round-trip for plain, nested, and nullable-string values; empty `Optional[list]`/`Optional[dict]` format→parse; LM-emitted `<items />` → `[]`.
- Full suite: `pytest tests/ --ignore=tests/reliability` → **1264 passed**, no failures (Python 3.11 / macOS).
- Verified pre-existing behavior is otherwise preserved (e.g. single-item scalar text in list tags still parses leniently; garbage input still raises `AdapterParseError`).
- `ruff check` clean on both changed files.