### PR TITLE
Preserve provider extras on file_id-only file content blocks

### DIFF
--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -1908,7 +1908,15 @@ def _binary_dict_to_part(file: dict[str, Any]) -> LMBinaryPart:
         media_type, data = _split_data_uri(file["data"])
         return LMBinaryPart(data=data, media_type=media_type, filename=file.get("filename"))
     if file.get("file_id") is not None:
-        return LMBinaryPart(file_id=file["file_id"], filename=file.get("filename"))
+        # Preserve provider-specific keys the typed LMBinaryPart can't represent
+        # (e.g. `format` / `detail` / `video_metadata` for AI Studio / Vertex
+        # video files) by stashing the original block; part_to_openai_blocks
+        # will re-emit it verbatim on the wire. See issue #9898.
+        known_keys = {"file_id", "filename"}
+        metadata: dict[str, Any] = {}
+        if any(key not in known_keys for key in file):
+            metadata["legacy_content_block"] = {"type": "file", "file": dict(file)}
+        return LMBinaryPart(file_id=file["file_id"], filename=file.get("filename"), metadata=metadata)
     raise ValueError("Binary content block requires data, file_data, or file_id.")
 
 

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -310,6 +310,56 @@ def test_file_content_block_with_data_and_id_round_trips_losslessly_to_responses
     ]
 
 
+def test_file_content_block_preserves_provider_extras_on_file_id_only_input():
+    """A ``{"type": "file", "file": {...}}`` block whose file dict carries provider
+    keys beyond ``file_id``/``filename`` (e.g. AI Studio / Vertex video files use
+    ``format`` / ``detail`` / ``video_metadata``) used to lose them when the wire
+    block was projected to :class:`LMBinaryPart`. The typed part now stashes the
+    original block so the outgoing wire representation is byte-for-byte identical.
+
+    Regression test for https://github.com/stanfordnlp/dspy/issues/9898.
+    """
+    from dspy.clients.openai_format import parts_to_openai_content
+
+    original_block = {
+        "type": "file",
+        "file": {
+            "file_id": "https://generativelanguage.googleapis.com/v1beta/files/abc123",
+            "format": "video/webm",
+            "detail": "high",
+            "video_metadata": {"fps": 1.0},
+        },
+    }
+
+    message = LMMessage(role="user", content=[original_block])
+    part = message.parts[0]
+
+    assert isinstance(part, LMBinaryPart)
+    assert part.file_id == original_block["file"]["file_id"]
+    assert part.metadata["legacy_content_block"] == original_block
+
+    assert parts_to_openai_content(message.parts) == [original_block]
+
+
+def test_file_content_block_without_extras_leaves_metadata_clean():
+    """A ``{"type": "file", "file": {...}}`` block that only uses recognized keys
+    (``file_id`` / ``filename``) still projects to a plain LMBinaryPart with no
+    stashed legacy block: the typed part can already re-emit it losslessly."""
+    from dspy.clients.openai_format import parts_to_openai_content
+
+    original_block = {
+        "type": "file",
+        "file": {"file_id": "file-abc", "filename": "notes.txt"},
+    }
+
+    message = LMMessage(role="user", content=[original_block])
+    part = message.parts[0]
+
+    assert isinstance(part, LMBinaryPart)
+    assert "legacy_content_block" not in part.metadata
+    assert parts_to_openai_content(message.parts) == [original_block]
+
+
 def test_document_source_url_stays_url_and_round_trips_through_history_messages():
     message = LMMessage(
         role="user",


### PR DESCRIPTION
## Summary

An OpenAI/litellm `{"type": "file", "file": {...}}` content block whose `file` dict carried provider-specific keys beyond `file_id` / `filename` — e.g. AI Studio / Vertex video files use `format`, `detail`, `video_metadata` — was projected to `LMBinaryPart` with only `file_id` / `filename`, and came back out as `{"type": "file", "file": {"file_id": "..."}}`. That silently dropped `format` (forcing litellm to HTTP-fetch the URL to infer its MIME type) and downgraded resolution / frame-sampling controls.

This reuses the existing `metadata["legacy_content_block"]` escape hatch (already used by `_binary_dict_to_part` for the `file_data` + `file_id` conflict case): when the input `file` dict has keys other than `file_id` / `filename`, stash the original block on the typed part. `part_to_openai_blocks` already re-emits `legacy_content_block` verbatim, so the outgoing wire representation is byte-for-byte identical to the input. Blocks that only use recognized keys keep the previous clean projection.

Fixes #9898.

## Test plan

- `tests/core/test_types.py::test_file_content_block_preserves_provider_extras_on_file_id_only_input` — mirrors the issue's reproducer: a video-file block with `format` / `detail` / `video_metadata` round-trips through `LMMessage` → `parts_to_openai_content` unchanged.
- `tests/core/test_types.py::test_file_content_block_without_extras_leaves_metadata_clean` — the plain `{file_id, filename}` case still produces an `LMBinaryPart` with no stashed legacy block, so unaffected inputs stay on the typed path.
- Existing coverage kept green: `test_file_content_block_with_data_and_id_round_trips_losslessly_to_responses_format` and every other `file`/`binary` test under `tests/core/test_types.py`, `tests/signatures/test_adapter_file.py`, and `tests/clients/test_lm.py` still pass locally (one unrelated failure on `test_save_load_file_signature` reproduces on `main` too: it's a Windows path-encoding issue with the workspace's Chinese-named parent directory, not something this PR touches).

## AI-assisted contribution disclosure

Per `CONTRIBUTING.md`: this fix was written with the help of Cursor (Claude). The bug scenario, root cause, and remediation are directly from the linked issue; the choice to piggy-back on the existing `legacy_content_block` mechanism (rather than growing `LMBinaryPart` with new provider-specific fields) is mine, so the typed model surface stays unchanged. I read every line I'm submitting, ran the tests locally, and verified the pre-existing `test_save_load_file_signature` failure is unrelated to this diff. The core prompt was: "Preserve `format` / `detail` / `video_metadata` when a `{"type": "file", "file": {...}}` input block projects to `LMBinaryPart`, without inventing new typed fields; reuse `metadata['legacy_content_block']` if it fits."
