### PR TITLE
docs(predict): fix CodeAct's stale constructor docstring

### DIFF
--- a/dspy/predict/code_act.py
+++ b/dspy/predict/code_act.py
@@ -30,7 +30,7 @@ class CodeAct(ReAct, ProgramOfThought):
         interpreter_factory: Callable[[], CodeInterpreter] = PythonInterpreter,
     ):
         """
-        Initializes the CodeAct class with the specified model, temperature, and max tokens.
+        Initializes the CodeAct class with the specified signature, tools, and max iterations.
 
         Args:
             signature (Union[str, Type[Signature]]): The signature of the module.


### PR DESCRIPTION
`CodeAct.__init__(signature, tools, max_iters, interpreter_factory)`'s docstring summary described "the specified model, temperature, and max tokens" — none of those are parameters (copy-paste from an older constructor). Reworded to match the signature.

**AI disclosure**: found and prepared with AI assistance (Claude, docs-audit pass); reviewed and submitted by @simpleqt.