### PR TITLE
docs(ecosystem): add Hybrid RAG Action to community showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ To install the very latest from `main`:
 pip install git+https://github.com/stanfordnlp/dspy.git
 ```
 
-
+## 🌐 Community & Ecosystem
+- [Hybrid RAG GitHub Action](https://github.com/Cagrik34/hybrid-rag-action): Zero-dependency GitHub Action & DSPy retriever combining Okapi BM25 and dense semantic embeddings with RRF for automated repo triage.
 
 
 ## 📜 Citation & Reading More

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install git+https://github.com/stanfordnlp/dspy.git
 ```
 
 ## 🌐 Community & Ecosystem
-- [Hybrid RAG GitHub Action](https://github.com/Cagrik34/hybrid-rag-action): Zero-dependency GitHub Action & DSPy retriever combining Okapi BM25 and dense semantic embeddings with RRF for automated repo triage.
+- [Hybrid RAG GitHub Action](https://github.com/Cagrik34/hybrid-rag-action): Zero-dependency GitHub Action for automated repository and PR triage combining AST-aware Okapi BM25 and dense vector RRF retrieval.
 
 
 ## 📜 Citation & Reading More


### PR DESCRIPTION
### Summary
Adds [Hybrid RAG Action](https://github.com/Cagrik34/hybrid-rag-action) to the community showcase.

### Description
`Hybrid RAG Action` is a zero-dependency automated GitHub issue and PR triage tool. It integrates Okapi BM25 sparse keyword retrieval with dense vector cosine similarity fused via Reciprocal Rank Fusion (RRF, $k=60$) to provide exact line citations.