### PR TITLE
fix(MIPROv2): honor an explicit seed=0 in compile

### DIFF
--- a/dspy/teleprompt/mipro_optimizer_v2.py
+++ b/dspy/teleprompt/mipro_optimizer_v2.py
@@ -167,7 +167,7 @@ class MIPROv2(Teleprompter):
             )
 
         # Set random seeds
-        seed = seed or self.seed
+        seed = seed if seed is not None else self.seed
         self._set_random_seeds(seed)
 
 

--- a/tests/teleprompt/test_mipro_optimizer_v2.py
+++ b/tests/teleprompt/test_mipro_optimizer_v2.py
@@ -1,0 +1,84 @@
+import pytest
+
+import dspy
+from dspy import Example
+from dspy.teleprompt.mipro_optimizer_v2 import MIPROv2
+from dspy.utils.dummies import DummyLM
+
+# A non-zero constructor seed, so falling back to it is distinguishable from
+# honoring an explicit seed=0.
+OPTIMIZER_SEED = 9
+
+
+def simple_metric(example, prediction, trace=None):
+    return example.output == prediction.output
+
+
+trainset = [
+    Example(input="Question: What is the color of the sky?", output="blue").with_inputs("input"),
+    Example(input="Question: What does the fox say?", output="Ring-ding-ding-ding-dingeringeding!").with_inputs(
+        "input"
+    ),
+]
+
+
+class SimpleModule(dspy.Module):
+    def __init__(self, signature):
+        super().__init__()
+        self.predictor = dspy.Predict(signature)
+
+    def forward(self, **kwargs):
+        return self.predictor(**kwargs)
+
+
+class _SeedCapturedError(Exception):
+    """Raised by the patched `_set_random_seeds` to stop `compile` early."""
+
+
+def _make_optimizer(**kwargs):
+    lm = DummyLM([])
+    return MIPROv2(metric=simple_metric, prompt_model=lm, task_model=lm, **kwargs)
+
+
+def _resolve_seed(optimizer, **compile_kwargs):
+    """Return the seed that `compile` resolves, without running the optimization.
+
+    `_set_random_seeds` is the first thing `compile` does with the resolved seed,
+    so intercepting it captures the value under test and lets us abort before
+    bootstrapping, instruction proposal, or the optuna-backed parameter search.
+    """
+    captured = []
+
+    def capture_seed(seed):
+        captured.append(seed)
+        raise _SeedCapturedError
+
+    optimizer._set_random_seeds = capture_seed
+
+    with pytest.raises(_SeedCapturedError):
+        optimizer.compile(SimpleModule("input -> output"), trainset=trainset, **compile_kwargs)
+
+    assert len(captured) == 1, "expected `_set_random_seeds` to be called exactly once"
+    return captured[0]
+
+
+def test_compile_honors_explicit_zero_seed():
+    """seed=0 is a valid seed and must not be replaced by the optimizer default."""
+    optimizer = _make_optimizer(seed=OPTIMIZER_SEED)
+    assert _resolve_seed(optimizer, seed=0) == 0
+
+
+def test_compile_honors_explicit_nonzero_seed():
+    optimizer = _make_optimizer(seed=OPTIMIZER_SEED)
+    assert _resolve_seed(optimizer, seed=42) == 42
+
+
+def test_compile_falls_back_to_optimizer_seed_when_none():
+    """None is the sentinel for "no override", so it falls back to the constructor seed."""
+    optimizer = _make_optimizer(seed=OPTIMIZER_SEED)
+    assert _resolve_seed(optimizer, seed=None) == OPTIMIZER_SEED
+
+
+def test_compile_falls_back_to_optimizer_seed_when_omitted():
+    optimizer = _make_optimizer(seed=OPTIMIZER_SEED)
+    assert _resolve_seed(optimizer) == OPTIMIZER_SEED


### PR DESCRIPTION
Fixes #10321

## The bug

`MIPROv2.compile` declares `seed: int | None = None`, so `None` is the sentinel meaning "no override". But the seed was resolved with truthiness:

```python
seed = seed or self.seed
```

`0` is a valid seed and is also falsy, so an explicit `seed=0` was silently replaced by the optimizer's constructor seed:

```python
optimizer = dspy.MIPROv2(metric=my_metric, auto="light")   # self.seed == 9
optimizer.compile(program, trainset=trainset, seed=0)      # 0 or 9 -> 9
```

## Why it matters beyond the optuna sampler

The resolved seed is not incidental to one component. It initializes `self.rng`, which is threaded through the whole run:

| Consumer | Effect |
|---|---|
| `create_minibatch(valset, rng=self.rng)` | which valset examples are sampled in auto mode |
| `create_n_fewshot_demo_sets(rng=self.rng)` | few-shot demo shuffling and bootstrap set sizes |
| `GroundedProposer(rng=self.rng)` | tip selection during instruction proposal |
| `eval_candidate_program(..., self.rng)` | minibatch evaluation sampling |
| `optuna.samplers.TPESampler(seed=seed)` | Bayesian search trajectory |

So a run that explicitly requested `seed=0` reproduced the default seed's trajectory end to end, rather than the configuration the user asked for.

## Why `0` has to be accepted

`0` is an ordinary seed elsewhere in DSPy, not an edge case:

- `SIMBA` defaults to `seed: int = 0`
- `GEPA` defaults to `seed: int | None = 0`
- `create_n_fewshot_demo_sets` — the helper MIPROv2 itself calls — defaults to `seed=0`

MIPROv2 was the one place `0` could not be passed.

## The fix

```python
seed = seed if seed is not None else self.seed
```

This matches how `compile` already resolves every one of its other optional overrides (`max_bootstrapped_demos`, `max_labeled_demos`, `max_errors`), all of which use `is not None`. The seed line was the lone outlier.

## Tests

Adds `tests/teleprompt/test_mipro_optimizer_v2.py` covering the resolution contract:

- `seed=0` resolves to `0` (fails without this fix: `assert 9 == 0`)
- `seed=42` resolves to `42`
- `seed=None` falls back to the constructor seed
- an omitted `seed` falls back to the constructor seed

The tests intercept `_set_random_seeds` — the first thing `compile` does with the resolved seed — to capture the value and stop before bootstrapping. So they need no LM, no dataset, and **no optuna**, which matters because `optuna` lives in the `test_extras` extra rather than `dev` and is not installed in the default test job. They run there unmarked, in about half a second.

Verified that reverting the one-line fix makes exactly the `seed=0` test fail while the other three still pass.

## Note (not addressed here)

`_bootstrap_fewshot_examples` passes `seed=seed` down to `create_n_fewshot_demo_sets`, but that argument is dead: the callee does `rng = rng or random.Random(seed)` and MIPROv2 always passes `rng=self.rng`, plus the parameter is immediately shadowed by the `for seed in range(-3, num_candidate_sets)` loop variable. Harmless, and left alone to keep this change minimal — happy to clean it up separately if maintainers want.
