### PR TITLE
fix(clients): preserve image content-block detail through LMPart normalization

### DIFF
--- a/dspy/adapters/_legacy_type_markers.py
+++ b/dspy/adapters/_legacy_type_markers.py
@@ -103,11 +103,12 @@ def _legacy_content_block_to_lm_part(block: Any) -> LMPart:
         return LMTextPart(text=block.get("text", ""))
     if block_type == "image_url":
         image_url = block.get("image_url", {})
+        detail = image_url.get("detail") if isinstance(image_url, dict) else None
         source = image_url.get("url") if isinstance(image_url, dict) else image_url
         if isinstance(source, str) and source.startswith("data:") and "," in source:
             media_type, data = _split_data_uri(source)
-            return LMImagePart(data=data, media_type=media_type)
-        return LMImagePart(url=source or "")
+            return LMImagePart(data=data, media_type=media_type, detail=detail)
+        return LMImagePart(url=source or "", detail=detail)
     if block_type == "input_audio":
         audio = block.get("input_audio", {})
         return LMAudioPart(data=audio.get("data", ""), media_type=f"audio/{audio.get('format', 'wav')}")

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -1637,7 +1637,10 @@ def _history_part_as_openai_content(part: LMPart) -> dict[str, Any]:
     if isinstance(part, LMTextPart):
         return {"type": "text", "text": part.text}
     if isinstance(part, LMImagePart):
-        return {"type": "image_url", "image_url": {"url": _history_part_source(part)}}
+        image_url: dict[str, Any] = {"url": _history_part_source(part)}
+        if part.detail is not None:
+            image_url["detail"] = part.detail
+        return {"type": "image_url", "image_url": image_url}
     if isinstance(part, LMAudioPart):
         input_audio = {"format": _history_media_format(part.media_type)}
         if part.data is not None:
@@ -1809,7 +1812,7 @@ def _parts_from_openai_content(content: Any) -> list[LMPart]:
             url = image.get("url")
             if url is None:
                 raise ValueError("Image content block requires url.")
-            parts.append(_image_source_to_part(url))
+            parts.append(_image_source_to_part(url, detail=image.get("detail")))
         elif item_type == "input_audio":
             audio = item.get("input_audio", {})
             parts.append(_audio_dict_to_part(audio))
@@ -1857,14 +1860,14 @@ def _tool_call_from_openai(tool_call: Any) -> LMToolCallPart:
     )
 
 
-def _image_source_to_part(source: str) -> LMImagePart:
+def _image_source_to_part(source: str, detail: str | None = None) -> LMImagePart:
     if not isinstance(source, str):
         raise TypeError("Image URL must be a string.")
     if source.startswith("data:"):
         media_type, data = _split_data_uri(source)
-        return LMImagePart(data=data, media_type=media_type)
+        return LMImagePart(data=data, media_type=media_type, detail=detail)
     media_type = mimetypes.guess_type(urlparse(source).path)[0] or "image/png"
-    return LMImagePart(url=source, media_type=media_type)
+    return LMImagePart(url=source, media_type=media_type, detail=detail)
 
 
 def _audio_dict_to_part(audio: dict[str, Any]) -> LMAudioPart:

--- a/tests/adapters/test_base_type.py
+++ b/tests/adapters/test_base_type.py
@@ -49,3 +49,29 @@ def test_extract_custom_type_from_annotation_with_nested_type():
         EventIdentifier,
         Event,
     ]
+
+
+def test_legacy_image_marker_preserves_detail():
+    from dspy.adapters._legacy_type_markers import _legacy_content_block_to_lm_part
+    from dspy.core.types import LMImagePart
+
+    url_part = _legacy_content_block_to_lm_part(
+        {"type": "image_url", "image_url": {"url": "https://example.com/chart.png", "detail": "high"}}
+    )
+    assert isinstance(url_part, LMImagePart)
+    assert url_part.url == "https://example.com/chart.png"
+    assert url_part.detail == "high"
+
+    data_part = _legacy_content_block_to_lm_part(
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,YWJj", "detail": "low"}}
+    )
+    assert isinstance(data_part, LMImagePart)
+    assert data_part.data == "YWJj"
+    assert data_part.media_type == "image/png"
+    assert data_part.detail == "low"
+
+    no_detail_part = _legacy_content_block_to_lm_part(
+        {"type": "image_url", "image_url": {"url": "https://example.com/chart.png"}}
+    )
+    assert isinstance(no_detail_part, LMImagePart)
+    assert no_detail_part.detail is None

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -133,6 +133,55 @@ def test_image_content_requires_mapping_with_url():
         LMMessage(role="user", content=[{"type": "image_url", "image_url": {}}])
 
 
+def test_image_content_block_preserves_detail_to_openai_and_history():
+    from dspy.clients.openai_format import to_openai_chat_request
+
+    message = LMMessage(
+        role="user",
+        content=[{"type": "image_url", "image_url": {"url": "https://example.com/chart.png", "detail": "high"}}],
+    )
+    image = message.parts[0]
+    assert isinstance(image, LMImagePart)
+    assert image.detail == "high"
+
+    # The provider payload must keep detail so it actually reaches the model.
+    wire = to_openai_chat_request(LMRequest(model="model", messages=[message]))["messages"][0]["content"]
+    assert wire == [{"type": "image_url", "image_url": {"url": "https://example.com/chart.png", "detail": "high"}}]
+
+    # History round-trips detail losslessly.
+    content = _history_entry(message).messages[0]["content"][0]
+    round_tripped = LMMessage(role="user", content=[content]).parts[0]
+    assert content == {"type": "image_url", "image_url": {"url": "https://example.com/chart.png", "detail": "high"}}
+    assert isinstance(round_tripped, LMImagePart)
+    assert round_tripped.detail == "high"
+
+
+def test_image_content_block_without_detail_omits_key():
+    from dspy.clients.openai_format import to_openai_chat_request
+
+    message = LMMessage(
+        role="user",
+        content=[{"type": "image_url", "image_url": {"url": "https://example.com/plain.png"}}],
+    )
+    assert message.parts[0].detail is None
+
+    wire = to_openai_chat_request(LMRequest(model="model", messages=[message]))["messages"][0]["content"]
+    assert wire == [{"type": "image_url", "image_url": {"url": "https://example.com/plain.png"}}]
+    assert "detail" not in wire[0]["image_url"]
+
+
+def test_data_uri_image_preserves_detail():
+    message = LMMessage(
+        role="user",
+        content=[{"type": "image_url", "image_url": {"url": "data:image/png;base64,YWJj", "detail": "low"}}],
+    )
+    image = message.parts[0]
+    assert isinstance(image, LMImagePart)
+    assert image.data == "YWJj"
+    assert image.media_type == "image/png"
+    assert image.detail == "low"
+
+
 def test_video_data_round_trips_through_history_messages():
     message = User(LMVideoPart(data="YWJj", media_type="video/mp4"))
     content = _history_entry(message).messages[0]["content"][0]


### PR DESCRIPTION
## What and why

The typed `LMPart` message-normalization layer (introduced in dspy 3.3) silently drops the `detail` field of `image_url` content blocks when converting OpenAI-style content into typed parts. Any request that specifies `detail` (`"low"`, `"high"`, `"auto"`), which is the standard OpenAI/Gemini vision format, loses it before the request reaches the provider. `detail` directly controls vision-token cost and output quality, so this is silent, hard-to-notice data loss on the request path.

`LMImagePart` already models `detail`, and the OpenAI serializer (`image_to_openai`) already emits it, so only the parse side and the history re-emit side were lossy. This PR closes those gaps.

This is also a prerequisite for the in-flight `dspy.Image(detail=...)` feature (#9198): today that value would be discarded by the normalization layer before reaching a provider. It fixes the same layer that #9898 and #9899 addressed for file and video blocks. It is complementary to, and does not overlap with, #10276 (which preserves provider extras on `file` blocks via `LMBinaryPart`); this PR threads the typed `LMImagePart.detail` field for `image_url` blocks.

## The bug (deterministic reproduction)

An `image_url` block carrying `detail`, run through the typed request path (`LMRequest.from_call` then `to_openai_chat_request`, i.e. `dspy.context(experimental=True)`), loses `detail` on the wire:

```python
raw = {"type": "image_url",
       "image_url": {"url": "https://example.com/chart.png", "detail": "high"}}
# before: wire block -> {"type": "image_url", "image_url": {"url": "https://example.com/chart.png"}}
# after:  wire block -> {"type": "image_url", "image_url": {"url": "https://example.com/chart.png", "detail": "high"}}
```

## Changes

- `dspy/core/types.py`
  - `_image_source_to_part(...)` now accepts and forwards `detail` on both the data-URI and url paths.
  - `_parts_from_openai_content(...)` reads `image.get("detail")` when building the part.
  - `_history_part_as_openai_content(...)` re-emits `part.detail` when present, so history round-trips losslessly.
- `dspy/adapters/_legacy_type_markers.py`
  - `_legacy_content_block_to_lm_part(...)` preserves `detail` on the parallel legacy custom-type marker parse path.

## Tests

All offline and deterministic (no network):

- `tests/core/test_types.py`
  - `test_image_content_block_preserves_detail_to_openai_and_history`
  - `test_image_content_block_without_detail_omits_key`
  - `test_data_uri_image_preserves_detail`
- `tests/adapters/test_base_type.py`
  - `test_legacy_image_marker_preserves_detail`

```
tests/core/test_types.py .............................                    [ ... ]
tests/adapters/test_base_type.py ...                                      [100%]
32 passed
```

## Notes

- The legacy (non-typed) `BaseLM.__call__` path passes messages straight to litellm and is unaffected. The bug is specific to the typed `LMPart` normalization path (the new architecture, `experimental=True`).
- No behavior change when `detail` is absent: the key is omitted exactly as before.
