### PR TITLE
fix: key Image.format cache on URL instead of self

### DIFF
--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -1,4 +1,5 @@
 import base64
+import copy
 import io
 import mimetypes
 import os
@@ -106,7 +107,9 @@ class Image(Type):
 
     def format(self) -> list[dict[str, Any]] | str:
         try:
-            return _format_image(self.url)
+            # Deep-copy so callers that mutate the nested list/dict cannot
+            # poison the shared @lru_cache entry for this URL.
+            return copy.deepcopy(_format_image(self.url))
         except Exception as e:
             raise ValueError(f"Failed to format image for DSPy: {e}")
 

--- a/dspy/adapters/types/image.py
+++ b/dspy/adapters/types/image.py
@@ -104,13 +104,11 @@ class Image(Type):
         # Delegate the rest of initialization to pydantic's BaseModel.
         super().__init__(**data)
 
-    @lru_cache(maxsize=32)
     def format(self) -> list[dict[str, Any]] | str:
         try:
-            image_url = encode_image(self.url)
+            return _format_image(self.url)
         except Exception as e:
             raise ValueError(f"Failed to format image for DSPy: {e}")
-        return [{"type": "image_url", "image_url": {"url": image_url}}]
 
     @classmethod
     def from_url(cls, url: str, verify: bool = True, timeout: float | None = 30.0) -> "Image":
@@ -161,6 +159,12 @@ class Image(Type):
             image_type = self.url.split(";")[0].split("/")[-1]
             return f"Image(url=data:image/{image_type};base64,<IMAGE_BASE_64_ENCODED({len_base64!s})>)"
         return f"Image(url='{self.url}')"
+
+
+@lru_cache(maxsize=32)
+def _format_image(url: str) -> list[dict[str, Any]] | str:
+    image_url = encode_image(url)
+    return [{"type": "image_url", "image_url": {"url": image_url}}]
 
 
 def is_url(string: str) -> bool:

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -1,7 +1,9 @@
 import base64
+import gc
 import os
 import tempfile
 import warnings
+import weakref
 from io import BytesIO
 
 import pydantic
@@ -10,7 +12,7 @@ import requests
 from PIL import Image as PILImage
 
 import dspy
-from dspy.adapters.types.image import encode_image
+from dspy.adapters.types.image import _format_image, encode_image
 from dspy.utils.dummies import DummyLM
 
 
@@ -463,6 +465,29 @@ def test_image_repr():
     assert str(pil_image).startswith('<<CUSTOM-TYPE-START-IDENTIFIER>>[{"type": "image_url",')
     assert str(pil_image).endswith("<<CUSTOM-TYPE-END-IDENTIFIER>>")
     assert "base64" in str(pil_image)
+
+
+def test_format_cache_does_not_retain_image_instances():
+    """lru_cache must key on the URL string, not the Image instance (see #10273)."""
+    _format_image.cache_clear()
+    image = dspy.Image("data:image/png;base64,AAAA")
+    reference = weakref.ref(image)
+
+    formatted = image.format()
+    assert formatted == [{"type": "image_url", "image_url": {"url": image.url}}]
+
+    # Same URL should hit the module-level cache without keeping `image` alive.
+    again = dspy.Image("data:image/png;base64,AAAA")
+    assert again.format() == formatted
+    info = _format_image.cache_info()
+    assert info.hits >= 1
+
+    del image
+    del again
+    gc.collect()
+
+    assert reference() is None
+    _format_image.cache_clear()
 
 
 def test_image_constructor_supports_positional_source_and_url_keyword():

--- a/tests/signatures/test_adapter_image.py
+++ b/tests/signatures/test_adapter_image.py
@@ -490,6 +490,30 @@ def test_format_cache_does_not_retain_image_instances():
     _format_image.cache_clear()
 
 
+def test_format_cache_payload_is_isolated_from_mutation():
+    """Mutating one format() result must not poison the shared cache entry."""
+    _format_image.cache_clear()
+    url = "https://example.com/isolation-test.jpg"
+    first = dspy.Image(url)
+    second = dspy.Image(url)
+
+    formatted_a = first.format()
+    formatted_b = second.format()
+    assert formatted_a == formatted_b
+    assert formatted_a is not formatted_b
+    assert formatted_a[0] is not formatted_b[0]
+
+    formatted_a[0]["image_url"]["url"] = "https://evil.example/poisoned.jpg"
+    formatted_a[0]["type"] = "tampered"
+
+    formatted_c = second.format()
+    expected = [{"type": "image_url", "image_url": {"url": url}}]
+    assert formatted_b == expected
+    assert formatted_c == expected
+    assert formatted_c is not formatted_a
+    _format_image.cache_clear()
+
+
 def test_image_constructor_supports_positional_source_and_url_keyword():
     source = "https://example.com/dog.jpg"
 


### PR DESCRIPTION
## Summary

Fixes #10273.

`@lru_cache` on `Image.format` keys on `self`, so the cache holds up to 32 `Image` instances (often with large base64 payloads) for the life of the process. Unique images never hit the cache, but still fill it.

Move the cache to a module-level helper keyed by the URL string. Same-URL formatting still hits; `Image` objects are no longer pinned.

## Test plan

- [x] `uv run --frozen pytest tests/signatures/test_adapter_image.py -q` — 29 passed, 2 xfailed
- [x] New `test_format_cache_does_not_retain_image_instances` (weakref + cache hits)
- [x] Issue repro script: after `trace.clear()`, alive count is 0 (was 32 before)

@TomeHirata — ready for review; this keeps the throughput win from #8842 without retaining `Image` instances.