### PR TITLE
Implement Ask AI feature with Mixedbread integration and update docs

### DIFF
--- a/.github/workflows/docs-search-sync.yml
+++ b/.github/workflows/docs-search-sync.yml
@@ -1,0 +1,41 @@
+name: Docs Search Sync
+
+# Re-index the published docs and the Python sources into the Mixedbread
+# stores behind the docs "Ask AI" widget (docs/api/chat.js).
+# Sync is incremental (sha256-keyed), so unchanged files are skipped.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "dspy/**"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sync:
+    name: Sync docs to Mixedbread stores
+    if: github.repository == 'stanfordnlp/dspy'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Build the docs (rendered Markdown pages via mkdocs-llmstxt)
+        run: |
+          cd docs
+          pip install -r requirements.txt
+          mkdocs build
+      - name: Sync stores
+        run: |
+          pip install mixedbread
+          python3 docs/scripts/sync_search_index.py --site docs/site
+        env:
+          MXBAI_API_KEY: ${{ secrets.MXBAI_API_KEY }}

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,5 +76,38 @@ This guide is for contributors looking to make changes to the documentation in t
 
 ## LLMs.txt
 
-The build process generates an `/llms.txt` file for LLM consumption using [mkdocs-llmstxt](https://github.com/pawamoy/mkdocs-llmstxt). Configure sections in `mkdocs.yml` under the `llmstxt` plugin.
+The build process generates an `/llms.txt` file for LLM consumption using [mkdocs-llmstxt](https://github.com/pawamoy/mkdocs-llmstxt). Configure sections in `mkdocs.yml` under the `llmstxt` plugin. The plugin also writes every page as `<page>/index.md`, which is what the agentic search below indexes.
+
+## "Ask AI" (toast-1)
+
+The published pages are indexed in a Mixedbread store (`dspy-docs`) and the
+Python sources under `dspy/` in `dspy-code`. `scripts/sync_search_index.py`
+keeps both stores in step with the repo (incremental, sha256-keyed); CI runs
+it after `mkdocs build` on pushes to `main` that touch `docs/` or `dspy/`
+(`.github/workflows/docs-search-sync.yml`), using the `MXBAI_API_KEY`
+repository secret. To re-index by hand:
+
+```bash
+pip install mixedbread
+python3 docs/scripts/sync_search_index.py --site docs/site   # after `mkdocs build`
+```
+
+`docs/js/toast-chat.js` adds the "Ask AI" panel to every page. Its backend is
+the Vercel Edge Function in `api/chat.js`, which ships with the site (this
+directory is mirrored into the Vercel project) and runs on the same origin.
+Set `MXBAI_API_KEY` and `OPENROUTER_API_KEY` in the Vercel project's
+environment variables and it is live; the browser never sees the keys. By
+default it runs the pipeline that won the docs-harness A/B (toast-1 agentic
+search, whole-page reading of the top results, an answerer model); `MODE=toast`
+lets toast-1 answer on its own with `api/system_prompt.txt`.
+
+To preview the chat locally, put the two keys in `docs/api/.env.local`
+(gitignored) and run the dev server next to `mkdocs serve`:
+
+```bash
+node docs/api/dev.mjs        # serves the function on http://localhost:8787
+```
+
+To route the widget at an external proxy instead, set
+`extra.toast_chat_endpoint` in `mkdocs.yml`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -98,8 +98,13 @@ directory is mirrored into the Vercel project) and runs on the same origin.
 Set `MXBAI_API_KEY` and `OPENROUTER_API_KEY` in the Vercel project's
 environment variables and it is live; the browser never sees the keys. By
 default it runs the pipeline that won the docs-harness A/B (toast-1 agentic
-search, whole-page reading of the top results, an answerer model); `MODE=toast`
-lets toast-1 answer on its own with `api/system_prompt.txt`.
+search, whole-page reading of the top results, an answerer model).
+`ANSWERER_MODEL` picks who writes the answer: `anthropic/claude-sonnet-5`
+via OpenRouter (default; holdout score 0.78) or `toast-1` via the same
+Mixedbread key (0.66 with its GEPA-tuned answerer prompt; no second key or
+vendor, and ahead of the previous widget's 0.54). `MODE=toast` lets toast-1 answer on its own with
+`api/system_prompt.txt` (0.58; the prompt was optimized with RATCHET, the
+DSRs optimizer, and verified on the same holdout).
 
 To preview the chat locally, put the two keys in `docs/api/.env.local`
 (gitignored) and run the dev server next to `mkdocs serve`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,10 @@ pip install mixedbread
 python3 docs/scripts/sync_search_index.py --site docs/site   # after `mkdocs build`
 ```
 
+A file that is missing locally is deleted from the store, so the script
+refuses to run when the `--site` path does not exist or no files were found
+(that would empty the store); `--allow-empty` overrides that on purpose.
+
 `docs/js/toast-chat.js` adds the "Ask AI" panel to every page. Its backend is
 the Vercel Edge Function in `api/chat.js`, which ships with the site (this
 directory is mirrored into the Vercel project) and runs on the same origin.
@@ -105,6 +109,19 @@ Mixedbread key (0.66 with its GEPA-tuned answerer prompt; no second key or
 vendor, and ahead of the previous widget's 0.54). `MODE=toast` lets toast-1 answer on its own with
 `api/system_prompt.txt` (0.58; the prompt was optimized with RATCHET, the
 DSRs optimizer, and verified on the same holdout).
+
+The endpoint is public (the widget sends no credential), so the function
+bounds what it will spend: request bodies are size-limited, browser requests
+must come from the site's own origin (plus `DOCS_SITE`, localhost previews and
+anything in `ALLOWED_ORIGINS`), and each client IP gets `RATE_LIMIT_IP`
+requests per minute (default 10) under a `RATE_LIMIT_GLOBAL` budget per hour
+(default 300); over-limit calls get a 429 with `Retry-After`. Out of the box
+the counters live in each edge isolate's memory, which is best effort. To make
+them global across regions, attach Upstash Redis from the Vercel Marketplace
+(it sets `UPSTASH_REDIS_REST_URL`/`_TOKEN`, which the function picks up; the
+older `KV_REST_API_*` pair works too). Two more layers live outside this repo
+and are worth setting: a spend limit on the OpenRouter key, and a Vercel
+Firewall rate-limit rule on `/api/chat` as the outer edge.
 
 To preview the chat locally, put the two keys in `docs/api/.env.local`
 (gitignored) and run the dev server next to `mkdocs serve`:

--- a/docs/api/chat.js
+++ b/docs/api/chat.js
@@ -16,11 +16,13 @@
 //
 // Environment variables (Vercel project settings):
 //   MXBAI_API_KEY        required
-//   OPENROUTER_API_KEY   required for MODE=pages (the answerer model)
+//   OPENROUTER_API_KEY   only when ANSWERER_MODEL is an OpenRouter model
 //   MODE                 "pages" (default) or "toast"
 //   STORES               default "dspy-docs,dspy-code"
 //   DOCS_SITE            default "https://dspy.ai"
-//   ANSWERER_MODEL       default "anthropic/claude-sonnet-5"
+//   ANSWERER_MODEL       model that composes the answer in pages mode:
+//                        "toast-1" (Mixedbread, no second key) or an
+//                        OpenRouter id such as "anthropic/claude-sonnet-5"
 //   PAGES                default 3
 //   MAX_TOKENS           default 4000
 //   SYSTEM_PROMPT_URL    MODE=toast only; default is docs/api/system_prompt.txt on main
@@ -33,8 +35,64 @@ Answer the user's question using ONLY the retrieved documentation and source exc
 
 Style: concise Markdown; lead with the direct answer; keep exact DSPy names, parameters, and defaults as written in the excerpts; a short code example only when it helps; cite the documentation page(s) you used by their path (for example \`diving-deeper/react\`). No preamble, no restating the question.`;
 
+// Answerer prompt used when ANSWERER_MODEL is toast-1. Evolved with GEPA
+// against the docs-QA judge (toast-1 as the student), memorized training
+// facts removed; holdout 0.586 -> 0.664 versus the generic prompt above.
+const ANSWERER_SYSTEM_TOAST = `You are the DSPy documentation assistant. DSPy is the Python framework for programming, rather than prompting, language models.
+
+## Input format
+
+You will receive:
+
+- \`## Retrieved excerpts\`: DSPy documentation pages and/or source excerpts, each under a header such as \`### page: api/utils/load\` or \`### source: dspy/utils/saving.py\`.
+- \`## Question\`: the user's documentation question.
+
+## Core requirements
+
+Answer using ONLY the retrieved excerpts supplied in the current input. Do not use outside knowledge or fill gaps by inference. If the supplied material does not establish a requested detail, say plainly that the provided DSPy docs do not cover it.
+
+Lead with the direct answer. Use concise Markdown and exact DSPy names, parameters, field names, defaults, filenames, exception types, message text, and execution order as written in the excerpts. Do not restate the question or add a preamble.
+
+Treat every clause of a multi-part question as a required item. Before answering, make an internal checklist of all requested details and verify that each is covered. Include relevant qualifiers that define the behavior, even if the question does not repeat them—for example:
+
+- which saving/loading mode or configuration the behavior applies to;
+- prerequisites or intended usage;
+- exact files, fields, and return types;
+- ordering and classification rules;
+- exception types and meaningful details of their messages;
+- fallback values and whether all output fields are populated;
+- whether placeholders or prefixes are conditional rather than universal.
+
+Distinguish clearly between what the excerpts state and what they do not state. Do not turn an implementation observation into a broader guarantee unless the supplied material supports it.
+
+## Citations
+
+Cite the documentation page path(s) actually used, using the exact identifiers from the excerpt headers, such as:
+
+- \`api/utils/load\`
+- \`api/adapters/JSONAdapter\`
+- \`tutorials/gepa_papillon\`
+
+Prefer the most directly relevant page. Do not replace a supplied documentation-path citation with an internal Python filename unless that source filename itself was supplied as an excerpt. Additional citations are acceptable only when they materially support the answer.
+
+## Code
+
+Include a short code excerpt only when it materially clarifies control flow, classification, ordering, or return behavior. Keep it focused and do not let code substitute for answering the question in prose.
+
+## Final quality check
+
+Before responding, verify:
+
+1. Every part of the question is answered.
+2. No unsupported facts were added.
+3. Conditions, exceptions, ordering, and fallback behavior are explicit.
+4. Exact DSPy terminology and literals are preserved.
+5. Citations use supplied documentation page paths.
+6. The answer is concise and contains no irrelevant background.`;
+
 const DEFAULT_SYSTEM_PROMPT_URL =
   "https://raw.githubusercontent.com/stanfordnlp/dspy/main/docs/api/system_prompt.txt";
+const DEFAULT_ANSWERER = "anthropic/claude-sonnet-5"; // set after the A/B, see README
 const PAGE_CHARS = 30000;
 const CHUNK_CHARS = 2500;
 
@@ -132,26 +190,45 @@ async function pagesMode(messages) {
   const context = [...pages, ...rest].join("\n\n") || "(no results)";
 
   const history = messages.slice(0, -1);
-  const upstream = await fetch("https://openrouter.ai/api/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${env("OPENROUTER_API_KEY")}`,
-      "Content-Type": "application/json",
-      "HTTP-Referer": site,
-      "X-Title": "dspy-docs-chat",
-    },
-    body: JSON.stringify({
-      model: env("ANSWERER_MODEL", "anthropic/claude-sonnet-5"),
-      stream: true,
-      max_tokens: Number(env("MAX_TOKENS", 4000)),
-      temperature: 0,
-      messages: [
-        { role: "system", content: ANSWERER_SYSTEM },
-        ...history,
-        { role: "user", content: `## Retrieved excerpts\n\n${context}\n\n## Question\n\n${question}` },
-      ],
-    }),
-  });
+  const answerer = env("ANSWERER_MODEL", DEFAULT_ANSWERER);
+  const chat = [
+    { role: "system", content: answerer.startsWith("toast") ? ANSWERER_SYSTEM_TOAST : ANSWERER_SYSTEM },
+    ...history,
+    { role: "user", content: `## Retrieved excerpts\n\n${context}\n\n## Question\n\n${question}` },
+  ];
+  // toast-1 as the answerer: same Mixedbread key, no hosted tools (it only
+  // sees the pages above); anything else goes to OpenRouter
+  const upstream = answerer.startsWith("toast")
+    ? await fetch("https://api.mixedbread.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${env("MXBAI_API_KEY")}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: answerer,
+          stream: true,
+          max_tokens: Number(env("MAX_TOKENS", 4000)),
+          temperature: 0,
+          messages: chat,
+        }),
+      })
+    : await fetch("https://openrouter.ai/api/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${env("OPENROUTER_API_KEY")}`,
+          "Content-Type": "application/json",
+          "HTTP-Referer": site,
+          "X-Title": "dspy-docs-chat",
+        },
+        body: JSON.stringify({
+          model: answerer,
+          stream: true,
+          max_tokens: Number(env("MAX_TOKENS", 4000)),
+          temperature: 0,
+          messages: chat,
+        }),
+      });
   if (!upstream.ok) return upstream;
 
   // prepend a synthetic event so the widget can show what was searched/read

--- a/docs/api/chat.js
+++ b/docs/api/chat.js
@@ -26,6 +26,16 @@
 //   PAGES                default 3
 //   MAX_TOKENS           default 4000
 //   SYSTEM_PROMPT_URL    MODE=toast only; default is docs/api/system_prompt.txt on main
+//   ALLOWED_ORIGINS      extra browser origins allowed to call the endpoint,
+//                        comma-separated ("*" disables the check). The site's
+//                        own origin, DOCS_SITE and localhost previews always are.
+//   RATE_LIMIT_IP        requests per minute per client IP (default 10; 0 = off)
+//   RATE_LIMIT_GLOBAL    requests per hour across all clients (default 300; 0 = off)
+//   UPSTASH_REDIS_REST_URL + UPSTASH_REDIS_REST_TOKEN (or the KV_REST_API_URL +
+//                        KV_REST_API_TOKEN pair the Vercel Marketplace sets):
+//                        optional Redis REST endpoint that makes the rate limits
+//                        global across edge regions. Without it every edge
+//                        isolate counts in its own memory (best effort).
 
 export const config = { runtime: "edge" };
 
@@ -101,6 +111,111 @@ const env = (name, fallback) => {
   return v === undefined || v === "" ? fallback : v;
 };
 const stores = () => env("STORES", "dspy-docs,dspy-code").split(",").map((s) => s.trim());
+
+// ── abuse controls ───────────────────────────────────────────────────────
+//
+// The endpoint is public: the widget calls it from the docs pages with no
+// credential, so what bounds spend on the paid providers behind it is
+//   * the body limits in the handler (input size, history length, MAX_TOKENS),
+//   * an origin check: a browser request must come from the docs site itself,
+//     DOCS_SITE, a localhost preview, or ALLOWED_ORIGINS. Browsers set Origin
+//     and a web page cannot forge it, so this stops other sites embedding the
+//     widget. It is not authentication (a script can omit or spoof it), hence
+//   * per-client and global rate limits keyed on the client IP that Vercel
+//     sets (x-real-ip / x-forwarded-for are overwritten at its edge and cannot
+//     be spoofed). Counters live in Redis when a REST endpoint is configured,
+//     making the limits global; otherwise in the memory of each edge isolate,
+//     which still caps what any one isolate can spend.
+
+function corsHeaders(request) {
+  // null: Origin present and not allowed. {}: no Origin (not a browser page).
+  const origin = request.headers.get("Origin");
+  if (!origin) return {};
+  const allowed = env("ALLOWED_ORIGINS", "").split(",").map((s) => s.trim()).filter(Boolean);
+  let ok = allowed.includes("*") || allowed.includes(origin);
+  if (!ok) {
+    let host = null;
+    try {
+      host = new URL(origin).host;
+    } catch {
+      return null; // "null" (sandboxed/file: pages) or malformed
+    }
+    const own = [new URL(request.url).host, request.headers.get("x-forwarded-host"), request.headers.get("host")];
+    ok =
+      own.includes(host) ||
+      origin === env("DOCS_SITE", "https://dspy.ai").replace(/\/$/, "") ||
+      /^(localhost|127\.0\.0\.1)(:\d+)?$/.test(host); // mkdocs serve previews
+  }
+  return ok ? { "Access-Control-Allow-Origin": origin, Vary: "Origin" } : null;
+}
+
+function clientIp(request) {
+  const h = request.headers;
+  return h.get("x-real-ip") || (h.get("x-forwarded-for") || "").split(",")[0].trim() || "unknown";
+}
+
+const limits = () => [
+  { scope: "ip", n: Number(env("RATE_LIMIT_IP", 10)), window: 60 },
+  { scope: "global", n: Number(env("RATE_LIMIT_GLOBAL", 300)), window: 3600 },
+];
+
+function redisConfig() {
+  const url = env("UPSTASH_REDIS_REST_URL", env("KV_REST_API_URL"));
+  const token = env("UPSTASH_REDIS_REST_TOKEN", env("KV_REST_API_TOKEN"));
+  return url && token ? { url: url.replace(/\/$/, ""), token } : null;
+}
+
+// Upstash / Vercel KV REST pipeline: INCR the window-scoped key, expire it
+// once the window is over. Returns the count after this request.
+async function bumpRedis({ url, token }, key, windowSec) {
+  const r = await fetch(`${url}/pipeline`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify([["INCR", key], ["EXPIRE", key, windowSec * 2]]),
+  });
+  if (!r.ok) throw new Error(`redis ${r.status}`);
+  const [incr] = await r.json();
+  if (!incr || incr.error) throw new Error(incr?.error || "redis: bad reply");
+  return Number(incr.result);
+}
+
+// Per-isolate fallback. Keys carry the window index, so a stale entry is just
+// garbage; prune it once the map grows instead of resetting live counts.
+const buckets = new Map();
+function bumpMemory(key, expiresAt, now) {
+  if (buckets.size > 10_000) {
+    for (const [k, v] of buckets) if (v.expiresAt <= now) buckets.delete(k);
+  }
+  const b = buckets.get(key) || { n: 0, expiresAt };
+  b.n += 1;
+  buckets.set(key, b);
+  return b.n;
+}
+
+// Seconds the client should wait, or 0 when the request may proceed. Fixed
+// windows; the per-IP limit is checked first so a blocked client does not
+// eat into the global budget.
+async function rateLimited(ip) {
+  const now = Date.now();
+  const redis = redisConfig();
+  for (const limit of limits()) {
+    if (!(limit.n > 0)) continue;
+    const idx = Math.floor(now / 1000 / limit.window);
+    const key = `rl:${limit.scope}:${limit.scope === "ip" ? ip : "all"}:${idx}`;
+    const resetAt = (idx + 1) * limit.window * 1000;
+    let n;
+    if (redis) {
+      try {
+        n = await bumpRedis(redis, key, limit.window);
+      } catch (e) {
+        console.error(`rate limit store unavailable, counting in isolate memory: ${e.message}`);
+      }
+    }
+    if (n === undefined) n = bumpMemory(key, resetAt, now);
+    if (n > limit.n) return Math.max(1, Math.ceil((resetAt - now) / 1000));
+  }
+  return 0;
+}
 
 // ── mode: toast (toast-1 answers with the hosted store tools) ────────────
 
@@ -259,13 +374,16 @@ async function pagesMode(messages) {
 // ── handler ──────────────────────────────────────────────────────────────
 
 export default async function handler(request) {
+  const cors = corsHeaders(request);
+  if (cors === null) return new Response("origin not allowed", { status: 403 });
   if (request.method === "OPTIONS") {
     return new Response(null, {
-      headers: { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Methods": "POST, OPTIONS",
+      status: 204,
+      headers: { ...cors, "Access-Control-Allow-Methods": "POST, OPTIONS",
                  "Access-Control-Allow-Headers": "Content-Type" },
     });
   }
-  if (request.method !== "POST") return new Response("POST only", { status: 405 });
+  if (request.method !== "POST") return new Response("POST only", { status: 405, headers: cors });
   if (!env("MXBAI_API_KEY")) return new Response("MXBAI_API_KEY is not configured", { status: 500 });
 
   let messages;
@@ -276,23 +394,31 @@ export default async function handler(request) {
     if (!Array.isArray(messages) || !messages.length) throw new Error();
     if (messages.some((m) => typeof m.content !== "string" || m.content.length > 4_000)) throw new Error();
   } catch {
-    return new Response("body must be {messages: [...]} within size limits", { status: 400 });
+    return new Response("body must be {messages: [...]} within size limits", { status: 400, headers: cors });
   }
   // keep history bounded; roles/content only, drop anything else
   messages = messages.slice(-12).map(({ role, content }) => ({ role, content }));
+
+  const retryAfter = await rateLimited(clientIp(request));
+  if (retryAfter) {
+    return new Response("too many requests, try again shortly", {
+      status: 429,
+      headers: { ...cors, "Retry-After": String(retryAfter) },
+    });
+  }
 
   const mode = env("MODE", "pages").toLowerCase();
   let upstream;
   try {
     upstream = mode === "toast" ? await toastMode(messages) : await pagesMode(messages);
   } catch (e) {
-    return new Response(`chat backend error: ${e.message}`, { status: 502 });
+    return new Response(`chat backend error: ${e.message}`, { status: 502, headers: cors });
   }
   if (!upstream.ok) {
     const detail = await upstream.text();
-    return new Response(`upstream ${upstream.status}: ${detail.slice(0, 300)}`, { status: 502 });
+    return new Response(`upstream ${upstream.status}: ${detail.slice(0, 300)}`, { status: 502, headers: cors });
   }
   return new Response(upstream.body, {
-    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-store" },
+    headers: { ...cors, "Content-Type": "text/event-stream", "Cache-Control": "no-store" },
   });
 }

--- a/docs/api/chat.js
+++ b/docs/api/chat.js
@@ -1,0 +1,221 @@
+// Vercel Edge Function behind the docs "Ask AI" widget: POST /api/chat.
+//
+// The docs are deployed by mirroring docs/ into the dspy-docs repo that the
+// Vercel project builds, so this file ships with the site and is served on
+// the same origin as the pages (no CORS, no separate host). For local
+// previews run `node docs/api/dev.mjs` next to `mkdocs serve`.
+//
+// Two modes, both grounded in the dspy-docs and dspy-code Mixedbread stores:
+//   pages  (default) toast-1 agentic store search picks the pages, the
+//          function reads the full rendered Markdown of the top result pages
+//          from the docs site, and ANSWERER_MODEL composes the answer. This
+//          is the pipeline that won the docs-harness A/B.
+//   toast  toast-1 itself answers with the hosted store_search/store_grep
+//          tools and system_prompt.txt (fetched from the repo). Cheaper and
+//          needs only MXBAI_API_KEY.
+//
+// Environment variables (Vercel project settings):
+//   MXBAI_API_KEY        required
+//   OPENROUTER_API_KEY   required for MODE=pages (the answerer model)
+//   MODE                 "pages" (default) or "toast"
+//   STORES               default "dspy-docs,dspy-code"
+//   DOCS_SITE            default "https://dspy.ai"
+//   ANSWERER_MODEL       default "anthropic/claude-sonnet-5"
+//   PAGES                default 3
+//   MAX_TOKENS           default 4000
+//   SYSTEM_PROMPT_URL    MODE=toast only; default is docs/api/system_prompt.txt on main
+
+export const config = { runtime: "edge" };
+
+const ANSWERER_SYSTEM = `You are the DSPy documentation assistant. DSPy is the Python framework for programming, rather than prompting, language models.
+
+Answer the user's question using ONLY the retrieved documentation and source excerpts provided. Do not use outside knowledge. If the excerpts do not establish the answer, say plainly that the DSPy docs do not cover it instead of guessing.
+
+Style: concise Markdown; lead with the direct answer; keep exact DSPy names, parameters, and defaults as written in the excerpts; a short code example only when it helps; cite the documentation page(s) you used by their path (for example \`diving-deeper/react\`). No preamble, no restating the question.`;
+
+const DEFAULT_SYSTEM_PROMPT_URL =
+  "https://raw.githubusercontent.com/stanfordnlp/dspy/main/docs/api/system_prompt.txt";
+const PAGE_CHARS = 30000;
+const CHUNK_CHARS = 2500;
+
+const env = (name, fallback) => {
+  const v = typeof process !== "undefined" && process.env ? process.env[name] : undefined;
+  return v === undefined || v === "" ? fallback : v;
+};
+const stores = () => env("STORES", "dspy-docs,dspy-code").split(",").map((s) => s.trim());
+
+// ── mode: toast (toast-1 answers with the hosted store tools) ────────────
+
+let systemPromptCache = null;
+async function systemPrompt() {
+  if (systemPromptCache) return systemPromptCache;
+  const r = await fetch(env("SYSTEM_PROMPT_URL", DEFAULT_SYSTEM_PROMPT_URL));
+  if (!r.ok) throw new Error(`system prompt fetch failed: ${r.status}`);
+  systemPromptCache = await r.text();
+  return systemPromptCache;
+}
+
+async function toastMode(messages) {
+  const ids = stores();
+  const system = await systemPrompt();
+  const call = (storeIds) =>
+    fetch("https://api.mixedbread.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${env("MXBAI_API_KEY")}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "toast-1",
+        stream: true,
+        max_tokens: 2048,
+        messages: [{ role: "system", content: system }, ...messages],
+        tools: [
+          { type: "store_search", store_identifiers: storeIds },
+          { type: "store_grep", store_identifiers: storeIds },
+        ],
+      }),
+    });
+  let upstream = await call(ids);
+  if (!upstream.ok && ids.length > 1) upstream = await call(ids.slice(0, 1));
+  return upstream;
+}
+
+// ── mode: pages (toast-1 retrieval, whole-page reading, answerer model) ──
+
+async function pagesMode(messages) {
+  const question = messages[messages.length - 1].content;
+  const site = env("DOCS_SITE", "https://dspy.ai").replace(/\/$/, "");
+  const nPages = Number(env("PAGES", 3));
+
+  const search = await fetch("https://api.mixedbread.com/v1/stores/search", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env("MXBAI_API_KEY")}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: question,
+      store_identifiers: stores(),
+      top_k: 10,
+      search_options: { agentic: true, return_metadata: true },
+    }),
+  });
+  if (!search.ok) return search;
+  const chunks = ((await search.json()).data || []).map((c) => ({
+    path: c.external_id || c.filename || "",
+    text: c.text || "",
+  }));
+
+  const slugs = [];
+  for (const c of chunks) {
+    if (c.path.endsWith(".md")) {
+      const slug = c.path.replace(/\/index\.md$/, "").replace(/\.md$/, "");
+      if (!slugs.includes(slug)) slugs.push(slug);
+    }
+    if (slugs.length === nPages) break;
+  }
+  const pages = await Promise.all(
+    slugs.map(async (slug) => {
+      try {
+        const r = await fetch(`${site}/${slug}/index.md`);
+        const body = r.ok ? await r.text() : `(fetch failed: ${r.status})`;
+        return `### page: ${slug}\n${body.slice(0, PAGE_CHARS)}`;
+      } catch (e) {
+        return `### page: ${slug}\n(fetch failed: ${e.message})`;
+      }
+    })
+  );
+  const rest = chunks
+    .filter((c) => !(c.path.endsWith(".md") && slugs.includes(c.path.replace(/\/index\.md$/, ""))))
+    .map((c) => `### ${c.path.endsWith(".md") ? "page" : "source"}: ${c.path}\n${c.text.slice(0, CHUNK_CHARS)}`);
+  const context = [...pages, ...rest].join("\n\n") || "(no results)";
+
+  const history = messages.slice(0, -1);
+  const upstream = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env("OPENROUTER_API_KEY")}`,
+      "Content-Type": "application/json",
+      "HTTP-Referer": site,
+      "X-Title": "dspy-docs-chat",
+    },
+    body: JSON.stringify({
+      model: env("ANSWERER_MODEL", "anthropic/claude-sonnet-5"),
+      stream: true,
+      max_tokens: Number(env("MAX_TOKENS", 4000)),
+      temperature: 0,
+      messages: [
+        { role: "system", content: ANSWERER_SYSTEM },
+        ...history,
+        { role: "user", content: `## Retrieved excerpts\n\n${context}\n\n## Question\n\n${question}` },
+      ],
+    }),
+  });
+  if (!upstream.ok) return upstream;
+
+  // prepend a synthetic event so the widget can show what was searched/read
+  const trace = `data: ${JSON.stringify({
+    hosted_tool_calls: [
+      { id: "search-1", type: "store_search_call", queries: [question] },
+      ...slugs.map((s, i) => ({ id: `read-${i}`, type: "store_grep_call", pattern: `read ${s}` })),
+    ],
+    choices: [{ delta: {} }],
+  })}\n\n`;
+  const reader = upstream.body.getReader();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(trace));
+    },
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) controller.close();
+      else controller.enqueue(value);
+    },
+    cancel() {
+      reader.cancel().catch(() => {});
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
+
+// ── handler ──────────────────────────────────────────────────────────────
+
+export default async function handler(request) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      headers: { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Methods": "POST, OPTIONS",
+                 "Access-Control-Allow-Headers": "Content-Type" },
+    });
+  }
+  if (request.method !== "POST") return new Response("POST only", { status: 405 });
+  if (!env("MXBAI_API_KEY")) return new Response("MXBAI_API_KEY is not configured", { status: 500 });
+
+  let messages;
+  try {
+    const raw = await request.text();
+    if (raw.length > 32_000) throw new Error(); // bound input-token spend
+    ({ messages } = JSON.parse(raw));
+    if (!Array.isArray(messages) || !messages.length) throw new Error();
+    if (messages.some((m) => typeof m.content !== "string" || m.content.length > 4_000)) throw new Error();
+  } catch {
+    return new Response("body must be {messages: [...]} within size limits", { status: 400 });
+  }
+  // keep history bounded; roles/content only, drop anything else
+  messages = messages.slice(-12).map(({ role, content }) => ({ role, content }));
+
+  const mode = env("MODE", "pages").toLowerCase();
+  let upstream;
+  try {
+    upstream = mode === "toast" ? await toastMode(messages) : await pagesMode(messages);
+  } catch (e) {
+    return new Response(`chat backend error: ${e.message}`, { status: 502 });
+  }
+  if (!upstream.ok) {
+    const detail = await upstream.text();
+    return new Response(`upstream ${upstream.status}: ${detail.slice(0, 300)}`, { status: 502 });
+  }
+  return new Response(upstream.body, {
+    headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-store" },
+  });
+}

--- a/docs/api/dev.mjs
+++ b/docs/api/dev.mjs
@@ -4,6 +4,9 @@
 // (gitignored, KEY=value lines). Needs Node 18+.
 //
 //     node docs/api/dev.mjs
+//
+// The function's rate limits apply locally too (every request comes from
+// 127.0.0.1); set RATE_LIMIT_IP=0 in .env.local when hammering it from evals.
 
 import http from "node:http";
 import { readFileSync } from "node:fs";
@@ -38,7 +41,7 @@ http
     for await (const c of req) chunks.push(c);
     const request = new Request(`http://localhost:${port}${req.url}`, {
       method: req.method,
-      headers: req.headers,
+      headers: { ...req.headers, "x-real-ip": req.socket.remoteAddress || "unknown" },
       body: req.method === "POST" ? Buffer.concat(chunks) : undefined,
     });
     let response;

--- a/docs/api/dev.mjs
+++ b/docs/api/dev.mjs
@@ -1,0 +1,56 @@
+// Local dev server for the Ask AI backend: serves docs/api/chat.js on
+// http://localhost:8787 (override with PORT) so `mkdocs serve` previews can
+// use the widget. Keys come from the environment or docs/api/.env.local
+// (gitignored, KEY=value lines). Needs Node 18+.
+//
+//     node docs/api/dev.mjs
+
+import http from "node:http";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+try {
+  for (const line of readFileSync(join(here, ".env.local"), "utf8").split("\n")) {
+    const m = /^\s*([A-Z0-9_]+)\s*=\s*(.*?)\s*$/.exec(line);
+    if (m && !process.env[m[1]]) process.env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+  }
+} catch {
+  /* no .env.local; rely on the environment */
+}
+
+const { default: handler } = await import("./chat.js");
+const port = Number(process.env.PORT || 8787);
+
+http
+  .createServer(async (req, res) => {
+    const cors = {
+      "Access-Control-Allow-Origin": req.headers.origin || "*",
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    };
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, cors);
+      return res.end();
+    }
+    const chunks = [];
+    for await (const c of req) chunks.push(c);
+    const request = new Request(`http://localhost:${port}${req.url}`, {
+      method: req.method,
+      headers: req.headers,
+      body: req.method === "POST" ? Buffer.concat(chunks) : undefined,
+    });
+    let response;
+    try {
+      response = await handler(request);
+    } catch (e) {
+      res.writeHead(500, cors);
+      return res.end(`dev server error: ${e.message}`);
+    }
+    res.writeHead(response.status, { ...Object.fromEntries(response.headers), ...cors });
+    if (!response.body) return res.end();
+    for await (const chunk of response.body) res.write(chunk);
+    res.end();
+  })
+  .listen(port, () => console.log(`Ask AI dev server on http://localhost:${port}  (MODE=${process.env.MODE || "pages"})`));

--- a/docs/api/system_prompt.txt
+++ b/docs/api/system_prompt.txt
@@ -1,0 +1,61 @@
+You are the DSPy documentation assistant. DSPy is the Python framework for programming, rather than prompting, language models. You answer questions using only two attached stores:
+
+- `dspy-docs`: published pages from https://dspy.ai, including guides, tutorials, FAQ, cheatsheet, and rendered API reference. Paths may look like `diving-deeper/react/index.md`.
+- `dspy-code`: Python source files under `dspy/`.
+
+The input is a user’s natural-language question about DSPy. Return one concise, source-grounded Markdown answer.
+
+## Mandatory retrieval workflow
+
+Treat your memory as unreliable. Every factual statement in the answer must be supported by text retrieved during the current conversation.
+
+1. Your first action for every question must be `store_search` over `dspy-docs` using the user’s question. Do not write answer text before that search returns.
+2. If the first search is not useful, search again using alternate wording, relevant concepts, or likely page names before concluding that the topic is undocumented.
+3. For exact details—symbols, signatures, parameters, defaults, accepted values, types, return values, class or method names, errors, paths, or code—run `store_grep` over `dspy-code` or `dspy-docs` for the relevant symbol and read the complete definition or code block. Never rely on a search-result snippet alone.
+4. For tutorial or example questions:
+   - Grep the tutorial-specific class, function, variable, or distinctive phrase in `dspy-docs`.
+   - Read the surrounding code block in full.
+   - Reproduce the tutorial’s structure and code as written; do not replace it with a simpler API that merely appears equivalent.
+5. If documentation and source disagree, state the discrepancy briefly and show each documented/source behavior with its path.
+6. Use only retrieved material. Do not use outside knowledge, including knowledge of linked external articles beyond what the DSPy page itself says.
+
+## Accuracy and honesty
+
+- Never invent or infer signatures, arguments, defaults, implementations, examples, error messages, file paths, or feature behavior.
+- Do not infer that a feature does not exist from an empty search.
+- If repeated searches show that the retrieved documentation does not describe the requested topic, answer exactly:
+  `The DSPy docs don't cover <topic>.`
+  Then stop.
+- If a page gives only a short description of an external tutorial, report only that description. Do not extrapolate a full DSPy implementation from nearby pages.
+- A docstring describing behavior is not proof that a shown implementation performs that behavior. Inspect and quote the actual implementation.
+- Preserve exact capitalization, field names, annotations, instructions, defaults, and values from the retrieved source.
+- Distinguish dataset construction, declared output types, and downstream use; include each when the question asks for a comparison.
+
+## Answer style
+
+- Lead immediately with the direct answer.
+- Answer once. Do not provide a preliminary answer and then repeat it.
+- Use concise Markdown and include only details needed by the question.
+- Do not narrate retrieval or confidence. Avoid phrases such as:
+  - “The evidence is conclusive.”
+  - “The answer is now unambiguous.”
+  - “The source confirms…”
+  - “The tutorial explicitly gives the answer…”
+  - “I will state…”
+- Do not restate the question.
+- Do not add speculative “In DSPy terms…” implementation details.
+- Use a short code example only when the user asks how to do something or when the tutorial’s exact code is the clearest answer.
+- When quoting tutorial code, preserve it exactly except for clearly marked omissions that do not affect the requested behavior.
+- No greeting and no closing offer.
+
+## Sources
+
+Finish with exactly one source line:
+
+`Sources: <path>, <path>`
+
+Use only paths actually retrieved and used. Normalize documentation page paths by removing the trailing `/index.md`, for example:
+
+`Sources: tutorials/agents, dspy/predict/react.py`
+
+Do not fabricate a source-code path when the answer is supported only by documentation. Include all necessary supporting documentation and source paths, but no irrelevant ones.

--- a/docs/api/system_prompt.txt
+++ b/docs/api/system_prompt.txt
@@ -1,61 +1,71 @@
-You are the DSPy documentation assistant. DSPy is the Python framework for programming, rather than prompting, language models. You answer questions using only two attached stores:
+You are the DSPy documentation assistant. DSPy is the Python framework for programming, rather than prompting, language models. Answer only from material retrieved in this conversation from:
 
-- `dspy-docs`: published pages from https://dspy.ai, including guides, tutorials, FAQ, cheatsheet, and rendered API reference. Paths may look like `diving-deeper/react/index.md`.
+- `dspy-docs`: published pages from https://dspy.ai, including guides, tutorials, FAQ, cheatsheets, and rendered API references.
 - `dspy-code`: Python source files under `dspy/`.
 
-The input is a user’s natural-language question about DSPy. Return one concise, source-grounded Markdown answer.
+## Mandatory retrieval
 
-## Mandatory retrieval workflow
+Your first action for every question must be a `store_search` over `dspy-docs` using the user’s question. Do not write answer text before that search returns.
 
-Treat your memory as unreliable. Every factual statement in the answer must be supported by text retrieved during the current conversation.
+Decompose the question into the claims required for a complete answer and retrieve support for each claim. Do not stop after finding only the main topic. As relevant, verify:
 
-1. Your first action for every question must be `store_search` over `dspy-docs` using the user’s question. Do not write answer text before that search returns.
-2. If the first search is not useful, search again using alternate wording, relevant concepts, or likely page names before concluding that the topic is undocumented.
-3. For exact details—symbols, signatures, parameters, defaults, accepted values, types, return values, class or method names, errors, paths, or code—run `store_grep` over `dspy-code` or `dspy-docs` for the relevant symbol and read the complete definition or code block. Never rely on a search-result snippet alone.
-4. For tutorial or example questions:
-   - Grep the tutorial-specific class, function, variable, or distinctive phrase in `dspy-docs`.
-   - Read the surrounding code block in full.
-   - Reproduce the tutorial’s structure and code as written; do not replace it with a simpler API that merely appears equivalent.
-5. If documentation and source disagree, state the discrepancy briefly and show each documented/source behavior with its path.
-6. Use only retrieved material. Do not use outside knowledge, including knowledge of linked external articles beyond what the DSPy page itself says.
+- recommended workflow, ordering, rationale, and tradeoffs;
+- signatures, accepted inputs and containers, defaults, and replacement mechanisms;
+- call binding, invocation mechanics, concurrency, and output shape;
+- failure branches, retries versus immediate propagation, exception types and catch behavior;
+- stage inputs, transformations, outputs, ordering, and aggregation;
+- mutation, copying, resetting, and returned-object behavior;
+- construction-time work versus work repeated on each call;
+- state preserved, changed, omitted, or requiring reconfiguration;
+- artifact origin and whether reasoning, labels, instructions, weights, demonstrations, or other fields are added;
+- dataset roles, overlap or leakage constraints, and separation of final evaluation data;
+- training, deployment, and compute implications.
 
-## Accuracy and honesty
+For exact details—identifiers, signatures, parameter types, defaults, accepted values, return behavior, mutation semantics, errors, paths, or code—run `store_grep` over `dspy-code` or `dspy-docs` for the relevant symbol. Read the complete definition and surrounding documentation rather than relying on snippets. Search both stores when necessary. If retrieval is insufficient, retry with symbol names, related methods, headings, and alternate conceptual terms before concluding that the topic is undocumented.
 
-- Never invent or infer signatures, arguments, defaults, implementations, examples, error messages, file paths, or feature behavior.
-- Do not infer that a feature does not exist from an empty search.
-- If repeated searches show that the retrieved documentation does not describe the requested topic, answer exactly:
-  `The DSPy docs don't cover <topic>.`
-  Then stop.
-- If a page gives only a short description of an external tutorial, report only that description. Do not extrapolate a full DSPy implementation from nearby pages.
-- A docstring describing behavior is not proof that a shown implementation performs that behavior. Inspect and quote the actual implementation.
-- Preserve exact capitalization, field names, annotations, instructions, defaults, and values from the retrieved source.
-- Distinguish dataset construction, declared output types, and downstream use; include each when the question asks for a comparison.
+For tutorials and examples:
 
-## Answer style
+- Grep the named class, function, or heading in `dspy-docs`.
+- Read the complete relevant section, including subsequent explanation and inspection steps.
+- Reproduce requested tutorial code faithfully rather than silently simplifying it.
+- Distinguish what an example demonstrates from guarantees of the general API.
 
-- Lead immediately with the direct answer.
-- Answer once. Do not provide a preliminary answer and then repeat it.
-- Use concise Markdown and include only details needed by the question.
-- Do not narrate retrieval or confidence. Avoid phrases such as:
-  - “The evidence is conclusive.”
-  - “The answer is now unambiguous.”
-  - “The source confirms…”
-  - “The tutorial explicitly gives the answer…”
-  - “I will state…”
-- Do not restate the question.
-- Do not add speculative “In DSPy terms…” implementation details.
-- Use a short code example only when the user asks how to do something or when the tutorial’s exact code is the clearest answer.
-- When quoting tutorial code, preserve it exactly except for clearly marked omissions that do not affect the requested behavior.
-- No greeting and no closing offer.
+## Workflow and lifecycle checks
 
-## Sources
+For optimizers, compilation, persistence, loading, evaluation, agents, or other multi-stage workflows, trace every requested stage end-to-end and distinguish:
 
-Finish with exactly one source line:
+1. what each stage optimizes, evaluates, or transforms;
+2. its documented default component and substitution mechanism;
+3. work performed during construction versus on every invocation;
+4. whether supplied objects are mutated, copied, reset, or replaced;
+5. the exact artifacts and fields in returned, aggregated, or saved results;
+6. search-time machinery versus state retained in the final result;
+7. configuration omitted from persistence and any reconfiguration required after loading;
+8. failure paths, including which failures are retried, converted, recorded, or propagated immediately.
 
-`Sources: <path>, <path>`
+For persistence compatibility checks, name the exact saved field supplying version information and include the warning’s documented consequences and recommended user action.
 
-Use only paths actually retrieved and used. Normalize documentation page paths by removing the trailing `/index.md`, for example:
+Never imply that candidate pools, feedback machinery, callbacks, client configuration, demonstrations, submodules, or other state transfers between stages or survives persistence unless retrieved documentation or source explicitly says so. Do not confuse optimization machinery with state stored in the compiled result.
 
-`Sources: tutorials/agents, dspy/predict/react.py`
+For API questions, provide the relevant contract: accepted inputs, processing and call mechanics, significant defaults, output shape, optional failure information, aggregation behavior, and documented exceptions. For data-splitting questions, identify each split’s role and preserve an independent final evaluation set when required by the retrieved material. For recommendations comparing prompt optimization, fine-tuning, or other costly stages, state both the documented order and its rationale, including relevant compute, training, and deployment tradeoffs.
 
-Do not fabricate a source-code path when the answer is supported only by documentation. Include all necessary supporting documentation and source paths, but no irrelevant ones.
+## Honesty and scope
+
+- Support every factual statement about DSPy with retrieved text.
+- Never invent signatures, types, parameters, defaults, accepted values, return behavior, mutation semantics, state transfer, errors, paths, or examples.
+- Do not infer nonexistence from an empty search.
+- If repeated searches do not document the requested topic, answer exactly: `The DSPy docs don't cover <topic>.` Then stop; do not speculate, offer an undocumented workaround, or add tangential findings.
+- If documentation and source disagree, describe both precisely and cite both.
+- Before answering, check that every requested part is covered. Omit unsupported embellishment rather than substituting generic knowledge.
+
+## Answer format
+
+- Write one direct, concise Markdown answer.
+- Lead with the conclusion or recommended workflow.
+- Do not greet, restate the question, narrate retrieval, announce confidence or evidence, use meta-transitions, repeat the conclusion, or add a closing offer.
+- Preserve exact DSPy identifiers and retrieved values.
+- Use code only when requested or when the documented example is the clearest explanation.
+- Clearly distinguish documented behavior from source-level implementation details.
+- End with exactly one source line listing every page and source file materially used:  
+  `Sources: <docs path>, <source path>`
+- Format documentation paths without `/index.md`.

--- a/docs/docs/js/toast-chat.js
+++ b/docs/docs/js/toast-chat.js
@@ -588,6 +588,8 @@
       body: JSON.stringify({ messages: history }),
     })
       .then(function (resp) {
+        if (resp.status === 429) throw new Error("too many questions in a short time. Please wait a minute and try again.");
+        if (resp.status === 403) throw new Error("this page is not allowed to use the docs chat.");
         if (!resp.ok) throw new Error("proxy returned " + resp.status);
         var reader = resp.body.getReader();
         var dec = new TextDecoder();

--- a/docs/docs/js/toast-chat.js
+++ b/docs/docs/js/toast-chat.js
@@ -1,0 +1,709 @@
+// DSPy docs "Ask AI" chat, powered by Mixedbread toast-1.
+// Loaded on every page via mkdocs.yml extra_javascript. The widget streams
+// answers from docs/api/chat.js, which holds the API keys and grounds answers
+// in the dspy-docs + dspy-code Mixedbread stores.
+//
+// Layout mirrors the "Ask DSPy" modal the site shipped before (centered
+// 800px dialog, gray footer, gray-tinted user turns) so the change is the
+// engine, not the UI. Theme follows Material's data-md-color-scheme.
+(function () {
+  "use strict";
+
+  // Backend: the Vercel Edge Function shipped with the site (docs/api/chat.js)
+  // on the same origin. Override with window.TOAST_CHAT_ENDPOINT (set from
+  // extra.toast_chat_endpoint in mkdocs.yml) to use an external proxy. Under
+  // `mkdocs serve` the widget targets the local dev server, since mkdocs does
+  // not run the function.
+  var ENDPOINT =
+    window.TOAST_CHAT_ENDPOINT ||
+    (location.hostname === "localhost" || location.hostname === "127.0.0.1"
+      ? "http://localhost:8787" // `node docs/api/dev.mjs`
+      : "/api/chat");
+
+  // Logos inlined as data URIs so the widget makes no external asset requests.
+  var DSPY_LOGO = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4gPHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZlcnNpb249IjEuMSIgdmlld0JveD0iMCAwIDIwMDAgMjAwMCI+IDxkZWZzPiA8c3R5bGU+IC5jbHMtMSB7IGZpbGw6ICNlZjQwMzY7IHN0cm9rZS13aWR0aDogMHB4OyB9IDwvc3R5bGU+IDwvZGVmcz4gPHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTI5OS4yOCwxOTMxLjA4Yy0zOS43MywwLTcyLjA4LS4yNi05Mi41OC0uODktMTExLjk0LTMuNDQtMzAxLjQ2LTMuNDgtNDMwLjgyLTEuNzMtOTMuNzgsMS4yNy0zNzIuOS04LjE2LTUzOS42Ny0xMy43OS01OC4xLTEuOTYtMTA4LjI3LTMuNjYtMTE1LjM5LTMuNjZoLTMuMzdjLTI0LjQzLS4wNy04MS4zOC4yMy04OC40NS03Ny40Ni0yLjAzLTIyLjI2LS43Ni0xNzQuNDgsMS42Ni00NDEuNTksMS41OS0xNzUuOSwzLjM5LTM3NS4yOCwzLjM5LTUwMy4xMywwLTI4MS41OSwzLjQ1LTYzOS4yNiw1LjI1LTcxOC4yOS41OS0yNS43OCw0LjI5LTU0Ljc2LDI3LjI5LTc0LjI0LDE4LjY1LTE1Ljc4LDM5LjkzLTE3LjIxLDYwLjUxLTE4LjU4LDguODgtLjU5LDE4LjA3LTEuMjEsMjguNjctMi44Niw0Mi40My02LjYzLDI1Mi4wNC02LjA4LDUyMS42Ny00LjY4LDY0LjY1LjM0LDEyNS43Mi42NSwxNjkuMzguNjVzMTE3LjEyLS4zMiwyMDEuODgtLjY5YzI3Ny4wMi0xLjIsNjU2LjQxLTIuODUsNzMzLjE5LDIuNTQsMTQuNjMsMS4wMywyOCwxLjY5LDQwLjkzLDIuMzQsMzkuNDcsMS45Nyw3MC42NSwzLjUzLDk1Ljc4LDE0LjIxLDI0Ljg5LDEwLjU3LDU0LjM1LDM0Ljc5LDUzLjM2LDkwLjExLTEuMTksNjYuNTUtLjc0LDI4NS43NS0uMzUsNDc5LjEzLjE4LDg5LjUxLjM1LDE3NC4yMS4zNSwyMzcuMzQsMCwxNDQuMS01LjI3LDU0NS40OS04LjQzLDc4NS4zMS0xLjE4LDkwLjI2LTIuMDQsMTU1LjQ3LTIuMDQsMTY0LjA3LDAsMTUuMiwwLDQ2LjgzLTI3LjA2LDY2LjA2LTE4LjUzLDEzLjE3LTQwLjksMTQuMjItNjguMjIsMTQuMjItMTEuMzUsMC01Mi42NS41NC0xMDkuOCwxLjI4LTEzMS45NywxLjcyLTMzMS40OCw0LjMyLTQ1Ny4xNSw0LjMyWk05NTYuOTIsMTgzNy41NmM5Mi4zMiwwLDE4NS45My44NiwyNTIuNTUsMi45MSw4My4zNiwyLjU2LDM4NC4xOC0xLjM2LDU0NS43OS0zLjQ3LDU3LjUtLjc1LDk5LjA0LTEuMjksMTEwLjk3LTEuMjksMi4wMywwLDMuODktLjAxLDUuNTktLjAzLjIzLTIyLjI4Ljk2LTc4LjE0LDEuOTgtMTU1Ljc1LDIuOTQtMjIzLjg5LDguNDItNjQwLjYyLDguNDItNzg0LjEzLDAtNjMuMDgtLjE3LTE0Ny43Mi0uMzUtMjM3LjE1LS4zOS0xOTMuODEtLjg0LTQxMy40Ny4zNi00ODAuOTIuMDUtMy0uMDktNS4xNC0uMjctNi41OC0xMC42NC0zLjg0LTM5Ljc5LTUuMjktNjMuNjEtNi40OC0xMi43NC0uNjQtMjcuMTktMS4zNi00Mi43My0yLjQ1LTczLjQ1LTUuMTYtNDY2LjQ2LTMuNDYtNzI2LjUyLTIuMzItODQuODYuMzctMTU4LjE2LjY5LTIwMi4yNy42OXMtMTA1LjA4LS4zMi0xNjkuODUtLjY1Yy0xODYuNjMtLjk3LTQ2OC42NS0yLjQ0LTUwNy4zNSwzLjYxLTE0LjUyLDIuMjctMjYuNzQsMy4wOS0zNi41NSwzLjc0LTEuMjQuMDgtMi41NC4xNy0zLjg1LjI2LS4wOCwxLjQ4LS4xNCwzLjE1LS4xOSw1LjAzaDBjLTEuNzksNzguNjktNS4yMyw0MzUuMjYtNS4yMyw3MTYuMjYsMCwxMjguMjUtMS44LDMyNy44NS0zLjQsNTAzLjk0LTEuNzQsMTkyLjg3LTMuNTQsMzkxLjk5LTIuMjQsNDI4LjQ5aDIuNjNjOC4yNywwLDQ0LjI3LDEuMiwxMTguNDIsMy43LDE1NS4wOSw1LjI0LDQ0My43OSwxNS4wNCw1MzUuNDMsMTMuNzUsNTMuNjctLjczLDExNy42NS0xLjE0LDE4Mi4yNS0xLjE0WiIvPiA8cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik01MTcuODksMTI1OC4zNWMtNTAuODMsMC04Ny40OC02LjkyLTExNS41Mi0yMS40MS00MS4zNS0yMS4zNy02My43Ni01OC4zMi02OC41MS0xMTIuOTctMy4xOS0zNi43LDEuNS02OS4wMiw4LjIxLTk0LjUtMjMuMDUtMi44Ni01MC4xMy01LjcxLTc0LjY4LTctNTguMS0zLjA3LTE4NS43NSwxLjU5LTE4Ny4wMiwxLjYzbC0zLjMxLTg5LjdjNS40LS4yLDEzMi45NS00LjgzLDE5NS4wNS0xLjU3LDYyLjU1LDMuMywxMzYuNDIsMTUuMjksMTM5LjUzLDE1LjgsMTQuODIsMi40MiwyNy42MiwxMS43OSwzMy44MiwyNS40Niw2LjIsMTMuNjcsNS4zMywyOS4yNC0yLjYxLDQxLjk4LS4wNy4xMy0yNC41Myw0My4wMy0xOS41NiwxMDAuMTIsMi44LDMyLjIxLDUuMjIsNjAuMDYsMTM5LjM5LDUwLjY3LDM2LjQtMi41NCw0Ni44LTE2LjI5LDUwLjIyLTIwLjgxLDIyLjU4LTI5Ljg3LDkuNC05Mi43MywzLjc4LTExOS41N2wtLjkzLTQuNDVjLTYuMTgtMjkuODQtMS4xMi01My42NSwxNS4wMy03MC43NCwyNS4xMS0yNi41OCw2MS4yNS0yMS4yMiw4Ny42Mi0xNy4zMmw1LjguODVjNy40NCwxLjA2LDI1LjM2LDMuODksNTIuNDksOC4xNyw5NS4xMSwxNC45OSwyOTMuMDIsNDYuMTksMzY1Ljg1LDUyLjM2LDQ3LjIzLDQsOTUuMjIsMy44MSwxMzAuMTgsMi43MS0xLjU1LTguMDgtMy0xNi42Ny00LjIxLTI1LjU0LTkuMjUtNjcuODEuMDMtMTE1LjA2LDI4LjM2LTE0NC40NCw1Ny4yNy01OS4zOSwyMDkuNjQtODUuMTIsMjk5LjI3LTI5LjM2LDY2LjM5LDQxLjMxLDU4LDEyNi45Myw0MS4yLDE4Ny43NCwxMTUuNjQtNi43OCwyODIuNTUtMjYuMDgsMjg0LjU5LTI2LjMybDEwLjM2LDg5LjE2Yy0xMC4yOCwxLjItMjUyLjg3LDI5LjI1LTM1OS44NiwyOS4yNS0xNS4zOSwwLTI5LjctNy44OC0zNy45My0yMC44OC04LjIzLTEzLTkuMjItMjkuMzEtMi42My00My4yMiwyMi43Ni00OC40Myw0MC4yMS0xMjQuOTgsMTYuODUtMTM5LjUyLTIzLjk2LTE0LjkxLTYyLjU4LTIwLjg3LTEwMy4zNC0xNS45NS00MS42OCw1LjAzLTcyLjcxLDE5LjgxLTgzLjg5LDMxLjQtMy4yNywzLjM5LTEwLjM4LDIyLjM3LTQuMTksNjguOTIsNC43MiwzNS40NCwxNC41Nyw2Ni45MSwxNC42Nyw2Ny4yMiw0LjEsMTMuMDEsMi4wOCwyNy4yMS01LjUzLDM4LjU0LTcuNiwxMS4zMy0xOS45NCwxOC42MS0zMy41MywxOS43NC00LjA3LjM0LTEwMC44OSw4LjIzLTE5Ny45NiwwLTc2LjA0LTYuNDQtMjc2LjEtMzcuOTgtMzcyLjI1LTUzLjEzLTI1Ljc4LTQuMDYtNDQuNDEtNy01MS4yLTcuOTdsLTMuOS0uNTdjMy41LDE4LjAxLDcuMzMsNDEuODIsNy43NSw2Ny4wNi43NCw0NC45NC05LjYzLDgxLjk1LTMwLjg0LDExMC0yNS41MSwzMy43NC02NC4zOSw1Mi42Ny0xMTUuNTgsNTYuMjQtMTguNDYsMS4yOS0zNS40MiwxLjk0LTUxLjA0LDEuOTRaTTcwMi45NCw5OTguODFoMHMwLDAsMCwwWiIvPiA8cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik0xMDE3LjgyLDE4ODYuNTJsLTg5Ljc3LS42NmMuMDItMi4yNCwxLjYyLTIyNC45OC4wMy0yNjcuOTItLjUyLTEzLjg4LTIuMDgtNTYuMTIsMzAuODEtNzguNjksMzEuODgtMjEuODksNzIuMzktOS4wOCwxMDQuMTEsNC41MSwzMy42MSwxNC40MSw2Ny45NiwxNy4yNSw4Ny41Miw3LjI1LDcuNTQtMy44NSwxOC4xOS0xMS44NSwyMy43Ny0zNi42OSwxMy40LTU5Ljc4LDEuOTMtMTE1Ljk5LTE2LjMyLTE0MC42Mi04LjQ5LTExLjQ2LTE1LjExLTExLjk1LTE3LjI4LTEyLjEyLTQ1LjQ2LTMuNC0xMTAuNjUsMTYuOTgtMTMxLjk1LDI1LjEyLTIwLjgsNy45Ni00NC4zNC0uNTMtNTUuMjItMTkuOTYtNS4yLTkuMjYtMzAuODMtNjIuMjctMjUuNTUtMTk2LjQ3LDMuMzktODYuMzUsMjYuNzQtMjMzLjIsNDMuNzgtMzQwLjQyLDYuOTMtNDMuNTcsMTQuMDctODguNTEsMTUuMzgtMTAyLjk5LTQzLjA4LDYuNjYtMTAxLjUzLDIuMjktMTQ0Ljk4LTMwLjE1LTI1LjYxLTE5LjEyLTU2Ljg5LTU2LjI0LTYwLjQ4LTEyNC41MS0zLjUyLTY2LjksMTAuNDYtMTIwLjA5LDQxLjU1LTE1OC4wOSwzMi45Ny00MC4zLDc0LjctNTAuNzMsOTYuNjQtNTMuMzcsMjUuNzUtMy4xLDUwLjY2LS4yMyw3MC41NSwyLjczLDQuNjktNTIuMDYsNy44Ny0xNTcuNjUsOC4zOC0yNDguNjlsODkuNzcuNWMwLC43NC0uNDQsNzQuODctMi45MSwxNDguNDUtMS40Niw0My42Ni0zLjM2LDc4Ljc3LTUuNjIsMTA0LjM0LTMuNDksMzkuNC03LjEsODAuMTQtNDUuNzYsODcuODMtMTQuNzIsMi45Mi0zMC4xOC41Mi00OC4xLTIuMjctMTcuNzMtMi43Ni0zNy44Mi01LjktNTUuNjEtMy43Ni00MS4zMiw0Ljk2LTYyLjkyLDQ3LjgzLTU5LjI0LDExNy42MSwxLjQzLDI3LjI5LDkuNDYsNDYuMDQsMjQuNTUsNTcuMjksMjQuMDgsMTcuOTgsNjQuODIsMTYuODIsODYuMzQsMTEuNjYsMTIuNDktMi45OSw0NS42Ny0xMC45Niw3MS41NCwxMC4zNywyNS44NywyMS4zMiwyNC40OCw1My4xOSwyMy4yNiw4MS4zLS42NSwxNS4wMy02LjE0LDUwLjA2LTE2LjYsMTE1Ljg0LTE1Ljc1LDk5LjA4LTM5LjU1LDI0OC44Mi00Mi43NCwzMjkuODYtMi4wOSw1My4yMiwxLjMyLDkwLjE2LDUuNCwxMTQuMSwzNC4xNC05LjM5LDgxLjU2LTE5LjAyLDEyNC4zMy0xNS44MywzMi41NSwyLjQ0LDYxLjE0LDE5LjEsODIuNjksNDguMTksMzcuMTcsNTAuMTYsNDkuNjUsMTM0LjA0LDMxLjc5LDIxMy43LTEyLjc1LDU2Ljg4LTQ1LjM3LDg0LjEzLTcwLjQ5LDk2Ljk4LTY0LjY3LDMzLjA3LTE0MS42OSw0Ljc5LTE2My43NS00LjY3LTMuNjEtMS41NS02LjgyLTIuODMtOS42NC0zLjksMS4zLDU3Ljg5LS4xMywyNTUuMzUtLjE5LDI2NC4xNVoiLz4gPC9zdmc+";
+  var MXB_LOGO = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAABHCAYAAADP00/HAAAW/UlEQVR42u2dC1xUddrHf6kgICCaCqKpqZWheUXNW/q+3hXB3rfb1l7ai7uV225ubqV5gVLbVExNURRU5I6Z99Q0TVNXy/KSrhdk5sx98Ipyse19d9vf/zBnODPMACLEMHY+n+czgsVw/H2f3/M8//M/ZwAPOc7kwLckEwNvb8DvSjbgDcbrjOdKctAG9fgwPI3m1okYbo3G760T8JplAl60xqB/ztNoiJ8OgKI/QJETvsvBze824AcX8W/+3Y6iHDxWn86LQne1xGA9hb+aH42bzsHv5/Lv3yQg/ves+Ldz8FsKXOxGeMfIwffCHerBad1HcadR5BuuhHcBwllTNHrde+JvwLQqCe8Uojx4tPgxWF0V4Z0gMJtjMOSeEb84CzHVEd/mBP+6nYnhHmn70Zh9p+LbIZgASRqN1l4vviEH/sx+c3UBKMnCyZL1OHp5OQI96bzM4xCZH4OC6gIgQxCDld5v/dmYVB3h2S/8syQVn1P8fzN+KErBm550XszgTXcjvg2Aa5axaOntjd+ndyx+Ji5S9EtCeCWK1+NbTzknfTTC71Z8JTgZ/NKrAWANL7xjy09BsVp8W/zbU8qANQrP1xQAbAgXe634tzLQ4o4yPxvnKXShC/HluLkWD3kEANH4MxtAXQ0BkOG1ABSuR6sqi5+FC7T56+7Et5WBSI/o/qMQbxkPA1+3EgT9XQKQ5rUAHE+Ej7yyV7n42krFXwvTzdV43BPOK388ZlrGUfzxkAiBAGE7hfy7aOruGIIYLPf2JlBbie3fdm74HIRPgaEwEV8UrcC/CpfjfzxiBByLOdbxyGXksR/YRBDO8fUyQyO7wgQc4JRwuYrrAa96OwCJFTZ9qTjoVvwkWfh/Mn6QYzmmeAQAw/GRZQS+tYzCR9ax2EsQJKsQfhxO2UC4TCi0BGErncFaEQDm8XjUqwEoykFPd2WAHf9xd+IXrsYBu/BKJGCdRwAwCJvNw7DOMpyCj6ATjMBmzvNf20DYxFezAgL/fJp9wnE3AHxyTywF0wXWurJ+2rvJlfhFyTjqLP6tBFy7tQgb+ePuq9MG8HF0MA/GJ5bBSDYPwX7zUKQLCOgKJ61j8HG+EH88DrEUfG2HIIqQROOE8yKQMQo97gkALucg8LscnHXI/nR5la+8+Cm4UrgC19TiFy7DuVvxuMz44cYCDKvLczFG4hfmx7HCPBCbCMAOwrCRbpBmc4Jcy0hk55c6wBmWgLMqCE7SCQz2BaBo/Ar30lGYg5Z0gmOy+Nlyx+9y3qf4h53Ev3AzHoVCfBmAuVhYV+ewH2hk6oMl5r44wNjPUpBEAI4x0ukEqXYIxmCDDYK9bPLy7RBM4NfsCe458dVjYUkO3ipOxU6X2b8Ol0W3b7f95bhxayFMQvibC/H/BXE4UhCLH67FYlSdLAF3RoyxE7YYH8MiGwQHzAOwwjQIR+gGm03DkKmUAzaB/xAQ8HWHvTGMwjbJ25u+qhzXliKYc/+kkhRksA/4hn/O5+u1oiR8QuGL7QAswhF75r+DQ0J8ETdmQ3v+Nwj6MX9nDdBeCsTb+o7YSAi2Gx7BfDsEg7DRNBjZlic4CQzHP2QXGIUcq5gEorCemZ9IAIbjp6OKXXYsAgo+RGTBQkxn5l+4MQf7FfFlB3gdn139I45ZXv1xrqRdRNOOecBbkg/SND6I17VHmgxBBOYb+2Kevi+e0PZFmNKgHu8DnzPDPOvydb0+rsdiHIU/L8S//gYOXPsj/s8WmvzJGFBb75sDNNQieLQGQdMlBK7SArMEBNrGeF/XCa9eeBgtflKnug3VMDZU0XhEbI2yTMQw65PoduZp+Lr77w1T4H99OuZdnYzbCgBXJqMg/wV8y/jY9BQGip9ZM3bfKlSHoCgtAmN1CJktIXi5FkHTJDRJ0qDB63m+FW9YPY2mzfLQ4uGLaP2oFmEdjiM84CfFlTk6GuMtMdjAsFonokAdBOEygUg3T8REd2JS9Fmy+K/gRv7P8ffLL6Ao/zk2XTG4Yo7GZjZdC8wj8ZJ+IEYZe+BhSy+0jAUauPpZ4vsngBBNYzySB7/BFPnXFHsyxV+pDrpAHL8fTyBeuoAgl1mfi7CWGoQ9pUHouxLCljoHQXiDYI08jxZB96Tw5ij0psB7nUWvIE7QIaJd/ayrL+F9in9KiG99HhLFPyNCbLa0jMU28wjO5gOxy9QLGeaeOMuuPVUfhjX6FnhHF4LZuiCkaH0xjXaeqW2EWE0DvE2Ln8MMX6NBk786AyCCALxzCoGtnH+XI2jrr0Xoc1q0XuJKeOfQoHU8IZlwBu7dzvvEj8ZLFP/qHYivdoVkwhPgBFMAxT8niz8R31D8U3SWC5YJ0FlG45R5GL7geHbJ1AM7bQCs04Vjt64lFhOApbom2Kb1Q5zOB1maRpjBoPgB0wUAWjR5zxUAdIFyVyLzEN5OQvg7VRG+PAhhM3PRpq33W34M4qojvAMEMdiXOxbBDj/3GYzj908TgGN8lSi+xTwaBywjsZ0z+Uem/rho7oHTMgBdmP2tcUh3PxbrQ7BMAKDxwxwBAJ0glgAsVAAohSB4iZP4r5UXv+1DIpurI74KgvkX0aqj14pP8V69W/FVTlDuOoBwB2sMblB8yTyGWT8Kh5n9500DsMfYj6WA4ovg7J6hACAFY7nsAP74mwCAZSCeAFDIxgvLAGjyhqMDNO3o3CRSvAV3I35ZbxA6LxfNg70x8yNEY1ZTANggeNGptEyyjGHGj4KRcVCIb34Cm2n/krEnUoX4pp7YbWiPdAGA/n4sowMkyQA0wSKKn8FI1/qAIvulUvx4GwCLNQheVpr9gbPLj4atp9WE+Kp4xRsB2FGT4tsA0GqHwc9+YWY4u/zRLAEjsMU8FFqK/wmbvzxh/xT+sGz/XbGWAKyWHaA5VrMHWCcA0AUgkQ3g+3IfQBfQonEChZ9W5gJBsgtoEPi0Y/a3fqKGxbeVg1bdvUZ8ce9bTYtvhyAaDoJYhuIcw8DYSes/L7Jf3xtZxu5YL3oAQ2fsNLRDos0B0hUApECkiQlABsAXMyU0YjPnH68AYINgWi4Ceqvfj+PcrNoBIOyPPzV+VXOBdU4AZDPzc5j5khDf1BeZpq44xwkgzdgNKcYO+FofjiwbAFul5siwAfCx1IhjoWgEG2KFBpguyoAWAbFqCDQIekR5r0sIf6A2xC/tBVp/4DWjoTkGe2oRAIcbRJj1GUJ4hsYUiQxZfIZwAENHfGbowGiNw/owfG5ojr10gFS5BIhJoAFWCQBkFwCmCgAY85xcoEvZYk+bAWzaXhOLOozZNdUIKpGHNg97hwNMhFRbAIjgSNjYDsBAZFL8fxi6Y7Mivgh9Z1v2t0eSyH4pFB8LAKRmyFQAkO7DR2wCF8ku4IMPbACwGfSbzuYvUQBwCYHdyup/2DM6hK1QgqLNJxAf1JwLhD7uFQBQpBu1CYD1SdhX5Iy9MM/QDcfU4psisEmIL0Kp/1JLJNscYJvdARqW9gFSQyRpG2BWHhqvKINA9AOB7AsC7PfySwj9jRqAUghCP6R48YTjrzXQCI70Fge4VpsASBPwoB2ArkhRi8+vT9L6dygA6NsgUwagFRIEAPpm2M36L68FiO6fZUBMA3E6+GTr0GiWAoASGvj3qwgAJVjD37t7B2g12luaQF1tAmCOQhcVAGsdrP8hrLVnfwfskps/MQK2xBLZAZphi+RP2y9dDp4nyoAGjWYIACT4pElovEgNgBY+/csAaPWCOwAoIMfI0Cl5CI+rfg8QNs5bSsDJ2gTAEA37zEzRV9uzPwLZivgyAO2xyg7A/VgsA9AU2brG2C41Qarkh7mlADR4t9QBBAQNKaTfyrJS4Pto2QgYHuMOgDIQWk+/88xvPosl6A86Py/ZNWSNxiq6wPlamwQmoK/dASIwVxb/UWQZHsSXquz/uy4cW1UAKA6QJgMQgKVaf7wvAOA/fjKzP6MMAp+FhGCdACAXZdcgJLQcWxkA7AVeF2v8VRPe/09SEKbqgxEvQgrBk14BQP54HLBGQW+dgM01vRwsl4AY2GulIQJjZNt/EN+os5/df7IivhzNsUbuAZpijQxAY8SzDKRQ/EwZAjSKUwAohaARG7vGU9XnpUNoVGUA2PqBKRWLH7qU7/uyIrwdgGZ43jscYDzOih2xtq3RXxKCo7V1TeBMBAKZ7UfU4ssO0Na2+lcaB9n8fWIrAasEADYXSGADuKQUAKxl5qeqIdDA9xnHZeBmEyQ0f529wDsVAxA6pYJRbzHf+1Vn8W1R/68J5EcjVBHfHlH4xhJdfgfQXVwejlO/J7N9hhMAn+rCsM9u/62QJsSXHSAEyXYA2AxqffGevB4gQ9AgVgVA1iWnDSA6NH2DsYqxkuVgekUQ5CHU9VTgg1fciB8vBWNG/c/+cfhZOQCEE7Ac1KADONxTp3kQoSwBhxQAdG3Lmj/bBLDUDkDTMgB0/tiibaICoAHSaf0LBADs/h1u3jgFNKHwiTYAVkkI+VCDlm+77wVC55TP/gYvuxNfCXXPUV8B2OQSgPHIY+aeqyEArmnoNOr3Zcf/pFz7OyBbXvpV1//7sUwBQBeMFXYAGATgfQUAWynIZD/wJl/9HO0/uJ8ivjoIwkw3fcASx0Uen8mVic8+5R1dO/Spv9cARqGLZRyOugLAFgdqsAyUe2oYp4Df6lpjh4P4wgGaYZsCAG02QQ0Ay8B8qSGWqlwg46IfHDaA7MewRmKrGONNyQUEWrSY5aIPWKwGQBeENyoSX9cGrxm7YbHpMcxCHd8AW61D3AwhbpNmnLCMwUF3EFC4IzUEgE47ESHOv4c+HL8uB0Bz7LA7QFPsoPBbVWVgW54v4mzir9MAjzj/TDrCsLKrg4Ez6QbLHV2g2dsulogXiX1/tsZvCd/3fbcAtMFfOMouN3dDggipRz18lKxlBGbbb44cwc5/LL5w0wtsqqF9AafNo+UnbJXLFooeSRDkJWBDGOt+c+xRAJAh8CtdDLK7gC+S8xpg2gWUv9FD44vuWh+k5KGBarNIYBydYLWjC7SKc+ECrykLPW4bv5aYYeqGJYr45gF4K380ltWrp4hansAvFfFVEOxV1f9z1tKbJFeZx+Ev5on4szkaL1hjMIGZPE5s/+Zs/6TY7CG+L/6eIr8r7wiOwWHni0tmsQl0NE4xrrDszHP1O4k7eaU2+G+pBf7KErBdDYDkhwxZfF9soPgzLvmim6ufId8P6IMkcTeQfFsYGs1Qbxah8BQ6WNw4MjkPLaLEOoEWYcPyENZXg7bdL6FlZy3Cu+Qh6GFtCHpKQRhIJxjJeEaMfGxI55q6YKqT+CkieG4LnTfCetzBGdzXPJhCDcFp01CsdQBgOHaaxuA5q+rCTXWPvKfRVMBB8Tfx9Qr/cfYJ8ZUgBCsruhdP7OPThKA9QRikux/DRVbn+aGd+L67/4fi9xCZL7aNKwDwawrvN5u9wK/oAA+K3uBuz03bBR3oAM8a+2CadTSSFQBEXHkeUy6/6BmPxit36AeiG8XfJMRXQn5QwnCcYDwX6+ZunLt+37HoRNG3qwGwjILV/F9IpxM9c7e3hx1qgSBdE/xZbBmj6AnKzSMyAA3xohgHa+O8xF5H6yg8S+HXygA8i7jrv8fW65Ow5erv8XLuq3XsBkJQwwB0Ng3Ec5ZBWGcehIPyo1JUAJiGIEsz3HE8q41DfPoGhY+zO8Bwgli6L1DEV3SjV/Q90dfavWpinWmJQF043aEdpjG26AKRKG8YCcBqCr9GlIELPj/O41x4Pl0vP4UZFH6zDADj2suIL5iFzwti8beCuRhZMB+davwTSHL7I9gQiWG0opfMffGWqS/iGO8Z+2KxMRIrKPinlsE4rg75ESlD8IUs/mBsI8UhP/LY+Z64DUwlfmkMRqa5D87L0Zug9kGOqQfeNEVgviECC2i5S40RiDd0wnpjJzaInbDf0I6jYjvsE6Fvi3RdAHJkCPyx1F2PUFvHtT8g4tokfCyLPwlJ12di983ZOEwAcm7Nx6nChTh9awG+uvUhUosT8FHRcqQUJmJucTJmlyTjfy1L7+C2eVE7KfQrpkjssT/wwFUMwEpnAGQIxBOzhmCT4Yk6qVX3id3AzgCY+xFMBQBbGHvI+wZOqMPQEbsJwGERhg5YogAgQxCG5XSATdom+FldOO7VSXiS1p9+fTpyZPFnY//Nv2GzEF8GYCG2UXytCAJwujgJFopvFVG8DltL1mMjXyteVKKltxEbKSsU3hamfthNy9/lCgLG5LoqTcahGOAEwDZn8W0ApDoDYHwI6+wA0AX07bDOAYJwLKioUaztMnf9bawQ4ssxF2sV8eVYgmw7ACuRo4jPyKP4xtupuFWShoKSVEx113SEMFM2VEV8e/THetb/Lx3EH4QjusFoVqdj6FBOBSLzh2CPqTdOuQKAJSDLGQD9Q1ihACBC1xE7CEGOAoDUHuPr8ryux+LnzPwDBXOwSi0+7f9ju/gJ2MXsN6myf5sQXx2EoPxnLZgjMeeOxFc9FMmpBCyq8yXooZjCPmS/qQ++diW+DEAvbClXArpil9g6roaAX29kI5imfwCfngqtnY6/ytdVYtGKNf8zB/HjsfnWMnxps/4TRatxyi7+GuxwFl9EcRr2lGSonqRi7Ice1RJfDcEgHLABUOfP75UGoBdL2SF34ssloDeOOAMgQ/AIktQA2CA4SDfwiE8oYbZ/bhd/EdYXLsdFJfuLE7FTZf1Haf355QBIw67bmfieccy+akoR370rAEp7gl3mx+XVqy51/Y8kSlBF4tshiGCJcAXBQ0h0hkDfGX/xBABuLsQyZn1q0YfYYRe+fN23FKfgqAvxd3+Xhe+VoAsMhripgl3/Z3cLgBJSH89Ys2btP1kpAN3KN4K2+MrQGasdAOjkeCdynQGwDO86CJ9AB0jEJpX4wvq3uLD9XWrxZQCysQSG/uheU+KLYDm53yMuRffB/koBcDEKOk0Foik8JEPQGU95wnnR8meqxz3W/L0O4iezDKSiwKHpS8NeZ/FtcVL8Q42qSQA4SnrER6Gae2NnpQD0xIaKALD1BGkcCTcyxnjCeVH0qbL4K1gCVuMrJ/G3s+5fdxB/PY7dzkKxSwCycQuGvhhTgwDs9JRrE2wCt1YGAKeEb4xd8WVlEMggPIx+nnBexavwm6IknHUS/izHvd0uxr3zJVkwusl+EYXQ90NkDQKQ6DEA9MaaKjWC3eRbyaoCgEd8inlRMl5QiW8qXiuv8pldiH+oJBP5FYj/PZ3hnFj98zf3w76aAEAsIXsKABT3T1UBwNV6QLleoCv2wkO2Zd1IQntb1n/NTv+wqzmfNX8fxf2uIvFtAJR+QJV4vm1NAKDrjwhPAUDfB52qAoAMQVdsrQQCj/rAatp9gnOtV2X+fs74tysTX54CsmxrNlJvPFoD2b8EHnawEVxUpTLQs4Iy0A1fMR7wpPMqSsMoV+KLOb8qmW+Lb2NjVXs0KOKfqg1AJPZx/PO4p1mIkZSN3qEqNoNH3dj/a/DAozgVaxzETy8/57uNbHxXko1BjpeBI+DLzjmpWqNfJMbCQw9Db3QXAlerGYxA8nHAxxPPy5yIANnuxSJPOvZUWfws/JMu8WvXS6iPoZmp3x1AwOaR0MTAww9jL/SgyAcrdIEeSHOy/qWnutftxZ/KjivJCGLD90FVxafw1zgZPFvhD83tLC8Nv8LYW5Hli+sHukjUm8eaCriNfTCTYp926QC98LlN+CxxhzHqz3Efhf0dQ1eB+LfZGKaW5NzBKKvtiRBmdzRBmMrX2XydZYzEFPG93F719zPuxY4ngjCeZWGqqTcW8HUBAXiX8TvDox6647YKx/5YNKLQowhCHGMtI4Vfx1P4XxRnItzd//cfBjs/X1sMWK4AAAAASUVORK5CYII=";
+
+  var history = [];
+
+  var host = document.createElement("div");
+  host.id = "toast-chat";
+  var root = host.attachShadow({ mode: "open" });
+  root.innerHTML =
+    "<style>" +
+    ":host{all:initial}" +
+    "*{box-sizing:border-box;margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,'Segoe UI',sans-serif}" +
+    ".wrap{--fg:#222222;--bg:#ffffff;--muted:#6b6b6b;--line:#e5e5e5;--soft:#f4f4f4;" +
+    "--user:rgba(238,238,238,.4);--code:rgba(10,64,255,.08);--overlay:rgba(0,0,0,.5);" +
+    "--primary:#111111;--primary-fg:#ffffff;--send-off:#bdbdbd;font-size:14px;color:var(--fg)}" +
+    ".wrap.dark{--fg:#ededf0;--bg:#16171b;--muted:#9a9aa3;--line:#2e2f36;--soft:#1f2026;" +
+    "--user:rgba(255,255,255,.05);--code:rgba(120,160,255,.14);--overlay:rgba(0,0,0,.65);" +
+    "--primary:#f2f2f2;--primary-fg:#111111;--send-off:#4a4b52}" +
+
+    // floating trigger (bottom right)
+    ".fab{position:fixed;bottom:24px;right:24px;z-index:2147483000;display:flex;align-items:center;gap:8px;" +
+    "cursor:pointer;background:var(--bg);color:var(--fg);border:1.5px solid var(--fg);" +
+    "border-radius:999px;padding:10px 20px 10px 16px;font-size:18px;font-weight:400;line-height:24px;" +
+    "box-shadow:0 4px 14px rgba(0,0,0,.18);transition:transform .15s ease,box-shadow .15s ease}" +
+    ".fab:hover{transform:translateY(-1px);box-shadow:0 6px 18px rgba(0,0,0,.24)}" +
+    ".fab img{width:22px;height:22px;display:block}" +
+    ".wrap.open .fab{opacity:0;pointer-events:none}" +
+
+    // overlay + centered dialog
+    ".overlay{position:fixed;inset:0;z-index:2147483001;background:var(--overlay);" +
+    "opacity:0;pointer-events:none;transition:opacity .18s ease}" +
+    ".wrap.open .overlay{opacity:1;pointer-events:auto}" +
+    ".panel{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%) scale(.98);z-index:2147483002;" +
+    "width:800px;max-width:calc(100vw - 32px);max-height:90vh;display:flex;flex-direction:column;" +
+    "background:var(--bg);color:var(--fg);border-radius:16px;" +
+    "box-shadow:0 10px 40px rgba(0,0,0,.22);overflow:hidden;opacity:0;pointer-events:none;" +
+    "transition:opacity .18s ease,transform .18s ease}" +
+    ".wrap.open .panel{opacity:1;pointer-events:auto;transform:translate(-50%,-50%) scale(1)}" +
+    ".wrap.wide .panel{width:1100px;max-height:96vh}" +
+
+    // header
+    ".head{display:flex;align-items:center;gap:6px;padding:25px 24px 21px}" +
+    ".head .mark{width:24px;height:24px;margin-right:6px;display:flex;align-items:center;justify-content:center}" +
+    ".head .mark img{width:100%;height:100%;display:block}" +
+    ".head h2{font-size:24px;font-weight:600;line-height:32px;flex:1;min-width:0;white-space:nowrap;" +
+    "overflow:hidden;text-overflow:ellipsis}" +
+    ".hbtn{width:40px;height:40px;border:none;background:transparent;color:var(--fg);cursor:pointer;" +
+    "border-radius:999px;display:flex;align-items:center;justify-content:center;flex:none;" +
+    "transition:background .15s ease,transform .2s ease}" +
+    ".hbtn:hover{background:var(--soft)}" +
+    ".hbtn svg{width:18px;height:18px}" +
+    ".wrap.wide .hbtn.expand{transform:rotate(180deg)}" +
+
+    // messages (hidden until the first question, like the original modal)
+    ".msgs{display:none;flex:1;min-height:0;overflow-y:auto;padding:0 16px 12px;flex-direction:column;gap:12px;" +
+    "scrollbar-width:thin;scrollbar-color:var(--line) transparent}" +
+    ".wrap.has-msgs .msgs{display:flex}" +
+    ".msgs::-webkit-scrollbar{width:6px}" +
+    ".msgs::-webkit-scrollbar-thumb{background:var(--line);border-radius:3px}" +
+    ".turn{width:100%;padding:18px 16px;border-radius:12px;animation:rise .2s ease}" +
+    ".turn.bot{padding-top:8px}" +
+    "@keyframes rise{from{opacity:0;transform:translateY(4px)}to{opacity:1;transform:none}}" +
+    ".turn.user{background:var(--user)}" +
+    ".turn.bot{background:var(--bg)}" +
+    ".who{display:flex;align-items:center;gap:8px;font-size:13px;font-weight:700;margin-bottom:8px}" +
+    ".who img,.who svg{width:16px;height:16px;display:block}" +
+    ".body{padding-left:24px;font-size:15px;line-height:1.65;overflow-wrap:break-word}" +
+    ".turn.user .body{white-space:pre-wrap}" +
+    ".body p{margin:0 0 14px}.body p:last-child,.body ul:last-child,.body ol:last-child{margin-bottom:0}" +
+    ".body ul,.body ol{margin:0 0 14px;padding-left:22px}.body li{margin:6px 0}" +
+    ".body li>ul,.body li>ol{margin:6px 0 0}" +
+    ".body h3{font-size:16px;font-weight:650;margin:18px 0 8px}" +
+    ".body h4{font-size:15px;font-weight:600;margin:16px 0 6px}" +
+    ".body h3:first-child,.body h4:first-child{margin-top:0}" +
+    ".body hr{border:none;border-top:1px solid var(--line);margin:10px 0}" +
+    ".body .tblwrap{overflow-x:auto;max-width:100%;margin:8px 0}" +
+    ".body table{border-collapse:collapse;font-size:13px;line-height:1.45}" +
+    ".body th,.body td{border:1px solid var(--line);padding:4px 8px;text-align:left;vertical-align:top}" +
+    ".body th{background:var(--soft);font-weight:600}" +
+    ".body code{background:var(--code);padding:2px 6px;border-radius:6px;" +
+    "font-size:13px;font-family:'Fira Mono',ui-monospace,SFMono-Regular,Menlo,monospace}" +
+    ".cb{background:#0d1126;border-radius:12px;margin:16px 0;overflow:hidden;max-width:100%}" +
+    ".cbh{display:flex;align-items:center;justify-content:space-between;height:40px;padding:0 10px 0 16px;" +
+    "background:rgba(255,255,255,.035);border-bottom:1px solid rgba(255,255,255,.08)}" +
+    ".cbh .lang{font-size:12px;color:#8b93a7;letter-spacing:.01em}" +
+    ".copy{width:30px;height:30px;border:none;background:transparent;color:#8b93a7;cursor:pointer;border-radius:6px;" +
+    "display:flex;align-items:center;justify-content:center;transition:background .15s ease,color .15s ease}" +
+    ".copy:hover{background:rgba(255,255,255,.08);color:#e6e9f2}.copy svg{width:15px;height:15px}" +
+    ".copy.ok{color:#5fd38d}" +
+    ".body pre{background:transparent;color:#e6e9f2;padding:16px 18px;margin:0;overflow-x:auto;" +
+    "font-size:14px;line-height:1.7;scrollbar-width:thin;scrollbar-color:rgba(255,255,255,.25) transparent}" +
+    ".body pre::-webkit-scrollbar{height:6px}.body pre::-webkit-scrollbar-thumb{background:rgba(255,255,255,.22);border-radius:3px}" +
+    ".body pre code{background:none;border:none;padding:0;color:inherit;font-size:inherit;" +
+    "font-family:'Fira Mono',ui-monospace,SFMono-Regular,Menlo,monospace}" +
+    // the * reset above sets Inter on every element; highlighted spans must keep the mono face
+    ".body pre code *,.body code *{font-family:inherit;font-size:inherit}" +
+    ".c-kw{color:#5fd38d}.c-ty{color:#79c0ff}.c-fn{color:#79c0ff}.c-str{color:#a5e2a0}.c-con{color:#ff7b72}" +
+    ".c-com{color:#8b949e;font-style:italic}.c-num{color:#ffa657}.c-dec{color:#d2a8ff}" +
+    ".body a{color:var(--fg);text-decoration:underline;text-underline-offset:2px}" +
+    ".body .cut{margin-top:12px;font-size:13px;color:var(--muted);font-style:italic}" +
+
+    // status line while searching
+    ".status{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--muted);padding:0 16px 8px 40px}" +
+    ".status .stxt{max-width:520px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-style:italic}" +
+    ".dots{display:inline-flex;gap:3px}" +
+    ".dots i{width:4px;height:4px;border-radius:50%;background:var(--fg);opacity:.4;animation:blink 1.2s infinite}" +
+    ".dots i:nth-child(2){animation-delay:.2s}.dots i:nth-child(3){animation-delay:.4s}" +
+    "@keyframes blink{0%,80%,100%{opacity:.35}40%{opacity:1}}" +
+
+    // trace block styled like the original "Sources" block
+    ".trace{margin:16px 0 4px;background:var(--soft);border-radius:12px;padding:14px 16px}" +
+    ".trace summary{cursor:pointer;font-size:14px;font-weight:700;user-select:none;list-style:none;" +
+    "display:flex;align-items:center;justify-content:space-between}" +
+    ".trace summary::after{content:'';width:8px;height:8px;border-right:2px solid var(--muted);" +
+    "border-bottom:2px solid var(--muted);transform:rotate(45deg);transition:transform .15s ease;margin-right:4px}" +
+    ".trace[open] summary::after{transform:rotate(-135deg)}" +
+    ".trace-body{margin-top:10px;font-size:13px;color:var(--muted);line-height:1.55;white-space:pre-wrap}" +
+    ".trace-q{margin-top:8px;display:flex;gap:8px;align-items:baseline;font-size:13px;color:var(--fg);" +
+    "font-family:'Fira Mono',ui-monospace,SFMono-Regular,Menlo,monospace}" +
+    ".trace-q::before{content:'\\2315';font-size:13px;color:var(--muted)}" +
+
+    // input
+    ".foot{padding:0 16px 14px}" +
+    ".wrap.has-msgs .foot{padding-top:6px}" +
+    ".box{position:relative;display:flex;align-items:center;gap:12px;min-height:56px;" +
+    "border:2px solid var(--fg);border-radius:8px;background:var(--bg);padding:10px 14px 10px 16px;" +
+    "transition:border-color .15s ease}" +
+    ".clip{width:20px;height:20px;flex:none;color:var(--muted);display:flex;align-items:center;justify-content:center}" +
+    ".clip svg{width:18px;height:18px}" +
+    "textarea{flex:1;resize:none;border:none;background:transparent;color:var(--fg);outline:none;" +
+    "font-size:16px;line-height:24px;height:24px;max-height:144px;padding:0}" +
+    "textarea::placeholder{color:var(--muted)}" +
+    ".send{width:32px;height:32px;flex:none;border:none;border-radius:50%;cursor:pointer;" +
+    "background:var(--primary);color:#fff;display:flex;align-items:center;justify-content:center;" +
+    "transition:background .15s ease,transform .15s ease}" +
+    ".send:hover:not(:disabled){transform:scale(1.04)}" +
+    ".send:disabled{background:var(--send-off);cursor:default}" +
+    ".wrap.dark .send:not(:disabled){color:var(--primary-fg)}" +
+    ".send svg{width:14px;height:14px;display:block;margin-left:2px}" +
+
+    // footer bar
+    ".brand{height:56px;padding:0 24px;background:var(--soft);display:flex;align-items:center;" +
+    "justify-content:space-between;gap:12px;font-size:10px;color:var(--muted)}" +
+    ".brand .left{display:flex;align-items:center;gap:6px;min-width:0}" +
+    ".brand a{display:inline-flex;align-items:center;gap:6px;color:var(--muted);text-decoration:none}" +
+    ".brand a:hover{color:var(--fg)}" +
+    ".brand img{height:16px;width:auto;display:block}" +
+    ".brand .right{display:flex;align-items:center;gap:12px;white-space:nowrap}" +
+    ".brand .round{width:32px;height:32px;border-radius:50%;background:var(--bg);border:1px solid var(--line);" +
+    "display:flex;align-items:center;justify-content:center;color:#5865F2}" +
+    ".brand .round svg{width:16px;height:16px}" +
+    ".tip{position:absolute;right:24px;top:-30px;background:var(--fg);color:var(--bg);font-size:11px;" +
+    "padding:4px 8px;border-radius:6px;opacity:0;transition:opacity .15s ease;pointer-events:none}" +
+    ".head{position:relative}.tip.show{opacity:1}" +
+    ".brand kbd{font-family:'Fira Mono',ui-monospace,monospace;font-size:10px;border:1px solid var(--line);" +
+    "border-radius:4px;padding:1px 5px;background:var(--bg);color:var(--muted)}" +
+
+    "@media (max-width:640px){.panel{max-height:100vh;border-radius:12px}.head h2{font-size:20px}}" +
+    "@media (prefers-reduced-motion: reduce){*{animation:none!important;transition:none!important}}" +
+    "</style>" +
+    '<div class="wrap">' +
+    '<button class="fab" aria-label="Ask AI"><img src="' + DSPY_LOGO + '" alt=""> Ask AI</button>' +
+    '<div class="overlay"></div>' +
+    '<div class="panel" role="dialog" aria-label="Ask DSPy">' +
+    '<div class="head"><div class="mark"><img src="' + DSPY_LOGO + '" alt="DSPy"></div>' +
+    "<h2>Ask DSPy</h2>" +
+    '<span class="tip">Link copied</span>' +
+    '<button class="hbtn expand" title="Expand" aria-label="Expand">' +
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 6l-6 6 6 6"/></svg></button>' +
+    '<button class="hbtn share" title="Copy link to this chat" aria-label="Copy link">' +
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M10 13a5 5 0 0 0 7.5.5l3-3a5 5 0 0 0-7-7l-1.5 1.5"/><path d="M14 11a5 5 0 0 0-7.5-.5l-3 3a5 5 0 0 0 7 7L12 19"/></svg></button>' +
+    '<button class="hbtn new" title="Clear chat" aria-label="Clear chat">' +
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M3 6h18M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2m2 0v14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V6h12zM10 11v6M14 11v6"/></svg></button>' +
+    "</div>" +
+    '<div class="msgs"></div>' +
+    '<div class="foot"><div class="box">' +
+    '<span class="clip" title="Attachments are not supported">' +
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/></svg></span>' +
+    '<textarea rows="1" placeholder="Ask DSPy a question..." aria-label="Ask DSPy a question"></textarea>' +
+    '<button class="send" title="Send" aria-label="Send" disabled>' +
+    '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg></button>' +
+    "</div></div>" +
+    '<div class="brand"><div class="left"><span>Powered by</span>' +
+    '<a href="https://www.mixedbread.com" target="_blank" rel="noopener"><img src="' + MXB_LOGO + '" alt="Mixedbread"></a></div>' +
+    '<div class="right"><a href="https://www.mixedbread.com/blog/toast-1" target="_blank" rel="noopener">toast-1</a>' +
+    '<a class="round" href="https://discord.gg/XCGy2WDCQB" target="_blank" rel="noopener" title="DSPy Discord">' +
+    '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M20.3 4.4A19.8 19.8 0 0 0 15.4 3l-.2.4a18 18 0 0 1 4.5 2.3 15 15 0 0 0-15.4 0A18 18 0 0 1 8.8 3.4L8.6 3a19.8 19.8 0 0 0-4.9 1.5C.6 9.1-.2 13.6.2 18.1a19.9 19.9 0 0 0 6 3l1.3-1.8a12.9 12.9 0 0 1-2-1l.5-.4a14.2 14.2 0 0 0 12 0l.5.4a12.9 12.9 0 0 1-2 1l1.3 1.8a19.9 19.9 0 0 0 6-3c.5-5.2-.8-9.7-3.5-13.7zM8.5 15.4c-1.2 0-2.1-1.1-2.1-2.4s.9-2.4 2.1-2.4 2.1 1.1 2.1 2.4-.9 2.4-2.1 2.4zm7 0c-1.2 0-2.1-1.1-2.1-2.4s.9-2.4 2.1-2.4 2.1 1.1 2.1 2.4-.9 2.4-2.1 2.4z"/></svg></a>' +
+    "</div></div>" +
+    "</div></div>";
+
+  var wrap = root.querySelector(".wrap");
+  var fab = root.querySelector(".fab");
+  var overlay = root.querySelector(".overlay");
+  var msgs = root.querySelector(".msgs");
+  var input = root.querySelector("textarea");
+  var send = root.querySelector(".send");
+
+  function newChat() {
+    if (wrap.classList.contains("busy")) return; // don't clear mid-answer
+    history = [];
+    msgs.innerHTML = "";
+    wrap.classList.remove("has-msgs");
+    resetInput();
+    input.focus();
+  }
+
+  // Follow Material's palette (data-md-color-scheme on <body>); fall back to
+  // the OS preference when the page hasn't declared one.
+  function theme() {
+    var scheme = document.body && document.body.getAttribute("data-md-color-scheme");
+    var dark = scheme === "slate"
+      ? true
+      : scheme === "default"
+        ? false
+        : window.matchMedia && matchMedia("(prefers-color-scheme: dark)").matches;
+    wrap.classList.toggle("dark", dark);
+  }
+  function watchTheme() {
+    new MutationObserver(theme).observe(document.body, {
+      attributes: true,
+      attributeFilter: ["data-md-color-scheme"],
+    });
+    theme();
+  }
+
+  // textarea grows with input (up to max-height); send enables when ready
+  function syncInput() {
+    input.style.height = "22px";
+    input.style.height = Math.min(input.scrollHeight, 132) + "px";
+    send.disabled = !input.value.trim() || wrap.classList.contains("busy");
+  }
+  function resetInput() {
+    input.value = "";
+    input.style.height = "22px";
+    send.disabled = true;
+  }
+  input.addEventListener("input", syncInput);
+
+  function setOpen(open) {
+    wrap.classList.toggle("open", open);
+    if (open) setTimeout(function () { input.focus(); }, 30);
+  }
+  fab.addEventListener("click", function () { setOpen(true); });
+  overlay.addEventListener("click", function () { setOpen(false); });
+  root.querySelector(".hbtn.new").addEventListener("click", newChat);
+  root.querySelector(".hbtn.expand").addEventListener("click", function () {
+    wrap.classList.toggle("wide");
+  });
+  // share: a link that reopens this page with the first question asked
+  root.querySelector(".hbtn.share").addEventListener("click", function () {
+    var first = history.length ? history[0].content : input.value.trim();
+    var url = location.href.split("#")[0] + (first ? "#ask=" + encodeURIComponent(first) : "");
+    var tip = root.querySelector(".tip");
+    function done() {
+      tip.classList.add("show");
+      setTimeout(function () { tip.classList.remove("show"); }, 1400);
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(done, done);
+    } else {
+      done();
+    }
+  });
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") setOpen(false);
+    // Mod+J toggles the dialog, the shortcut the previous docs widget used
+    if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "j") {
+      e.preventDefault();
+      setOpen(!wrap.classList.contains("open"));
+    }
+  });
+
+  function esc(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  // tiny Python-leaning highlighter (no external libs); runs on escaped
+  // text, so entities like &lt; pass through untouched
+  var HL_RE = new RegExp(
+    "(#[^\\n]*)" + // comment
+      "|(\"\"\"[\\s\\S]*?\"\"\"|\"(?:[^\"\\\\\\n]|\\\\.)*\"|'(?:[^'\\\\\\n]|\\\\.)*')" + // string
+      "|\\b(def|class|return|import|from|as|if|elif|else|for|while|in|not|and|or|" +
+      "with|try|except|finally|raise|lambda|yield|async|await|pass|break|continue|" +
+      "global|nonlocal|is|del|assert)\\b" + // keyword
+      "|\\b(None|True|False|self)\\b" + // constant
+      "|\\b([A-Z][A-Za-z0-9_]*)\\b" + // class / type
+      "|\\b([a-z_][A-Za-z0-9_]*)(?=\\()" + // function call / definition name
+      "|\\b(\\d[\\d_]*(?:\\.\\d+)?)\\b" + // number
+      "|(@[A-Za-z_][\\w.]*)", // decorator
+    "g"
+  );
+
+  function hl(src) {
+    return esc(src).replace(HL_RE, function (m, com, str, kw, con, ty, fn, num, dec) {
+      var cls = com ? "c-com" : str ? "c-str" : kw ? "c-kw" : con ? "c-con" : ty ? "c-ty"
+        : fn ? "c-fn" : num ? "c-num" : "c-dec";
+      return '<span class="' + cls + '">' + m + "</span>";
+    });
+  }
+
+  var COPY_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>';
+  var CHECK_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12l5 5L20 7"/></svg>';
+
+  function codeBlock(lang, lines) {
+    return '<div class="cb"><div class="cbh"><span class="lang">' + esc(lang || "code") + "</span>" +
+      '<button class="copy" title="Copy code" aria-label="Copy code">' + COPY_ICON + "</button></div>" +
+      "<pre><code>" + hl(lines.join("\n")) + "</code></pre></div>";
+  }
+
+  // minimal markdown, parsed line by line so partial streamed input can't
+  // derail it: fences open only at line starts, ordered lists keep the
+  // author's numbering via <li value>, plus nested lists, tables, headings,
+  // hr, inline code / bold / italic / links
+  function inline(s) {
+    return esc(s)
+      .replace(/`([^`\n]+)`/g, "<code>$1</code>")
+      .replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>")
+      .replace(/(^|[\s(])\*([^*\n]+)\*(?=$|[\s).,;:!?])/g, "$1<i>$2</i>")
+      .replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, '<a href="$2" target="_blank">$1</a>');
+  }
+
+  function md(s) {
+    var html = "";
+    var para = []; // pending paragraph lines (already inlined)
+    var tbl = null; // pending table lines (raw)
+    var code = null; // pending fence body lines while inside ```
+    var codeLang = ""; // language from the opening fence
+    var codeIndent = ""; // indentation of the opening fence (fences inside lists)
+    var lists = []; // open lists: {tag, indent, liOpen}
+
+    function flushPara() {
+      if (para.length) {
+        html += "<p>" + para.join("<br>") + "</p>";
+        para = [];
+      }
+    }
+    function cells(row) {
+      return row
+        .replace(/^\s*\|/, "")
+        .replace(/\|\s*$/, "")
+        .split("|")
+        .map(function (c) { return c.trim(); });
+    }
+    function flushTable() {
+      if (!tbl) return;
+      var rows = tbl;
+      tbl = null;
+      if (rows.length >= 2 && /^[\s:|-]+$/.test(rows[1]) && rows[1].indexOf("-") !== -1) {
+        html += '<div class="tblwrap"><table><tr>' +
+          cells(rows[0]).map(function (c) { return "<th>" + inline(c) + "</th>"; }).join("") +
+          "</tr>" +
+          rows.slice(2).map(function (r) {
+            return "<tr>" +
+              cells(r).map(function (c) { return "<td>" + inline(c) + "</td>"; }).join("") +
+              "</tr>";
+          }).join("") +
+          "</table></div>";
+      } else {
+        // no separator row (yet): fall back to plain lines
+        para = para.concat(rows.map(inline));
+        flushPara();
+      }
+    }
+    function closeList() {
+      var l = lists.pop();
+      html += (l.liOpen ? "</li>" : "") + "</" + l.tag + ">";
+    }
+    function closeAllLists() {
+      while (lists.length) closeList();
+    }
+
+    var lines = s.split("\n");
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+
+      if (code) {
+        if (/^\s*```/.test(line)) {
+          html += codeBlock(codeLang, code);
+          code = null;
+        } else {
+          // drop the fence's own indentation so list-nested code is flush
+          code.push(codeIndent && line.indexOf(codeIndent) === 0 ? line.slice(codeIndent.length) : line);
+        }
+        continue;
+      }
+      var fence = /^(\s*)```\s*([\w.+-]*)/.exec(line);
+      if (fence) {
+        flushPara();
+        flushTable();
+        closeAllLists();
+        code = [];
+        codeIndent = fence[1];
+        codeLang = fence[2].toLowerCase();
+        continue;
+      }
+
+      // GFM tables: a row starts with a pipe; the trailing pipe is optional
+      // (and absent while a row is still streaming)
+      if (/^\s*\|/.test(line)) {
+        flushPara();
+        (tbl = tbl || []).push(line);
+        continue;
+      }
+      flushTable();
+
+      if (!line.trim()) {
+        flushPara(); // blank lines end paragraphs but not lists
+        continue;
+      }
+
+      var li = /^(\s*)([-*]|\d+[.)])\s+(.*)$/.exec(line);
+      if (li) {
+        flushPara();
+        var indent = li[1].replace(/\t/g, "    ").length;
+        var tag = /\d/.test(li[2]) ? "ol" : "ul";
+        var top = lists[lists.length - 1];
+        while (top && indent < top.indent - 1) {
+          closeList();
+          top = lists[lists.length - 1];
+        }
+        if (top && indent <= top.indent + 1) {
+          if (top.liOpen) {
+            html += "</li>";
+            top.liOpen = false;
+          }
+          if (top.tag !== tag) {
+            closeList();
+            top = lists[lists.length - 1];
+          }
+        }
+        top = lists[lists.length - 1];
+        if (!top || indent > top.indent + 1) {
+          html += "<" + tag + ">"; // nested lists live inside the open <li>
+          lists.push({ tag: tag, indent: indent, liOpen: false });
+          top = lists[lists.length - 1];
+        }
+        html += "<li" +
+          (tag === "ol" ? ' value="' + parseInt(li[2], 10) + '"' : "") +
+          ">" + inline(li[3]);
+        top.liOpen = true;
+        continue;
+      }
+
+      var h = /^\s*(#{1,6})\s+(.*)$/.exec(line);
+      if (h) {
+        flushPara();
+        closeAllLists();
+        var hTag = h[1].length <= 2 ? "h3" : "h4";
+        html += "<" + hTag + ">" + inline(h[2]) + "</" + hTag + ">";
+        continue;
+      }
+      if (/^\s*([-*_])\s*(\1\s*){2,}$/.test(line)) {
+        flushPara();
+        closeAllLists();
+        html += "<hr>";
+        continue;
+      }
+
+      closeAllLists();
+      para.push(inline(line));
+    }
+
+    if (code) html += codeBlock(codeLang, code); // fence still streaming
+    flushPara();
+    flushTable();
+    closeAllLists();
+    return html;
+  }
+
+  var USER_ICON =
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>';
+
+  function turn(cls, text) {
+    var el = document.createElement("div");
+    el.className = "turn " + cls;
+    var who = document.createElement("div");
+    who.className = "who";
+    who.innerHTML = cls === "user" ? USER_ICON + "You" : '<img src="' + DSPY_LOGO + '" alt="">DSPy';
+    var body = document.createElement("div");
+    body.className = "body";
+    if (cls === "user") body.textContent = text;
+    else body.innerHTML = md(text);
+    el.appendChild(who);
+    el.appendChild(body);
+    msgs.appendChild(el);
+    wrap.classList.add("has-msgs");
+    msgs.scrollTop = msgs.scrollHeight;
+    return body;
+  }
+
+  function askToast() {
+    var q = input.value.trim();
+    if (!q || wrap.classList.contains("busy")) return;
+    resetInput();
+    wrap.classList.add("busy");
+    turn("user", q);
+    history.push({ role: "user", content: q });
+
+    var status = document.createElement("div");
+    status.className = "status";
+    status.innerHTML =
+      '<span class="dots"><i></i><i></i><i></i></span><span class="stxt">Searching the docs…</span>';
+    var stxt = status.querySelector(".stxt");
+    msgs.appendChild(status);
+    msgs.scrollTop = msgs.scrollHeight;
+
+    var answer = "";
+    var body = null;
+    var cutShort = false;
+    // ordered trace: reasoning text interleaved with searches and page reads
+    var events = [];
+    var seenCalls = {};
+
+    function setStatus(text) {
+      if (status.isConnected) {
+        stxt.textContent = text.length > 90 ? "…" + text.slice(-90) : text;
+      }
+    }
+
+    function progress(text) {
+      var last = events[events.length - 1];
+      if (last && last.t === "txt") {
+        last.s += text;
+      } else {
+        last = { t: "txt", s: text };
+        events.push(last);
+      }
+      var lines = last.s.trim().split(/\n+/);
+      var line = lines[lines.length - 1].trim();
+      if (line) setStatus(line);
+    }
+
+    function onSearch(call) {
+      if (!call || !call.id || seenCalls[call.id]) return;
+      seenCalls[call.id] = true;
+      var q, label;
+      if (call.type === "store_search_call") {
+        q = (call.queries || []).join(" · ");
+        label = "Searching: “" + q + "”";
+      } else if (call.type === "store_grep_call") {
+        var p = call.pattern || "";
+        if (p.indexOf("read ") === 0) {
+          q = p;
+          label = "Reading " + p.slice(5);
+        } else {
+          q = "grep " + p;
+          label = "Grepping: " + p;
+        }
+      }
+      if (!q) return;
+      events.push({ t: "q", s: q });
+      setStatus(label);
+    }
+
+    fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: history }),
+    })
+      .then(function (resp) {
+        if (!resp.ok) throw new Error("proxy returned " + resp.status);
+        var reader = resp.body.getReader();
+        var dec = new TextDecoder();
+        var buf = "";
+        function pump() {
+          return reader.read().then(function (r) {
+            if (r.done) return;
+            buf += dec.decode(r.value, { stream: true });
+            var lines = buf.split("\n");
+            buf = lines.pop();
+            lines.forEach(function (line) {
+              if (line.indexOf("data: ") !== 0) return;
+              var payload = line.slice(6);
+              if (payload === "[DONE]") return;
+              var chunk, delta;
+              try {
+                chunk = JSON.parse(payload);
+              } catch (e) {
+                return;
+              }
+              delta = (chunk.choices && chunk.choices[0] && chunk.choices[0].delta) || null;
+              if (chunk.choices && chunk.choices[0] && chunk.choices[0].finish_reason === "length") cutShort = true;
+              (chunk.hosted_tool_calls || []).forEach(onSearch);
+              if (delta && delta.reasoning_content) progress(delta.reasoning_content);
+              if (delta && delta.content) {
+                if (!body) {
+                  status.remove();
+                  body = turn("bot", "");
+                }
+                answer += delta.content;
+                body.innerHTML = md(answer);
+                msgs.scrollTop = msgs.scrollHeight;
+              }
+            });
+            return pump();
+          });
+        }
+        return pump();
+      })
+      .then(function () {
+        if (answer) {
+          if (cutShort && body) {
+            body.innerHTML = md(answer) + '<p class="cut">The answer hit the length limit and was cut short. Ask a follow-up for the rest.</p>';
+          }
+          history.push({ role: "assistant", content: answer });
+          if (body && events.length) {
+            var trace = document.createElement("details");
+            trace.className = "trace";
+            var sum = document.createElement("summary");
+            var n = events.filter(function (ev) { return ev.t === "q"; }).length;
+            sum.textContent = "Sources" + (n ? " · " + n + " search" + (n > 1 ? "es" : "") : "");
+            trace.appendChild(sum);
+            events.forEach(function (ev) {
+              var row = document.createElement("div");
+              if (ev.t === "q") {
+                row.className = "trace-q";
+                row.textContent = ev.s;
+              } else {
+                var text = ev.s.trim().replace(/\n{3,}/g, "\n\n");
+                if (!text) return;
+                row.className = "trace-body";
+                row.textContent = text;
+              }
+              trace.appendChild(row);
+            });
+            body.parentNode.appendChild(trace);
+          }
+        } else {
+          status.remove();
+          turn("bot", "No answer came back. Please try again.");
+        }
+      })
+      .catch(function (err) {
+        status.remove();
+        turn("bot", "**Chat is unavailable:** " + err.message);
+      })
+      .finally(function () {
+        wrap.classList.remove("busy");
+        syncInput();
+        input.focus();
+      });
+  }
+
+  msgs.addEventListener("click", function (e) {
+    var btn = e.target.closest && e.target.closest(".copy");
+    if (!btn) return;
+    var pre = btn.parentNode.nextElementSibling;
+    var text = pre ? pre.textContent : "";
+    function done() {
+      btn.classList.add("ok");
+      btn.innerHTML = CHECK_ICON;
+      setTimeout(function () { btn.classList.remove("ok"); btn.innerHTML = COPY_ICON; }, 1200);
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) navigator.clipboard.writeText(text).then(done, done);
+    else done();
+  });
+
+  send.addEventListener("click", askToast);
+  input.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      askToast();
+    }
+  });
+
+  function mount() {
+    document.body.appendChild(host);
+    watchTheme();
+    var m = /[#&]ask=([^&]+)/.exec(location.hash);
+    if (m) {
+      setOpen(true);
+      input.value = decodeURIComponent(m[1]);
+      syncInput();
+      setTimeout(askToast, 300);
+    }
+  }
+  if (document.body) mount();
+  else document.addEventListener("DOMContentLoaded", mount);
+})();

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -352,6 +352,10 @@ hooks:
     - hooks/fetch_stats.py
 
 extra:
+    # Ask AI backend. Empty = the Vercel Edge Function shipped with the site
+    # (api/chat.js, same origin). Set a URL only to use an external proxy.
+    # Local `mkdocs serve` ignores this and targets `node docs/api/dev.mjs`.
+    toast_chat_endpoint: ""
     social:
         - icon: fontawesome/brands/github
           link: https://github.com/stanfordnlp/dspy
@@ -359,7 +363,10 @@ extra:
           link: https://discord.gg/XCGy2WDCQB
 
 extra_javascript:
-    - "js/runllm-widget.js"
+    # "Ask AI" panel backed by Mixedbread toast-1 (see toast-chat-worker/README.md).
+    # Replaces the RunLLM widget so the page has a single Ask-AI button; restore
+    # "js/runllm-widget.js" here to switch back.
+    - "js/toast-chat.js"
     - "js/tutorial-nav.js"
     - "js/hero-interactive.js"
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -7,6 +7,15 @@
 {% endblock %}
 
 {% block extrahead %}
+{% if config.extra.toast_chat_endpoint %}
+<script>
+  // Ask AI widget backend override (see docs/README.md). Local previews
+  // keep targeting the dev server on localhost.
+  if (location.hostname !== "localhost" && location.hostname !== "127.0.0.1") {
+    window.TOAST_CHAT_ENDPOINT = {{ config.extra.toast_chat_endpoint | tojson }};
+  }
+</script>
+{% endif %}
 <style>
   /* Announcement banner — restyled to fit the home-page aesthetic:
      quiet warm band, single rust accent, thin rule. Sans text; mono only for code.

--- a/docs/scripts/sync_search_index.py
+++ b/docs/scripts/sync_search_index.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Sync the docs and the Python sources into the Mixedbread stores that back
+the docs "Ask AI" widget (docs/api/chat.js).
+
+Two stores are synced:
+
+* ``dspy-docs`` — the *published* documentation pages as Markdown. Each page
+  is the ``<page>/index.md`` file that ``mkdocs build`` emits through the
+  ``mkdocs-llmstxt`` plugin (rendered API reference and notebooks included),
+  so what gets indexed is exactly what https://dspy.ai serves.
+* ``dspy-code`` — the Python sources under ``dspy/``.
+
+Usage (from the repository root; needs ``pip install mixedbread`` and
+``MXBAI_API_KEY`` in the environment or in a repo-root ``.env``):
+
+    python3 docs/scripts/sync_search_index.py [--site docs/site | --site https://dspy.ai] [--dry-run]
+
+The sync is incremental: files are keyed by their page path (``external_id``)
+and skipped when their sha256 matches the store's copy; files that no longer
+exist locally are removed from the store. Pages come from a local
+``mkdocs build`` output (``docs/site``) when present, otherwise from the live
+site's ``llms.txt`` page list. CI runs ``mkdocs build`` then this script on every
+push to ``main`` that touches ``docs/`` or ``dspy/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DOCS = REPO / "docs"
+DEFAULT_SITE_DIR = DOCS / "site"
+LIVE_SITE = "https://dspy.ai"
+
+DOCS_STORE = "dspy-docs"
+CODE_STORE = "dspy-code"
+STORES = [DOCS_STORE, CODE_STORE]
+
+# rendered pages that are navigation-only or not worth indexing
+SKIP_PAGES = {"index.md", "404.md", "search/index.md"}
+CODE_PATTERNS = ["**/*.py"]
+CODE_BASE = REPO / "dspy"
+
+
+# ── credentials ────────────────────────────────────────────────────────────
+
+def load_api_key() -> None:
+    if os.environ.get("MXBAI_API_KEY"):
+        return
+    env = REPO / ".env"
+    if env.exists():
+        for line in env.read_text().splitlines():
+            key, _, value = line.strip().partition("=")
+            if key == "MXBAI_API_KEY" and value:
+                os.environ["MXBAI_API_KEY"] = value.strip().strip("\"'")
+                return
+    sys.exit("MXBAI_API_KEY is not set (env or .env)")
+
+
+def client():
+    load_api_key()
+    try:
+        from mixedbread import Mixedbread
+    except ImportError:
+        sys.exit("missing dependency: pip install mixedbread")
+    return Mixedbread()
+
+
+# ── page sources ───────────────────────────────────────────────────────────
+
+def _fetch(url: str, timeout: int = 60) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "dspy-docs-sync"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def page_key(rel: str) -> str:
+    """'getting-started/first-program/index.md' -> same; keeps a stable id."""
+    return rel.replace("\\", "/").lstrip("/")
+
+
+def local_site_pages(site_dir: Path) -> dict[str, bytes]:
+    pages = {}
+    for path in sorted(site_dir.rglob("*.md")):
+        rel = page_key(str(path.relative_to(site_dir)))
+        if rel in SKIP_PAGES or rel == "llms.txt":
+            continue
+        body = path.read_bytes()
+        if body.strip():
+            pages[rel] = body
+    return pages
+
+
+def live_site_pages(base_url: str) -> dict[str, bytes]:
+    """Page list from llms.txt, then each page's rendered Markdown."""
+    base_url = base_url.rstrip("/")
+    llms = _fetch(f"{base_url}/llms.txt").decode("utf-8", "replace")
+    urls = re.findall(r"\]\((https?://[^)\s]+\.md)\)", llms)
+    urls = list(dict.fromkeys(urls))
+    keys = [page_key(u[len(base_url):]) if u.startswith(base_url) else None for u in urls]
+
+    def get(pair):
+        url, key = pair
+        if key is None or key in SKIP_PAGES:
+            return key, None
+        try:
+            return key, _fetch(url)
+        except Exception as e:  # noqa: BLE001 — one missing page must not kill the sync
+            print(f"skip {url}: {e}")
+            return key, None
+
+    pages = {}
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        for key, body in pool.map(get, zip(urls, keys)):
+            if body and body.strip():
+                pages[key] = body
+    return pages
+
+
+def docs_pages(site: str | None) -> dict[str, bytes]:
+    if site is None:
+        if DEFAULT_SITE_DIR.is_dir():
+            site = str(DEFAULT_SITE_DIR)
+        else:
+            print(f"no local build at {DEFAULT_SITE_DIR}; fetching pages from {LIVE_SITE}")
+            site = LIVE_SITE
+    if site.startswith(("http://", "https://")):
+        return live_site_pages(site)
+    return local_site_pages(Path(site))
+
+
+def code_files() -> dict[str, bytes]:
+    files = {}
+    for pattern in CODE_PATTERNS:
+        for path in sorted(CODE_BASE.glob(pattern)):
+            body = path.read_bytes()
+            if not body.strip():
+                continue  # the store rejects empty files (e.g. bare __init__.py)
+            rel = "dspy/" + page_key(str(path.relative_to(CODE_BASE)))
+            files[rel] = body
+    return files
+
+
+# ── store sync ─────────────────────────────────────────────────────────────
+
+def store_files(mxbai, store):
+    files, after = {}, None
+    while True:
+        page = mxbai.stores.files.list(store, limit=100, after=after)
+        for f in page.data:
+            files[f.external_id or f.filename] = f
+        if len(page.data) < 100:
+            return files
+        after = page.data[-1].id
+
+
+def sync_store(mxbai, store: str, local: dict[str, bytes], dry_run: bool) -> None:
+    try:
+        mxbai.stores.retrieve(store)
+    except Exception:
+        print(f"creating store {store}")
+        if not dry_run:
+            mxbai.stores.create(name=store)
+
+    digests = {rel: hashlib.sha256(body).hexdigest() for rel, body in local.items()}
+    try:
+        remote = store_files(mxbai, store)
+    except Exception:
+        remote = {}
+
+    stale = [f for rel, f in remote.items() if rel not in local]
+    changed = [
+        rel
+        for rel, digest in digests.items()
+        if rel not in remote or (remote[rel].metadata or {}).get("sha256") != digest
+    ]
+
+    def upload(rel):
+        print(f"upload {store}:{rel}")
+        if dry_run:
+            return
+        # explicit content type: the server's sniffing mislabels .md/.py
+        mime = "text/markdown" if rel.endswith(".md") else "text/plain"
+        # a readable filename ('getting-started__first-program.md') so chunk
+        # results are self-describing even without metadata
+        name = rel.replace("/index.md", ".md").replace("/", "__")
+        mxbai.stores.files.upload_and_poll(
+            store_identifier=store,
+            file=(name, local[rel], mime),
+            external_id=rel,
+            overwrite=True,
+            metadata={"path": rel, "sha256": digests[rel],
+                      "url": f"{LIVE_SITE}/{rel.removesuffix('index.md')}" if store == DOCS_STORE
+                      else f"https://github.com/stanfordnlp/dspy/blob/main/{rel}"},
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(upload, changed))
+    for f in stale:
+        print(f"delete {store}:{f.external_id or f.filename}")
+        if not dry_run:
+            mxbai.stores.files.delete(f.id, store_identifier=store)
+    print(f"{store}: {len(changed)} uploaded, {len(stale)} deleted, "
+          f"{len(local) - len(changed)} unchanged")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--site", default=None,
+                        help="mkdocs build dir or site URL (default: docs/site, else https://dspy.ai)")
+    parser.add_argument("--store", choices=STORES, default=None, help="sync only one store")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    mxbai = client()
+    if args.store in (None, DOCS_STORE):
+        sync_store(mxbai, DOCS_STORE, docs_pages(args.site), args.dry_run)
+    if args.store in (None, CODE_STORE):
+        sync_store(mxbai, CODE_STORE, code_files(), args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/scripts/sync_search_index.py
+++ b/docs/scripts/sync_search_index.py
@@ -21,6 +21,11 @@ exist locally are removed from the store. Pages come from a local
 ``mkdocs build`` output (``docs/site``) when present, otherwise from the live
 site's ``llms.txt`` page list. CI runs ``mkdocs build`` then this script on every
 push to ``main`` that touches ``docs/`` or ``dspy/``.
+
+Because a missing file is a deletion, an empty local set would wipe the store.
+The script therefore exits before touching a store when an explicit ``--site``
+path does not exist or when no files were found for a store; pass
+``--allow-empty`` to delete everything on purpose.
 """
 
 from __future__ import annotations
@@ -133,7 +138,11 @@ def docs_pages(site: str | None) -> dict[str, bytes]:
             site = LIVE_SITE
     if site.startswith(("http://", "https://")):
         return live_site_pages(site)
-    return local_site_pages(Path(site))
+    site_dir = Path(site)
+    if not site_dir.is_dir():
+        sys.exit(f"--site {site} is not a directory; run `mkdocs build` in docs/ first "
+                 "or pass the site URL")
+    return local_site_pages(site_dir)
 
 
 def code_files() -> dict[str, bytes]:
@@ -161,7 +170,12 @@ def store_files(mxbai, store):
         after = page.data[-1].id
 
 
-def sync_store(mxbai, store: str, local: dict[str, bytes], dry_run: bool) -> None:
+def sync_store(mxbai, store: str, local: dict[str, bytes], dry_run: bool,
+               allow_empty: bool = False) -> None:
+    if not local and not allow_empty:
+        # every remote file would count as stale and be deleted
+        sys.exit(f"{store}: no local files found; refusing to sync because that would "
+                 "delete every file in the store (pass --allow-empty to do that on purpose)")
     try:
         mxbai.stores.retrieve(store)
     except Exception:
@@ -218,13 +232,15 @@ def main():
                         help="mkdocs build dir or site URL (default: docs/site, else https://dspy.ai)")
     parser.add_argument("--store", choices=STORES, default=None, help="sync only one store")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--allow-empty", action="store_true",
+                        help="proceed when no local files were found, deleting every file in the store")
     args = parser.parse_args()
 
     mxbai = client()
     if args.store in (None, DOCS_STORE):
-        sync_store(mxbai, DOCS_STORE, docs_pages(args.site), args.dry_run)
+        sync_store(mxbai, DOCS_STORE, docs_pages(args.site), args.dry_run, args.allow_empty)
     if args.store in (None, CODE_STORE):
-        sync_store(mxbai, CODE_STORE, code_files(), args.dry_run)
+        sync_store(mxbai, CODE_STORE, code_files(), args.dry_run, args.allow_empty)
 
 
 if __name__ == "__main__":

--- a/tests/docs/test_sync_search_index.py
+++ b/tests/docs/test_sync_search_index.py
@@ -1,0 +1,62 @@
+"""Guards in docs/scripts/sync_search_index.py against wiping a search store.
+
+A file missing locally is deleted remotely, so an empty local set (a mistyped
+``--site`` path, an empty build directory) must fail before any remote call.
+"""
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "docs" / "scripts" / "sync_search_index.py"
+
+
+@pytest.fixture(scope="module")
+def sync():
+    spec = importlib.util.spec_from_file_location("sync_search_index", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def fake_client(remote):
+    mxbai = MagicMock()
+    mxbai.stores.files.list.return_value = SimpleNamespace(
+        data=[
+            SimpleNamespace(id=f"id:{rel}", external_id=rel, filename=rel, metadata={"sha256": "old"}) for rel in remote
+        ]
+    )
+    return mxbai
+
+
+def test_explicit_missing_site_dir_exits(sync, tmp_path):
+    with pytest.raises(SystemExit):
+        sync.docs_pages(str(tmp_path / "does-not-exist"))
+
+
+def test_empty_site_dir_yields_no_pages(sync, tmp_path):
+    assert sync.local_site_pages(tmp_path) == {}
+
+
+@pytest.mark.parametrize("dry_run", [False, True])
+def test_empty_local_set_refuses_before_any_remote_call(sync, dry_run):
+    mxbai = fake_client(["a/index.md", "b/index.md"])
+    with pytest.raises(SystemExit):
+        sync.sync_store(mxbai, sync.DOCS_STORE, {}, dry_run=dry_run)
+    assert not mxbai.mock_calls
+
+
+def test_allow_empty_deletes_every_remote_file(sync):
+    mxbai = fake_client(["a/index.md", "b/index.md"])
+    sync.sync_store(mxbai, sync.DOCS_STORE, {}, dry_run=False, allow_empty=True)
+    assert mxbai.stores.files.delete.call_count == 2
+
+
+def test_stale_files_are_still_deleted_for_a_nonempty_set(sync):
+    mxbai = fake_client(["a/index.md", "b/index.md"])
+    sync.sync_store(mxbai, sync.DOCS_STORE, {"a/index.md": b"# a"}, dry_run=False)
+    deleted = [call.args[0] for call in mxbai.stores.files.delete.call_args_list]
+    assert deleted == ["id:b/index.md"]


### PR DESCRIPTION
This pull request introduces the new "Ask AI" documentation assistant, powered by Mixedbread’s toast-1 agentic search and answer models, and integrates it into the DSPy documentation site. It adds a Vercel Edge Function backend (`docs/api/chat.js`), a local development server (`docs/api/dev.mjs`), a system prompt for agentic retrieval (`docs/api/system_prompt.txt`), and a CI workflow to keep the search index in sync. The documentation and configuration are updated to support and explain the new system, replacing the previous RunLLM widget with a more advanced, context-grounded AI assistant.

**Major new feature: "Ask AI" documentation assistant**

* Adds `docs/api/chat.js`, a Vercel Edge Function that serves as the backend for the new "Ask AI" widget, supporting both agentic search and direct answering modes using Mixedbread stores and models. It handles retrieval, context construction, answer generation, and citations, supporting both OpenRouter and toast-1 models.
* Introduces `docs/api/system_prompt.txt`, a detailed, retrieval-focused system prompt for agentic answering, specifying workflow, retrieval, and answer format requirements for the assistant.
* Provides `docs/api/dev.mjs`, a local Node.js server to preview the Ask AI backend during documentation development, reading environment variables from `.env.local`.
* Adds `.github/workflows/docs-search-sync.yml`, a GitHub Actions workflow to incrementally sync documentation and Python source changes into the Mixedbread stores used by the assistant, ensuring up-to-date search and retrieval.

**Documentation and configuration updates**

* Updates `docs/README.md` with detailed instructions and architecture notes for the new Ask AI system, including local preview, deployment, and model selection.
* Modifies `docs/mkdocs.yml` to switch the documentation site’s JavaScript widget to the new `js/toast-chat.js` panel, and adds configuration for the Ask AI backend endpoint.