### PR TITLE
fix(utils): fail all callers when batch_fn's output count mismatches its inputs

### DIFF
--- a/dspy/utils/unbatchify.py
+++ b/dspy/utils/unbatchify.py
@@ -68,7 +68,12 @@ class Unbatchify:
             if batch:
                 try:
                     outputs = self.batch_fn(batch)
-                    for output, future in zip(outputs, futures, strict=False):
+                    if len(outputs) != len(futures):
+                        raise ValueError(
+                            f"batch_fn returned {len(outputs)} outputs for "
+                            f"{len(futures)} inputs; cannot unbatch."
+                        )
+                    for output, future in zip(outputs, futures):
                         future.set_result(output)
                 except Exception as e:
                     for future in futures:

--- a/tests/utils/test_unbatchify_mismatch.py
+++ b/tests/utils/test_unbatchify_mismatch.py
@@ -1,0 +1,31 @@
+"""Regression test: a batch_fn output/input count mismatch must surface as an
+exception in the caller, not hang it forever.
+
+https://github.com/stanfordnlp/dspy/issues/10313
+"""
+import threading
+
+from dspy.utils.unbatchify import Unbatchify
+
+
+def test_short_batch_output_raises_in_caller():
+    def flaky_batch_fn(items):
+        # Simulates a batched endpoint that silently drops the last item.
+        return items[:-1]
+
+    with Unbatchify(flaky_batch_fn, max_batch_size=8, max_wait_time=0.01) as unbatch:
+        result = {}
+
+        def call():
+            try:
+                unbatch("a")
+            except Exception as e:
+                result["error"] = e
+
+        thread = threading.Thread(target=call, daemon=True)
+        thread.start()
+        thread.join(timeout=10.0)
+
+    assert not thread.is_alive(), "caller hung forever on an unresolved Future"
+    assert "error" in result
+    assert "cannot unbatch" in str(result["error"]) or "outputs for" in str(result["error"])


### PR DESCRIPTION
Fixes #10313

## Summary

`Unbatchify`'s worker zipped `batch_fn(batch)`'s outputs against the caller futures with `strict=False`. When a batched endpoint returned fewer outputs than inputs (partial failure dropping items), the unmatched `Future` was never resolved and never received an exception — every caller of `Unbatchify.__call__` blocked **forever** on `future.result()` (no timeout), while the worker thread returned to the queue. Extra outputs were silently discarded.

## Fix

The output count is now checked against the futures count; a mismatch raises inside the worker, and the existing handler delivers the exception to every caller. Callers get a clear `ValueError` naming the counts instead of a permanent hang.

## Regression test

A `batch_fn` that drops the last item: before, the caller thread hung (verified with a 10s join — the thread never terminated); after, the caller raises immediately. Verified the test fails on the original code and passes with the fix.

## AI disclosure

Prepared with AI assistance (Claude) during a human-directed audit; reviewed and submitted by @simpleqt.