### PR TITLE
fix(predict): reject reserved `trajectory` output name in ReAct (follow-up to #9852)

### DIFF
--- a/dspy/predict/react.py
+++ b/dspy/predict/react.py
@@ -39,6 +39,11 @@ class ReAct(Module):
         """
         super().__init__()
         self.signature = signature = ensure_signature(signature)
+        if "trajectory" in signature.output_fields:
+            raise ValueError(
+                "Output field `trajectory` is reserved by ReAct, which attaches it to every returned "
+                "Prediction. Please rename it in your signature."
+            )
         self.max_iters = max_iters
 
         tools = [t if isinstance(t, Tool) else Tool(t) for t in tools]

--- a/tests/predict/test_react.py
+++ b/tests/predict/test_react.py
@@ -534,3 +534,8 @@ async def test_async_error_retry():
     for i in range(2):
         obs = traj[f"observation_{i}"]
         assert re.search(r"\btool error\b", obs), f"unexpected observation_{i!r}: {obs}"
+
+
+def test_react_rejects_reserved_output_field_trajectory():
+    with pytest.raises(ValueError, match="reserved by ReAct"):
+        dspy.ReAct("question -> answer, trajectory: str", tools=[])


### PR DESCRIPTION
Follow-up to #9852. **Rebased onto `main` and re-scoped** — see the note at the bottom.

## Problem

`ReAct` attaches `trajectory` to every returned `Prediction`:

```python
# dspy/predict/react.py:121, :149
return dspy.Prediction(trajectory=trajectory, **extract)
```

If the user's signature declares an output field named `trajectory`, the `**` expansion collides:

```
TypeError: dspy.Prediction() got multiple values for keyword argument 'trajectory'
```

As with the ReActV2 case, two things make this worse than a normal misconfiguration error:

1. **It fails mid-`forward()`, not at construction** — the failure only appears *after* the agent loop has already made (and billed) its LM calls.
2. **The message doesn't point at the cause.** Nothing tells the user that `trajectory` is a name ReAct reserves, so the fix isn't discoverable from the traceback.

This is the exact case #9852 identified and deferred:

> ReAct v1 has the same bug class with a different reserved key — `dspy.Prediction(trajectory=trajectory, **extract)` at `dspy/predict/react.py:118` and `:143`. A user signature with an output field named `trajectory` would hit the identical TypeError. **Not addressed here since it predates 3.3.0 and isn't a regression, but worth tracking as a follow-up.**

Agreed that it isn't a regression — this PR is that follow-up.

## Reproduction

Reproduces on current `main` (`b3897e2`) with `DummyLM`, no API key needed:

```python
import dspy

def lookup(query: str) -> str:
    return f"found {query}"

lm = dspy.utils.DummyLM([
    {"next_thought": "done", "next_tool_name": "finish", "next_tool_args": {}},
    {"reasoning": "r", "answer": "x", "trajectory": "t"},
])

with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
    dspy.ReAct("question -> answer, trajectory: str", tools=[lookup])(question="q")
# TypeError: dspy.Prediction() got multiple values for keyword argument 'trajectory'
```

## Fix

Validate the signature's output fields in `__init__` and raise a clear `ValueError`, mirroring the guard #9852 added to `ReActV2`:

```
ValueError: Output field `trajectory` is reserved by ReAct, which attaches it to
every returned Prediction. Please rename it in your signature.
```

The error now surfaces at construction, before any LM call.

I deliberately kept this as a plain `in` check rather than lifting #9852's `frozenset` pattern into a shared helper — `ReAct` reserves exactly one name and the two modules don't currently share a base. Happy to unify them if you'd prefer a single reserved-keys utility.

## Tests

One test added to `tests/predict/test_react.py`, confirmed to **fail** against pre-fix code and pass after:

```
FAILED tests/predict/test_react.py::test_react_rejects_reserved_output_field_trajectory
```

## Verification

- `pytest tests/predict/ tests/primitives/test_module.py tests/flex/` → **373 passed, 63 skipped**
- `ruff check` on both changed files → clean
- Diff is **+10 / −0** across 2 files; no behaviour change for signatures that don't use the name.

---

### Note on the re-scope

This PR originally also fixed the `ReActV2` half (`history` / `termination_reason`). #9852 landed that while this was open, so I rebased onto `main` and **dropped the now-duplicate ReActV2 change and its tests**, leaving only the `ReAct` v1 gap that #9852 explicitly deferred. The earlier conflict in `tests/predict/test_react_v2.py` is resolved as a result — this branch no longer touches that file.