### PR TITLE
fix(predict): reset Parallel failed-example state between forward() calls

### DIFF
--- a/dspy/predict/parallel.py
+++ b/dspy/predict/parallel.py
@@ -77,6 +77,11 @@ class Parallel:
     def forward(self, exec_pairs: list[tuple[Any, Example]], num_threads: int | None = None) -> list[Any]:
         num_threads = num_threads if num_threads is not None else self.num_threads
 
+        # Reset per-call accumulators so a reused Parallel instance does not carry
+        # failed examples/exceptions over from a previous forward() call.
+        self.failed_examples = []
+        self.exceptions = []
+
         executor = ParallelExecutor(
             num_threads=num_threads,
             max_errors=self.max_errors,

--- a/tests/predict/test_parallel.py
+++ b/tests/predict/test_parallel.py
@@ -234,6 +234,40 @@ def test_batch_with_failed_examples():
     assert str(exceptions[0]) == "test error"
 
 
+def test_parallel_reuse_does_not_accumulate_failed_examples():
+    class FailingModule(dspy.Module):
+        def forward(self, value: int) -> str:
+            if value < 0:
+                raise ValueError(f"negative value: {value}")
+            return f"success-{value}"
+
+    module = FailingModule()
+    parallel = dspy.Parallel(return_failed_examples=True, provide_traceback=True)
+
+    # First call: a single failure on value=-1.
+    results1, failed1, exceptions1 = parallel(
+        [
+            (module, dspy.Example(value=1).with_inputs("value")),
+            (module, dspy.Example(value=-1).with_inputs("value")),
+        ]
+    )
+    assert results1 == ["success-1", None]
+    assert [example.inputs()["value"] for example in failed1] == [-1]
+    assert len(exceptions1) == 1
+
+    # Reusing the same instance for a second call must report only this call's
+    # failure (value=-2), not accumulate the previous call's failure (value=-1).
+    results2, failed2, exceptions2 = parallel(
+        [
+            (module, dspy.Example(value=2).with_inputs("value")),
+            (module, dspy.Example(value=-2).with_inputs("value")),
+        ]
+    )
+    assert results2 == ["success-2", None]
+    assert [example.inputs()["value"] for example in failed2] == [-2]
+    assert len(exceptions2) == 1
+
+
 def test_parallel_timeout_and_straggler_limit_params():
     parallel_default = dspy.Parallel()
     assert parallel_default.timeout == 120


### PR DESCRIPTION
### Summary

`dspy.Parallel` keeps `failed_examples` and `exceptions` as instance attributes that are initialized once in `__init__`. When `return_failed_examples=True`, `forward()` only appends the current call's failures to those lists and returns them; it never clears them at the start of the call. The `ParallelExecutor` it reads from is rebuilt on every call, so reusing a single `Parallel` instance across multiple `forward()` / `__call__` invocations makes the reported failures accumulate: each call appends to the lists returned by the previous ones, so every batch after the first reports its own failed examples plus all the failures from earlier calls, and exceptions grows the same way.

The fix resets the two accumulators at the top of `forward()`, so each call reports only its own failures. No public signature changes.

### Testing

- Added `test_parallel_reuse_does_not_accumulate_failed_examples` in `tests/predict/test_parallel.py`. It reuses one `Parallel(return_failed_examples=True)` instance across two calls with different failing inputs and asserts the second call reports only its own failure. It fails on `main` (the second call returns both failures) and passes with this change. Uses a synchronous `FailingModule`, so no live LM or network is needed.
- `pytest tests/predict/test_parallel.py` -> 9 passed (no regressions).
- `ruff check` and `ruff format --check` clean on both files; `git diff --check` clean.