### PR TITLE
Add field_markers opt-out to ChatAdapter

### DIFF
--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -97,7 +97,7 @@ class ChatAdapter(Adapter):
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
         processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
-        self._validate_field_markers(signature)
+        self._validate_field_markers(processed_signature)
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
@@ -118,8 +118,8 @@ class ChatAdapter(Adapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
-         processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
-        self._validate_field_markers(signature)
+        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
+        self._validate_field_markers(processed_signature)
         try:
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -57,12 +57,11 @@ class ChatAdapter(Adapter):
                 If True, when an error occurs (except ContextWindowExceededError), the adapter will retry using
                 JSONAdapter. Defaults to True.
             parallel_tool_calls: Whether to request provider-side parallel tool-call generation when native function
-                calling is active. If None, the adapter does not set the p0ovider option.
+                calling is active. If None, the adapter does not set the provider option.
             field_markers: Whether to wrap each field in `[[ ## field_name ## ]]` markers in prompts and
                 completions. Defaults to True. Set to False to reduce token overhead — only supported for
                 signatures with a single output field, since markers are what let the parser separate
-                multiple output fields in the r
-                aw completion text.
+                multiple output fields in the raw completion text
         """
         super().__init__(
             callbacks=callbacks,
@@ -217,10 +216,12 @@ class ChatAdapter(Adapter):
             else:
                 return ""
 
-        if not self.field_markers:
+        if not self.field_markers:         
+            if not signature.output_fields:
+                return None
             (f, v), = signature.output_fields.items()
-            return f"Respond with the value for `{f}`{type_info(v)}. Do not include any other text."
-    
+            return f"Respond with the value for `{f}`{type_info(v)}. Do not include any other text."   # <-- also inside type_info(), and dedented one level short
+
         message = "Respond with the corresponding output fields, starting with the field "
         message += ", then ".join(f"`[[ ## {f} ## ]]`{type_info(v)}" for f, v in signature.output_fields.items())
         message += ", and then ending with the marker for `[[ ## completed ## ]]`."

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -245,6 +245,8 @@ class ChatAdapter(Adapter):
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
         if not self.field_markers:
+            if not signature.output_fields:
+                return {}
             (field_name, field_info), = signature.output_fields.items()
             try:
                 return {field_name: parse_value(completion.strip(), field_info.annotation)}

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -46,6 +46,7 @@ class ChatAdapter(Adapter):
         native_response_types: list[type[type]] | None = None,
         use_json_adapter_fallback: bool = True,
         parallel_tool_calls: bool | None = None,
+        field_markers : bool = True,
     ):
         """
         Args:
@@ -56,7 +57,12 @@ class ChatAdapter(Adapter):
                 If True, when an error occurs (except ContextWindowExceededError), the adapter will retry using
                 JSONAdapter. Defaults to True.
             parallel_tool_calls: Whether to request provider-side parallel tool-call generation when native function
-                calling is active. If None, the adapter does not set the provider option.
+                calling is active. If None, the adapter does not set the p0ovider option.
+            field_markers: Whether to wrap each field in `[[ ## field_name ## ]]` markers in prompts and
+                completions. Defaults to True. Set to False to reduce token overhead — only supported for
+                signatures with a single output field, since markers are what let the parser separate
+                multiple output fields in the r
+                aw completion text.
         """
         super().__init__(
             callbacks=callbacks,
@@ -65,15 +71,24 @@ class ChatAdapter(Adapter):
             native_response_types=native_response_types,
         )
         self.use_json_adapter_fallback = use_json_adapter_fallback
+        self.field_markers = field_markers
+        
+    def _validate_field_markers(self, signature: type[Signature]) -> None:
+        if not self.field_markers and len(signature.output_fields) > 1:
+            raise ValueError(
+                "field_markers=False is only supported for signatures with a single output field, "
+                f"but got {len(signature.output_fields)} output fields: "
+                f"{list(signature.output_fields.keys())}. Field markers are required to separate "
+                "multiple output fields in the raw completion text. Use JSONAdapter instead if you "
+                "need both low token overhead and multiple output fields."
+            )
 
     def _make_json_adapter_fallback(self):
         from dspy.adapters.json_adapter import JSONAdapter
-
         return JSONAdapter(
             use_native_function_calling=self.use_native_function_calling,
             parallel_tool_calls=self.parallel_tool_calls,
         )
-
     def __call__(
         self,
         lm: BaseLM,
@@ -82,6 +97,7 @@ class ChatAdapter(Adapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
+        self._validate_field_markers(signature)
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
@@ -102,6 +118,7 @@ class ChatAdapter(Adapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
+        self._validate_field_markers(signature)
         try:
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)
         except Exception as e:
@@ -126,6 +143,8 @@ class ChatAdapter(Adapter):
         `[[ ## field_name ## ]]`. An arbitrary field `completed` ([[ ## completed ## ]]) is added to the end of the
         output fields section to indicate the end of the output fields.
         """
+        if not self.field_markers:
+            return ""
         parts = []
         parts.append("All interactions will be structured in the following way, with the appropriate values filled in.")
 
@@ -160,8 +179,10 @@ class ChatAdapter(Adapter):
             if k in inputs:
                 value = inputs.get(k)
                 formatted_field_value = format_field_value(field_info=v, value=value)
-                messages.append(f"[[ ## {k} ## ]]\n{formatted_field_value}")
-
+                if self.field_markers:
+                   messages.append(f"[[ ## {k} ## ]]\n{formatted_field_value}")
+                else:
+                   messages.append(formatted_field_value)
         if main_request:
             output_requirements = self.user_message_output_requirements(signature)
             if output_requirements is not None:
@@ -196,6 +217,10 @@ class ChatAdapter(Adapter):
             else:
                 return ""
 
+        if not self.field_markers:
+            (f, v), = signature.output_fields.items()
+            return f"Respond with the value for `{f}`{type_info(v)}. Do not include any other text."
+    
         message = "Respond with the corresponding output fields, starting with the field "
         message += ", then ".join(f"`[[ ## {f} ## ]]`{type_info(v)}" for f, v in signature.output_fields.items())
         message += ", and then ending with the marker for `[[ ## completed ## ]]`."
@@ -213,10 +238,23 @@ class ChatAdapter(Adapter):
                 for k, v in signature.output_fields.items()
             },
         )
-        assistant_message_content += "\n\n[[ ## completed ## ]]\n"
+        if self.field_markers:
+            assistant_message_content += "\n\n[[ ## completed ## ]]\n"
         return assistant_message_content
 
     def parse(self, signature: type[Signature], completion: str) -> dict[str, Any]:
+        if not self.field_markers:
+            (field_name, field_info), = signature.output_fields.items()
+            try:
+                return {field_name: parse_value(completion.strip(), field_info.annotation)}
+            except Exception as e:
+                raise AdapterParseError(
+                    adapter_name="ChatAdapter",
+                    signature=signature,
+                    lm_response=completion,
+                    message=f"Failed to parse field {field_name} with value {completion!r} from the LM response. Error message: {e}",
+                )
+
         sections = [(None, [])]
 
         for line in completion.splitlines():
@@ -270,8 +308,10 @@ class ChatAdapter(Adapter):
         output = []
         for field, field_value in fields_with_values.items():
             formatted_field_value = format_field_value(field_info=field.info, value=field_value)
-            output.append(f"[[ ## {field.name} ## ]]\n{formatted_field_value}")
-
+            if self.field_markers:
+               output.append(f"[[ ## {field.name} ## ]]\n{formatted_field_value}")
+            else:
+               output.append(formatted_field_value)
         return "\n\n".join(output).strip()
 
     def format_finetune_data(

--- a/dspy/adapters/chat_adapter.py
+++ b/dspy/adapters/chat_adapter.py
@@ -96,6 +96,7 @@ class ChatAdapter(Adapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
+        processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
         self._validate_field_markers(signature)
         try:
             return super().__call__(lm, lm_kwargs, signature, demos, inputs)
@@ -117,6 +118,7 @@ class ChatAdapter(Adapter):
         demos: list[dict[str, Any]],
         inputs: dict[str, Any],
     ) -> list[dict[str, Any]]:
+         processed_signature = self._call_preprocess(lm, lm_kwargs, signature, inputs)
         self._validate_field_markers(signature)
         try:
             return await super().acall(lm, lm_kwargs, signature, demos, inputs)

--- a/tests/adapters/test_chat_adapter.py
+++ b/tests/adapters/test_chat_adapter.py
@@ -2946,3 +2946,31 @@ def test_optional_type_syntax_missing_required_output_field_still_raises():
     with dspy.context(lm=DummyLM(responses), adapter=dspy.ChatAdapter()):
         with pytest.raises(AdapterParseError):
             dspy.Predict(OptionalSyntaxSignature)(question="anything")
+
+def test_field_markers_false_single_output_field():
+    """field_markers=False should produce marker-free prompts and parse correctly for single-output signatures."""
+    adapter = dspy.ChatAdapter(field_markers=False)
+
+    class SimpleSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+
+    messages = adapter.format(SimpleSignature, [], {"question": "What is 2+2?"})
+    full_text = " ".join(m["content"] for m in messages)
+    assert "[[ ##" not in full_text  # no markers anywhere in the prompt
+
+    parsed = adapter.parse(SimpleSignature, "4")
+    assert parsed == {"answer": "4"}
+
+
+def test_field_markers_false_multi_output_field_raises():
+    """field_markers=False should raise a clear error for signatures with more than one output field."""
+    adapter = dspy.ChatAdapter(field_markers=False)
+
+    class MultiOutputSignature(dspy.Signature):
+        question: str = dspy.InputField()
+        answer: str = dspy.OutputField()
+        confidence: float = dspy.OutputField()
+
+    with pytest.raises(ValueError, match="single output field"):
+        adapter._validate_field_markers(MultiOutputSignature)


### PR DESCRIPTION
Summary
Adds a "field_markers: bool = True"  parameter to "ChatAdapter" that, when set to
"False", omits the "[[ ## field_name ## ]]" structural markers from prompts and
completions — reducing token overhead for signatures with a single output field.

Closes #10073

Design notes
- Defaults to "True", so existing behavior is fully unchanged unless explicitly opted out.
- Only supported for signatures with a "single output field". Markers are what let
  "parse()" separate multiple output fields in the raw completion text — without them,
  there's no reliable way to split a multi-field completion. Attempting to use
  "field_markers=False" with more than one output field raises a clear "ValueError"
  at call time (see "_validate_field_markers").
- For multi-field, low-token-overhead use cases, "JSONAdapter" remains the
  recommended alternative.

Testing
Added two tests:
- "test_field_markers_false_single_output_field" — confirms no markers appear in
  the prompt and parsing works correctly for a single-output signature.
- "test_field_markers_false_multi_output_field_raises" — confirms the clear error
  is raised for multi-output signatures.

All 78 existing tests in "test_chat_adapter.py" continue to pass.