### PR TITLE
fix(cache): isolate values and evict unreadable entries

### DIFF
--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -139,7 +139,7 @@ class Cache:
                 response = self.disk_cache.get(key)
             except DeserializationError:
                 logger.debug("Failed to deserialize disk cache entry %s", key)
-                self.disk_cache.delete(key)
+                self._evict_unreadable_disk_entry(key)
                 return None
 
             if response is None:
@@ -149,7 +149,7 @@ class Cache:
                 prepared_response = self._prepare_cached_response(response)
             except Exception as e:
                 logger.debug("Failed to prepare disk cache entry %s: %s", key, e)
-                self.disk_cache.delete(key)
+                self._evict_unreadable_disk_entry(key)
                 return None
 
             if self.enable_memory_cache:
@@ -170,6 +170,25 @@ class Cache:
             object.__setattr__(response, "cache_hit", True)
         return response
 
+    def _evict_unreadable_disk_entry(self, key: str) -> None:
+        try:
+            with self.disk_cache.transact():
+                try:
+                    current_response = self.disk_cache.get(key)
+                except DeserializationError:
+                    self.disk_cache.delete(key)
+                    return
+
+                if current_response is None:
+                    return
+
+                try:
+                    self._prepare_cached_response(current_response)
+                except Exception:
+                    self.disk_cache.delete(key)
+        except Exception as e:
+            logger.debug("Failed to evict unreadable disk cache entry %s: %s", key, e)
+
     def put(
         self,
         request: dict[str, Any],
@@ -189,8 +208,8 @@ class Cache:
             logger.debug("Failed to generate cache key for request: %s", request)
             return
 
-        # Keep a private snapshot so callers cannot mutate the cached value, and verify
-        # that the value can be copied again when it is read from the cache.
+        # Store a private snapshot so callers cannot mutate the cached value.
+        # If creating the snapshot fails, treat the value as uncacheable.
         try:
             value_to_cache = copy.deepcopy(value)
         except Exception as e:

--- a/dspy/clients/cache.py
+++ b/dspy/clients/cache.py
@@ -126,7 +126,13 @@ class Cache:
             with self._lock:
                 response = self.memory_cache.get(key)
             if response is not None:
-                return self._prepare_cached_response(response)
+                try:
+                    return self._prepare_cached_response(response)
+                except Exception as e:
+                    logger.debug("Failed to prepare memory cache entry %s: %s", key, e)
+                    with self._lock:
+                        if self.memory_cache.get(key) is response:
+                            self.memory_cache.pop(key, None)
 
         if self.enable_disk_cache:
             try:
@@ -139,10 +145,17 @@ class Cache:
             if response is None:
                 return None
 
+            try:
+                prepared_response = self._prepare_cached_response(response)
+            except Exception as e:
+                logger.debug("Failed to prepare disk cache entry %s: %s", key, e)
+                self.disk_cache.delete(key)
+                return None
+
             if self.enable_memory_cache:
                 with self._lock:
                     self.memory_cache[key] = response
-            return self._prepare_cached_response(response)
+            return prepared_response
 
         return None
 
@@ -176,15 +189,23 @@ class Cache:
             logger.debug("Failed to generate cache key for request: %s", request)
             return
 
+        # Keep a private snapshot so callers cannot mutate the cached value, and verify
+        # that the value can be copied again when it is read from the cache.
+        try:
+            value_to_cache = copy.deepcopy(value)
+        except Exception as e:
+            logger.debug("Failed to copy value for cache: %s", e)
+            return
+
         if enable_memory_cache:
             with self._lock:
-                self.memory_cache[key] = value
+                self.memory_cache[key] = value_to_cache
 
         if self.enable_disk_cache:
             try:
-                self.disk_cache.set(key, value)
+                self.disk_cache.set(key, value_to_cache)
             except Exception as e:
-                logger.debug("Failed to put value in disk cache: %s, %s", value, e)
+                logger.debug("Failed to put value in disk cache: %s", e)
 
     def reset_memory_cache(self) -> None:
         if not self.enable_memory_cache:

--- a/tests/clients/test_cache.py
+++ b/tests/clients/test_cache.py
@@ -186,6 +186,37 @@ def test_get_evicts_unreadable_disk_entry(cache):
     assert cache.cache_key(request) not in cache.memory_cache
 
 
+def test_get_preserves_disk_entry_replaced_during_preparation(cache):
+    request = {"prompt": "Hello", "model": "openai/gpt-4o-mini"}
+    key = cache.cache_key(request)
+    stale_response = {"result": "STALE"}
+    replacement = {"result": "REPLACEMENT"}
+    cache.disk_cache.set(key, stale_response)
+    original_prepare = cache._prepare_cached_response
+
+    def replace_then_fail(response):
+        if response == stale_response:
+            cache.disk_cache.set(key, replacement)
+            raise TypeError("stale response cannot be prepared")
+        return original_prepare(response)
+
+    with patch.object(cache, "_prepare_cached_response", side_effect=replace_then_fail):
+        assert cache.get(request) is None
+
+    assert cache.disk_cache.get(key) == replacement
+
+
+def test_get_returns_miss_when_disk_eviction_fails(cache):
+    request = {"prompt": "Hello", "model": "openai/gpt-4o-mini"}
+    response = {"result": "SUCCESS", "lock": threading.RLock()}
+
+    with (
+        patch.object(cache.disk_cache, "get", return_value=response),
+        patch.object(cache.disk_cache, "delete", side_effect=OSError("disk is read-only")),
+    ):
+        assert cache.get(request) is None
+
+
 def test_cache_miss(cache):
     """Test getting a non-existent key."""
     assert cache.get({"prompt": "Non-existent", "model": "gpt-4"}) is None

--- a/tests/clients/test_cache.py
+++ b/tests/clients/test_cache.py
@@ -1,4 +1,5 @@
 import os
+import threading
 from dataclasses import dataclass
 from unittest.mock import patch
 
@@ -162,6 +163,29 @@ def test_put_and_get(cache):
     assert cache.cache_key(request) in cache.memory_cache
 
 
+def test_get_evicts_unreadable_memory_entry(cache):
+    request = {"prompt": "Hello", "model": "openai/gpt-4o-mini"}
+    key = cache.cache_key(request)
+    cache.memory_cache[key] = {"result": "SUCCESS", "lock": threading.RLock()}
+
+    assert cache.get(request) is None
+    assert key not in cache.memory_cache
+
+
+def test_get_evicts_unreadable_disk_entry(cache):
+    request = {"prompt": "Hello", "model": "openai/gpt-4o-mini"}
+    response = {"result": "SUCCESS", "lock": threading.RLock()}
+
+    with (
+        patch.object(cache.disk_cache, "get", return_value=response),
+        patch.object(cache.disk_cache, "delete") as delete,
+    ):
+        assert cache.get(request) is None
+
+    delete.assert_called_once_with(cache.cache_key(request))
+    assert cache.cache_key(request) not in cache.memory_cache
+
+
 def test_cache_miss(cache):
     """Test getting a non-existent key."""
     assert cache.get({"prompt": "Non-existent", "model": "gpt-4"}) is None
@@ -260,6 +284,44 @@ def test_request_cache_decorator(cache):
         # Call with different arguments should compute again
         result3 = test_function(prompt="Different", model="openai/gpt-4o-mini")
         assert result3 == "Response for Different with openai/gpt-4o-mini"
+
+
+def test_request_cache_does_not_share_mutable_result_with_cache(cache):
+    from dspy.clients.cache import request_cache
+
+    call_count = 0
+
+    with patch("dspy.cache", cache):
+        @request_cache()
+        def test_function():
+            nonlocal call_count
+            call_count += 1
+            return {"choices": [{"message": {"content": "ORIGINAL"}}]}
+
+        first_result = test_function()
+        first_result["choices"][0]["message"]["content"] = "MUTATED"
+        second_result = test_function()
+
+    assert second_result["choices"][0]["message"]["content"] == "ORIGINAL"
+    assert call_count == 1
+
+
+def test_request_cache_recomputes_values_that_cannot_be_copied(cache):
+    from dspy.clients.cache import request_cache
+
+    call_count = 0
+
+    with patch("dspy.cache", cache):
+        @request_cache()
+        def test_function():
+            nonlocal call_count
+            call_count += 1
+            return {"result": "SUCCESS", "lock": threading.RLock()}
+
+        assert test_function()["result"] == "SUCCESS"
+        assert test_function()["result"] == "SUCCESS"
+
+    assert call_count == 2
 
 
 def test_request_cache_decorator_with_ignored_args_for_cache_key(cache):


### PR DESCRIPTION
## Summary

Fixes #10373. Discovered while investigating #10345.

On a cache miss, DSPy stores the same mutable object it returns to the caller. Mutating that response therefore changes subsequent cache hits. Results that cannot be deep-copied can also enter the cache and cause repeated failures on matching reads.

This change:

- Stores a deep-copied snapshot so caller mutations do not affect cached values.
- Treats values that fail during deep copy as uncacheable, allowing the decorated call to return the original result normally.
- Evicts unreadable memory and disk entries so matching requests can be recomputed.
- Prepares disk entries before promoting them to the memory cache.
- Rechecks unreadable disk entries inside a transaction before eviction, preserving valid concurrent replacements.

This adds one deep-copy attempt to each enabled cache write; cache hits already perform a deep copy. The shared cache remains type-agnostic. Raw `stream=True` validation is handled separately by #10346 and #10360.

## Testing

- `pytest tests/clients/test_cache.py -q` — 28 passed
- `pytest tests/clients/test_lm.py -q` — 87 passed
- `pytest tests/clients/test_embedding.py -q` — 9 passed
- `pytest tests/streaming/test_streaming.py -q` — 35 passed, 3 skipped
- `pre-commit run --files dspy/clients/cache.py tests/clients/test_cache.py` — passed

## AI assistance disclosure

I used OpenAI Codex to trace the cache flow, test the failure modes, and help draft the implementation and regression tests. The main prompts asked it to analyze the original stream/cache failure, look for cache poisoning without streaming, produce minimal reproducers, and implement general cache hardening. I reviewed the diff and test results before submitting it.