### PR TITLE
fix(clients): preserve supported image detail

### DIFF
--- a/dspy/adapters/_legacy_type_markers.py
+++ b/dspy/adapters/_legacy_type_markers.py
@@ -9,7 +9,16 @@ from typing import Any
 import json_repair
 
 from dspy.adapters.types.base_type import CUSTOM_TYPE_END_IDENTIFIER, CUSTOM_TYPE_START_IDENTIFIER
-from dspy.core.types import LMAudioPart, LMBinaryPart, LMDocumentPart, LMImagePart, LMMessage, LMPart, LMTextPart
+from dspy.core.types import (
+    LMAudioPart,
+    LMBinaryPart,
+    LMDocumentPart,
+    LMImagePart,
+    LMMessage,
+    LMPart,
+    LMTextPart,
+    _normalize_image_detail,
+)
 
 
 def _expand_legacy_custom_type_markers_in_chat_message(message: dict[str, Any]) -> dict[str, Any]:
@@ -103,11 +112,13 @@ def _legacy_content_block_to_lm_part(block: Any) -> LMPart:
         return LMTextPart(text=block.get("text", ""))
     if block_type == "image_url":
         image_url = block.get("image_url", {})
+        detail = image_url.get("detail") if isinstance(image_url, dict) else None
+        detail = _normalize_image_detail(detail)
         source = image_url.get("url") if isinstance(image_url, dict) else image_url
         if isinstance(source, str) and source.startswith("data:") and "," in source:
             media_type, data = _split_data_uri(source)
-            return LMImagePart(data=data, media_type=media_type)
-        return LMImagePart(url=source or "")
+            return LMImagePart(data=data, media_type=media_type, detail=detail)
+        return LMImagePart(url=source or "", detail=detail)
     if block_type == "input_audio":
         audio = block.get("input_audio", {})
         return LMAudioPart(data=audio.get("data", ""), media_type=f"audio/{audio.get('format', 'wav')}")

--- a/dspy/core/types.py
+++ b/dspy/core/types.py
@@ -1637,7 +1637,10 @@ def _history_part_as_openai_content(part: LMPart) -> dict[str, Any]:
     if isinstance(part, LMTextPart):
         return {"type": "text", "text": part.text}
     if isinstance(part, LMImagePart):
-        return {"type": "image_url", "image_url": {"url": _history_part_source(part)}}
+        image_url: dict[str, Any] = {"url": _history_part_source(part)}
+        if part.detail is not None:
+            image_url["detail"] = part.detail
+        return {"type": "image_url", "image_url": image_url}
     if isinstance(part, LMAudioPart):
         input_audio = {"format": _history_media_format(part.media_type)}
         if part.data is not None:
@@ -1809,7 +1812,7 @@ def _parts_from_openai_content(content: Any) -> list[LMPart]:
             url = image.get("url")
             if url is None:
                 raise ValueError("Image content block requires url.")
-            parts.append(_image_source_to_part(url))
+            parts.append(_image_source_to_part(url, detail=image.get("detail")))
         elif item_type == "input_audio":
             audio = item.get("input_audio", {})
             parts.append(_audio_dict_to_part(audio))
@@ -1857,14 +1860,19 @@ def _tool_call_from_openai(tool_call: Any) -> LMToolCallPart:
     )
 
 
-def _image_source_to_part(source: str) -> LMImagePart:
+def _normalize_image_detail(detail: Any) -> str | None:
+    return detail if detail in ("low", "high", "auto") else None
+
+
+def _image_source_to_part(source: str, detail: Any = None) -> LMImagePart:
     if not isinstance(source, str):
         raise TypeError("Image URL must be a string.")
+    detail = _normalize_image_detail(detail)
     if source.startswith("data:"):
         media_type, data = _split_data_uri(source)
-        return LMImagePart(data=data, media_type=media_type)
+        return LMImagePart(data=data, media_type=media_type, detail=detail)
     media_type = mimetypes.guess_type(urlparse(source).path)[0] or "image/png"
-    return LMImagePart(url=source, media_type=media_type)
+    return LMImagePart(url=source, media_type=media_type, detail=detail)
 
 
 def _audio_dict_to_part(audio: dict[str, Any]) -> LMAudioPart:

--- a/tests/adapters/test_base_type.py
+++ b/tests/adapters/test_base_type.py
@@ -1,6 +1,8 @@
 import pydantic
+import pytest
 
 import dspy
+from dspy.adapters._legacy_type_markers import _legacy_content_block_to_lm_part
 
 
 def test_basic_extract_custom_type_from_annotation():
@@ -49,3 +51,18 @@ def test_extract_custom_type_from_annotation_with_nested_type():
         EventIdentifier,
         Event,
     ]
+
+
+@pytest.mark.parametrize(
+    ("image_url", "expected_detail"),
+    [
+        ({"url": "https://example.com/chart.png", "detail": "high"}, "high"),
+        ({"url": "data:image/png;base64,YWJj", "detail": "low"}, "low"),
+        ({"url": "https://example.com/plain.png"}, None),
+        ({"url": "https://example.com/plain.png", "detail": "original"}, None),
+    ],
+)
+def test_legacy_image_marker_preserves_supported_detail(image_url, expected_detail):
+    block = {"type": "image_url", "image_url": image_url}
+
+    assert _legacy_content_block_to_lm_part(block).detail == expected_detail

--- a/tests/core/test_types.py
+++ b/tests/core/test_types.py
@@ -133,6 +133,29 @@ def test_image_content_requires_mapping_with_url():
         LMMessage(role="user", content=[{"type": "image_url", "image_url": {}}])
 
 
+@pytest.mark.parametrize(
+    ("image_url", "expected_detail"),
+    [
+        ({"url": "https://example.com/chart.png", "detail": "high"}, "high"),
+        ({"url": "data:image/png;base64,YWJj", "detail": "low"}, "low"),
+        ({"url": "https://example.com/plain.png"}, None),
+        ({"url": "https://example.com/plain.png", "detail": "original"}, None),
+    ],
+)
+def test_image_content_preserves_supported_detail(image_url, expected_detail):
+    from dspy.clients.openai_format import to_openai_chat_request
+
+    message = LMMessage(role="user", content=[{"type": "image_url", "image_url": image_url}])
+    assert message.parts[0].detail == expected_detail
+
+    wire = to_openai_chat_request(LMRequest(model="model", messages=[message]))["messages"][0]["content"]
+    history_content = _history_entry(message).messages[0]["content"][0]
+    assert history_content == wire[0]
+    assert wire[0]["image_url"].get("detail") == expected_detail
+    assert ("detail" in wire[0]["image_url"]) is (expected_detail is not None)
+    assert LMMessage(role="user", content=[history_content]).parts[0].detail == expected_detail
+
+
 def test_video_data_round_trips_through_history_messages():
     message = User(LMVideoPart(data="YWJj", media_type="video/mp4"))
     content = _history_entry(message).messages[0]["content"][0]


### PR DESCRIPTION
## Summary

Narrowed replacement for #10310, co-authored with @zamal-db:

- preserve OpenAI image `detail` values (`low`, `high`, and `auto`) through typed message normalization, provider serialization, history round-tripping, and legacy marker conversion;
- continue dropping unsupported values at untyped OpenAI/legacy boundaries, preserving existing behavior instead of introducing a new `ValidationError` path;
- keep direct `LMImagePart` construction strict under its existing Pydantic `Literal` contract;
- consolidate overlapping scenarios into parameterized tests.

## Why this layer

`LMImagePart` already owns the typed `detail` contract, and the OpenAI serializer already emits it. The loss occurs only while untyped content blocks become typed parts and while history becomes OpenAI-shaped content again, so those normalization boundaries are the complete fix surface.

The shared core normalizer contains the supported-value policy used by both the typed and legacy input paths. URL/data parsing behavior is otherwise unchanged.

## Verification

- `uv run --frozen pytest -q tests/core/test_types.py tests/adapters/test_base_type.py` — 36 passed.
- Ruff on all four changed files — passed.
- Baseline/branch check: current main drops both supported and unsupported values; this branch preserves `low`/`high`/`auto` while continuing to drop `original`.
- Direct `LMImagePart(detail="original")` still raises Pydantic `ValidationError`.
- `git diff --check` — passed.

## Attribution

This is a narrowed version of the implementation and test approach contributed by @zamal-db in #10310. The commit includes Zamal's original Git identity as a `Co-authored-by` trailer.