### PR TITLE
fix(json_adapter): don't break JSON extraction on braces inside string values (#8759)

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -4,7 +4,6 @@ from typing import Any, get_origin
 
 import json_repair
 import pydantic
-import regex
 from pydantic.fields import FieldInfo
 
 from dspy.adapters.chat_adapter import ChatAdapter, FieldInfoWithName
@@ -36,6 +35,46 @@ def _has_open_ended_mapping(signature: SignatureMeta) -> bool:
         if get_origin(annotation) is dict:
             return True
     return False
+
+
+def _extract_json_object(text: str) -> str | None:
+    """
+    Return the outermost JSON object in ``text`` as a substring.
+
+    Unlike a naive recursive regex, this scanner understands JSON string literals, so
+    curly braces that appear inside string values (e.g. a code snippet such as
+    ``"if (user) {"``) are not mistaken for structural braces. This matters because LM
+    responses frequently embed source code or prose containing braces inside string
+    fields, which previously broke JSON extraction (see issue #8759).
+
+    Returns ``None`` if no balanced object is found.
+    """
+    start = text.find("{")
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        char = text[i]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
 
 
 class JSONAdapter(ChatAdapter):
@@ -169,11 +208,9 @@ class JSONAdapter(ChatAdapter):
         fields = json_repair.loads(completion)
 
         if not isinstance(fields, dict):
-            pattern = r"\{(?:[^{}]|(?R))*\}"
-            match = regex.search(pattern, completion, regex.DOTALL)
-            if match:
-                completion = match.group(0)
-                fields = json_repair.loads(completion)
+            extracted = _extract_json_object(completion)
+            if extracted is not None:
+                fields = json_repair.loads(extracted)
 
         if not isinstance(fields, dict):
             raise AdapterParseError(

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -936,6 +936,40 @@ def test_json_adapter_parse_raise_error_on_mismatch_fields():
     )
 
 
+def test_extract_json_object_handles_braces_inside_string_values():
+    from dspy.adapters.json_adapter import _extract_json_object
+
+    # Braces inside string values must be ignored when locating the outer object.
+    text = 'Here is the result:\n{\n  "reasoning": "ok",\n  "snippet": "if (user) { print(\'x\') }"\n}'
+    extracted = _extract_json_object(text)
+    assert extracted is not None
+    assert extracted.strip().endswith("}")
+    assert '"snippet": "if (user) { print(\'x\') }"' in extracted
+
+    # No object present.
+    assert _extract_json_object("no json here") is None
+
+    # Nested objects resolve to the outermost balanced braces.
+    nested = '{"a": {"b": 1}}'
+    assert _extract_json_object(nested) == nested
+
+
+def test_json_adapter_parse_fallback_handles_braces_inside_string_values():
+    # Regression test for #8759: when the top-level response is not a JSON object
+    # (here a JSON array, so json_repair.loads returns a list and the object
+    # extraction fallback runs), curly braces inside string values must not break
+    # extraction.
+    class FindIssue(dspy.Signature):
+        reasoning: str = dspy.OutputField()
+        snippet: str = dspy.OutputField()
+
+    adapter = dspy.JSONAdapter()
+    completion = '["preamble", {"reasoning": "ok", "snippet": "if (user) { print(\'x\') }"}]'
+    result = adapter.parse(FindIssue, completion)
+    assert result["reasoning"] == "ok"
+    assert result["snippet"] == "if (user) { print('x') }"
+
+
 def test_json_adapter_formats_image():
     # Test basic image formatting
     image = dspy.Image(url="https://example.com/image.jpg")


### PR DESCRIPTION
## Summary
Fixes #8759. `JSONAdapter.parse` failed to extract the output JSON object when a
string value contained curly braces (e.g. a code snippet like `"if (user) {").`

### Root cause
The extraction fallback used a recursive regex:
```python
pattern = r"\{(?:[^{}]|(?R))*\}"
match = regex.search(pattern, completion, regex.DOTALL)
```
This pattern ignores JSON **string literals**, so a `{` or `}` inside a string value
was treated as a structural brace and broke brace matching — the match terminated at
the wrong position and the object couldn't be parsed.

### Fix
Replace the regex with a small string-aware brace matcher, `_extract_json_object`,
that scans character-by-character, tracking quote/escape state so braces inside
strings are ignored. It returns the outermost balanced `{...}` (or `None`).

- `dspy/adapters/json_adapter.py`: add `_extract_json_object`, use it in `parse`, drop the now-unused `regex` import.
- `tests/adapters/test_json_adapter.py`: add a unit test for the helper and an integration test that forces the extraction fallback path with braces inside a string value.

## Verification
- `uv run pytest tests/adapters/test_json_adapter.py` → 41 passed (includes the 2 new regression tests).
- `uv run ruff check dspy/adapters/json_adapter.py tests/adapters/test_json_adapter.py` → all checks passed.

## Disclosure
This change was developed with the assistance of an AI coding agent (opencode). I read
and understand the full `JSONAdapter` code path and the failing tests; the fix and tests
are mine to own.

🤖 Generated with [OpenCode](https://opencode.ai)