### PR TITLE
fix(clients): await async callables in Embedder.acall

### DIFF
--- a/dspy/clients/embedding.py
+++ b/dspy/clients/embedding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from typing import Any, Callable
 
 from dspy.clients._litellm import get_litellm
@@ -24,7 +25,8 @@ class Embedder:
     For hosted models, simply pass the model name as a string (e.g., "openai/text-embedding-3-small"). The class will use
     litellm to handle the API calls and caching.
 
-    For custom embedding models, pass a callable function that:
+    For custom embedding models, pass a callable function (sync or async, an async callable is awaited by
+    `acall`) that:
     - Takes a list of strings as input.
     - Returns embeddings as either:
         - A 2D numpy array of float32 values
@@ -176,7 +178,10 @@ async def _acompute_embeddings(model, batch_inputs, caching=False, **kwargs):
         embedding_response = await _get_litellm().aembedding(model=model, input=batch_inputs, caching=caching, **kwargs)
         return [data["embedding"] for data in embedding_response.data]
     elif callable(model):
-        return model(batch_inputs, **kwargs)
+        embeddings = model(batch_inputs, **kwargs)
+        if inspect.isawaitable(embeddings):
+            embeddings = await embeddings
+        return embeddings
     else:
         raise ValueError(f"`model` in `dspy.Embedder` must be a string or a callable, but got {type(model)}.")
 

--- a/tests/clients/test_embedding.py
+++ b/tests/clients/test_embedding.py
@@ -197,3 +197,42 @@ async def test_acall_caching_true_overrides_instance_false(cache):
         await embedding.acall(inputs, caching=True)
         await embedding.acall(inputs, caching=True)
         assert mock_litellm.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_async_callable_embedding():
+    embeddings = {
+        "hello": [0.1, 0.2, 0.3],
+        "world": [0.4, 0.5, 0.6],
+        "test": [0.7, 0.8, 0.9],
+    }
+    calls = []
+
+    async def async_embedding_fn(texts):
+        calls.append(texts)
+        return [embeddings[text] for text in texts]
+
+    embedder = Embedder(async_embedding_fn, caching=False)
+
+    result = await embedder.acall(["hello", "world", "test"], batch_size=2)
+
+    assert calls == [["hello", "world"], ["test"]]
+    np.testing.assert_allclose(result, [embeddings["hello"], embeddings["world"], embeddings["test"]])
+
+
+@pytest.mark.asyncio
+async def test_async_callable_embedding_with_caching(cache):
+    call_count = 0
+
+    async def async_embedding_fn(texts):
+        nonlocal call_count
+        call_count += 1
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    embedder = Embedder(async_embedding_fn, caching=True)
+
+    first = await embedder.acall(["hello"])
+    second = await embedder.acall(["hello"])
+
+    assert call_count == 1
+    np.testing.assert_allclose(first, second)


### PR DESCRIPTION
## Summary

`dspy.Embedder` accepts any callable as a custom embedding model, but the async path never awaits it, so an async embedding function crashes instead of returning embeddings:

```python
async def aemb(texts):
    return np.random.rand(len(texts), 4)

await dspy.Embedder(aemb).acall(["a", "b"])
# TypeError: 'coroutine' object is not iterable
```

`_acompute_embeddings` returns `model(batch_inputs)` directly, so for an async callable `acall` gets a coroutine object and tries to `extend()` a list with it. This also leaks an un-awaited coroutine.

The fix awaits an awaitable result, mirroring what `dspy.Tool` already does for async tool functions (`dspy/adapters/types/tool.py`):

```python
embeddings = model(batch_inputs, **kwargs)
if inspect.isawaitable(embeddings):
    embeddings = await embeddings
return embeddings
```

Sync callables and the litellm string-model path are unchanged. Tests cover an async callable with batching (asserting the batches it receives) and the cached `acall` path; the docstring now states that async callables are awaited by `acall`.
