### PR TITLE
fix(dspy): exclude *args/**kwargs from native tool JSON schema

### DIFF
--- a/dspy/adapters/types/tool.py
+++ b/dspy/adapters/types/tool.py
@@ -93,15 +93,16 @@ class Tool(Type):
         sig = inspect.signature(annotations_func)
         # Get available type hints
         available_hints = get_type_hints(annotations_func)
-        # Build a dictionary of arg name -> type (defaulting to Any when missing)
-        hints = {param_name: available_hints.get(param_name, Any) for param_name in sig.parameters.keys()}
-        default_values = {param_name: sig.parameters[param_name].default for param_name in sig.parameters.keys()}
 
         # Process each argument's type to generate its JSON schema.
-        for k, v in hints.items():
-            arg_types[k] = v
-            if k == "return":
+        # *args / **kwargs are not JSON-schema parameters; including them makes
+        # native function-calling treat a phantom "kwargs"/"args" field as required.
+        for param_name, param in sig.parameters.items():
+            if param.kind in (param.VAR_POSITIONAL, param.VAR_KEYWORD):
                 continue
+            k = param_name
+            v = available_hints.get(k, Any)
+            arg_types[k] = v
             # Check if the type (or its origin) is a subclass of Pydantic's BaseModel
             origin = get_origin(v) or v
             if isinstance(origin, type) and issubclass(origin, BaseModel):
@@ -110,8 +111,8 @@ class Tool(Type):
                 args[k] = v_json_schema
             else:
                 args[k] = _resolve_json_schema_reference(TypeAdapter(v).json_schema())
-            if default_values[k] is not inspect.Parameter.empty:
-                args[k]["default"] = default_values[k]
+            if param.default is not inspect.Parameter.empty:
+                args[k]["default"] = param.default
             if arg_desc and k in arg_desc:
                 args[k]["description"] = arg_desc[k]
 

--- a/tests/adapters/test_tool.py
+++ b/tests/adapters/test_tool.py
@@ -284,6 +284,30 @@ def test_tool_call_kwarg():
     assert tool(x=1, y=2, z=3) == {"y": 2, "z": 3}
 
 
+def test_tool_schema_excludes_varargs_and_kwargs():
+    def fn(x: int, *args, y: str = "ok", **kwargs):
+        return (x, args, y, kwargs)
+
+    tool = Tool(fn)
+
+    assert "x" in tool.args
+    assert "y" in tool.args
+    assert "args" not in tool.args
+    assert "kwargs" not in tool.args
+    assert tool.has_kwargs is True
+
+    schema = tool.format_as_litellm_function_call()
+    properties = schema["function"]["parameters"]["properties"]
+    required = schema["function"]["parameters"]["required"]
+    assert "x" in properties
+    assert "y" in properties
+    assert "args" not in properties
+    assert "kwargs" not in properties
+    assert "x" in required
+    assert "y" not in required
+    assert "kwargs" not in required
+
+
 def test_tool_str():
     def add(x: int, y: int = 0) -> int:
         """Add two integers."""


### PR DESCRIPTION
## 📝 Changes Description

This PR contains the following changes:

`Tool._parse_function` was putting `*args` / `**kwargs` into the JSON schema. Native function-calling then marked a phantom `kwargs` (or `args`) field as required, even though runtime already accepts extra kwargs via `has_kwargs`. Skip `VAR_POSITIONAL` / `VAR_KEYWORD` when building `args`.

## ✅ Contributor Checklist

- [x] Pre-Commit checks are passing locally (`ruff check` on the two files; `pytest tests/adapters/test_tool.py` → 40 passed)
- [ ] Pre-Commit checks are passing remotely
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## ⚠️ Warnings

No issue linked. Behavior change is schema-only; calling `Tool` with extra kwargs is unchanged.

## Test plan

```bash
uv run pytest tests/adapters/test_tool.py
uv run ruff check dspy/adapters/types/tool.py tests/adapters/test_tool.py
```

## AI assistance

Assisted with Cursor. I asked it to stop `*args`/`**kwargs` leaking into the native tool JSON schema and to add a regression test. I reviewed the signature walk, kept `has_kwargs` for runtime extra kwargs, and ran pytest locally.