### PR TITLE
fix(predict): raise when ReActV2 cannot submit final outputs

### DIFF
--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -26,10 +26,17 @@ if TYPE_CHECKING:
 
 @experimental
 class ReActV2(Module):
-    """A tool-calling agent whose unsuccessful outputs are all ``None``.
+    """An agent that interleaves reasoning and tool calls to fulfill a signature.
 
-    Check ``termination_reason`` for ``submit`` or ``forced_submit`` before using
-    outputs as successful results. Failed submit arguments remain in ``history``.
+    The model selects tools, observes their results, and calls ``submit`` with the
+    final outputs. Supports native function calling and text-based tool calls.
+    Predictions include the declared outputs, conversation history, and termination
+    reason.
+
+    Args:
+        signature: The signature defining the agent's inputs and outputs.
+        tools: Functions, callable objects, or ``dspy.Tool`` instances available to the agent.
+        max_iters: Maximum number of tool-calling turns before a final submit attempt.
     """
 
     def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
@@ -203,11 +210,11 @@ class ReActV2(Module):
             tool_calls = _ensure_tool_call_ids(_coerce_tool_calls(getattr(pred, "tool_calls", None)), turn_index)
         except (AdapterParseError, ValueError, ContextWindowExceededError) as err:
             logger.warning("Forced submit failed: %s", format_error_for_lm(err, traceback_frames=5))
-            return self._failed_prediction(history, break_reason)
+            raise
 
         submit_calls = ToolCalls(tool_calls=[call for call in tool_calls.tool_calls if call.name == "submit"])
         if not submit_calls.tool_calls:
-            return self._failed_prediction(history, break_reason)
+            raise ValueError(f"ReActV2 failed to produce final outputs after {break_reason}: no submit call.")
 
         tool_call_results, final_outputs = self._execute_tool_calls(submit_calls)
         event = self._history_event(pending_inputs, pred, submit_calls, tool_call_results)
@@ -218,13 +225,9 @@ class ReActV2(Module):
         if final_outputs is not None:
             return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
 
-        return self._failed_prediction(history, break_reason)
-
-    def _failed_prediction(self, history: dspy.History, break_reason: str) -> Prediction:
-        return Prediction(
-            **dict.fromkeys(self.signature.output_fields),
-            history=history,
-            termination_reason=break_reason or "failed",
+        errors = "\n".join(str(result.value) for result in tool_call_results.tool_call_results if result.is_error)
+        raise ValueError(
+            f"ReActV2 failed to produce final outputs after {break_reason}: submit failed.\n{errors}"
         )
 
 

--- a/dspy/predict/react_v2.py
+++ b/dspy/predict/react_v2.py
@@ -26,6 +26,12 @@ if TYPE_CHECKING:
 
 @experimental
 class ReActV2(Module):
+    """A tool-calling agent whose unsuccessful outputs are all ``None``.
+
+    Check ``termination_reason`` for ``submit`` or ``forced_submit`` before using
+    outputs as successful results. Failed submit arguments remain in ``history``.
+    """
+
     def __init__(self, signature: type[Signature], tools: list[Callable | Tool], max_iters: int = 20):
         super().__init__()
         self.signature = ensure_signature(signature)
@@ -197,11 +203,11 @@ class ReActV2(Module):
             tool_calls = _ensure_tool_call_ids(_coerce_tool_calls(getattr(pred, "tool_calls", None)), turn_index)
         except (AdapterParseError, ValueError, ContextWindowExceededError) as err:
             logger.warning("Forced submit failed: %s", format_error_for_lm(err, traceback_frames=5))
-            return Prediction(history=history, termination_reason=break_reason or "failed")
+            return self._failed_prediction(history, break_reason)
 
         submit_calls = ToolCalls(tool_calls=[call for call in tool_calls.tool_calls if call.name == "submit"])
         if not submit_calls.tool_calls:
-            return Prediction(history=history, termination_reason=break_reason or "failed")
+            return self._failed_prediction(history, break_reason)
 
         tool_call_results, final_outputs = self._execute_tool_calls(submit_calls)
         event = self._history_event(pending_inputs, pred, submit_calls, tool_call_results)
@@ -212,7 +218,14 @@ class ReActV2(Module):
         if final_outputs is not None:
             return Prediction(**final_outputs, history=history, termination_reason="forced_submit")
 
-        return Prediction(history=history, termination_reason=break_reason or "failed")
+        return self._failed_prediction(history, break_reason)
+
+    def _failed_prediction(self, history: dspy.History, break_reason: str) -> Prediction:
+        return Prediction(
+            **dict.fromkeys(self.signature.output_fields),
+            history=history,
+            termination_reason=break_reason or "failed",
+        )
 
 
 def _json_schema_for_annotation(annotation: Any) -> dict[str, Any]:

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -337,7 +337,7 @@ def test_react_v2_rejects_reserved_output_field_names(reserved):
 
 @pytest.mark.parametrize("break_reason", ["max_iters", "empty_tool_calls", "parse_error", "context_window_exceeded"])
 @pytest.mark.parametrize("forced_result", ["no_submit", "missing_field", "parse_error", "context_window_exceeded"])
-def test_react_v2_failed_termination_preserves_output_fields(mocker, break_reason, forced_result):
+def test_react_v2_failed_termination_raises(mocker, break_reason, forced_result):
     react = dspy.ReActV2("question -> answer: str, count: int", tools=[], max_iters=1)
     empty = dspy.Prediction(tool_calls=dspy.ToolCalls(tool_calls=[]))
     incomplete = dspy.Prediction(
@@ -353,34 +353,38 @@ def test_react_v2_failed_termination_preserves_output_fields(mocker, break_reaso
     }
     mocker.patch.object(react.react, "forward", side_effect=[outcomes[break_reason], outcomes[forced_result]])
 
-    pred = react(question="cats")
+    history = dspy.History(messages=[])
+    error_type = ContextWindowExceededError if forced_result == "context_window_exceeded" else ValueError
+    with pytest.raises(error_type) as exc:
+        react(question="cats", history=history)
 
-    assert pred.answer is None
-    assert pred.count is None
-    assert pred.termination_reason == break_reason
-    assert isinstance(pred.history, dspy.History)
+    if forced_result in {"parse_error", "context_window_exceeded"}:
+        assert exc.value is outcomes[forced_result]
+    else:
+        assert f"failed to produce final outputs after {break_reason}" in str(exc.value)
+    if forced_result == "no_submit":
+        assert "no submit call" in str(exc.value)
     if forced_result == "missing_field":
-        event = pred.history.messages[-1]
+        assert "Missing required final output field(s): count" in str(exc.value)
+        event = history.messages[-1]
         assert event["tool_calls"].tool_calls[0].args == {"answer": "partial"}
         assert event["tool_calls"].tool_call_results.tool_call_results[0].is_error is True
 
 
-def test_react_v2_failed_outputs_are_accessible_to_evaluate():
+def test_react_v2_evaluate_reports_submission_failure(caplog):
     lm = dspy.utils.DummyLM([{"next_thought": "No answer.", "tool_calls": dspy.ToolCalls(tool_calls=[])}] * 2)
-    observed = []
 
     def metric(example, pred, trace=None):
-        observed.append((pred.answer, pred.termination_reason))
-        return pred.answer == example.answer
+        pytest.fail("A failed submission must not reach the metric")
 
     evaluate = dspy.Evaluate(
         devset=[dspy.Example(question="cats", answer="felines").with_inputs("question")],
         metric=metric,
         num_threads=1,
+        max_errors=1,
         display_progress=False,
     )
     with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
-        result = evaluate(dspy.ReActV2("question -> answer", tools=[]))
-
-    assert observed == [(None, "empty_tool_calls")]
-    assert result.score == 0.0
+        with pytest.raises(Exception, match="Execution cancelled due to errors"):
+            evaluate(dspy.ReActV2("question -> answer", tools=[]))
+    assert "failed to produce final outputs after empty_tool_calls: no submit call" in caplog.text

--- a/tests/predict/test_react_v2.py
+++ b/tests/predict/test_react_v2.py
@@ -2,6 +2,7 @@ import pytest
 
 import dspy
 from dspy.dsp.utils.utils import dotdict
+from dspy.utils.exceptions import ContextWindowExceededError
 
 
 class ReasoningDummyLM(dspy.utils.DummyLM):
@@ -332,3 +333,54 @@ def test_react_v2_native_parallel_tool_calls_are_requested_and_replayed():
 def test_react_v2_rejects_reserved_output_field_names(reserved):
     with pytest.raises(ValueError, match=reserved):
         dspy.ReActV2(f"question -> answer, {reserved}: str", tools=[])
+
+
+@pytest.mark.parametrize("break_reason", ["max_iters", "empty_tool_calls", "parse_error", "context_window_exceeded"])
+@pytest.mark.parametrize("forced_result", ["no_submit", "missing_field", "parse_error", "context_window_exceeded"])
+def test_react_v2_failed_termination_preserves_output_fields(mocker, break_reason, forced_result):
+    react = dspy.ReActV2("question -> answer: str, count: int", tools=[], max_iters=1)
+    empty = dspy.Prediction(tool_calls=dspy.ToolCalls(tool_calls=[]))
+    incomplete = dspy.Prediction(
+        tool_calls=dspy.ToolCalls.from_dict_list([{"name": "submit", "args": {"answer": "partial"}}])
+    )
+    outcomes = {
+        "max_iters": incomplete,
+        "empty_tool_calls": empty,
+        "no_submit": empty,
+        "missing_field": incomplete,
+        "parse_error": ValueError("invalid tool calls"),
+        "context_window_exceeded": ContextWindowExceededError(message="too long"),
+    }
+    mocker.patch.object(react.react, "forward", side_effect=[outcomes[break_reason], outcomes[forced_result]])
+
+    pred = react(question="cats")
+
+    assert pred.answer is None
+    assert pred.count is None
+    assert pred.termination_reason == break_reason
+    assert isinstance(pred.history, dspy.History)
+    if forced_result == "missing_field":
+        event = pred.history.messages[-1]
+        assert event["tool_calls"].tool_calls[0].args == {"answer": "partial"}
+        assert event["tool_calls"].tool_call_results.tool_call_results[0].is_error is True
+
+
+def test_react_v2_failed_outputs_are_accessible_to_evaluate():
+    lm = dspy.utils.DummyLM([{"next_thought": "No answer.", "tool_calls": dspy.ToolCalls(tool_calls=[])}] * 2)
+    observed = []
+
+    def metric(example, pred, trace=None):
+        observed.append((pred.answer, pred.termination_reason))
+        return pred.answer == example.answer
+
+    evaluate = dspy.Evaluate(
+        devset=[dspy.Example(question="cats", answer="felines").with_inputs("question")],
+        metric=metric,
+        num_threads=1,
+        display_progress=False,
+    )
+    with dspy.context(lm=lm, adapter=dspy.ChatAdapter()):
+        result = evaluate(dspy.ReActV2("question -> answer", tools=[]))
+
+    assert observed == [(None, "empty_tool_calls")]
+    assert result.score == 0.0


### PR DESCRIPTION
Fixes #10243.

ReActV2 now returns a complete prediction or raises when its final forced-submit attempt fails. Final parse/context-window errors propagate; missing or invalid submissions raise a descriptive ValueError. Successful submissions and the existing recovery attempt are unchanged. No placeholder None outputs or additional LM calls are introduced.

The class docstring describes the agent generally: reasoning, tool selection, submission, supported tool-calling modes, and constructor arguments.

Tests cover all loop exit reasons, failed final submissions, preserved exception identity and tool errors, and Evaluate reporting the submission failure before invoking a metric. Evaluate retains its normal error budget; max_errors=1 stops on the first error. All 29 ReActV2 tests passed on this branch; Ruff and pre-commit passed.

First in the stack; #10356 adds async execution and real MCP end-to-end coverage with the same failure contract.

AI assistance: Isaac Miller directed Amp to implement and verify these changes and explicitly requested PR submission. Prompts and verification: https://ampcode.com/threads/T-01a0866c-9157-771f-8383-0fa3db002850