### PR TITLE
test(predict): cover cancellation during real MCP tool execution

### DIFF
--- a/tests/utils/resources/mcp_server.py
+++ b/tests/utils/resources/mcp_server.py
@@ -1,3 +1,6 @@
+import asyncio
+from pathlib import Path
+
 from pydantic import BaseModel
 
 try:
@@ -46,6 +49,15 @@ def get_account_name(account: Account):
 def current_datetime() -> str:
     """Get the current datetime"""
     return "2025-07-23T09:10:10.0+00:00"
+
+
+@mcp.tool()
+async def wait_for_release(started: str, release: str) -> str:
+    """Signal that a request is in flight, then wait for the test to release it."""
+    Path(started).touch()
+    while not Path(release).exists():
+        await asyncio.sleep(0.01)
+    return "released"
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_mcp.py
+++ b/tests/utils/test_mcp.py
@@ -301,3 +301,83 @@ async def test_react_v2_native_mcp_end_to_end():
     results = pred.history.messages[0]["tool_calls"].tool_call_results.tool_call_results
     assert [(r.call_id, r.is_error) for r in results] == [("mcp_error", True), ("mcp_add", False)]
     assert results[1].value == "42"
+
+
+@pytest.mark.asyncio
+@pytest.mark.extra
+async def test_react_v2_mcp_cancellation_preserves_session(tmp_path):
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    started, release = tmp_path / "started", tmp_path / "release"
+    executed = []
+
+    def later() -> str:
+        executed.append("later")
+        return "unexpected"
+
+    async def wait_until_started():
+        while not started.exists():
+            await asyncio.sleep(0.01)
+
+    lm = dspy.utils.DummyLM(
+        [
+            {
+                "next_thought": "Wait.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [
+                        {"name": "wait_for_release", "args": {"started": str(started), "release": str(release)}},
+                        {"name": "later", "args": {}},
+                        {"name": "submit", "args": {"answer": 999}},
+                    ]
+                ),
+            },
+            {
+                "next_thought": "Add.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [
+                        {"name": "add", "args": {"a": 23, "b": -6}},
+                    ]
+                ),
+            },
+            {
+                "next_thought": "Done.",
+                "tool_calls": dspy.ToolCalls.from_dict_list(
+                    [
+                        {"name": "submit", "args": {"answer": 17}},
+                    ]
+                ),
+            },
+        ]
+    )
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=[str(Path(__file__).parent / "resources" / "mcp_server.py")],
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await asyncio.wait_for(session.initialize(), timeout=5)
+            tools = [Tool.from_mcp_tool(session, tool) for tool in (await session.list_tools()).tools]
+            agent = dspy.ReActV2("question -> answer: int", tools=[*tools, later])
+            with dspy.context(lm=lm, adapter=dspy.ChatAdapter(use_native_function_calling=False)):
+                task = asyncio.create_task(agent.acall(question="Wait for release"))
+                try:
+                    # Cancel only after the remote tool has actually started.
+                    await asyncio.wait_for(wait_until_started(), timeout=5)
+                    task.cancel()
+                    with pytest.raises(asyncio.CancelledError):
+                        await asyncio.wait_for(task, timeout=5)
+                    assert executed == []
+                    assert len(lm.history) == 1  # No continuation or forced-submit request.
+
+                    # The agent borrows the session: cancellation must not close it.
+                    pred = await asyncio.wait_for(agent.acall(question="What is 23 minus 6?"), timeout=5)
+                    assert (pred.answer, pred.termination_reason) == (17, "submit")
+                    result = pred.history.messages[0]["tool_calls"].tool_call_results.tool_call_results[0]
+                    assert result.value == "17"
+                    assert result.is_error is False
+                finally:
+                    # Local cancellation need not stop remote work. Release it explicitly.
+                    release.touch()
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)


### PR DESCRIPTION
Third PR in the stack, based on #10356 (#10355 is merged). Tests only; no production changes.

Adds one real-stdio-MCP test that cancels ReActV2 only after the server confirms its tool has started. It checks CancelledError propagation, no subsequent batch tools or forced-submit request, and successful reuse of the same agent and borrowed MCP session.

The server fixture has an explicit release signal for cleanup. The test does not require cancellation to stop remote work or roll back side effects.

Validation:
- pytest tests/predict/test_react_v2.py tests/utils/test_mcp.py --extra -q: 81 passed, 1 SDK-v2-only skip (installed MCP 1.29.0).
- An in-memory mutation changing the async tool handler to catch BaseException makes this test fail with DID NOT RAISE CancelledError. No production source was modified for that check.
- Ruff, pre-commit, and git diff --check passed.

AI assistance: Isaac Miller directed Amp to implement, test, and submit this follow-up. Prompts and verification: https://ampcode.com/threads/T-01a0866c-9157-771f-8383-0fa3db002850