### PR TITLE
Add opt-in OpenAI provider batches for Module.batch (successor to #8815)

### DIFF
--- a/docs/docs/learn/programming/modules.md
+++ b/docs/docs/learn/programming/modules.md
@@ -236,6 +236,82 @@ hop = Hop()
 print(hop(claim="Stephen Curry is the best 3 pointer shooter ever in the human history"))
 ```
 
+## How do I use provider Batch APIs?
+
+`Module.batch` normally runs examples concurrently using regular LM requests.
+Opt into **provider-side batch processing** with the keyword-only `batch_mode=True`:
+
+```python
+import dspy
+
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+program = dspy.Predict("question -> answer")
+examples = [
+    dspy.Example(question="What is the capital of France?").with_inputs("question"),
+    dspy.Example(question="What is the capital of Japan?").with_inputs("question"),
+]
+
+# This submits billable remote jobs and blocks until the program finishes.
+results = program.batch(
+    examples,
+    batch_mode=True,
+    num_threads=32,
+    batch_timeout=86400,
+    batch_poll_interval=30,
+)
+```
+
+The initial implementation supports **synchronous `dspy.LM` calls to OpenAI chat
+models** through the OpenAI Files and Batches APIs. Check that your model and
+account support the [OpenAI Batch API](https://platform.openai.com/docs/guides/batch).
+Text, Responses, streaming, and asynchronous LM calls are rejected in batch mode.
+Custom `BaseLM` implementations are not intercepted. `Evaluate` has no batch-mode
+option. Nested `batch_mode=True` invocations are not supported.
+
+Multi-step programs work without requiring every example to make the same number
+of LM calls. Each active worker queues its next call; ready calls are collected
+over a short window and submitted together. Finished examples do not hold other
+examples back. `num_threads` bounds concurrent examples, **not** the total dataset
+size; increase it to allow larger remote batches. A batch may contain fewer calls
+than workers, and different models or connection settings require separate jobs.
+This implementation is blocking and in-memory, not a durable job queue: it cannot
+resume a program after the process exits. Local tools still execute normally.
+
+Per-call generation settings, prompt/messages, tools, structured output schemas,
+and connection overrides are preserved. Generation parameters must be supported
+by OpenAI's chat endpoint; LiteLLM-specific routing/translation options are not
+supported. DSPy's normal cache, LM history, callbacks, and token usage tracking
+remain active. Cache hits need no remote batch. Provider batch discounts are not
+estimated in DSPy's history.
+
+`max_errors`, `return_failed_examples`, progress, and traceback controls retain
+their normal meaning. Results remain in input order with `None` at failed positions.
+Missing responses become errors; duplicate or unknown response IDs fail the affected
+remote batch rather than guessing which example a result belongs to. Available
+results from expired or remotely cancelled jobs are returned, with errors for
+unfinished requests.
+
+**Latency and cancellation:** each remote job uses OpenAI's `24h` completion
+window. A multi-step program may require several such jobs. `batch_timeout` is
+the wait limit **per remote job**, not a whole-program deadline. Status polling
+uses `batch_poll_interval`; each HTTP operation has a timeout capped at 60 seconds
+(or a smaller per-call `timeout`). In-flight HTTP operations and cleanup can extend
+the wait beyond `batch_timeout`. The usual `Module.batch(timeout=...)` straggler
+resubmission is disabled in batch mode to avoid duplicate paid work.
+
+Ctrl-C or reaching `max_errors` releases local LM waiters and requests cancellation
+of active remote jobs. Python cannot forcibly stop arbitrary local tool code.
+Remote cancellation is best-effort, may take minutes, and does not undo charges.
+Batch submission is not automatically retried: if the server accepts a job but
+its response is lost, the job may still run. DSPy logs job/input-file IDs for
+manual inspection. Completed input/output/error files are deleted best-effort;
+files associated with uncertain or still-active jobs are retained. Inspect those
+jobs and remove retained files in OpenAI after confirming their status.
+
+The same keyword options are available on `dspy.Parallel` for heterogeneous
+`(module, example)` pairs. Existing positional calls such as
+`program.batch(examples, 8)` continue to mean eight threads, not provider batching.
+
 ## How do I track LM usage?
 
 !!! note "Version Requirement"

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -247,6 +247,15 @@ class LM(BaseLM):
             completion = litellm_text_completion
         elif self.model_type == "responses":
             completion = litellm_responses_completion
+        coordinator = dspy.settings.get("batch_coordinator")
+        if coordinator is not None:
+            if self.model_type != "chat" or dspy.settings.send_stream is not None or kwargs.get("stream"):
+                raise LMUnsupportedFeatureError("Provider batch execution supports non-streaming chat calls only")
+
+            @functools.wraps(completion)
+            def completion(request, **_):
+                return coordinator.submit(self, request)
+
         completion, litellm_cache_args = self._get_cached_completion_fn(completion, cache)
 
         try:
@@ -287,6 +296,9 @@ class LM(BaseLM):
                 failures, which adapters use to avoid inappropriate fallback
                 retries when the prompt is too long.
         """
+        if dspy.settings.get("batch_coordinator") is not None:
+            raise LMUnsupportedFeatureError("Provider batch execution supports synchronous LM calls only")
+
         # Build the request.
         kwargs = dict(kwargs)
         cache = kwargs.pop("cache", self.cache)

--- a/dspy/clients/openai.py
+++ b/dspy/clients/openai.py
@@ -1,11 +1,18 @@
+import json
+import logging
+import math
 import time
 from datetime import datetime
 from typing import Any
 
 import openai
+import pydantic
 
+from dspy.clients.openai_format import response_format_to_responses
 from dspy.clients.provider import Provider, TrainingJob
 from dspy.clients.utils_finetune import TrainDataFormat, TrainingStatus, save_data
+
+logger = logging.getLogger(__name__)
 
 
 class TrainingJobOpenAI(TrainingJob):
@@ -44,6 +51,178 @@ class OpenAIProvider(Provider):
         super().__init__()
         self.finetunable = True
         self.TrainingJob = TrainingJobOpenAI
+
+    def batch(self, lm, requests, *, cancel_event, timeout, poll_interval):
+        """Run chat batches using the public OpenAI Files and Batches APIs.
+
+        Separate credentials, headers, endpoints and models never share a job.
+        No automatic submission retries: a lost create response may represent
+        an accepted, billable job. Completed files are deleted best-effort;
+        uncertain remote state is retained and logged for manual recovery.
+        """
+        from dspy.utils.exceptions import LMUnsupportedFeatureError
+
+        groups = []
+        for index, request in enumerate(requests):
+            body = dict(request)
+            model = body["model"]
+            if lm.model_type != "chat" or not self.is_provider_model(model) or body.get("stream"):
+                raise LMUnsupportedFeatureError("OpenAI batches require non-streaming OpenAI chat models", model=model)
+            body["model"] = self._remove_provider_prefix(model)
+            body.pop("rollout_id", None)
+            response_format = body.get("response_format")
+            if isinstance(response_format, type) and issubclass(response_format, pydantic.BaseModel):
+                schema_format = response_format_to_responses(response_format)
+                schema_format.pop("type")
+                body["response_format"] = {"type": "json_schema", "json_schema": {**schema_format, "strict": True}}
+            options = {}
+            for name in ("api_key", "organization", "project"):
+                if body.get(name) is not None:
+                    options[name] = body.pop(name)
+                else:
+                    body.pop(name, None)
+            base_url = body.pop("base_url", None)
+            api_base = body.pop("api_base", None)
+            if base_url and api_base and base_url != api_base:
+                raise ValueError("Conflicting base_url and api_base for OpenAI batch")
+            if base_url or api_base:
+                options["base_url"] = base_url or api_base
+            headers = body.pop("headers", None)
+            if headers is not None:
+                options["default_headers"] = headers
+            # Bound each HTTP operation, including cancellation and cleanup.
+            request_timeout = body.pop("timeout", 60)
+            if (
+                not isinstance(request_timeout, (int, float))
+                or not math.isfinite(request_timeout)
+                or request_timeout <= 0
+            ):
+                raise ValueError("OpenAI batch request timeout must be a finite positive number of seconds")
+            options["timeout"] = min(request_timeout, timeout, 60)
+            options["max_retries"] = 0
+            for group_options, group_model, entries in groups:
+                if options == group_options and body["model"] == group_model:
+                    entries.append((index, body))
+                    break
+            else:
+                groups.append((options, body["model"], [(index, body)]))
+
+        outcomes = [None] * len(requests)
+        for options, _, entries in groups:
+            try:
+                with openai.OpenAI(**options) as client:
+                    results = self._run_batch(client, entries, cancel_event, timeout, poll_interval)
+                for index, result in results.items():
+                    outcomes[index] = result
+            except Exception as error:
+                for index, _ in entries:
+                    outcomes[index] = lm._wrap_litellm_exception(error)
+        return outcomes
+
+    @staticmethod
+    def _run_batch(client, entries, cancel_event, timeout, poll_interval):
+        from dspy.utils.exceptions import LMProviderError, LMTimeoutError
+
+        endpoint = "/v1/chat/completions"
+        payload = "\n".join(
+            json.dumps({"custom_id": str(index), "method": "POST", "url": endpoint, "body": body})
+            for index, body in entries
+        ).encode()
+        if len(entries) > 50000 or len(payload) > 200_000_000:
+            raise ValueError("OpenAI batch exceeds 50,000 requests or 200 MB; reduce num_threads or input size")
+        file_ids = set()
+        job = None
+        creating = False
+        terminal = {"completed", "failed", "expired", "cancelled"}
+        deadline = time.monotonic() + timeout
+
+        def check_cancelled():
+            if cancel_event.is_set():
+                raise LMProviderError("Provider batch execution cancelled")
+            if time.monotonic() >= deadline:
+                raise LMTimeoutError("Timed out waiting for OpenAI batch completion")
+
+        try:
+            check_cancelled()
+            uploaded = client.files.create(file=("dspy-batch.jsonl", payload, "application/jsonl"), purpose="batch")
+            file_ids.add(uploaded.id)
+            check_cancelled()
+            creating = True
+            job = client.batches.create(input_file_id=uploaded.id, endpoint=endpoint, completion_window="24h")
+            creating = False
+            logger.info("OpenAI batch submitted: %s", job.id)
+            while job.status not in terminal:
+                check_cancelled()
+                if job.status not in {"validating", "in_progress", "finalizing", "cancelling"}:
+                    raise LMProviderError(f"Unknown OpenAI batch status {job.status!r} for {job.id}")
+                cancel_event.wait(min(poll_interval, max(0, deadline - time.monotonic())))
+                check_cancelled()
+                job = client.batches.retrieve(job.id)
+
+            file_ids.update(file_id for file_id in (job.output_file_id, job.error_file_id) if file_id)
+            if job.status == "failed":
+                raise LMProviderError(f"OpenAI batch {job.id} failed: {job.errors}")
+            rows = []
+            for file_id in (job.output_file_id, job.error_file_id):
+                if file_id:
+                    check_cancelled()
+                    rows.extend(json.loads(line) for line in client.files.content(file_id).text.splitlines() if line)
+            return OpenAIProvider._parse_batch_results(entries, rows, job.id, job.status)
+        finally:
+            if job is not None and job.status not in terminal:
+                try:
+                    client.batches.cancel(job.id)
+                except Exception:
+                    logger.warning("Could not cancel OpenAI batch %s; check its remote status", job.id)
+                logger.warning("OpenAI batch %s may still be running; retained files %s", job.id, sorted(file_ids))
+            elif creating:
+                logger.warning(
+                    "OpenAI batch submission outcome unknown; check batches for input files %s", sorted(file_ids)
+                )
+            else:
+                for file_id in file_ids:
+                    try:
+                        client.files.delete(file_id)
+                    except Exception:
+                        logger.warning("Could not delete OpenAI batch file %s", file_id)
+
+    @staticmethod
+    def _parse_batch_results(entries, rows, job_id, status):
+        from dspy.clients._litellm import get_litellm
+        from dspy.clients.lm import _lm_error_class_from_status
+        from dspy.utils.exceptions import LMProviderError
+
+        expected = {str(index): (index, body) for index, body in entries}
+        results = {}
+        for row in rows:
+            custom_id = row.get("custom_id")
+            if custom_id not in expected or custom_id in results:
+                raise LMProviderError(f"Unknown or duplicate custom_id in OpenAI batch {job_id}")
+            _, body = expected[custom_id]
+            response = row.get("response") or {}
+            error = row.get("error") or (response.get("body") or {}).get("error")
+            code = response.get("status_code")
+            if error or code != 200:
+                error = error or {}
+                results[custom_id] = _lm_error_class_from_status(code)(
+                    error.get("message", "OpenAI batch request failed"),
+                    model=body["model"],
+                    provider="openai",
+                    status=code,
+                    provider_code=error.get("code"),
+                    request_id=response.get("request_id"),
+                )
+            else:
+                response_body = response.get("body")
+                if not isinstance(response_body, dict) or not response_body.get("choices"):
+                    raise LMProviderError(f"Malformed response in OpenAI batch {job_id}")
+                results[custom_id] = get_litellm(feature="OpenAI batch responses").ModelResponse(**response_body)
+        return {
+            index: results.get(
+                custom_id, LMProviderError(f"Missing result {custom_id} in OpenAI batch {job_id} ({status})")
+            )
+            for custom_id, (index, _) in expected.items()
+        }
 
     @staticmethod
     def is_provider_model(model: str) -> bool:

--- a/dspy/clients/provider.py
+++ b/dspy/clients/provider.py
@@ -216,6 +216,17 @@ class Provider:
         self.TrainingJob = TrainingJob
         self.ReinforceJob = ReinforceJob
 
+    def batch(self, lm, requests, *, cancel_event, timeout, poll_interval):
+        """Return one provider response or exception per request, in input order.
+
+        Implementations must reconcile provider IDs, honor cancellation, and
+        bound network operations. This synchronous boundary is used only by
+        explicit provider-batch execution, never by ordinary LM calls.
+        """
+        from dspy.utils.exceptions import LMUnsupportedFeatureError
+
+        raise LMUnsupportedFeatureError("This provider does not support Batch API execution", model=lm.model)
+
     @staticmethod
     def is_provider_model(model: str) -> bool:
         """Check if a model identifier is supported by this provider.

--- a/dspy/predict/parallel.py
+++ b/dspy/predict/parallel.py
@@ -17,6 +17,10 @@ class Parallel:
         disable_progress_bar: bool = False,
         timeout: int = 120,
         straggler_limit: int = 3,
+        *,
+        batch_mode: bool = False,
+        batch_timeout: float = 86400,
+        batch_poll_interval: float = 30,
     ):
         """
         A utility class for parallel, multi-threaded execution of (module, example) pairs.
@@ -30,6 +34,10 @@ class Parallel:
             return_failed_examples (bool): Whether to return failed examples. Defaults to False.
             provide_traceback (Optional[bool]): Whether to provide traceback. Defaults to None.
             disable_progress_bar (bool): Whether to disable progress bar. Defaults to False.
+            batch_mode (bool): Use provider Batch APIs for synchronous dspy.LM calls.
+                See Module.batch for supported providers and limitations.
+            batch_timeout (float): Maximum wait in seconds per remote batch.
+            batch_poll_interval (float): Seconds between remote batch status checks.
 
         Example:
             ```python
@@ -67,6 +75,9 @@ class Parallel:
         self.disable_progress_bar = disable_progress_bar
         self.timeout = timeout
         self.straggler_limit = straggler_limit
+        self.batch_mode = batch_mode
+        self.batch_timeout = batch_timeout
+        self.batch_poll_interval = batch_poll_interval
 
         self.error_count = 0
         self.error_lock = threading.Lock()
@@ -82,7 +93,7 @@ class Parallel:
             max_errors=self.max_errors,
             provide_traceback=self.provide_traceback,
             disable_progress_bar=self.disable_progress_bar,
-            timeout=self.timeout,
+            timeout=0 if self.batch_mode else self.timeout,
             straggler_limit=self.straggler_limit,
         )
 
@@ -108,7 +119,16 @@ class Parallel:
             return result
 
         # Execute the processing function over the execution pairs
-        results = executor.execute(process_pair, exec_pairs)
+        if self.batch_mode:
+            from dspy.utils.batch import BatchCoordinator
+
+            if settings.get("batch_coordinator") is not None:
+                raise ValueError("Nested provider batch execution is not supported")
+            with BatchCoordinator(executor.cancel_jobs, self.batch_timeout, self.batch_poll_interval) as coordinator:
+                with settings.context(batch_coordinator=coordinator):
+                    results = executor.execute(process_pair, exec_pairs)
+        else:
+            results = executor.execute(process_pair, exec_pairs)
 
         # Populate failed examples and exceptions from the executor
         if self.return_failed_examples:

--- a/dspy/primitives/module.py
+++ b/dspy/primitives/module.py
@@ -277,6 +277,10 @@ class Module(BaseModule, metaclass=ProgramMeta):
         disable_progress_bar: bool = False,
         timeout: int = 120,
         straggler_limit: int = 3,
+        *,
+        batch_mode: bool = False,
+        batch_timeout: float = 86400,
+        batch_poll_interval: float = 30,
     ) -> list[Example] | tuple[list[Example], list[Example], list[Exception]]:
         """
         Processes a list of dspy.Example instances in parallel using the Parallel module.
@@ -291,6 +295,10 @@ class Module(BaseModule, metaclass=ProgramMeta):
             disable_progress_bar: Whether to display the progress bar.
             timeout: Seconds before a straggler task is resubmitted. Set to 0 to disable.
             straggler_limit: Only check for stragglers when this many or fewer tasks remain.
+            batch_mode: Use provider Batch APIs for synchronous dspy.LM calls. Initially
+                supports OpenAI chat models only. Disables straggler resubmission.
+            batch_timeout: Maximum wait in seconds per remote batch (not per program).
+            batch_poll_interval: Seconds between remote batch status checks.
 
         Returns:
             List of results, and optionally failed examples and exceptions.
@@ -307,6 +315,9 @@ class Module(BaseModule, metaclass=ProgramMeta):
             disable_progress_bar=disable_progress_bar,
             timeout=timeout,
             straggler_limit=straggler_limit,
+            batch_mode=batch_mode,
+            batch_timeout=batch_timeout,
+            batch_poll_interval=batch_poll_interval,
         )
 
         # Execute the forward method of Parallel

--- a/dspy/utils/batch.py
+++ b/dspy/utils/batch.py
@@ -1,0 +1,104 @@
+"""Coalesce synchronous LM calls without imposing lockstep program execution."""
+
+import math
+import threading
+from concurrent.futures import Future, TimeoutError
+
+from dspy.utils.exceptions import LMProviderError
+
+
+class BatchCoordinator:
+    """One dispatcher per Parallel invocation; the existing executor owns workers.
+
+    A short collection window batches ready calls, not a fixed number of examples.
+    Workers may finish, fail, hit a cache, or make additional calls independently.
+    Providers must honor cancellation and bound their network operations.
+    """
+
+    def __init__(self, cancel_event, timeout, poll_interval):
+        if not all(math.isfinite(value) and value > 0 for value in (timeout, poll_interval)):
+            raise ValueError("batch_timeout and batch_poll_interval must be finite and positive")
+        self.cancel_event = cancel_event
+        self.timeout = timeout
+        self.poll_interval = poll_interval
+        self.condition = threading.Condition()
+        self.pending = []
+        self.closed = False
+        self.thread = threading.Thread(target=self._dispatch, name="dspy-batch-dispatch")
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        with self.condition:
+            self.closed = True
+            self.cancel_event.set()
+            self.condition.notify_all()
+        self.thread.join()
+
+    def submit(self, lm, request):
+        future = Future()
+        with self.condition:
+            if self.closed or self.cancel_event.is_set():
+                raise LMProviderError("Provider batch execution cancelled")
+            self.pending.append((lm, request, future))
+            self.condition.notify()
+        while True:
+            try:
+                return future.result(timeout=0.1)
+            except TimeoutError:
+                if future.done():
+                    # The provider's outcome itself may be a TimeoutError.
+                    return future.result()
+                if self.cancel_event.is_set():
+                    raise LMProviderError("Provider batch execution cancelled")
+
+    def _dispatch(self):
+        calls = []
+        try:
+            while not self.cancel_event.is_set():
+                with self.condition:
+                    self.condition.wait_for(lambda: self.pending or self.closed, timeout=0.1)
+                    if self.closed:
+                        break
+                    if not self.pending:
+                        continue
+                # Give other ready workers a chance to enqueue. Never wait for
+                # a worker that has finished or takes a different program path.
+                if self.cancel_event.wait(0.01):
+                    break
+                with self.condition:
+                    calls, self.pending = self.pending, []
+                groups = {}
+                for lm, request, future in calls:
+                    groups.setdefault(lm, []).append((request, future))
+                for lm, group in groups.items():
+                    try:
+                        if self.cancel_event.is_set():
+                            raise LMProviderError("Provider batch execution cancelled")
+                        outcomes = lm.provider.batch(
+                            lm,
+                            [request for request, _ in group],
+                            cancel_event=self.cancel_event,
+                            timeout=self.timeout,
+                            poll_interval=self.poll_interval,
+                        )
+                        if len(outcomes) != len(group):
+                            raise LMProviderError("Provider batch returned an incorrect number of outcomes")
+                    except Exception as error:
+                        outcomes = [error] * len(group)
+                    for (_, future), outcome in zip(group, outcomes, strict=False):
+                        if isinstance(outcome, Exception):
+                            future.set_exception(outcome)
+                        else:
+                            future.set_result(outcome)
+                calls = []
+        finally:
+            with self.condition:
+                self.closed = True
+                remaining = calls + self.pending
+                self.pending = []
+            for _, _, future in remaining:
+                if not future.done():
+                    future.set_exception(LMProviderError("Provider batch execution cancelled"))

--- a/tests/clients/test_provider_batch.py
+++ b/tests/clients/test_provider_batch.py
@@ -1,0 +1,550 @@
+"""Offline public-flow tests: no provider credentials or network are needed."""
+
+import asyncio
+import json
+import threading
+from types import SimpleNamespace
+
+import httpx
+import litellm
+import pytest
+from openai import OpenAI
+
+import dspy
+from dspy.clients.cache import Cache
+from dspy.clients.openai import OpenAIProvider
+from dspy.utils.exceptions import LMProviderError, LMRateLimitError, LMTimeoutError, LMUnsupportedFeatureError
+
+
+class FakeOpenAI:
+    def __init__(self):
+        self.inputs = {}
+        self.outputs = {}
+        self.jobs = {}
+        self.options = []
+        self.deleted = []
+        self.cancelled = []
+        self.closed = 0
+        self.mode = "completed"
+        self.submitted = threading.Event()
+        self.transform = lambda rows: rows
+        self.files = SimpleNamespace(create=self.upload, content=self.content, delete=self.deleted.append)
+        self.batches = SimpleNamespace(create=self.create, retrieve=self.retrieve, cancel=self.cancelled.append)
+
+    def client(self, **options):
+        self.options.append(options)
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.closed += 1
+
+    def upload(self, *, file, purpose):
+        assert purpose == "batch"
+        file_id = f"input-{len(self.inputs)}"
+        self.inputs[file_id] = [json.loads(line) for line in file[1].decode().splitlines()]
+        return SimpleNamespace(id=file_id)
+
+    def create(self, *, input_file_id, endpoint, completion_window):
+        assert endpoint == "/v1/chat/completions"
+        assert completion_window == "24h"
+        self.submitted.set()
+        if self.mode == "submit-error":
+            raise RuntimeError("lost submission response")
+        job_id = f"job-{len(self.jobs)}"
+        rows = []
+        for entry in reversed(self.inputs[input_file_id]):
+            assert entry["url"] == endpoint and entry["method"] == "POST"
+            body = entry["body"]
+            content = body["messages"][-1]["content"]
+            rows.append(
+                {
+                    "custom_id": entry["custom_id"],
+                    "response": {
+                        "status_code": 200,
+                        "request_id": f"request-{entry['custom_id']}",
+                        "body": {
+                            "id": "chatcmpl-test",
+                            "object": "chat.completion",
+                            "created": 0,
+                            "model": body["model"],
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "message": {"role": "assistant", "content": content},
+                                    "finish_reason": "stop",
+                                }
+                            ],
+                            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+                        },
+                    },
+                    "error": None,
+                }
+            )
+        rows = self.transform(rows)
+        output = f"output-{job_id}"
+        errors = f"errors-{job_id}"
+        self.outputs[output] = [row for row in rows if not row.get("error")]
+        self.outputs[errors] = [row for row in rows if row.get("error")]
+        status = "in_progress" if self.mode in {"stall", "poll-error", "poll"} else self.mode
+        job = SimpleNamespace(
+            id=job_id, status=status, output_file_id=output, error_file_id=errors, errors="invalid input"
+        )
+        self.jobs[job_id] = job
+        return job
+
+    def retrieve(self, job_id):
+        if self.mode == "poll-error":
+            raise RuntimeError("poll failed")
+        job = self.jobs[job_id]
+        if self.mode == "poll":
+            job.status = "completed"
+        return job
+
+    def content(self, file_id):
+        return SimpleNamespace(text="\n".join(json.dumps(row) for row in self.outputs[file_id]))
+
+
+@pytest.fixture
+def backend(monkeypatch, tmp_path):
+    fake = FakeOpenAI()
+    monkeypatch.setattr("dspy.clients.openai.openai.OpenAI", fake.client)
+    monkeypatch.setattr(
+        dspy, "cache", Cache(enable_disk_cache=False, enable_memory_cache=True, disk_cache_dir=tmp_path)
+    )
+
+    def forbid_online(*args, **kwargs):
+        pytest.fail("Provider batch must not call the synchronous completion API")
+
+    monkeypatch.setattr(litellm, "completion", forbid_online)
+    yield fake
+    assert not any(thread.name == "dspy-batch-dispatch" for thread in threading.enumerate())
+    assert dspy.settings.get("batch_coordinator") is None
+    assert fake.closed == len(fake.options)
+
+
+class Program(dspy.Module):
+    def forward(self, value, steps=1, fail=None, **config):
+        if fail == "before":
+            raise ValueError("local failure before LM")
+        answers = []
+        for step in range(steps):
+            answers.append(dspy.settings.lm(f"{value}:{step}", **config)[0])
+            if fail == "after":
+                raise ValueError("local failure after LM")
+        return dspy.Prediction(answers=answers)
+
+
+def examples(*items):
+    return [dspy.Example(**item).with_inputs(*item) for item in items]
+
+
+def run(program, data, **kwargs):
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+    with dspy.context(lm=lm):
+        return program.batch(data, batch_mode=True, disable_progress_bar=True, batch_poll_interval=0.001, **kwargs)
+
+
+@pytest.mark.parametrize("steps", [(2, 2), (1, 3), (0, 2)])
+@pytest.mark.parametrize("num_threads", [1, 2])
+def test_equal_unequal_and_zero_call_programs(backend, steps, num_threads):
+    result = run(
+        Program(),
+        examples({"value": "a", "steps": steps[0]}, {"value": "b", "steps": steps[1]}),
+        num_threads=num_threads,
+    )
+    assert [r.answers for r in result] == [
+        [f"{value}:{i}" for i in range(count)] for value, count in zip("ab", steps, strict=False)
+    ]
+    assert sum(len(entries) for entries in backend.inputs.values()) == sum(steps)
+    assert set(backend.deleted) == set(backend.inputs) | set(backend.outputs)
+
+
+def test_empty(backend):
+    assert run(Program(), []) == []
+    assert not backend.inputs
+
+
+@pytest.mark.parametrize("fail", ["before", "after"])
+def test_local_errors_keep_successes_and_failure_details(backend, fail):
+    result, failed, errors = run(
+        Program(),
+        examples({"value": "a", "fail": fail}, {"value": "b", "steps": 2}),
+        return_failed_examples=True,
+        max_errors=5,
+        num_threads=2,
+    )
+    assert result[0] is None and result[1].answers == ["b:0", "b:1"]
+    assert len(failed) == len(errors) == 1
+    assert failed[0].value == "a" and isinstance(errors[0], ValueError)
+
+
+@pytest.mark.parametrize("problem", ["missing", "duplicate", "unknown", "malformed", "error", "status"])
+def test_invalid_results_resolve_waiters(backend, problem):
+    def transform(rows):
+        if problem == "missing":
+            return []
+        if problem == "duplicate":
+            return rows + rows
+        if problem == "unknown":
+            rows[0]["custom_id"] = "unknown"
+        if problem == "malformed":
+            rows[0]["response"]["body"] = {}
+        if problem == "error":
+            for row in rows:
+                row.update(response=None, error={"message": "request expired", "code": "batch_expired"})
+        if problem == "status":
+            for row in rows:
+                row["response"].update(status_code=429, body={"error": {"message": "quota", "code": "rate_limit"}})
+        return rows
+
+    backend.transform = transform
+    result, failed, errors = run(Program(), examples({"value": "a"}), return_failed_examples=True, max_errors=5)
+    assert result == [None] and len(failed) == len(errors) == 1
+    assert isinstance(errors[0], dspy.LMError)
+    if problem == "status":
+        assert isinstance(errors[0], LMRateLimitError)
+        assert errors[0].status == 429
+
+
+@pytest.mark.parametrize("mode", ["failed", "submit-error", "poll-error", "unexpected-status"])
+def test_batch_level_failure(backend, mode):
+    backend.mode = mode
+    result, failed, errors = run(
+        Program(), examples({"value": "a"}, {"value": "b"}), return_failed_examples=True, num_threads=2, max_errors=5
+    )
+    assert result == [None, None] and len(failed) == len(errors) == 2
+    assert all(isinstance(error, dspy.LMError) for error in errors)
+    if mode == "submit-error":
+        assert not backend.deleted  # Outcome unknown: don't destroy recovery evidence.
+    if mode in {"poll-error", "unexpected-status"}:
+        assert set(backend.cancelled) == set(backend.jobs)
+
+
+@pytest.mark.parametrize("mode", ["poll", "expired", "cancelled"])
+def test_polling_and_partial_terminal_results(backend, mode):
+    backend.mode = mode
+    result = run(Program(), examples({"value": "a"}))
+    assert result[0].answers == ["a:0"]
+    assert not backend.cancelled
+
+
+def test_timeout_cancels_remote_job_without_resubmission(backend):
+    backend.mode = "stall"
+    _, _, errors = run(
+        Program(), examples({"value": "a"}), return_failed_examples=True, batch_timeout=0.02, timeout=0.001
+    )
+    assert isinstance(errors[0], LMTimeoutError)
+    assert len(backend.jobs) == 1 and backend.cancelled == ["job-0"]
+    assert not backend.deleted
+
+
+def test_max_errors_cancels_other_waiting_workers(backend):
+    backend.mode = "stall"
+
+    class FailingProgram(Program):
+        def forward(self, value):
+            if value == "fail":
+                assert backend.submitted.wait(2)
+                raise ValueError("stop")
+            return super().forward(value)
+
+    with pytest.raises(Exception, match="cancelled"):
+        run(FailingProgram(), examples({"value": "wait"}, {"value": "fail"}), num_threads=2, max_errors=1)
+    assert backend.cancelled == ["job-0"]
+
+
+def test_effective_kwargs_and_client_configuration(backend):
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False, temperature=0.4, max_tokens=100, api_key="fake-default")
+    with dspy.context(lm=lm):
+        result = Program().batch(
+            examples(
+                {
+                    "value": "a",
+                    "temperature": 0.8,
+                    "max_tokens": 23,
+                    "api_key": "fake-override",
+                    "api_base": "https://example.invalid/v1",
+                    "headers": {"X-Test": "test"},
+                    "rollout_id": 2,
+                    "response_format": {"type": "json_object"},
+                }
+            ),
+            batch_mode=True,
+            disable_progress_bar=True,
+        )
+    assert result[0].answers == ["a:0"]
+    body = next(iter(backend.inputs.values()))[0]["body"]
+    assert body == {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "a:0"}],
+        "temperature": 0.8,
+        "max_tokens": 23,
+        "response_format": {"type": "json_object"},
+    }
+    assert backend.options[0]["api_key"] == "fake-override"
+    assert backend.options[0]["base_url"] == "https://example.invalid/v1"
+    assert backend.options[0]["default_headers"] == {"X-Test": "test"}
+    assert backend.options[0]["max_retries"] == 0
+
+
+def test_typed_request_cache_usage_history_and_settings(backend):
+    lm = dspy.LM("openai/gpt-4o-mini")
+
+    class TypedProgram(dspy.Module):
+        def forward(self, value):
+            response = dspy.settings.lm(dspy.LMRequest.from_call(model=lm.model, prompt=value))
+            assert isinstance(response, dspy.LMResponse)
+            assert dspy.settings.test_batch_setting == "inherited"
+            return dspy.Prediction(answer=response.to_legacy_outputs()[0])
+
+    with dspy.context(lm=lm, test_batch_setting="inherited", track_usage=True):
+        for iteration in range(2):
+            result = TypedProgram().batch(examples({"value": "typed"}), batch_mode=True, disable_progress_bar=True)
+            assert result[0].answer == "typed"
+            usage = result[0].get_lm_usage()
+            assert sum(value["total_tokens"] for value in usage.values()) == (3 if iteration == 0 else 0)
+    assert len(backend.jobs) == 1
+    assert len(lm.history) == 2
+
+
+def test_heterogeneous_parallel_and_lms(backend):
+    class First(dspy.Module):
+        def forward(self, value):
+            return dspy.settings.lm(value)[0]
+
+    class Second(dspy.Module):
+        def forward(self, value):
+            return dspy.LM("openai/gpt-4o", cache=False)(value + "!")[0]
+
+    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):
+        result = dspy.Parallel(2, batch_mode=True, disable_progress_bar=True)(
+            [(First(), {"value": "first"}), (Second(), {"value": "second"})]
+        )
+    assert result == ["first", "second!"]
+    assert {entry["body"]["model"] for entries in backend.inputs.values() for entry in entries} == {
+        "gpt-4o",
+        "gpt-4o-mini",
+    }
+
+
+@pytest.mark.parametrize("model_type", ["text", "responses"])
+def test_unsupported_model_types_do_not_submit(backend, model_type):
+    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", model_type=model_type)):
+        _, _, errors = Program().batch(
+            examples({"value": "a"}), batch_mode=True, return_failed_examples=True, disable_progress_bar=True
+        )
+    assert isinstance(errors[0], LMUnsupportedFeatureError)
+    assert not backend.inputs
+
+
+def test_unsupported_provider_does_not_submit(backend):
+    with dspy.context(lm=dspy.LM("anthropic/claude-sonnet-4-5", cache=False)):
+        _, _, errors = Program().batch(
+            examples({"value": "a"}), batch_mode=True, return_failed_examples=True, disable_progress_bar=True
+        )
+    assert isinstance(errors[0], LMUnsupportedFeatureError)
+    assert not backend.inputs
+
+
+@pytest.mark.asyncio
+async def test_sync_batch_inside_event_loop(backend):
+    assert run(Program(), examples({"value": "a"}), num_threads=1)[0].answers == ["a:0"]
+
+
+def test_async_lm_is_explicitly_rejected(backend):
+    class AsyncProgram(dspy.Module):
+        def forward(self, value):
+            return asyncio.run(dspy.settings.lm.acall(value))
+
+    _, _, errors = run(AsyncProgram(), examples({"value": "a"}), return_failed_examples=True)
+    assert isinstance(errors[0], LMUnsupportedFeatureError)
+    assert not backend.inputs
+
+
+def test_existing_positional_apis_do_not_enable_batch(backend, monkeypatch):
+    def online_completion(**kwargs):
+        return litellm.ModelResponse(
+            choices=[
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": kwargs["messages"][-1]["content"]},
+                    "finish_reason": "stop",
+                }
+            ]
+        )
+
+    monkeypatch.setattr(litellm, "completion", online_completion)
+
+    class RegularLMProgram(dspy.Module):
+        def forward(self, value):
+            return dspy.settings.lm(str(value))[0]
+
+    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False)):
+        assert RegularLMProgram().batch(examples({"value": 1}), 2, 3, False, False, True, 0, 3) == ["1"]
+        assert dspy.Parallel(2, 3, True, False, False, True, 0, 3)([(RegularLMProgram(), {"value": 2})]) == ["2"]
+    assert not backend.inputs
+
+
+def test_provider_rejects_wrong_cardinality(backend):
+    class BrokenProvider(OpenAIProvider):
+        def batch(self, *args, **kwargs):
+            return []
+
+    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", provider=BrokenProvider(), cache=False)):
+        _, _, errors = Program().batch(
+            examples({"value": "a"}), batch_mode=True, return_failed_examples=True, disable_progress_bar=True
+        )
+    assert isinstance(errors[0], LMProviderError)
+
+
+@pytest.mark.parametrize("experimental", [False, True])
+@pytest.mark.parametrize("json_adapter", [False, True])
+def test_predict_data_dependent_calls(backend, experimental, json_adapter):
+    def answer(rows):
+        for row in rows:
+            message = row["response"]["body"]["choices"][0]["message"]
+            value = "continue" if "\nlong\n" in message["content"] else "stop"
+            message["content"] = (
+                json.dumps({"answer": value})
+                if json_adapter
+                else f"[[ ## answer ## ]]\n{value}\n\n[[ ## completed ## ]]"
+            )
+        return rows
+
+    backend.transform = answer
+
+    class PredictProgram(dspy.Module):
+        def __init__(self):
+            super().__init__()
+            self.predict = dspy.Predict("value -> answer")
+
+        def forward(self, value):
+            result = self.predict(value=value)
+            if result.answer == "continue":
+                return self.predict(value=result.answer)
+            return result
+
+    adapter = dspy.JSONAdapter() if json_adapter else dspy.ChatAdapter()
+    with dspy.context(experimental=experimental, adapter=adapter):
+        result = run(PredictProgram(), examples({"value": "short"}, {"value": "long"}), num_threads=2)
+    assert [r.answer for r in result] == ["stop", "stop"]
+    assert sum(len(entries) for entries in backend.inputs.values()) == 3
+    if json_adapter:
+        formats = [entry["body"]["response_format"] for entries in backend.inputs.values() for entry in entries]
+        assert all(format["type"] == "json_schema" and format["json_schema"]["strict"] for format in formats)
+
+
+def test_keyboard_interrupt_cancels_and_closes(backend, monkeypatch):
+    backend.mode = "stall"
+
+    def interrupt(*args, **kwargs):
+        assert backend.submitted.wait(2)
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("dspy.utils.parallelizer.wait", interrupt)
+    with pytest.raises(KeyboardInterrupt):
+        run(Program(), examples({"value": "a"}), num_threads=2)
+    assert backend.cancelled == ["job-0"]
+
+
+def test_ready_calls_are_coalesced_and_partitioned_by_credentials(backend):
+    # The provider boundary also accepts a cohort deterministically, so this
+    # assertion does not rely on the OS scheduling all workers in 10 ms.
+    lm = dspy.LM("openai/gpt-4o-mini", cache=False)
+    requests = [
+        {"model": lm.model, "messages": [{"role": "user", "content": str(i)}], "api_key": key}
+        for i, key in enumerate(["fake-a", "fake-b", "fake-a"])
+    ]
+    result = lm.provider.batch(lm, requests, cancel_event=threading.Event(), timeout=1, poll_interval=0.001)
+    assert [r.choices[0].message.content for r in result] == ["0", "1", "2"]
+    assert sorted(len(entries) for entries in backend.inputs.values()) == [1, 2]
+    assert {options["api_key"] for options in backend.options} == {"fake-a", "fake-b"}
+
+
+@pytest.mark.parametrize("value", [0, -1, float("inf"), float("nan")])
+def test_invalid_timeout_fails_before_submission(backend, value):
+    with pytest.raises(ValueError, match="finite and positive"):
+        run(Program(), [], batch_timeout=value)
+    assert not backend.inputs
+
+
+def test_public_openai_sdk_with_offline_http_transport(monkeypatch):
+    requests = []
+
+    def handle(request):
+        requests.append(request)
+        if request.method == "POST" and request.url.path == "/v1/files":
+            assert b'"model": "gpt-4o-mini"' in request.content
+            assert b"fake-sdk-key" not in request.content
+            return httpx.Response(
+                200,
+                json={
+                    "id": "input",
+                    "object": "file",
+                    "bytes": 1,
+                    "created_at": 0,
+                    "filename": "input.jsonl",
+                    "purpose": "batch",
+                },
+            )
+        if request.method == "POST" and request.url.path == "/v1/batches":
+            assert json.loads(request.content) == {
+                "input_file_id": "input",
+                "endpoint": "/v1/chat/completions",
+                "completion_window": "24h",
+            }
+            return httpx.Response(
+                200,
+                json={
+                    "id": "job",
+                    "object": "batch",
+                    "status": "completed",
+                    "endpoint": "/v1/chat/completions",
+                    "completion_window": "24h",
+                    "input_file_id": "input",
+                    "output_file_id": "output",
+                    "created_at": 0,
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/files/output/content":
+            return httpx.Response(
+                200,
+                text=json.dumps(
+                    {
+                        "custom_id": "0",
+                        "response": {
+                            "status_code": 200,
+                            "body": {
+                                "id": "chatcmpl-sdk",
+                                "model": "gpt-4o-mini",
+                                "object": "chat.completion",
+                                "created": 0,
+                                "choices": [
+                                    {
+                                        "index": 0,
+                                        "message": {"role": "assistant", "content": "sdk works"},
+                                        "finish_reason": "stop",
+                                    }
+                                ],
+                            },
+                        },
+                    }
+                ),
+            )
+        if request.method == "DELETE" and request.url.path in {"/v1/files/input", "/v1/files/output"}:
+            return httpx.Response(
+                200, json={"id": request.url.path.rsplit("/", 1)[1], "object": "file", "deleted": True}
+            )
+        raise AssertionError(f"Unexpected HTTP request: {request.method} {request.url.path}")
+
+    def client(**options):
+        return OpenAI(**options, http_client=httpx.Client(transport=httpx.MockTransport(handle)))
+
+    monkeypatch.setattr("dspy.clients.openai.openai.OpenAI", client)
+    with dspy.context(lm=dspy.LM("openai/gpt-4o-mini", cache=False, api_key="fake-sdk-key")):
+        result = Program().batch(examples({"value": "a"}), batch_mode=True, disable_progress_bar=True)
+    assert result[0].answers == ["sdk works"]
+    assert len(requests) == 5


### PR DESCRIPTION
Independent successor to #8815, originally proposed by @manwithplan (ahuet), implemented against current main. The original author's branch is unchanged.

Adds opt-in `Module.batch(..., batch_mode=True)` and `Parallel` support for OpenAI chat Batch APIs. Reuses the existing executor with queued LM calls, including unequal data-dependent Predict paths, rather than fixed barriers. Preserves positional arguments, effective per-call settings, caching, and failed-example/error controls. Reconciles provider results and handles polling, timeout, cancellation, and file cleanup without global LiteLLM patches.

Verification: 45 new offline tests; combined relevant suites: **798 passed, 91 skipped**. Batch/import tests with LiteLLM 1.99.0: **49 passed**. Ruff/pre-commit checks passed. Tests include the real OpenAI SDK over an offline HTTP transport; no paid provider calls were made.

Draft limitations: OpenAI synchronous chat only; in-memory/blocking execution, not resumable; no Evaluate support. Remote cancellation is best-effort, may incur charges, and uncertain jobs/files need manual inspection. Live provider behavior has not been tested.

AI disclosure: Amp implemented and tested this successor. User prompt: “Lets make a new version of 8815 in a new orb. Make it a draft PR on the dspy repo”. Implementation brief: preserve attribution and current contracts; support unequal multi-step programs; replace fixed barriers and private monkeypatches with owner-local provider handling and dynamic pending calls; use offline fakes only, verify failure/liveness cases, document limitations, and follow CONTRIBUTING.md. This draft is submitted at isaacbmiller's explicit direction; human review and understanding of the implementation remain required.
