### PR TITLE
fix(teleprompt): respect MIPROv2.compile seed=0

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -167,7 +167,7 @@ class MIPROv2(Teleprompter):
             )
 
         # Set random seeds
-        seed = seed or self.seed
+        seed = seed if seed is not None else self.seed
         self._set_random_seeds(seed)
 
 

--- a/tests/teleprompt/test_mipro_optimizer_v2.py
+++ b/tests/teleprompt/test_mipro_optimizer_v2.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dspy.teleprompt.mipro_optimizer_v2 import MIPROv2
+
+
+def test_compile_respects_seed_zero():
+    """compile(seed=0) must keep seed 0 instead of falling back to the constructor default.
+
+    Regression test for https://github.com/stanfordnlp/dspy/issues/10321
+    """
+    lm = MagicMock()
+    optimizer = MIPROv2(metric=lambda *args, **kwargs: True, auto="light", prompt_model=lm, task_model=lm)
+
+    with (
+        patch.object(optimizer, "_set_random_seeds") as mock_set_seeds,
+        patch.object(optimizer, "_set_and_validate_datasets", side_effect=RuntimeError("stop after seed")),
+    ):
+        with pytest.raises(RuntimeError, match="stop after seed"):
+            optimizer.compile(MagicMock(), trainset=[], seed=0)
+
+    mock_set_seeds.assert_called_once_with(0)


### PR DESCRIPTION
## Changes

`MIPROv2.compile` applied the seed with `seed = seed or self.seed`. In Python, `0 or self.seed` is `self.seed`, so `compile(..., seed=0)` silently used the constructor default (`seed=9`).

The fallback is now `seed = seed if seed is not None else self.seed`. Only a missing/`None` seed uses the constructor value; `seed=0` is kept.

A unit test asserts that `compile(..., seed=0)` calls `_set_random_seeds(0)`.

Fixes #10321.