### PR TITLE
fix(dspy): include Pydantic models in source context

### DIFF
--- a/dspy/propose/utils.py
+++ b/dspy/propose/utils.py
@@ -1,6 +1,9 @@
 import inspect
 import json
 import re
+from typing import get_args
+
+from pydantic import BaseModel
 
 import dspy
 
@@ -143,6 +146,50 @@ def create_example_string(fields, example):
     # Joining all the field strings
     return "\n".join(output)
 
+
+def _referenced_pydantic_models(signature):
+    models = []
+    seen = set()
+
+    def visit(annotation):
+        try:
+            is_pydantic_model = isinstance(annotation, type) and issubclass(annotation, BaseModel)
+        except TypeError:
+            is_pydantic_model = False
+
+        if is_pydantic_model:
+            if annotation in seen:
+                return
+            seen.add(annotation)
+            if annotation.__module__.split(".", 1)[0] in {"dspy", "pydantic"}:
+                return
+            for base in annotation.__bases__:
+                visit(base)
+            for field in annotation.model_fields.values():
+                visit(field.annotation)
+            models.append(annotation)
+            return
+
+        for argument in get_args(annotation):
+            visit(argument)
+
+    for field in signature.fields.values():
+        visit(field.annotation)
+
+    return models
+
+
+def _pydantic_model_sources(signature):
+    sources = []
+    for model in _referenced_pydantic_models(signature):
+        try:
+            sources.append(inspect.getsource(model))
+        except (TypeError, OSError):
+            schema = json.dumps(model.model_json_schema(), indent=2, sort_keys=True)
+            sources.append(f"# JSON Schema for {model.__name__}\n{schema}")
+    return sources
+
+
 def get_dspy_source_code(module):
     header = []
     base_code = ""
@@ -172,7 +219,15 @@ def get_dspy_source_code(module):
             except TypeError:
                 continue
             if isinstance(item, Parameter):
-                if hasattr(item, "signature") and item.signature is not None and item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig" not in completed_set:
+                if (
+                    hasattr(item, "signature")
+                    and item.signature is not None
+                    and item.signature.__pydantic_parent_namespace__["signature_name"] + "_sig" not in completed_set
+                ):
+                    for model_source in _pydantic_model_sources(item.signature):
+                        if model_source not in completed_set:
+                            header.append(model_source)
+                            completed_set.add(model_source)
                     try:
                         header.append(inspect.getsource(item.signature))
                         print(inspect.getsource(item.signature))

--- a/dspy/propose/utils.py
+++ b/dspy/propose/utils.py
@@ -1,6 +1,10 @@
+import ast
 import inspect
 import json
 import re
+import textwrap
+from dataclasses import fields, is_dataclass
+from enum import Enum
 from typing import get_args
 
 from pydantic import BaseModel
@@ -147,27 +151,135 @@ def create_example_string(fields, example):
     return "\n".join(output)
 
 
-def _referenced_pydantic_models(signature):
-    models = []
+def _referenced_annotation_declarations(signature):
+    declarations = []
     seen = set()
 
-    def visit(annotation):
+    def is_user_class(annotation):
+        if not isinstance(annotation, type):
+            return False
+        return annotation.__module__.split(".", 1)[0] not in {
+            "builtins",
+            "dataclasses",
+            "dspy",
+            "enum",
+            "pydantic",
+            "typing",
+        }
+
+    def namespace(annotation):
+        module = inspect.getmodule(annotation)
+        values = dict(vars(module)) if module else {}
+        for name, value in (getattr(annotation, "__pydantic_parent_namespace__", None) or {}).items():
+            if callable(value) and type(value).__name__ == "_PydanticWeakRef":
+                value = value()
+            values[name] = value
+        return values
+
+    def alias_source(owner, alias_name):
+        module = inspect.getmodule(owner)
+        if module is None:
+            return None
+        try:
+            source = inspect.getsource(module)
+            tree = ast.parse(source)
+        except (OSError, SyntaxError, TypeError):
+            return None
+        for node in tree.body:
+            target = None
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                target = node.targets[0]
+            elif isinstance(node, ast.AnnAssign):
+                target = node.target
+            elif type(node).__name__ == "TypeAlias":
+                target = node.name
+            if isinstance(target, ast.Name) and target.id == alias_name:
+                return ast.get_source_segment(source, node)
+        return None
+
+    def visit_source_dependencies(annotation):
+        try:
+            tree = ast.parse(textwrap.dedent(inspect.getsource(annotation)))
+        except (IndentationError, OSError, SyntaxError, TypeError):
+            return
+        class_node = next((node for node in tree.body if isinstance(node, ast.ClassDef)), None)
+        if class_node is None:
+            return
+        annotation_nodes = list(class_node.bases)
+        annotation_nodes.extend(
+            node.annotation for node in class_node.body if isinstance(node, ast.AnnAssign)
+        )
+        values = namespace(annotation)
+        for annotation_node in annotation_nodes:
+            for node in ast.walk(annotation_node):
+                if not isinstance(node, ast.Name) or node.id not in values:
+                    continue
+                value = values[node.id]
+                source = alias_source(annotation, node.id)
+                if is_user_class(value):
+                    visit(value)
+                elif source is not None:
+                    visit(value, alias_name=node.id, alias_source_text=source, alias_owner=annotation)
+
+    def visit(annotation, alias_name=None, alias_source_text=None, alias_owner=None):
+        if alias_name is not None:
+            key = ("alias", alias_name, id(annotation))
+            if key in seen:
+                return
+            seen.add(key)
+            values = namespace(alias_owner)
+            try:
+                tree = ast.parse(alias_source_text)
+            except SyntaxError:
+                tree = None
+            if tree is not None:
+                for node in ast.walk(tree):
+                    if not isinstance(node, ast.Name) or node.id == alias_name or node.id not in values:
+                        continue
+                    value = values[node.id]
+                    source = alias_source(alias_owner, node.id)
+                    if is_user_class(value):
+                        visit(value)
+                    elif source is not None:
+                        visit(value, alias_name=node.id, alias_source_text=source, alias_owner=alias_owner)
+            declarations.append((alias_name, annotation, alias_source_text))
+            return
+
         try:
             is_pydantic_model = isinstance(annotation, type) and issubclass(annotation, BaseModel)
         except TypeError:
             is_pydantic_model = False
 
-        if is_pydantic_model:
-            if annotation in seen:
+        is_enum = isinstance(annotation, type) and issubclass(annotation, Enum)
+        if is_pydantic_model or is_enum or (is_user_class(annotation) and is_dataclass(annotation)):
+            key = ("class", annotation)
+            if key in seen or not is_user_class(annotation):
                 return
-            seen.add(annotation)
-            if annotation.__module__.split(".", 1)[0] in {"dspy", "pydantic"}:
-                return
+            seen.add(key)
             for base in annotation.__bases__:
                 visit(base)
-            for field in annotation.model_fields.values():
-                visit(field.annotation)
-            models.append(annotation)
+            if is_pydantic_model:
+                for field in annotation.model_fields.values():
+                    visit(field.annotation)
+            else:
+                for field_annotation in getattr(annotation, "__annotations__", {}).values():
+                    visit(field_annotation)
+            visit_source_dependencies(annotation)
+            declarations.append(annotation)
+            return
+
+        if isinstance(annotation, (list, tuple)):
+            for argument in annotation:
+                visit(argument)
+            return
+
+        alias_value = getattr(annotation, "__value__", None)
+        if alias_value is not None and type(annotation).__name__ == "TypeAliasType":
+            key = ("alias_value", id(annotation))
+            if key in seen:
+                return
+            seen.add(key)
+            visit(alias_value)
             return
 
         for argument in get_args(annotation):
@@ -176,17 +288,31 @@ def _referenced_pydantic_models(signature):
     for field in signature.fields.values():
         visit(field.annotation)
 
-    return models
+    return declarations
 
 
 def _pydantic_model_sources(signature):
     sources = []
-    for model in _referenced_pydantic_models(signature):
+    for declaration in _referenced_annotation_declarations(signature):
+        if isinstance(declaration, tuple):
+            name, annotation, source = declaration
+            sources.append(source or f"{name} = {inspect.formatannotation(annotation)}")
+            continue
         try:
-            sources.append(inspect.getsource(model))
+            sources.append(inspect.getsource(declaration))
         except (TypeError, OSError):
-            schema = json.dumps(model.model_json_schema(), indent=2, sort_keys=True)
-            sources.append(f"# JSON Schema for {model.__name__}\n{schema}")
+            if issubclass(declaration, BaseModel):
+                schema = json.dumps(declaration.model_json_schema(), indent=2, sort_keys=True)
+                sources.append(f"# JSON Schema for {declaration.__name__}\n{schema}")
+            elif issubclass(declaration, Enum):
+                members = {name: member.value for name, member in declaration.__members__.items()}
+                sources.append(f"{declaration.__name__} = Enum({declaration.__name__!r}, {members!r})")
+            elif is_dataclass(declaration):
+                field_sources = "\n".join(
+                    f"    {field.name}: {inspect.formatannotation(field.type, base_module=declaration.__module__)}"
+                    for field in fields(declaration)
+                )
+                sources.append(f"@dataclass\nclass {declaration.__name__}:\n{field_sources}")
     return sources
 
 

--- a/tests/propose/test_utils.py
+++ b/tests/propose/test_utils.py
@@ -1,3 +1,7 @@
+from dataclasses import dataclass, make_dataclass
+from enum import Enum
+from typing import Callable
+
 from pydantic import BaseModel, Field, create_model
 
 import dspy
@@ -16,12 +20,63 @@ class Evidence(EvidenceBase):
     metadata: EvidenceMetadata
 
 
+class EvidenceKind(Enum):
+    QUOTE = "quote"
+
+
+class OptionalOnlyKind(Enum):
+    SUMMARY = "summary"
+
+
+class CallableOnlyKind(Enum):
+    FACT = "fact"
+
+
+class NestedAliasOnlyKind(Enum):
+    CLAIM = "claim"
+
+
+@dataclass
+class EvidenceLocation:
+    page: int
+
+
+EvidenceKinds = list[EvidenceKind]
+MaybeEvidenceKind = OptionalOnlyKind | None
+EvidenceKindFormatter = Callable[[CallableOnlyKind], str]
+NestedEvidenceKinds = list[NestedAliasOnlyKind]
+NestedEvidenceKindMap = dict[str, NestedEvidenceKinds]
+UnusedEvidenceKinds = tuple[EvidenceKind, ...]
+
+RuntimeEvidenceKind = Enum("RuntimeEvidenceKind", {"QUOTE": "quote"})
+RuntimeEvidenceLocation = make_dataclass("RuntimeEvidenceLocation", [("page", int)])
+
+
+class TypedEvidence(BaseModel):
+    kind: EvidenceKind
+    location: EvidenceLocation
+    allowed_kinds: EvidenceKinds
+    maybe_kind: MaybeEvidenceKind
+    formatter: EvidenceKindFormatter
+    nested_kinds: NestedEvidenceKindMap
+
+    def unrelated_helper(self):
+        return UnusedEvidenceKinds
+
+
+class RuntimeTypedEvidence(BaseModel):
+    kind: RuntimeEvidenceKind
+    location: RuntimeEvidenceLocation
+
+
 class ExtractEvidence(dspy.Signature):
     """Extract structured evidence from the input."""
 
     text: str = dspy.InputField()
     evidence: list[Evidence] | None = dspy.OutputField()
     backup_evidence: Evidence = dspy.OutputField()
+    typed_evidence: TypedEvidence = dspy.OutputField()
+    runtime_typed_evidence: RuntimeTypedEvidence = dspy.OutputField()
 
 
 class EvidenceModule(dspy.Module):
@@ -63,6 +118,38 @@ def test_get_dspy_source_code_includes_referenced_pydantic_models():
     )
     assert source.index("class EvidenceMetadata(BaseModel):") < source.index(
         "class Evidence(EvidenceBase):"
+    )
+    assert "class EvidenceKind(Enum):" in source
+    assert "class Enum(metaclass=EnumType):" not in source
+    assert "class Flag(Enum" not in source
+    assert "class EvidenceLocation:" in source
+    assert "EvidenceKinds = list[EvidenceKind]" in source
+    assert "MaybeEvidenceKind = OptionalOnlyKind | None" in source
+    assert "class OptionalOnlyKind(Enum):" in source
+    assert "EvidenceKindFormatter = Callable[[CallableOnlyKind], str]" in source
+    assert "class CallableOnlyKind(Enum):" in source
+    assert "NestedEvidenceKinds = list[NestedAliasOnlyKind]" in source
+    assert "NestedEvidenceKindMap = dict[str, NestedEvidenceKinds]" in source
+    assert "class NestedAliasOnlyKind(Enum):" in source
+    assert source.index("class NestedAliasOnlyKind(Enum):") < source.index(
+        "NestedEvidenceKinds = list[NestedAliasOnlyKind]"
+    )
+    assert source.index("NestedEvidenceKinds = list[NestedAliasOnlyKind]") < source.index(
+        "NestedEvidenceKindMap = dict[str, NestedEvidenceKinds]"
+    )
+    assert "UnusedEvidenceKinds = tuple[EvidenceKind, ...]" not in source
+    assert "RuntimeEvidenceKind = Enum(" in source
+    assert "class RuntimeEvidenceLocation:" in source
+    assert source.count("RuntimeEvidenceKind = Enum(") == 1
+    assert source.count("class RuntimeEvidenceLocation:") == 1
+    assert source.index("class EvidenceKind(Enum):") < source.index(
+        "class TypedEvidence(BaseModel):"
+    )
+    assert source.index("class EvidenceLocation:") < source.index(
+        "class TypedEvidence(BaseModel):"
+    )
+    assert source.index("EvidenceKinds = list[EvidenceKind]") < source.index(
+        "class TypedEvidence(BaseModel):"
     )
     assert source.index("class Evidence(EvidenceBase):") < source.index("StringSignature(")
 

--- a/tests/propose/test_utils.py
+++ b/tests/propose/test_utils.py
@@ -1,0 +1,75 @@
+from pydantic import BaseModel, Field, create_model
+
+import dspy
+from dspy.propose.utils import get_dspy_source_code
+
+
+class EvidenceMetadata(BaseModel):
+    confidence: float = Field(description="Confidence in the extracted evidence")
+
+
+class EvidenceBase(BaseModel):
+    quote: str = Field(description="The exact supporting text")
+
+
+class Evidence(EvidenceBase):
+    metadata: EvidenceMetadata
+
+
+class ExtractEvidence(dspy.Signature):
+    """Extract structured evidence from the input."""
+
+    text: str = dspy.InputField()
+    evidence: list[Evidence] | None = dspy.OutputField()
+    backup_evidence: Evidence = dspy.OutputField()
+
+
+class EvidenceModule(dspy.Module):
+    def __init__(self):
+        self.predictor = dspy.ChainOfThought(ExtractEvidence)
+
+    def forward(self, text: str):
+        return self.predictor(text=text)
+
+
+DynamicEvidence = create_model(
+    "DynamicEvidence",
+    value=(str, Field(description="Dynamically generated evidence value")),
+)
+
+
+class ExtractDynamicEvidence(dspy.Signature):
+    text: str = dspy.InputField()
+    evidence: DynamicEvidence = dspy.OutputField()
+
+
+class DynamicEvidenceModule(dspy.Module):
+    def __init__(self):
+        self.predictor = dspy.ChainOfThought(ExtractDynamicEvidence)
+
+
+def test_get_dspy_source_code_includes_referenced_pydantic_models():
+    source = get_dspy_source_code(EvidenceModule())
+
+    assert "class EvidenceMetadata(BaseModel):" in source
+    assert "confidence: float" in source
+    assert "class EvidenceBase(BaseModel):" in source
+    assert "quote: str" in source
+    assert "class Evidence(EvidenceBase):" in source
+    assert "metadata: EvidenceMetadata" in source
+    assert source.count("class Evidence(EvidenceBase):") == 1
+    assert source.index("class EvidenceBase(BaseModel):") < source.index(
+        "class Evidence(EvidenceBase):"
+    )
+    assert source.index("class EvidenceMetadata(BaseModel):") < source.index(
+        "class Evidence(EvidenceBase):"
+    )
+    assert source.index("class Evidence(EvidenceBase):") < source.index("StringSignature(")
+
+
+def test_get_dspy_source_code_uses_json_schema_for_dynamic_models():
+    source = get_dspy_source_code(DynamicEvidenceModule())
+
+    assert "# JSON Schema for DynamicEvidence" in source
+    assert '"value"' in source
+    assert "Dynamically generated evidence value" in source


### PR DESCRIPTION
Fixes #7934.

## 📝 Changes Description

This PR adds the Pydantic model definitions referenced by DSPy Signature fields to the source context produced by `get_dspy_source_code`.

- recursively discovers custom `BaseModel` types through generic annotations, nested fields, and inheritance
- emits dependency models before the models and Signatures that reference them
- falls back to a stable JSON Schema representation for dynamically created models whose source cannot be inspected
- deduplicates repeated model references and skips DSPy/Pydantic built-in models
- adds offline regression tests for nested, inherited, optional/list, duplicate, and dynamic Pydantic models

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing locally
- [x] Title follows the required format
- [x] Commit message follows `{label}(dspy): {message}`

Tests:
- `pytest tests/propose -q` on Python 3.12: 6 passed
- `pytest tests/propose -q` on Python 3.10: 6 passed
- `pre-commit run --files dspy/propose/utils.py tests/propose/test_utils.py`: passed

## ⚠️ Warnings

None.

## AI Assistance Disclosure

I used TRAE/TraeWork as an AI-assisted coding tool for repository exploration, implementation suggestions, edge-case review, and test planning. I reviewed the resulting changes, ran the tests above locally, and take responsibility for the submitted code.

Prompts used included:
- “Investigate DSPy issue #7934 and reproduce why Pydantic model definitions are missing from grounded proposer source context.”
- “Implement an offline-testable fix that recursively discovers referenced Pydantic models, preserves dependency order, deduplicates models, and handles dynamically created models.”
- “Review the change for Python 3.10 compatibility, nested annotations, inheritance, dynamic models, and regression risks.”
## 🧩本次 Review 补充修复

- Enum 与 dataclass 依赖
- 模块级 type alias 依赖
- 动态 Enum / dataclass 回退
- 递归 PEP 695 支持
- 过采集负测

---

✅ 结论：本次改动未引入回归，测试与 pre-commit 均通过。