### PR TITLE
fix(dspy): align docstring parameter names with signatures

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -365,7 +365,7 @@ class ToolCalls(Type):
         """Convert a list of dictionaries to a ToolCalls instance.
 
         Args:
-            dict_list: A list of dictionaries, where each dictionary should have 'name' and 'args' keys.
+            tool_calls_dicts: A list of dictionaries, where each dictionary should have 'name' and 'args' keys.
 
         Returns:
             A ToolCalls instance.

--- a/dspy/dsp/utils/dpr.py
+++ b/dspy/dsp/utils/dpr.py
@@ -89,7 +89,7 @@ class Tokens:
             uncased: lower cases text
             filter_fn: user function that takes in an ngram list and returns
               True or False to keep or not keep the ngram
-            as_string: return the ngram as a string vs list
+            as_strings: return the ngram as a string vs list
         """
 
         def _skip(gram):


### PR DESCRIPTION
## PR checklist

- [x] I have run the pre-commit script locally
- [x] This PR title matches the required format `{label}(dspy): {message}`
- [x] The commit message follows the commit format `{label}(dspy): {message}`

## Rationale

Two docstrings documented parameter names that don't exist in their signatures:

- `ToolCalls.from_dict_list(cls, tool_calls_dicts)` documented `dict_list:`
- `dspy/dsp/utils/dpr.py` `ngrams(..., as_strings=True)` documented `as_string:`

These names render in the API docs and IDE tooltips. Docstring-only change.

## Changes

Two one-word docstring fixes, each verified against the signature directly above it.