### PR TITLE
fix(lm): validate and reject raw stream=True before caching or provider calls

### DIFF
--- a/dspy/clients/execution.py
+++ b/dspy/clients/execution.py
@@ -108,6 +108,16 @@ def prepare(lm, prompt, messages, kwargs, *, asynchronous=False, direct=False):
         use_cache = kwargs.get("cache", lm.cache) if managed and getattr(lm, "_cache_responses", True) else False
         return PreparedCall(None, None, kwargs, legacy, request, use_cache, 1, managed)
     merged = {**lm.kwargs, **{key: val for key, val in kwargs.items() if key != "cache"}}
+    if merged.get("stream"):
+        if hasattr(lm, "_validate_stream_arg"):
+            lm._validate_stream_arg(merged)
+        else:
+            raise LMUnsupportedFeatureError(
+                "dspy.LM does not support raw 'stream=True'. Use 'dspy.streamify' for streaming responses.",
+                model=getattr(lm, "model", None),
+                provider=getattr(lm, "_provider_name", None),
+                features=["stream"],
+            )
     prompt_cache = merged.get("prompt_cache")
     if prompt_cache is not None:
         if not isinstance(prompt_cache, CacheConfig):

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -154,6 +154,7 @@ class LM(BaseLM):
 
         if initial_kwargs.get("rollout_id") is None:
             initial_kwargs.pop("rollout_id", None)
+        self._validate_stream_arg(initial_kwargs)
         return initial_kwargs
 
     @property
@@ -194,6 +195,15 @@ class LM(BaseLM):
                 stacklevel=3,
             )
             self._warned_zero_temp_rollout = True
+
+    def _validate_stream_arg(self, kwargs: dict[str, Any]):
+        if kwargs.get("stream"):
+            raise LMUnsupportedFeatureError(
+                "dspy.LM does not support raw 'stream=True'. Use 'dspy.streamify' for streaming responses.",
+                model=self.model,
+                provider=self._provider_name,
+                features=["stream"],
+            )
 
     def _get_cached_completion_fn(self, completion_fn, cache):
         ignored_args_for_cache_key = ["api_key", "api_base", "base_url"]
@@ -248,6 +258,7 @@ class LM(BaseLM):
             for engine in engines:
                 cleanup.callback(engine.close)
 
+
     async def aclose(self):
         """Close this event loop's owned pools and the synchronous pools."""
         import asyncio
@@ -301,6 +312,7 @@ class LM(BaseLM):
         self._async_engine_spec = getattr(self, "_async_engine_spec", None)
         self._engine_lock = threading.RLock()
         self._engine_store = {}
+
 
     def launch(self, launch_kwargs: dict[str, Any] | None = None):
         self.provider.launch(self, launch_kwargs)

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -1741,3 +1741,62 @@ def test_lm_responses_does_not_validate_reasoning_temperature_client_side():
     sent = responses.call_args.kwargs
     assert sent["temperature"] == 0.7
     assert sent["reasoning"] == {"effort": "low", "summary": "auto"}
+
+def test_lm_rejects_stream_true_in_init():
+    with pytest.raises(dspy.LMUnsupportedFeatureError) as exc_info:
+        dspy.LM("openai/gpt-4o", stream=True)
+    assert "dspy.streamify" in str(exc_info.value)
+    assert exc_info.value.features == ["stream"]
+
+
+def test_lm_rejects_stream_true_in_forward_and_does_not_pollute_cache():
+    original_cache = dspy.cache
+    dspy.configure_cache(enable_disk_cache=False, enable_memory_cache=True)
+    cache = dspy.cache
+    cache.reset_memory_cache()
+
+    try:
+        with (
+            mock.patch.object(cache, "get", wraps=cache.get) as cache_get_spy,
+            mock.patch.object(cache, "put", wraps=cache.put) as cache_put_spy,
+        ):
+            lm = dspy.LM("openai/gpt-4o", cache=True)
+
+            with pytest.raises(dspy.LMUnsupportedFeatureError) as exc_info:
+                lm("test prompt", stream=True)
+            assert "dspy.streamify" in str(exc_info.value)
+            assert exc_info.value.features == ["stream"]
+
+            # Verify that neither cache lookup nor cache storage occurred
+            cache_get_spy.assert_not_called()
+            cache_put_spy.assert_not_called()
+            assert len(cache.memory_cache) == 0
+    finally:
+        dspy.cache = original_cache
+
+
+@pytest.mark.asyncio
+async def test_lm_rejects_stream_true_in_aforward_and_does_not_pollute_cache():
+    original_cache = dspy.cache
+    dspy.configure_cache(enable_disk_cache=False, enable_memory_cache=True)
+    cache = dspy.cache
+    cache.reset_memory_cache()
+
+    try:
+        with (
+            mock.patch.object(cache, "get", wraps=cache.get) as cache_get_spy,
+            mock.patch.object(cache, "put", wraps=cache.put) as cache_put_spy,
+        ):
+            lm = dspy.LM("openai/gpt-4o", cache=True)
+
+            with pytest.raises(dspy.LMUnsupportedFeatureError) as exc_info:
+                await lm.aforward("test prompt", stream=True)
+            assert "dspy.streamify" in str(exc_info.value)
+            assert exc_info.value.features == ["stream"]
+
+            cache_get_spy.assert_not_called()
+            cache_put_spy.assert_not_called()
+            assert len(cache.memory_cache) == 0
+    finally:
+        dspy.cache = original_cache
+


### PR DESCRIPTION
### Summary

Resolves #10345.

Passing `stream=True` directly to `dspy.LM(...)` or in `forward()` / `aforward()` calls causes LiteLLM to return a live `CustomStreamWrapper`. When caching is enabled, this un-subscriptable and un-pickleable generator wrapper is stored in cache before downstream response processing runs. This causes the initial call to fail with `TypeError: 'CustomStreamWrapper' object is not subscriptable` and all subsequent calls to crash on cache deepcopy with `LMUnexpectedError: cannot pickle '_thread.RLock' object`.

### Proposed Changes

1. **Early Validation in `dspy.LM`**: Added `_validate_stream_arg()` to check arguments in `_get_initial_kwargs()`, `forward()`, and `aforward()`.
2. **Actionable Error**: Raises structured `LMUnsupportedFeatureError` with `features=["stream"]` and an actionable message directing callers to use `dspy.streamify`.
3. **Cache Protection**: Because validation fails fast before `_get_cached_completion_fn()`, the cache is neither queried nor polluted with live generator objects.
4. **Unit Tests**: Added regression tests in `tests/clients/test_lm.py` covering `dspy.LM(..., stream=True)`, synchronous `lm(..., stream=True)`, and async `await lm.aforward(..., stream=True)`, verifying both error raising and zero cache pollution.

### Verification

- `ruff check` passed with zero errors.
- Added regression tests in `tests/clients/test_lm.py` passed (3/3).
- Existing offline streaming test suite in `tests/streaming/test_streaming.py` verified (33 passed).
