### PR TITLE
fix(utils): align syncify with Tool's running-loop policy

### DIFF
--- a/dspy/utils/syncify.py
+++ b/dspy/utils/syncify.py
@@ -7,20 +7,29 @@ if TYPE_CHECKING:
 
 
 def run_async(coro):
-    """Run an async coroutine from a synchronous context."""
+    """Run an async coroutine from a synchronous context.
+
+    Inside a running event loop (e.g. Jupyter, or a server handler) a sync
+    call cannot be served without nested-loop hacks: `nest_asyncio` patches
+    the event loop process-wide as an import side effect and does not support
+    alternative loops such as uvloop. Follow the same fail-fast contract as
+    `dspy.Tool` and direct the caller to the native async path instead.
+    """
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
+        # Run the coroutine outside of "except" block to avoid propagation
         loop = None
 
-    if loop and loop.is_running():
-        # If we're in a running event loop (e.g., Jupyter), use asyncio.create_task and run until done
-        import nest_asyncio
-
-        nest_asyncio.apply()
-        return asyncio.get_event_loop().run_until_complete(coro)
-    else:
+    if loop is None:
         return asyncio.run(coro)
+
+    coro.close()
+    raise ValueError(
+        "You are calling a syncified program from within a running event loop, which cannot be "
+        "converted to a sync call. Please use the module's native async path instead, e.g. "
+        "`await program.aforward(...)` (or `await program.acall(...)`)."
+    )
 
 
 def syncify(program: "Module", in_place: bool = True) -> "Module":

--- a/tests/utils/test_syncify.py
+++ b/tests/utils/test_syncify.py
@@ -1,4 +1,8 @@
 import asyncio
+import gc
+import warnings
+
+import pytest
 
 import dspy
 
@@ -55,3 +59,62 @@ def test_syncify_works_with_optimizers():
     sync_program = dspy.syncify(async_program, in_place=False)
     optimized_program = optimizer.compile(sync_program, trainset=dataset)
     assert len(optimized_program.predictors()[0].demos) == 2
+
+
+def test_syncify_raises_inside_a_running_event_loop():
+    """Inside a running loop the sync call fails fast toward the native async path (#10337)."""
+
+    class MyProgram(dspy.Module):
+        async def aforward(self, x: int) -> int:
+            return x + 1
+
+    sync_program = dspy.syncify(MyProgram())
+
+    async def call_inside_loop():
+        with pytest.raises(ValueError, match="native async path"):
+            sync_program(1)
+
+    asyncio.run(call_inside_loop())
+
+
+def test_syncify_raise_path_does_not_leak_a_coroutine():
+    """The refused coroutine is closed, so no 'never awaited' RuntimeWarning escapes."""
+
+    class MyProgram(dspy.Module):
+        async def aforward(self, x: int) -> int:
+            return x + 1
+
+    sync_program = dspy.syncify(MyProgram())
+
+    async def call_inside_loop():
+        with pytest.raises(ValueError):
+            sync_program(1)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        asyncio.run(call_inside_loop())
+        gc.collect()
+
+
+def test_syncify_and_tool_share_the_running_loop_policy():
+    """syncify and Tool refuse a sync call inside a running loop the same way, so the two policies cannot drift apart again."""
+
+    async def add_one(x: int) -> int:
+        return x + 1
+
+    tool = dspy.Tool(add_one)
+
+    class MyProgram(dspy.Module):
+        async def aforward(self, x: int) -> int:
+            return x + 1
+
+    sync_program = dspy.syncify(MyProgram())
+
+    async def call_both():
+        with pytest.raises(ValueError):
+            sync_program(1)
+        with dspy.context(allow_tool_async_sync_conversion=True):
+            with pytest.raises(ValueError):
+                tool(x=1)
+
+    asyncio.run(call_both())


### PR DESCRIPTION
Fixes #10337 — implements option 1 from the proposal discussed on the issue.

## Problem

`run_async` applied `nest_asyncio.apply()` when called inside a running event
loop: a process-wide monkey-patch as an implicit side effect of a library
call, unsupported on alternative loops such as uvloop, and an undeclared
dependency (`nest-asyncio` is not in `pyproject.toml`) that only failed once a
syncified program ran inside an active loop. Meanwhile `Tool._run_async_in_sync`
deliberately established the opposite policy in #10146: close the coroutine and
raise an actionable error. Behavior depended on which DSPy abstraction did the
conversion.

## Changes

- `run_async` follows `Tool`'s fail-fast contract inside a running loop: the
  refused coroutine is closed and a `ValueError` directs the caller to the
  module's native async path (`await program.aforward(...)` /
  `await program.acall(...)`). No more `nest_asyncio`, no global patching, no
  undeclared import.
- The no-loop path is unchanged (`asyncio.run`), so scripts and notebooks
  calling syncified programs from plain sync contexts are unaffected.

## Testing (the issue's requested coverage)

- Conversion with no running loop (existing tests, unchanged)
- The raise inside a standard running asyncio loop, message pinned
- No leaked un-awaited-coroutine `RuntimeWarning` on the raise path
  (warnings-as-errors + forced GC)
- A drift guard asserting `syncify` and `Tool` refuse a running-loop sync call
  the same way, so the two policies cannot diverge again

`tests/utils/test_syncify.py`: 6 passed.
