### PR TITLE
fix(dspy): divide field counts, not lists, when grading partial failed parses

### DIFF
--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -88,7 +88,8 @@ def bootstrap_trace_data(
                     failed_pred = FailedPrediction(
                         completion_text=completion_str,
                         format_reward=format_failure_score
-                        + (failure_score - format_failure_score) * (present / expected),
+                        + (failure_score - format_failure_score)
+                        * (len(present) / len(expected)),
                     )
                 else:
                     failed_pred = FailedPrediction(completion_text=completion_str, format_reward=format_failure_score)

--- a/tests/teleprompt/test_bootstrap_trace.py
+++ b/tests/teleprompt/test_bootstrap_trace.py
@@ -178,3 +178,45 @@ def test_capture_crashes_does_not_capture_lm_errors():
         Flaky(), dataset=[example], num_threads=1, capture_crashes=True, raise_on_error=False
     )
     assert data == []  # handled by the evaluator as an error, never repainted as a FailedPrediction
+
+
+def test_bootstrap_trace_partial_parse_capture():
+    """A response that parses as JSON but misses output fields is captured with an interpolated format reward."""
+    import pytest
+
+    class TwoFieldSignature(dspy.Signature):
+        """Convert a string number to integer and echo its word"""
+
+        text: str = dspy.InputField()
+        number: int = dspy.OutputField()
+        word: str = dspy.OutputField()
+
+    program = dspy.Predict(TwoFieldSignature)
+    dataset = [Example(text="one", number=1, word="one").with_inputs("text")]
+
+    def exact_match_metric(example, prediction, trace=None):
+        return example.number == prediction.number
+
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o-mini", cache=False), adapter=dspy.JSONAdapter())
+
+    # Valid JSON that is missing the 'word' output field -> AdapterParseError with a non-empty parsed_result
+    partial_response = ModelResponse(
+        choices=[Choices(message=Message(content='```json\n{"number": 1}\n```'))],
+        model="openai/gpt-4o-mini",
+    )
+
+    with mock.patch("litellm.completion", return_value=partial_response):
+        results = bootstrap_trace_data(
+            program=program,
+            dataset=dataset,
+            metric=exact_match_metric,
+            num_threads=1,
+            raise_on_error=False,
+            capture_failed_parses=True,
+        )
+
+    assert len(results) == 1, f"Expected 1 result, got {len(results)}"
+    prediction = results[0]["prediction"]
+    assert isinstance(prediction, FailedPrediction)
+    # 1 of 2 expected fields present -> halfway between format_failure_score (-1) and failure_score (0)
+    assert prediction.format_reward == pytest.approx(-0.5)


### PR DESCRIPTION
## PR checklist

- [x] I have run the pre-commit script locally
- [x] This PR title matches the required format `{label}(dspy): {message}`
- [x] The commit message follows the commit format `{label}(dspy): {message}`

## Rationale

With `capture_failed_parses=True`, a **partially** parsed response (valid JSON that is missing one or more output fields — `JSONAdapter` raises `AdapterParseError` with `parsed_result=fields`) took the `if present:` branch in `bootstrap_trace_data`, where the format reward interpolation did:

```python
(present / expected)
```

Both `present` and `expected` are **lists**, so this raised `TypeError: unsupported operand type(s) for /: 'list' and 'list'` and the failed-parse example was dropped instead of being captured. The evident intent — interpolating between `format_failure_score` and `failure_score` by the fraction of output fields parsed — is `len(present) / len(expected)`.

This is the exact path GEPA uses for trace capture (`dspy/teleprompt/gepa/gepa_utils.py` passes `capture_failed_parses=True`).

## Changes

- `dspy/teleprompt/bootstrap_trace.py`: divide field **counts** instead of the lists.
- `tests/teleprompt/test_bootstrap_trace.py`: regression test feeding a partial parse (`{"number": 1}` against a two-output-field signature via `JSONAdapter`); asserts the failed parse is captured with `format_reward == -0.5` (halfway between the `-1` format-failure and `0` failure defaults). The existing tests only cover `parsed_result=None`, which is why this branch was untested.

## Result

Before: `TypeError`, example dropped. After: captured `FailedPrediction` with the interpolated reward; new test passes (4/4 in `tests/teleprompt/test_bootstrap_trace.py`), and the new test fails on the unfixed code.
