### PR TITLE
fix(rlm): honor positive odd truncation limits

### DIFF
--- a/dspy/primitives/repl_types.py
+++ b/dspy/primitives/repl_types.py
@@ -58,8 +58,9 @@ class REPLVariable(pydantic.BaseModel):
             value_str = str(jsonable)
         is_truncated = len(value_str) > preview_chars
         if is_truncated:
-            half = preview_chars // 2
-            preview = value_str[:half] + "..." + value_str[-half:]
+            head_chars = preview_chars // 2
+            tail_chars = preview_chars - head_chars if preview_chars > 0 else head_chars
+            preview = value_str[:head_chars] + "..." + value_str[-tail_chars:]
         else:
             preview = value_str
 
@@ -113,9 +114,10 @@ class REPLEntry(pydantic.BaseModel):
         """Format output with head+tail truncation, preserving true length in header."""
         raw_len = len(output)
         if raw_len > max_output_chars:
-            half = max_output_chars // 2
+            head_chars = max_output_chars // 2
+            tail_chars = max_output_chars - head_chars if max_output_chars > 0 else head_chars
             omitted = raw_len - max_output_chars
-            output = output[:half] + f"\n\n... ({omitted:,} characters omitted) ...\n\n" + output[-half:]
+            output = output[:head_chars] + f"\n\n... ({omitted:,} characters omitted) ...\n\n" + output[-tail_chars:]
         return f"Output ({raw_len:,} chars):\n{output}"
 
     def format(self, index: int, max_output_chars: int = 10_000) -> str:

--- a/tests/predict/test_rlm.py
+++ b/tests/predict/test_rlm.py
@@ -698,6 +698,15 @@ class TestREPLTypes:
         # True original length shown in header
         assert "200 chars" in formatted
 
+    @pytest.mark.parametrize(
+        ("limit", "head", "tail"),
+        [(1, "", "f"), (5, "ab", "def"), (0, "", "abcdef"), (-1, "abcde", "bcdef")],
+    )
+    def test_repl_entry_truncation_limits(self, limit, head, tail):
+        formatted = REPLEntry.format_output("abcdef", max_output_chars=limit)
+
+        assert formatted == f"Output (6 chars):\n{head}\n\n... ({6 - limit} characters omitted) ...\n\n{tail}"
+
     def test_repl_entry_format_no_truncation(self):
         """Test REPLEntry.format() passes short output through without truncation."""
         output = "a" * 50
@@ -729,6 +738,15 @@ class TestREPLTypes:
         assert var.preview.startswith("a" * 25)
         assert var.preview.endswith("b" * 25)
         assert "..." in var.preview
+
+    @pytest.mark.parametrize(
+        ("limit", "expected"),
+        [(1, "...f"), (5, "ab...def"), (0, "...abcdef"), (-1, "abcde...bcdef")],
+    )
+    def test_repl_variable_truncation_limits(self, limit, expected):
+        var = REPLVariable.from_value("value", "abcdef", preview_chars=limit)
+
+        assert var.preview == expected
 
     def test_repl_variable_with_field_info(self):
         """Test REPLVariable includes desc and constraints from field_info."""


### PR DESCRIPTION
## Summary

Narrowed replacement for #10019 after review:

- make both RLM truncation paths retain exactly the configured number of source characters for positive odd limits;
- assign the odd remainder to the tail, where final results and exception details commonly appear;
- preserve even positive limits and the exact existing behavior for zero and negative values;
- avoid defining a new public validation/error contract in this arithmetic fix.

## Problem

Both truncation paths currently floor-divide the limit and reuse that count for both slices:

```python
half = limit // 2
head = value[:half]
tail = value[-half:]
```

A positive odd limit normally retains `limit - 1` characters. At limit `1`, `half == 0`, and Python's `value[-0:]` returns the complete value, so the smallest positive limit leaks the entire output.

The corrected positive-limit split uses a floor-sized head and assigns the remainder to the tail. A guard in the arithmetic retains the existing non-positive slicing behavior rather than silently changing those inputs or choosing whether they should become errors.

## Verification

- `uv run --frozen pytest --deno -q tests/predict/test_rlm.py` — 151 passed, 2 skipped.
- Baseline comparison confirmed zero and negative outputs are byte-for-byte unchanged.
- Added regressions for limits 1 and 5 and for adjacent zero and negative values at both truncation sites.
- Ruff reports the same pre-existing RUF043 finding in `tests/predict/test_rlm.py` on this branch and untouched `origin/main`; no new finding.
- `git diff --check` — passed.