### PR TITLE
fix(dspy): support legacy lazy-import loaders

### DIFF
--- a/dspy/utils/lazy_import.py
+++ b/dspy/utils/lazy_import.py
@@ -106,6 +106,16 @@ class _LazyModule(types.ModuleType):
                 return loaded
 
             spec = self._dspy_lazy_spec
+            if not hasattr(spec.loader, "exec_module"):
+                # Let importlib drive loaders that only implement the legacy
+                # load_module protocol.
+                sys.modules.pop(module_name, None)
+                try:
+                    return importlib.import_module(module_name)
+                except Exception:
+                    sys.modules[module_name] = self
+                    raise
+
             module = importlib.util.module_from_spec(spec)
             sys.modules[module_name] = module
             try:

--- a/tests/utils/test_lazy_import.py
+++ b/tests/utils/test_lazy_import.py
@@ -1,10 +1,12 @@
+import importlib
 import sys
 import threading
+import types
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from dspy.utils.lazy_import import _INSTALL_HINTS, _detect_dspy_dist, _MissingModule, is_available, require
+from dspy.utils.lazy_import import _INSTALL_HINTS, _detect_dspy_dist, _LazyModule, _MissingModule, is_available, require
 
 
 def test_is_available_true_for_stdlib():
@@ -37,6 +39,26 @@ def test_require_returns_lazy_module_when_present():
 def test_require_returns_cached_module():
     mod = require("json")
     assert mod is sys.modules["json"]
+
+
+def test_lazy_module_supports_loader_without_exec_module(monkeypatch):
+    module_name = "dspy_lazy_legacy_loader_module"
+    spec = importlib.machinery.ModuleSpec(module_name, object())
+    proxy = _LazyModule(module_name, spec, threading.RLock())
+    module = types.ModuleType(module_name)
+    module.value = 42
+    monkeypatch.setitem(sys.modules, module_name, proxy)
+
+    def import_module(name):
+        assert name == module_name
+        assert name not in sys.modules
+        sys.modules[name] = module
+        return module
+
+    monkeypatch.setattr(importlib, "import_module", import_module)
+
+    assert proxy.value == 42
+    assert sys.modules[module_name] is module
 
 
 def test_require_is_safe_under_concurrent_first_use(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #10283

## 📝 Changes Description

This MR/PR contains the following changes:

- Falls back to the standard import machinery when a lazy module's loader only implements the legacy `load_module` protocol.
- Restores the lazy proxy if that fallback import fails, preserving the existing retry behavior.
- Adds regression coverage for a loader without `exec_module`.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

N/A

## Tests

- `uv run pytest tests/utils/test_lazy_import.py -q` (14 passed)
- `uv run ruff check dspy/utils/lazy_import.py tests/utils/test_lazy_import.py`
- `uv run pre-commit run --files dspy/utils/lazy_import.py tests/utils/test_lazy_import.py`
