### PR TITLE
fix(adapters): enforce pydantic Field constraints in parse_value (addresses #7925)

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -235,7 +235,7 @@ class ChatAdapter(Adapter):
         for k, v in sections:
             if (k not in fields) and (k in signature.output_fields):
                 try:
-                    fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                    fields[k] = parse_value(v, signature.output_fields[k].annotation, signature.output_fields[k])
                 except Exception as e:
                     raise AdapterParseError(
                         adapter_name="ChatAdapter",

--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -188,7 +188,7 @@ class JSONAdapter(ChatAdapter):
         # Attempt to cast each value to type signature.output_fields[k].annotation.
         for k, v in fields.items():
             if k in signature.output_fields:
-                fields[k] = parse_value(v, signature.output_fields[k].annotation)
+                fields[k] = parse_value(v, signature.output_fields[k].annotation, signature.output_fields[k])
 
         fields = apply_output_field_defaults(signature, fields)
         if fields.keys() != signature.output_fields.keys():

--- a/dspy/adapters/utils.py
+++ b/dspy/adapters/utils.py
@@ -184,9 +184,21 @@ def find_enum_member(enum, identifier):
     raise ValueError(f"{identifier} is not a valid name or value for the enum {enum.__name__}")
 
 
-def parse_value(value, annotation):
+def parse_value(value, annotation, field_info=None):
+    # Field constraints (max_length, ge, le, ...) live in FieldInfo.metadata, not in the bare
+    # annotation, so a TypeAdapter built from the annotation alone silently ignores them. Re-attach
+    # them via Annotated before validating so the constraints are actually enforced (#7925).
+    constraints = list(field_info.metadata) if field_info is not None else []
+
+    def _validate(candidate):
+        target = Annotated[(annotation, *constraints)] if constraints else annotation
+        return TypeAdapter(target).validate_python(candidate)
+
     if annotation is str:
-        return str(value)
+        result = str(value)
+        # Enforce str constraints (e.g. max_length) while keeping the literal-string coercion that
+        # avoids ast.literal_eval turning "1234" into an int.
+        return _validate(result) if constraints else result
 
     if isinstance(annotation, enum.EnumMeta):
         return find_enum_member(annotation, value)
@@ -212,11 +224,11 @@ def parse_value(value, annotation):
             value = v
 
     if not isinstance(value, str):
-        return TypeAdapter(annotation).validate_python(value)
+        return _validate(value)
 
     if origin in (Union, types.UnionType) and type(None) in get_args(annotation) and str in get_args(annotation):
         # Handle union annotations, e.g., `str | None`, `Optional[str]`, `Union[str, int, None]`, etc.
-        return TypeAdapter(annotation).validate_python(value)
+        return _validate(value)
 
     candidate = json_repair.loads(value)  # json_repair.loads returns "" on failure.
     if candidate == "" and value != "":
@@ -226,12 +238,12 @@ def parse_value(value, annotation):
             candidate = value
 
     try:
-        return TypeAdapter(annotation).validate_python(candidate)
+        return _validate(candidate)
     except pydantic.ValidationError as e:
         if _annotation_is_subclass(annotation, DspyType):
             try:
                 # For dspy.Type, try parsing from the original value in case it has a custom parser
-                return TypeAdapter(annotation).validate_python(value)
+                return _validate(value)
             except Exception:
                 raise e
         raise

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -114,7 +114,7 @@ class XMLAdapter(ChatAdapter):
                 try:
                     value = self._elements_to_value(elements[name], candidate, schema.get("$defs", {}))
                     try:
-                        fields[name] = parse_value(value, field.annotation)
+                        fields[name] = parse_value(value, field.annotation, field)
                     except pydantic.ValidationError:
                         fields[name] = adapter.validate_python(value, by_name=True)
                     break

--- a/dspy/adapters/xml_adapter.py
+++ b/dspy/adapters/xml_adapter.py
@@ -1,7 +1,7 @@
 import types
 import xml.etree.ElementTree as ET
 from collections import defaultdict
-from typing import Any, Union, get_args, get_origin
+from typing import Annotated, Any, Union, get_args, get_origin
 from xml.sax.saxutils import quoteattr
 
 import pydantic
@@ -116,7 +116,15 @@ class XMLAdapter(ChatAdapter):
                     try:
                         fields[name] = parse_value(value, field.annotation, field)
                     except pydantic.ValidationError:
-                        fields[name] = adapter.validate_python(value, by_name=True)
+                        # By-name retry for aliased nested models. Keep the FieldInfo
+                        # constraints attached, so this fallback cannot accept a value
+                        # the primary path just rejected for violating them (#7925).
+                        target = (
+                            Annotated[(field.annotation, *field.metadata)]
+                            if field.metadata
+                            else field.annotation
+                        )
+                        fields[name] = TypeAdapter(target).validate_python(value, by_name=True)
                     break
                 except Exception as e:
                     error = e

--- a/dspy/predict/flex/bridge.py
+++ b/dspy/predict/flex/bridge.py
@@ -316,7 +316,7 @@ class BridgeRuntime:
                 if out[name] is None:
                     out[name] = TypeAdapter(field.annotation).validate_python(None)
                 else:
-                    out[name] = parse_value(out[name], field.annotation)
+                    out[name] = parse_value(out[name], field.annotation, field)
             except Exception as e:
                 raise CodeInterpreterError(
                     f"Sandboxed forward returned {out[name]!r} for output field {name!r}, which is "

--- a/dspy/predict/rlm.py
+++ b/dspy/predict/rlm.py
@@ -585,7 +585,7 @@ class RLM(Module):
             field = self.signature.output_fields[name]
             annotation = getattr(field, "annotation", str)
             try:
-                parsed_outputs[name] = parse_value(raw_output[name], annotation)
+                parsed_outputs[name] = parse_value(raw_output[name], annotation, field)
             except (ValueError, pydantic.ValidationError) as e:
                 type_errors.append(
                     f"{name}: expected {annotation.__name__ if hasattr(annotation, '__name__') else annotation}, "

--- a/tests/adapters/test_adapter_utils.py
+++ b/tests/adapters/test_adapter_utils.py
@@ -2,9 +2,11 @@
 
 from typing import Literal, Optional, Union
 
+import pydantic
 import pytest
 from pydantic import BaseModel
 
+import dspy
 from dspy.adapters.utils import parse_value
 
 
@@ -115,3 +117,40 @@ def test_parse_value_json_repair():
     malformed = "not json or literal"
     with pytest.raises(Exception):
         parse_value(malformed, dict)
+
+
+def test_parse_value_honors_str_max_length_constraint():
+    """#7925: parse_value validated against the bare annotation, dropping pydantic constraints (which
+    live in FieldInfo.metadata). A str OutputField(max_length=N) must now be enforced."""
+
+    class Sig(dspy.Signature):
+        answer: str = dspy.OutputField(max_length=3)
+
+    fi = Sig.output_fields["answer"]
+    assert parse_value("ok", fi.annotation, fi) == "ok"
+    with pytest.raises(pydantic.ValidationError):
+        parse_value("toolong", fi.annotation, fi)
+
+
+def test_parse_value_honors_int_range_constraint():
+    """#7925: numeric ge/le constraints (stored in FieldInfo.metadata) must be enforced."""
+
+    class Sig(dspy.Signature):
+        n: int = dspy.OutputField(ge=1, le=5)
+
+    fi = Sig.output_fields["n"]
+    assert parse_value("3", fi.annotation, fi) == 3
+    with pytest.raises(pydantic.ValidationError):
+        parse_value("9", fi.annotation, fi)
+
+
+def test_parse_value_without_constraints_is_unchanged():
+    """Backward compatibility: no FieldInfo (or a field with no constraints) behaves as before."""
+
+    assert parse_value("toolong", str) == "toolong"
+
+    class Sig(dspy.Signature):
+        answer: str = dspy.OutputField()
+
+    fi = Sig.output_fields["answer"]
+    assert parse_value("anything", fi.annotation, fi) == "anything"

--- a/tests/adapters/test_xml_adapter.py
+++ b/tests/adapters/test_xml_adapter.py
@@ -85,6 +85,43 @@ def test_xml_adapter_parse_raises_on_type_error():
     assert "Failed to parse field" in str(e.value)
 
 
+def test_xml_adapter_parse_enforces_field_constraints():
+    # The by-name fallback used to retry with the bare annotation, silently
+    # accepting values the constrained primary path had just rejected (#7925).
+    class TestSignature(dspy.Signature):
+        score: int = dspy.OutputField(ge=1, le=5)
+
+    adapter = XMLAdapter()
+
+    assert adapter.parse(TestSignature, "<score>3</score>") == {"score": 3}
+
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError) as e:
+        adapter.parse(TestSignature, "<score>9</score>")
+    assert "Failed to parse field" in str(e.value)
+
+
+def test_xml_adapter_by_name_fallback_keeps_field_constraints():
+    # Aliased models are what the by-name fallback exists for: parse_value validates
+    # without by_name, fails on the alias-only model, and the fallback retries with
+    # by_name=True. The retry must keep the FieldInfo constraints attached (#7925).
+    class Item(pydantic.BaseModel):
+        item_name: str = pydantic.Field(alias="item name")
+
+    class TestSignature(dspy.Signature):
+        items: list[Item] = dspy.OutputField(min_length=2)
+
+    adapter = XMLAdapter()
+    two = "<items><item_name>a</item_name></items><items><item_name>b</item_name></items>"
+    assert adapter.parse(TestSignature, two) == {
+        "items": [Item(**{"item name": "a"}), Item(**{"item name": "b"})]
+    }
+
+    one = "<items><item_name>a</item_name></items>"
+    with pytest.raises(dspy.utils.exceptions.AdapterParseError) as e:
+        adapter.parse(TestSignature, one)
+    assert "Failed to parse field" in str(e.value)
+
+
 def test_xml_adapter_repeated_dict_elements_and_empty_lists():
     class TestSignature(dspy.Signature):
         counts: dict[str, list[int]] = dspy.OutputField()

--- a/tests/flex/test_flex_output_types.py
+++ b/tests/flex/test_flex_output_types.py
@@ -460,3 +460,17 @@ def test_render_annotation_rejects_what_the_grammar_cannot_carry() -> None:
     # render time instead of producing a token that fails to parse back.
     with pytest.raises(ValueError):
         render_annotation(NotShared)
+
+
+def test_output_field_constraints_enforced_at_the_bridge() -> None:
+    """The bridge's parse_value call passes the full FieldInfo, so pydantic Field
+    constraints declared on an output field reject a violating sandbox result
+    instead of being silently dropped (the bare-annotation path ignored them)."""
+    class Constrained(dspy.Signature):
+        q: str = dspy.InputField()
+        a: str = dspy.OutputField(max_length=5)
+
+    program = Flex(Constrained, interpreter_factory=MockInterpreter)
+    with pytest.raises(CodeInterpreterError, match="not a valid"):
+        program._bridge._to_prediction({"a": "WAY_TOO_LONG"})
+    assert program._bridge._to_prediction({"a": "ok"}).a == "ok"


### PR DESCRIPTION
# Enforce pydantic field constraints in parse_value

Addresses #7925.

## The problem

`parse_value()` validates against the bare type annotation, so pydantic `Field` constraints
(`max_length`, `ge`/`le`, `pattern`, ...) declared on a signature field are accepted rather
than rejected: a `str` field with `max_length=5` happily takes a 12-character value.

## The change

`parse_value` now validates through the full `FieldInfo` (annotation + constraints) when
constraints are present, so a violating value raises `pydantic.ValidationError` exactly as it
would in a plain pydantic model. Values without constraints take the same path as before.

## Scope, stated plainly

Measured per adapter on this branch:

- **Chat**: violating value rejected (`AdapterParseError`) — enforced.
- **JSON**: violating value rejected (`ValidationError`) — enforced.
- **RLM**: shares the chat parse path — enforced.
- **Flex** (added after the review bot flagged it): the bridge's `parse_value` call passed only
  the bare annotation, dropping constraints on that path too — now passes the `FieldInfo` and is
  pinned by a bridge-level test (`0e24627`).
- **XML** (enforced in `79db8d0`, after the review bot rightly pushed back on our first
  scope call): the adapter's by-name fallback (`xml_adapter.py`) re-validated with a bare
  `TypeAdapter(field.annotation)` on `ValidationError`, which dropped the constraints the
  primary path had just enforced. The fallback now attaches `FieldInfo.metadata` via
  `Annotated`, so the aliased-model retry it exists for still works while a constraint
  violation propagates as `AdapterParseError`. Covered by two tests: a scalar `ge/le` case
  and an aliased-model `min_length` case that exercises the fallback path itself.

One remaining non-goal: the `Literal`/`Enum` fast paths in `parse_value` return the matched
member before the constraint-aware validation runs. On a fixed-member set an extra Field
constraint is degenerate, so we left those paths untouched rather than widen the diff.

## Relationship to #10114

#10114 targets the same issue and came first; it has been conflicting with main since early
August. This PR is offered as a currently-mergeable alternative — if #10114 is revived we are
happy to defer to it or help reconcile the two.

## Testing

Three new tests in the parse_value suite: `test_parse_value_honors_str_max_length_constraint`,
`test_parse_value_honors_int_range_constraint`,
`test_parse_value_without_constraints_is_unchanged` — all fail without the fix.
Full suite on this branch: 1250 passed, 253 skipped, 2 xfailed
(one unrelated timing test, `test_unbatchify_honors_max_wait_time_under_trickling_input`,
flakes under parallel load and passes in isolation on both this branch and main).





AI-assisted (Claude Code): the change and its tests were drafted with AI assistance from the issue thread and the failing behaviour, then reviewed hunk by hunk and verified by me (the constraint tests fail without the fix, the full suite passes on this branch, CI on my fork before opening the PR); the XML by-name fallback follow-up went through the same review. This contribution is my own and offered under the project's MIT license.
