### PR TITLE
fix(tool): resolve JSON schema refs as local pointers with cycle detection

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -520,29 +520,62 @@ def _normalize_tool_call_dict(data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_UNRESOLVED_REF = object()
+
+
 def _resolve_json_schema_reference(schema: dict) -> dict:
-    """Recursively resolve json model schema, expanding all references."""
+    """Recursively resolve json model schema, expanding all references.
 
-    # If there are no definitions to resolve, return the main schema
-    if "$defs" not in schema and "definitions" not in schema:
-        return schema
+    References are resolved as local JSON pointers (e.g. `#/$defs/Foo`, `#/definitions/Foo`,
+    `#/properties/foo`) against the document root. Cyclic references (e.g. from self-referential
+    pydantic models) are replaced with `{}` (the JSON Schema that accepts anything) instead of
+    recursing forever, and unresolvable references are left as-is instead of raising.
+    """
 
-    def resolve_refs(obj: Any) -> Any:
+    def lookup_ref(ref: str) -> Any:
+        if not ref.startswith("#"):
+            # Only local references can be resolved; leave remote ones untouched.
+            return _UNRESOLVED_REF
+        target: Any = schema
+        # Walk the JSON pointer segments from the document root, unescaping `~1` and `~0`.
+        for segment in [s.replace("~1", "/").replace("~0", "~") for s in ref[1:].split("/")[1:]]:
+            if isinstance(target, dict) and segment in target:
+                target = target[segment]
+            elif isinstance(target, list) and segment.isdigit() and int(segment) < len(target):
+                target = target[int(segment)]
+            else:
+                break
+        else:
+            return target
+        # Fall back to looking up the last path segment in `$defs`/`definitions`.
+        name = ref.split("/")[-1]
+        for definitions in (schema.get("$defs"), schema.get("definitions")):
+            if isinstance(definitions, dict) and name in definitions:
+                return definitions[name]
+        return _UNRESOLVED_REF
+
+    def resolve_refs(obj: Any, seen: frozenset[str]) -> Any:
         if not isinstance(obj, (dict, list)):
             return obj
         if isinstance(obj, dict):
-            if "$ref" in obj:
-                ref_path = obj["$ref"].split("/")[-1]
-                return resolve_refs(schema["$defs"][ref_path])
-            return {k: resolve_refs(v) for k, v in obj.items()}
+            ref = obj.get("$ref")
+            if isinstance(ref, str):
+                if ref in seen:
+                    # Cyclic reference: stop expanding and accept anything at this position.
+                    return {}
+                target = lookup_ref(ref)
+                if target is not _UNRESOLVED_REF:
+                    return resolve_refs(target, seen | {ref})
+            return {k: resolve_refs(v, seen) for k, v in obj.items()}
 
         # Must be a list
-        return [resolve_refs(item) for item in obj]
+        return [resolve_refs(item, seen) for item in obj]
 
     # Resolve all references in the main schema
-    resolved_schema = resolve_refs(schema)
-    # Remove the $defs key as it's no longer needed
+    resolved_schema = resolve_refs(schema, frozenset())
+    # Remove the definition keys as they are no longer needed
     resolved_schema.pop("$defs", None)
+    resolved_schema.pop("definitions", None)
     return resolved_schema
 
 
@@ -564,11 +597,12 @@ def convert_input_schema_to_tool_args(
 
     required = schema.get("required", [])
 
-    defs = schema.get("$defs", {})
+    # Resolve references against the full schema so that local pointers outside `$defs`
+    # (e.g. `#/definitions/...` or `#/properties/...`) resolve as well.
+    resolved_properties = _resolve_json_schema_reference(schema).get("properties", {})
 
     for name, prop in properties.items():
-        if len(defs) > 0:
-            prop = _resolve_json_schema_reference({"$defs": defs, **prop})
+        prop = resolved_properties.get(name, prop)
         args[name] = prop
         arg_types[name] = _TYPE_MAPPING.get(prop.get("type"), Any)
         arg_desc[name] = prop.get("description", "No description provided.")

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -709,6 +709,90 @@ def test_tool_convert_input_schema_to_tool_args_lang_chain():
     }
 
 
+def test_tool_from_function_with_recursive_pydantic_model():
+    class TreeNode(BaseModel):
+        name: str
+        children: list["TreeNode"] = []
+
+    TreeNode.model_rebuild()
+
+    def organize(tree: TreeNode) -> str:
+        """Summarize a tree."""
+        return "ok"
+
+    tool = Tool(organize)
+
+    assert "$defs" not in str(tool.args["tree"])
+    assert tool.args["tree"]["type"] == "object"
+    assert tool.args["tree"]["properties"]["name"]["type"] == "string"
+    # The cyclic reference is replaced with the "accept anything" schema.
+    assert tool.args["tree"]["properties"]["children"]["items"] == {}
+
+
+def test_tool_convert_input_schema_to_tool_args_recursive_schema():
+    args, arg_types, arg_desc = convert_input_schema_to_tool_args(
+        schema={
+            "type": "object",
+            "$defs": {
+                "TreeNode": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "children": {"type": "array", "items": {"$ref": "#/$defs/TreeNode"}},
+                    },
+                }
+            },
+            "properties": {"tree": {"$ref": "#/$defs/TreeNode"}},
+            "required": ["tree"],
+        }
+    )
+    assert args["tree"]["type"] == "object"
+    assert args["tree"]["properties"]["name"]["type"] == "string"
+    assert args["tree"]["properties"]["children"]["items"] == {}
+    assert arg_types == {"tree": dict}
+    assert arg_desc == {"tree": "No description provided. (Required)"}
+
+
+def test_tool_convert_input_schema_to_tool_args_legacy_definitions_ref():
+    args, arg_types, arg_desc = convert_input_schema_to_tool_args(
+        schema={
+            "type": "object",
+            "properties": {"node": {"$ref": "#/definitions/Node"}},
+            "required": ["node"],
+            "definitions": {"Node": {"type": "object", "properties": {"name": {"type": "string"}}}},
+        }
+    )
+    assert args["node"] == {"type": "object", "properties": {"name": {"type": "string"}}}
+    assert arg_types == {"node": dict}
+    assert arg_desc == {"node": "No description provided. (Required)"}
+
+
+def test_tool_convert_input_schema_to_tool_args_local_pointer_ref():
+    args, arg_types, _ = convert_input_schema_to_tool_args(
+        schema={
+            "type": "object",
+            "properties": {
+                "x": {"type": "integer"},
+                "y": {"type": "object", "properties": {"z": {"$ref": "#/properties/x"}}},
+            },
+        }
+    )
+    assert args["x"] == {"type": "integer"}
+    assert args["y"]["properties"]["z"] == {"type": "integer"}
+    assert arg_types == {"x": int, "y": dict}
+
+
+def test_tool_convert_input_schema_to_tool_args_unresolvable_ref():
+    # Unresolvable references are left as-is instead of raising.
+    args, arg_types, _ = convert_input_schema_to_tool_args(
+        schema={
+            "type": "object",
+            "$defs": {"Other": {"type": "string"}},
+            "properties": {"node": {"$ref": "#/definitions/Missing"}},
+        }
+    )
+    assert args["node"] == {"$ref": "#/definitions/Missing"}
+    assert arg_types == {"node": Any}
 
 
 def test_tool_call_execute():


### PR DESCRIPTION
## 📝 Changes Description

Fixes #10327

`_resolve_json_schema_reference` (dspy/adapters/types/tool.py) expanded `$ref`s with unbounded recursion and a lookup that assumed every ref's last path segment exists in `$defs`. All three failure modes from the issue are reachable from public API (`dspy.Tool(fn)` and MCP tool conversion via `convert_input_schema_to_tool_args`):

1. Self-referential pydantic models (e.g. `TreeNode` with `children: list["TreeNode"]`) → `RecursionError`.
2. Local refs not shaped like `#/$defs/<name>` (e.g. `#/definitions/Node`, `#/properties/x`) → `KeyError`.
3. Legacy `definitions`-only schemas → dangling `$ref`s passed through and arg types silently degraded to `Any`.

This PR:

- Resolves refs as **local JSON pointers** (with RFC 6901 `~0`/`~1` unescaping) against the document root, with a fallback last-segment lookup in `$defs`/`definitions`.
- Adds **cycle detection**: refs on the current expansion stack are tracked in a `frozenset`, mirroring the `seen` guard in `XMLAdapter._schema_to_xml` (#10239). When a cycle closes, `{}` (the accept-anything schema) is emitted instead of recursing, so depth is bounded by the ref graph.
- Leaves **unresolvable refs as-is** instead of raising.
- `convert_input_schema_to_tool_args` now resolves properties against the full schema, so `#/definitions/...` and other non-`$defs` pointers resolve, and legacy `definitions`-only schemas no longer silently degrade.

Behavior-preserving for today's working paths: `#/$defs/X` refs from pydantic resolve identically; only cycles and currently-crashing inputs change.

### Verification

- Ran the repro snippets from the issue: recursive `dspy.Tool(organize)` now constructs (cycle point becomes `{}`), `#/definitions/Node` resolves, the dangling `#/properties/x` ref passes through instead of raising, and the legacy `definitions`-only schema resolves with `arg_types == {"node": dict}`.
- Added regression tests in `tests/adapters/test_tool.py`: recursive pydantic model via `dspy.Tool`, recursive schema via `convert_input_schema_to_tool_args`, `#/definitions/...` ref, nested `#/properties/...` pointer, and an unresolvable ref left as-is.
- `pytest tests/adapters tests/utils/test_mcp.py tests/utils/test_langchain_tool.py` → 289 passed, 33 skipped (optional-dep skips).
- `ruff check` passes on both changed files.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

None. Cyclic refs now expand to `{}` at the point of recurrence, which is the JSON Schema "any" form and universally accepted by providers.