### PR TITLE
fix(teleprompt): partial-credit fraction and zero format_reward handling

### DIFF
--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -54,7 +54,7 @@ def bootstrap_trace_data(
     def wrapped_metric(example, prediction, trace=None):
         prediction, _ = prediction
         if isinstance(prediction, FailedPrediction):
-            return prediction.format_reward or format_failure_score
+            return prediction.format_reward if prediction.format_reward is not None else format_failure_score
         return metric(example, prediction, trace) if metric else True
 
     # Use `object.__getattribute__` to bypass the custom hook `Module.__getattribute__` so that we avoid
@@ -88,7 +88,7 @@ def bootstrap_trace_data(
                     failed_pred = FailedPrediction(
                         completion_text=completion_str,
                         format_reward=format_failure_score
-                        + (failure_score - format_failure_score) * (present / expected),
+                        + (failure_score - format_failure_score) * (len(present) / len(expected)),
                     )
                 else:
                     failed_pred = FailedPrediction(completion_text=completion_str, format_reward=format_failure_score)

--- a/dspy/teleprompt/grpo.py
+++ b/dspy/teleprompt/grpo.py
@@ -476,7 +476,7 @@ class GRPO(FinetuneTeleprompter):
                             )
 
                             if isinstance(trace_instance[2], FailedPrediction):
-                                score = trace_instance[2].format_reward or self.format_failure_score
+                                score = trace_instance[2].format_reward if trace_instance[2].format_reward is not None else self.format_failure_score
                                 example_training_data[group_idx].append({
                                     "messages": inp_messages,
                                     "completion": {

--- a/tests/teleprompt/test_bootstrap_trace.py
+++ b/tests/teleprompt/test_bootstrap_trace.py
@@ -178,3 +178,35 @@ def test_capture_crashes_does_not_capture_lm_errors():
         Flaky(), dataset=[example], num_threads=1, capture_crashes=True, raise_on_error=False
     )
     assert data == []  # handled by the evaluator as an error, never repainted as a FailedPrediction
+
+
+def test_bootstrap_trace_partial_credit_and_zero_reward():
+    class TwoFieldSignature(dspy.Signature):
+        text: str = dspy.InputField()
+        number: int = dspy.OutputField()
+        explanation: str = dspy.OutputField()
+
+    program = dspy.Predict(TwoFieldSignature)
+    dataset = [Example(text="one", number=1, explanation="e").with_inputs("text")]
+
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o-mini", cache=False), adapter=dspy.JSONAdapter())
+
+    partial_response = ModelResponse(
+        choices=[Choices(message=Message(content='```json\n{"number": 1}\n```'))],
+        model="openai/gpt-4o-mini",
+    )
+    with mock.patch("litellm.completion", return_value=partial_response):
+        results = bootstrap_trace_data(
+            program=program,
+            dataset=dataset,
+            metric=lambda example, prediction, trace=None: True,
+            num_threads=1,
+            raise_on_error=False,
+            capture_failed_parses=True,
+            failure_score=1,
+            format_failure_score=-1,
+        )
+
+    assert len(results) == 1
+    assert isinstance(results[0]["prediction"], FailedPrediction)
+    assert results[0]["score"] == 0.0


### PR DESCRIPTION
## Changes Description

Fixes #10362

Two defects in the format-reward path shared by bootstrap_trace and GRPO:

- Partial format credit divided two lists (present / expected), raising TypeError on every partial parse. It now divides their lengths
- A legitimate format_reward of 0.0 was replaced by the failure penalty because of an or fallback. Only None falls back now, in both bootstrap_trace and grpo

Added a regression test: a two-field signature with a one-field parse scores exactly 0.0 with failure_score=1 and format_failure_score=-1. The test fails on the old code with TypeError and passes with the fix. Ran tests/teleprompt/test_bootstrap_trace.py, 4 passed

## Contributor Checklist

- [x] Pre-Commit checks are passing (locally and remotely)
- [x] Title of your PR / MR corresponds to the required format
- [x] Commit message follows required format {label}(dspy): {message}

## Warnings

None