### PR TITLE
Fail all callers when batch_fn returns the wrong number of outputs

### DIFF
--- a/dspy/utils/unbatchify.py
+++ b/dspy/utils/unbatchify.py
@@ -2,6 +2,7 @@ import queue
 import threading
 import time
 from concurrent.futures import Future
+from itertools import islice
 from typing import Any, Callable
 
 
@@ -67,10 +68,14 @@ class Unbatchify:
 
             if batch:
                 try:
-                    outputs = list(self.batch_fn(batch))
+                    # Take at most one output beyond the batch size: enough to detect a
+                    # too-long result, but bounded, so a lazy or unterminated iterable
+                    # cannot stall the worker and hang every caller in the batch.
+                    outputs = list(islice(iter(self.batch_fn(batch)), len(batch) + 1))
                     if len(outputs) != len(batch):
+                        got = len(outputs) if len(outputs) < len(batch) else f"more than {len(batch)}"
                         raise ValueError(
-                            f"batch_fn returned {len(outputs)} output(s) for {len(batch)} input(s). "
+                            f"batch_fn returned {got} output(s) for {len(batch)} input(s). "
                             "batch_fn must return exactly one output per input, in the same order."
                         )
                     for output, future in zip(outputs, futures, strict=True):

--- a/dspy/utils/unbatchify.py
+++ b/dspy/utils/unbatchify.py
@@ -67,12 +67,18 @@ class Unbatchify:
 
             if batch:
                 try:
-                    outputs = self.batch_fn(batch)
-                    for output, future in zip(outputs, futures, strict=False):
+                    outputs = list(self.batch_fn(batch))
+                    if len(outputs) != len(batch):
+                        raise ValueError(
+                            f"batch_fn returned {len(outputs)} output(s) for {len(batch)} input(s). "
+                            "batch_fn must return exactly one output per input, in the same order."
+                        )
+                    for output, future in zip(outputs, futures, strict=True):
                         future.set_result(output)
                 except Exception as e:
                     for future in futures:
-                        future.set_exception(e)
+                        if not future.done():
+                            future.set_exception(e)
             else:
                 time.sleep(0.01)
 

--- a/tests/utils/test_unbatchify.py
+++ b/tests/utils/test_unbatchify.py
@@ -2,6 +2,8 @@ import time
 from concurrent.futures import Future
 from unittest.mock import MagicMock
 
+import pytest
+
 from dspy.utils.unbatchify import Unbatchify
 
 
@@ -95,3 +97,59 @@ def test_unbatchify_honors_max_wait_time_under_trickling_input():
     assert elapsed < wait_time * 1.5
 
     unbatcher.close()
+
+
+def test_unbatchify_raises_when_batch_fn_returns_fewer_outputs():
+    """Every caller in the batch must fail fast if batch_fn drops outputs, instead of hanging."""
+
+    def dropping_batch_fn(batch):
+        # Simulates a batch_fn that filters its inputs, e.g. skipping items it cannot handle.
+        return [item for item in batch if item % 2 == 0]
+
+    unbatcher = Unbatchify(batch_fn=dropping_batch_fn, max_batch_size=2, max_wait_time=5.0)
+
+    try:
+        futures = [unbatcher.submit(1), unbatcher.submit(2)]
+
+        for future in futures:
+            with pytest.raises(ValueError, match="exactly one output per input"):
+                future.result(timeout=5)
+    finally:
+        unbatcher.close()
+
+
+def test_unbatchify_raises_when_batch_fn_returns_more_outputs():
+    """Extra outputs are a contract violation too, and must not be silently discarded."""
+
+    def duplicating_batch_fn(batch):
+        return [item for item in batch for _ in range(2)]
+
+    unbatcher = Unbatchify(batch_fn=duplicating_batch_fn, max_batch_size=2, max_wait_time=5.0)
+
+    try:
+        futures = [unbatcher.submit(1), unbatcher.submit(2)]
+
+        for future in futures:
+            with pytest.raises(ValueError, match="exactly one output per input"):
+                future.result(timeout=5)
+    finally:
+        unbatcher.close()
+
+
+def test_unbatchify_does_not_misalign_outputs_when_batch_fn_drops_items():
+    """A dropped output must never shift a later output onto an earlier input's future."""
+
+    def drop_first_batch_fn(batch):
+        return [f"result-for-{item}" for item in batch[1:]]
+
+    unbatcher = Unbatchify(batch_fn=drop_first_batch_fn, max_batch_size=2, max_wait_time=5.0)
+
+    try:
+        future = unbatcher.submit("a")
+        unbatcher.submit("b")
+
+        # Before the fix this future resolved to "result-for-b" -- the wrong input's output.
+        with pytest.raises(ValueError, match="exactly one output per input"):
+            future.result(timeout=5)
+    finally:
+        unbatcher.close()

--- a/tests/utils/test_unbatchify.py
+++ b/tests/utils/test_unbatchify.py
@@ -1,3 +1,4 @@
+import itertools
 import time
 from concurrent.futures import Future
 from unittest.mock import MagicMock
@@ -151,5 +152,28 @@ def test_unbatchify_does_not_misalign_outputs_when_batch_fn_drops_items():
         # Before the fix this future resolved to "result-for-b" -- the wrong input's output.
         with pytest.raises(ValueError, match="exactly one output per input"):
             future.result(timeout=5)
+    finally:
+        unbatcher.close()
+
+
+def test_unbatchify_does_not_stall_on_unbounded_batch_fn_output():
+    """An output iterable that never terminates must not block the worker thread.
+
+    The worker cannot fully materialize the result before resolving futures, or a lazy
+    batch_fn hangs every caller in the batch -- the exact failure this validation exists
+    to prevent.
+    """
+
+    def unbounded_batch_fn(batch):
+        return itertools.count()
+
+    unbatcher = Unbatchify(batch_fn=unbounded_batch_fn, max_batch_size=2, max_wait_time=5.0)
+
+    try:
+        futures = [unbatcher.submit(1), unbatcher.submit(2)]
+
+        for future in futures:
+            with pytest.raises(ValueError, match="exactly one output per input"):
+                future.result(timeout=5)
     finally:
         unbatcher.close()


### PR DESCRIPTION
Fixes #10313

`Unbatchify._worker` currently uses `zip(outputs, futures, strict=False)` to pair outputs with futures. This causes problems when `batch_fn` doesn't return one output per input.

If there are fewer outputs, the remaining futures are never resolved, so callers can block indefinitely on `future.result()`. If there are extra outputs, they are silently dropped. Filtering is also problematic because the remaining outputs can end up assigned to the wrong futures.

Reproducible on current main:

```python
from concurrent.futures import Future
from dspy.utils.unbatchify import Unbatchify

def submit(self, item):
    f = Future()
    self.input_queue.put((item, f))
    return f

Unbatchify.submit = submit

u = Unbatchify(
    batch_fn=lambda batch: [i for i in batch if i % 2 == 0],
    max_batch_size=2,
    max_wait_time=0.05,
)

f1, f2 = u.submit(2), u.submit(3)
print(f1.result(timeout=2))  # 2
print(f2.result(timeout=2))  # times out
```

The fix checks that the number of outputs matches the batch size before resolving the futures. If it doesn't, a `ValueError` is set on all futures in that batch so callers fail instead of hanging.

I also added a `future.done()` check when setting exceptions to avoid an `InvalidStateError` killing the worker thread if a future has already been resolved.

Added tests for fewer outputs, extra outputs, and the filtering/misalignment case. They fail on main and pass with this change. `tests/utils/test_unbatchify.py` and `tests/retrievers` are passing.

I left the unrelated `__init__` formatting unchanged.
