### PR TITLE
fix(dspy): fall back to memory-only cache in configure_cache on disk cache init failure

### DIFF
--- a/dspy/clients/__init__.py
+++ b/dspy/clients/__init__.py
@@ -39,15 +39,41 @@ def configure_cache(
         safe_types: Additional types to allow when restrict_pickle is True.
     """
 
-    DSPY_CACHE = Cache(
-        enable_disk_cache,
-        enable_memory_cache,
-        disk_cache_dir,
-        disk_size_limit_bytes,
-        memory_max_entries,
-        restrict_pickle=restrict_pickle,
-        safe_types=safe_types,
-    )
+    # Cache only validates these once disk caching is actually attempted, but we need them
+    # to raise here regardless of enable_disk_cache so a config mistake can't get silently
+    # swallowed by the disk-cache-init fallback below and turned into a memory-only cache.
+    if restrict_pickle:
+        for t in safe_types or []:
+            if not isinstance(t, type):
+                raise TypeError(f"safe_types entries must be types, got {t!r}")
+    if disk_size_limit_bytes is not None and not isinstance(disk_size_limit_bytes, int):
+        raise TypeError(f"disk_size_limit_bytes must be None or an int, got {disk_size_limit_bytes!r}")
+
+    try:
+        DSPY_CACHE = Cache(
+            enable_disk_cache,
+            enable_memory_cache,
+            disk_cache_dir,
+            disk_size_limit_bytes,
+            memory_max_entries,
+            restrict_pickle=restrict_pickle,
+            safe_types=safe_types,
+        )
+    except Exception as e:
+        if not enable_disk_cache:
+            raise
+        # Same fallback used when the cache is first created at import time: a corrupted
+        # or unwritable disk cache directory shouldn't leave the process without a cache.
+        logger.warning("Failed to initialize disk cache, falling back to memory-only cache: %s", e)
+        DSPY_CACHE = Cache(
+            False,
+            enable_memory_cache,
+            disk_cache_dir,
+            disk_size_limit_bytes,
+            memory_max_entries,
+            restrict_pickle=restrict_pickle,
+            safe_types=safe_types,
+        )
 
     import dspy
 

--- a/tests/clients/test_cache.py
+++ b/tests/clients/test_cache.py
@@ -382,6 +382,71 @@ def test_cache_fallback_on_restricted_environment():
             os.environ["DSPY_CACHEDIR"] = old_env
 
 
+def test_get_dspy_cache_falls_back_on_corrupted_sqlite_file(tmp_path):
+    """A truncated/garbage sqlite file in the cache dir shouldn't crash `import dspy`."""
+    from dspy.clients import _get_dspy_cache
+
+    shard_dir = tmp_path / "000"
+    shard_dir.mkdir()
+    (shard_dir / "cache.db").write_bytes(b"not a sqlite database" * 50)
+
+    old_env = os.environ.get("DSPY_CACHEDIR")
+    try:
+        os.environ["DSPY_CACHEDIR"] = str(tmp_path)
+
+        cache = _get_dspy_cache()  # this is what `import dspy` runs at module load time
+
+        assert cache.disk_cache == {}
+        request = {"model": "test", "prompt": "corrupted_sqlite_file"}
+        cache.put(request, "fallback_result")
+        assert cache.get(request) == "fallback_result"
+    finally:
+        if old_env is None:
+            os.environ.pop("DSPY_CACHEDIR", None)
+        else:
+            os.environ["DSPY_CACHEDIR"] = old_env
+
+
+def test_configure_cache_falls_back_on_corrupted_sqlite_file(tmp_path):
+    """A corrupted disk cache shouldn't crash configure_cache the way it shouldn't crash import-time init."""
+    shard_dir = tmp_path / "000"
+    shard_dir.mkdir()
+    (shard_dir / "cache.db").write_bytes(b"not a sqlite database" * 50)
+
+    original_cache = dspy.cache
+    try:
+        dspy.configure_cache(enable_disk_cache=True, enable_memory_cache=True, disk_cache_dir=str(tmp_path))
+
+        assert dspy.cache.disk_cache == {}
+        request = {"model": "test", "prompt": "corrupted_disk"}
+        dspy.cache.put(request, "fallback_result")
+        assert dspy.cache.get(request) == "fallback_result"
+    finally:
+        dspy.cache = original_cache
+
+
+def test_configure_cache_still_raises_for_non_disk_errors():
+    """configure_cache shouldn't swallow errors that have nothing to do with the disk cache."""
+    with pytest.raises(ValueError, match=r"`memory_max_entries` must be a positive number"):
+        dspy.configure_cache(enable_disk_cache=False, enable_memory_cache=True, memory_max_entries=-1)
+
+
+def test_configure_cache_raises_for_invalid_safe_types_even_with_disk_cache_enabled():
+    """An invalid safe_types entry is a config error, not a disk-init failure, so the
+    disk-cache-init fallback shouldn't retry with disk disabled and swallow it."""
+    with pytest.raises(TypeError, match=r"safe_types entries must be types"):
+        dspy.configure_cache(enable_disk_cache=True, restrict_pickle=True, safe_types=["not_a_type"])
+
+
+def test_configure_cache_raises_for_invalid_disk_size_limit_bytes(tmp_path):
+    """Same as above for disk_size_limit_bytes: a bad type shouldn't get silently
+    converted into a memory-only cache by the disk-cache-init fallback."""
+    with pytest.raises(TypeError, match=r"disk_size_limit_bytes must be None or an int"):
+        dspy.configure_cache(
+            enable_disk_cache=True, disk_cache_dir=str(tmp_path), disk_size_limit_bytes="not-a-number"
+        )
+
+
 def test_cache_init_with_disk_disabled_and_none_dir():
     cache = Cache(
         enable_disk_cache=False,


### PR DESCRIPTION
Fixes #8600

`import dspy` already survives a corrupted disk cache — it falls back to memory-only with a warning. But `dspy.configure_cache()`, the documented way to reconfigure caching at runtime, didn't have the same protection. Calling it against a broken `~/.dspy_cache` (e.g. the corrupted sqlite file case in #8600) still crashed with `sqlite3.DatabaseError: file is not a database`.

This adds the same try/except fallback that `_get_dspy_cache()` already uses at import time, so `configure_cache` degrades gracefully instead of crashing. Added tests covering both the existing import-time fallback and the new `configure_cache` path.

Used Claude Code to help investigate and write this fix; reviewed and tested every line before opening this.