### PR TITLE
fix(teleprompt): repair partial-credit format rewards

### DIFF
--- a/dspy/teleprompt/bootstrap_trace.py
+++ b/dspy/teleprompt/bootstrap_trace.py
@@ -54,7 +54,9 @@ def bootstrap_trace_data(
     def wrapped_metric(example, prediction, trace=None):
         prediction, _ = prediction
         if isinstance(prediction, FailedPrediction):
-            return prediction.format_reward or format_failure_score
+            # `format_reward=None` means "not set"; 0.0 is a real reward (the
+            # best partial credit under the default scores) and must survive.
+            return prediction.format_reward if prediction.format_reward is not None else format_failure_score
         return metric(example, prediction, trace) if metric else True
 
     # Use `object.__getattribute__` to bypass the custom hook `Module.__getattribute__` so that we avoid
@@ -88,7 +90,7 @@ def bootstrap_trace_data(
                     failed_pred = FailedPrediction(
                         completion_text=completion_str,
                         format_reward=format_failure_score
-                        + (failure_score - format_failure_score) * (present / expected),
+                        + (failure_score - format_failure_score) * (len(present) / len(expected)),
                     )
                 else:
                     failed_pred = FailedPrediction(completion_text=completion_str, format_reward=format_failure_score)

--- a/dspy/teleprompt/grpo.py
+++ b/dspy/teleprompt/grpo.py
@@ -476,7 +476,8 @@ class GRPO(FinetuneTeleprompter):
                             )
 
                             if isinstance(trace_instance[2], FailedPrediction):
-                                score = trace_instance[2].format_reward or self.format_failure_score
+                                format_reward = trace_instance[2].format_reward
+                                score = format_reward if format_reward is not None else self.format_failure_score
                                 example_training_data[group_idx].append({
                                     "messages": inp_messages,
                                     "completion": {

--- a/tests/teleprompt/test_bootstrap_trace.py
+++ b/tests/teleprompt/test_bootstrap_trace.py
@@ -178,3 +178,74 @@ def test_capture_crashes_does_not_capture_lm_errors():
         Flaky(), dataset=[example], num_threads=1, capture_crashes=True, raise_on_error=False
     )
     assert data == []  # handled by the evaluator as an error, never repainted as a FailedPrediction
+
+
+def test_bootstrap_trace_data_partial_parse_gets_fractional_format_reward():
+    """A partial parse earns fractional format credit, and a 0.0 reward survives (#10362).
+
+    One of two output fields parsing used to crash with ``TypeError: unsupported
+    operand type(s) for /: 'list' and 'list'`` (``present / expected`` on lists),
+    and a legitimate ``format_reward`` of exactly ``0.0`` was rescored to
+    ``format_failure_score`` by the ``or`` fallback in ``wrapped_metric``. With
+    ``failure_score=1`` and ``format_failure_score=-1``, one field out of two
+    parsing lands exactly on ``0.0``, pinning both fixes at once.
+    """
+
+    class TwoFieldSignature(dspy.Signature):
+        """Convert a string number to an integer and explain."""
+
+        text: str = dspy.InputField()
+        number: int = dspy.OutputField()
+        explanation: str = dspy.OutputField()
+
+    program = dspy.Predict(TwoFieldSignature)
+
+    dataset = [
+        Example(text="one", number=1, explanation="the word one").with_inputs("text"),
+        Example(text="two", number=2, explanation="the word two").with_inputs("text"),
+    ]
+
+    def exact_match_metric(example, prediction, trace=None):
+        return example.number == prediction.number
+
+    dspy.configure(lm=dspy.LM(model="openai/gpt-4o-mini", cache=False), adapter=dspy.JSONAdapter())
+
+    complete_response = ModelResponse(
+        choices=[Choices(message=Message(content='```json\n{"number": 1, "explanation": "the word one"}\n```'))],
+        model="openai/gpt-4o-mini",
+    )
+    # Valid JSON that parses only one of the two output fields, for both
+    # structured-output mode and the JSON-mode fallback retry.
+    partial_response = ModelResponse(
+        choices=[Choices(message=Message(content='```json\n{"number": 2}\n```'))],
+        model="openai/gpt-4o-mini",
+    )
+
+    def completion_side_effect(*args, **kwargs):
+        call_count = completion_side_effect.call_count
+        completion_side_effect.call_count += 1
+        if call_count == 0:
+            return complete_response
+        return partial_response
+
+    completion_side_effect.call_count = 0
+
+    with mock.patch("litellm.completion", side_effect=completion_side_effect):
+        results = bootstrap_trace_data(
+            program=program,
+            dataset=dataset,
+            metric=exact_match_metric,
+            num_threads=1,
+            raise_on_error=False,
+            capture_failed_parses=True,
+            failure_score=1,
+            format_failure_score=-1,
+        )
+
+    failed = [result for result in results if isinstance(result["prediction"], FailedPrediction)]
+    assert len(failed) == 1, f"Expected 1 failed prediction, got {len(failed)}"
+
+    # One of two expected fields parsed: -1 + (1 - -1) * (1/2) == 0.0 exactly.
+    assert failed[0]["prediction"].format_reward == 0.0
+    # The 0.0 must reach the recorded score instead of falling back to -1.
+    assert failed[0]["score"] == 0.0


### PR DESCRIPTION
Fixes #10362

## Problem

Two related defects in the format-reward path shared by `bootstrap_trace` and GRPO:

1. **The partial-credit branch crashes on every partial parse.** `patched_forward` computed the credit fraction as `present / expected` where both are **lists**, so the moment an adapter reports a partial parse (e.g. `JSONAdapter.parse` raises `AdapterParseError(parsed_result=fields)` when some but not all output fields parse), trace collection dies with `TypeError: unsupported operand type(s) for /: 'list' and 'list'`.

2. **A legitimate `format_reward` of `0.0` is rescored to the failure penalty.** Both consumers used `or` where `None` is the documented sentinel (`FailedPrediction.format_reward: float | None = None`): `wrapped_metric` in `bootstrap_trace.py` and the training-data builder in `grpo.py`. With the in-tree defaults (`failure_score=0`, `format_failure_score=-1`) the fixed formula yields exactly `0.0` when every expected field parsed — the best partial credit — and `0.0 or -1` silently turns it into the worst, so GRPO trains against corrupted rewards. Same falsy-zero class as #10321 (`seed=0`), applied to training signal.

## Changes

- `bootstrap_trace.py`: partial credit uses `len(present) / len(expected)`
- `bootstrap_trace.py` (`wrapped_metric`) and `grpo.py`: fall back to `format_failure_score` only when `format_reward is None`
- Regression test: parses one of two output fields with `failure_score=1` / `format_failure_score=-1`, landing exactly on `0.0` so a single test pins both fixes. It fails with the TypeError on the previous code (verified by stash-and-run) and passes with the fix.

## Testing

- `tests/teleprompt/test_bootstrap_trace.py` 4/4 (incl. the new regression test); `test_grpo.py` and `test_bootstrap.py` green — 13 passed total.