### PR TITLE
fix: avoid retaining Image instances in format cache

### DIFF
--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -104,13 +104,11 @@ class Image(Type):
         # Delegate the rest of initialization to pydantic's BaseModel.
         super().__init__(**data)
 
-    @lru_cache(maxsize=32)
     def format(self) -> list[dict[str, Any]] | str:
         try:
-            image_url = encode_image(self.url)
+            return _format_image(self.url)
         except Exception as e:
             raise ValueError(f"Failed to format image for DSPy: {e}")
-        return [{"type": "image_url", "image_url": {"url": image_url}}]
 
     @classmethod
     def from_url(cls, url: str, verify: bool = True, timeout: float | None = 30.0) -> "Image":
@@ -161,6 +159,12 @@ class Image(Type):
             image_type = self.url.split(";")[0].split("/")[-1]
             return f"Image(url=data:image/{image_type};base64,<IMAGE_BASE_64_ENCODED({len_base64!s})>)"
         return f"Image(url='{self.url}')"
+
+
+@lru_cache(maxsize=32)
+def _format_image(url: str) -> list[dict[str, Any]] | str:
+    image_url = encode_image(url)
+    return [{"type": "image_url", "image_url": {"url": image_url}}]
 
 
 def is_url(string: str) -> bool:

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -1,7 +1,9 @@
 import base64
+import gc
 import os
 import tempfile
 import warnings
+import weakref
 from io import BytesIO
 
 import pydantic
@@ -10,7 +12,7 @@ import requests
 from PIL import Image as PILImage
 
 import dspy
-from dspy.adapters.types.image import encode_image
+from dspy.adapters.types.image import _format_image, encode_image
 from dspy.utils.dummies import DummyLM
 
 
@@ -463,6 +465,19 @@ def test_image_repr():
     assert str(pil_image).startswith('<<CUSTOM-TYPE-START-IDENTIFIER>>[{"type": "image_url",')
     assert str(pil_image).endswith("<<CUSTOM-TYPE-END-IDENTIFIER>>")
     assert "base64" in str(pil_image)
+
+
+def test_format_cache_does_not_retain_image_instances():
+    _format_image.cache_clear()
+    image = dspy.Image("data:image/png;base64,AAAA")
+    reference = weakref.ref(image)
+
+    image.format()
+    del image
+    gc.collect()
+
+    assert reference() is None
+    _format_image.cache_clear()
 
 
 def test_image_constructor_supports_positional_source_and_url_keyword():


### PR DESCRIPTION
## Summary / Problem

Fixes #10273. `Image.format` cached bound method calls with `lru_cache`, causing the cache to retain up to 32 `Image` instances and their potentially large data URIs for the lifetime of the process.

## Changes

- Cache formatted image payloads by URL in a module-level helper.
- Add a regression test proving formatted images are not retained by the cache.

## Tests

- `uv run --frozen python -c "..."` — passed; the image is collectible after formatting.
- `uv run --frozen python -m compileall -q dspy tests/signatures/test_adapter_image.py` — passed.
- `git diff --check` — passed.
- `uv run --frozen pytest tests/signatures/test_adapter_image.py -q` — blocked by the host environment: the installed `litellm` requires a newer Pydantic export (`Discriminator`) than the available version.

## Compatibility / Known limitations

The cache remains bounded at 32 entries and continues to reuse formatting for identical URLs. The full pytest module should be rerun in the project's supported dependency environment.

Issue: https://github.com/stanfordnlp/dspy/issues/10273
