### PR TITLE
fix(gepa): keep trace-capture outputs aligned to the batch when the program raises

### DIFF
--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -248,11 +248,18 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 format_failure_score=self.failure_score,
                 callback_metadata=callback_metadata,
             )
-            return self._make_evaluation_batch(
-                outputs=[t["prediction"] for t in trajs],
-                raw_scores=[t.get("score") for t in trajs],
-                trajectories=trajs,
-            )
+            # bootstrap_trace_data drops examples whose program call raised (dspy.Evaluate
+            # substitutes an empty Prediction it cannot unpack), so `trajs` may be shorter than
+            # `batch`. gepa merges valset results by batch position, so keep outputs and scores
+            # sized to the batch and fill by example_ind, as evaluate_with_trace does for Flex.
+            # A dropped example keeps a None score, which _make_evaluation_batch maps to
+            # failure_score.
+            outputs: list[Any] = [None] * len(batch)
+            raw_scores: list[Any] = [None] * len(batch)
+            for t in trajs:
+                outputs[t["example_ind"]] = t["prediction"]
+                raw_scores[t["example_ind"]] = t.get("score")
+            return self._make_evaluation_batch(outputs=outputs, raw_scores=raw_scores, trajectories=trajs)
         else:
             evaluator = Evaluate(
                 devset=batch,

--- a/dspy/teleprompt/gepa/gepa_utils.py
+++ b/dspy/teleprompt/gepa/gepa_utils.py
@@ -248,12 +248,8 @@ class DspyAdapter(GEPAAdapter[Example, TraceData, Prediction]):
                 format_failure_score=self.failure_score,
                 callback_metadata=callback_metadata,
             )
-            # bootstrap_trace_data drops examples whose program call raised (dspy.Evaluate
-            # substitutes an empty Prediction it cannot unpack), so `trajs` may be shorter than
-            # `batch`. gepa merges valset results by batch position, so keep outputs and scores
-            # sized to the batch and fill by example_ind, as evaluate_with_trace does for Flex.
-            # A dropped example keeps a None score, which _make_evaluation_batch maps to
-            # failure_score.
+            # bootstrap_trace_data drops examples whose program raised, but gepa indexes results by
+            # batch position, so keep outputs and scores batch-sized (dropped -> failure_score).
             outputs: list[Any] = [None] * len(batch)
             raw_scores: list[Any] = [None] * len(batch)
             for t in trajs:

--- a/tests/teleprompt/test_gepa.py
+++ b/tests/teleprompt/test_gepa.py
@@ -97,6 +97,50 @@ def test_gepa_adapter_disables_logging_on_minibatch_eval(monkeypatch, reflection
     assert captured_kwargs["callback_metadata"] == expected_callback_metadata
 
 
+def test_gepa_adapter_evaluate_keeps_outputs_aligned_when_program_crashes(monkeypatch):
+    from dspy.teleprompt.gepa import gepa_utils
+
+    class CrashingModule(dspy.Module):
+        def forward(self, **kwargs):
+            if kwargs["input"] == "crash":
+                raise RuntimeError("boom")
+            return dspy.Prediction(output=kwargs["input"])
+
+    def always_one_metric(example, prediction, trace=None, pred_name=None, pred_trace=None):
+        return 1.0
+
+    adapter = gepa_utils.DspyAdapter(
+        student_module=SimpleModule("input -> output"),
+        metric_fn=always_one_metric,
+        feedback_map={},
+        failure_score=-0.5,
+    )
+    monkeypatch.setattr(
+        gepa_utils.DspyAdapter,
+        "build_program",
+        lambda self, candidate: CrashingModule(),
+    )
+
+    batch = [
+        Example(input="first", output="first").with_inputs("input"),
+        Example(input="crash", output="crash").with_inputs("input"),
+        Example(input="third", output="third").with_inputs("input"),
+    ]
+
+    with dspy.context(max_errors=100):
+        result = adapter.evaluate(batch=batch, candidate={}, capture_traces=True)
+
+    # gepa's valset evaluation indexes outputs and scores by batch position, so a
+    # crashed example must keep its slot rather than shrinking the lists.
+    assert len(result.outputs) == 3
+    assert len(result.scores) == 3
+    assert result.outputs[0].output == "first"
+    assert result.outputs[1] is None
+    assert result.outputs[2].output == "third"
+    assert result.scores == [1.0, -0.5, 1.0]
+    assert [t["example_ind"] for t in result.trajectories] == [0, 2]
+
+
 def test_gepa_adapter_forwards_sparse_objective_scores():
     from dspy.teleprompt.gepa import gepa_utils
 


### PR DESCRIPTION
## The bug

When GEPA evaluates a candidate with trace capture on, `DspyAdapter.evaluate` (`dspy/teleprompt/gepa/gepa_utils.py`) calls `bootstrap_trace_data`. If the student program raises an exception that is not an `AdapterParseError` for some example, `dspy.Evaluate` substitutes an empty `dspy.Prediction()` for it. `bootstrap_trace_data` can't unpack that into a `(prediction, trace)` pair, logs "Failed to unpack prediction and trace", and drops the example from its result list. `DspyAdapter.evaluate` built `outputs` and `scores` directly from that list, so both came back shorter than the batch.

gepa 0.1.4 (which dspy now pins) runs valset evaluation through `DspyAdapter.batch_evaluate`, which always captures traces. In `gepa/core/engine.py`, `_evaluate_programs_on_valset` merges results by batch position (`eb.outputs[j]`), so a short list raises `IndexError: list index out of range` and the whole optimization fails. Before 0.1.4 the valset path used `capture_traces=False`, which always returns one result per example, so this wasn't reachable.

## The fix

In the `capture_traces` branch, pre-size `outputs` and `scores` to `len(batch)` and fill them by `t["example_ind"]`. This is the same pattern `evaluate_with_trace` in `dspy/teleprompt/gepa/gepa_flex_utils.py` already uses for the `dspy.Flex` path.

A dropped example keeps a `None` score, which `_make_evaluation_batch` maps to `failure_score`, so a crashed example is now scored at `failure_score`, the same treatment `dspy.Evaluate` gives a crashed example on the test set. `trajectories` is left as the list `bootstrap_trace_data` returned, so what the reflection model sees is unchanged. `bootstrap_trace_data` itself is not modified and `capture_crashes` is not enabled.

## Reproduction

`test_gepa_adapter_evaluate_keeps_outputs_aligned_when_program_crashes` in `tests/teleprompt/test_gepa.py`: a `DspyAdapter` with `failure_score=-0.5` and a metric returning `1.0`, `build_program` patched to return a module whose `forward` raises `RuntimeError` for the second of three examples, then `adapter.evaluate(batch=batch, candidate={}, capture_traces=True)` inside `dspy.context(max_errors=100)`.

Before the fix:

```
assert len(result.outputs) == 3
AssertionError: assert 2 == 3
 +  where 2 = len([Prediction(output='first'), Prediction(output='third')])
```

After the fix the test asserts `len(result.outputs) == 3`, `result.outputs[1] is None` with the other two being the expected predictions, `result.scores == [1.0, -0.5, 1.0]`, and `[t["example_ind"] for t in result.trajectories] == [0, 2]`.

## Verification

- `uv run pytest tests/teleprompt/test_gepa.py -p no:cacheprovider` — 25 passed
- `uv run ruff check` on both changed files — no new findings (the test file's 10 pre-existing findings are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBSEmFxNqFuYLJPkPh86ub
