### PR TITLE
fix(predict): stop BestOfN/Refine from leaking the failure budget across calls

### DIFF
--- a/dspy/predict/best_of_n.py
+++ b/dspy/predict/best_of_n.py
@@ -52,6 +52,7 @@ class BestOfN(Module):
         start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]
         best_pred, best_trace, best_reward = None, None, -float("inf")
+        remaining_failures = self.fail_count
 
         for idx, rid in enumerate(rollout_ids):
             lm_ = lm.copy(rollout_id=rid, temperature=1.0)
@@ -74,9 +75,9 @@ class BestOfN(Module):
 
             except Exception as e:
                 print(f"BestOfN: Attempt {idx + 1} failed with rollout id {rid}: {e}")
-                if idx > self.fail_count:
+                if remaining_failures <= 0:
                     raise e
-                self.fail_count -= 1
+                remaining_failures -= 1
 
         if best_trace:
             dspy.settings.trace.extend(best_trace)

--- a/dspy/predict/refine.py
+++ b/dspy/predict/refine.py
@@ -100,6 +100,7 @@ class Refine(Module):
         start = lm.kwargs.get("rollout_id", 0)
         rollout_ids = [start + i for i in range(self.N)]
         best_pred, best_trace, best_reward = None, None, -float("inf")
+        remaining_failures = self.fail_count
         advice = None
         adapter = dspy.settings.adapter or dspy.ChatAdapter()
 
@@ -169,9 +170,9 @@ class Refine(Module):
 
             except Exception as e:
                 print(f"Refine: Attempt failed with rollout id {rid}: {e}")
-                if idx > self.fail_count:
+                if remaining_failures <= 0:
                     raise e
-                self.fail_count -= 1
+                remaining_failures -= 1
         if best_trace:
             dspy.settings.trace.extend(best_trace)
         return best_pred

--- a/tests/predict/test_fail_count_budget.py
+++ b/tests/predict/test_fail_count_budget.py
@@ -1,0 +1,69 @@
+"""Regression tests: BestOfN/Refine must not leak the failure budget across calls.
+
+Before the fix, forward() decremented self.fail_count in place, so the
+budget decayed monotonically over the life of the module: with
+fail_count=1, call 1 tolerated one failure but call 3 raised on the very
+first attempt. The budget must apply per call.
+
+https://github.com/stanfordnlp/dspy/issues/10312
+"""
+import dspy
+import pytest
+from dspy.predict.best_of_n import BestOfN
+from dspy.predict.refine import Refine
+from dspy.predict.predict import Predict
+from dspy.utils.dummies import DummyLM
+
+INVOCATIONS = {"n": 0}
+
+
+class CountingFailures(dspy.Module):
+    """Every invocation raises; counts invocations so tests can measure
+    how many attempts each forward() call consumed before raising."""
+
+    def __init__(self):
+        super().__init__()
+        self.predictor = Predict("question -> answer")
+
+    def forward(self, **kwargs):
+        INVOCATIONS["n"] += 1
+        raise ValueError("permanent failure")
+
+
+@pytest.fixture(autouse=True)
+def _reset_and_configure():
+    INVOCATIONS["n"] = 0
+    dspy.configure(lm=DummyLM([{"answer": "ok"}] * 40))
+
+
+def _attempts_before_raise(make_module, forward_owner):
+    """Call forward() once, count attempts consumed, expect the raise."""
+    module = make_module()
+    owner = forward_owner(module)
+    before = INVOCATIONS["n"]
+    with pytest.raises(ValueError, match="permanent failure"):
+        owner.forward(question="x")
+    return INVOCATIONS["n"] - before
+
+
+def test_best_of_n_budget_identical_across_calls():
+    def make():
+        return CountingFailures()
+
+    bon = BestOfN(module=make(), N=3, reward_fn=lambda _, __: 1.0,
+                  threshold=0.0, fail_count=1)
+    counts = [_attempts_before_raise(make, lambda m: bon) for _ in range(3)]
+    # With fail_count=1 every call must tolerate one failure and raise on
+    # the second attempt. The buggy version decayed the budget in place
+    # (1 → 0 → -1), so call 3 raised on the FIRST attempt.
+    assert counts == [2, 2, 2]
+
+
+def test_refine_budget_identical_across_calls():
+    def make():
+        return CountingFailures()
+
+    ref = Refine(module=make(), N=3, reward_fn=lambda _, __: 1.0,
+                 threshold=0.0, fail_count=1)
+    counts = [_attempts_before_raise(make, lambda m: ref) for _ in range(3)]
+    assert counts == [2, 2, 2]


### PR DESCRIPTION
Fixes #10312

## Summary

`BestOfN.forward` and `Refine.forward` decrement `self.fail_count` in place after every tolerated failure. `fail_count` is instance state on a long-lived `dspy.Module`, so the budget decays monotonically over the module's life: with `fail_count=1, N=3`, a module reused across a devset tolerated one transient failure on call 1 but raised on the **first** transient failure from call 3 onward — the configured budget was gone forever. (Related open reports: #10319, #10153, #9301.)

## Fix

Track the remaining budget in a forward-local variable (`remaining_failures`); `self.fail_count` stays untouched. Every call now starts with the configured budget.

## AI disclosure

This fix was prepared with AI assistance (Claude) as part of a human-directed audit session: the repro was executed, the fix reviewed line-by-line, and the regression tests designed to fail on the original code (verified by temporarily reverting the fix) before submission, per the AI-Generated Contributions policy.