### PR TITLE
fix(lm): reject direct stream=True before request handling

### DIFF
--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -136,6 +136,7 @@ class LM(BaseLM):
 
         if initial_kwargs.get("rollout_id") is None:
             initial_kwargs.pop("rollout_id", None)
+        self._reject_raw_streaming(initial_kwargs)
         return initial_kwargs
 
     @property
@@ -169,6 +170,17 @@ class LM(BaseLM):
                 stacklevel=3,
             )
             self._warned_zero_temp_rollout = True
+
+    def _reject_raw_streaming(self, kwargs: dict[str, Any]) -> None:
+        """Reject direct provider streaming; DSPy streams through `dspy.streamify()`."""
+        if kwargs.get("stream"):
+            raise LMUnsupportedFeatureError(
+                "`stream=True` is not supported as a direct `dspy.LM` argument. "
+                "Use `dspy.streamify(...)` for streaming.",
+                model=self.model,
+                provider=self._provider_name,
+                features=["stream"],
+            )
 
     def _get_cached_completion_fn(self, completion_fn, cache):
         ignored_args_for_cache_key = ["api_key", "api_base", "base_url"]
@@ -237,6 +249,7 @@ class LM(BaseLM):
         if self.use_developer_role and self.model_type == "responses":
             messages = [{**m, "role": "developer"} if m.get("role") == "system" else m for m in messages]
         kwargs = {**self.kwargs, **kwargs}
+        self._reject_raw_streaming(kwargs)
         self._warn_zero_temp_rollout(kwargs.get("temperature"), kwargs.get("rollout_id"))
         if kwargs.get("rollout_id") is None:
             kwargs.pop("rollout_id", None)
@@ -295,6 +308,7 @@ class LM(BaseLM):
         if self.use_developer_role and self.model_type == "responses":
             messages = [{**m, "role": "developer"} if m.get("role") == "system" else m for m in messages]
         kwargs = {**self.kwargs, **kwargs}
+        self._reject_raw_streaming(kwargs)
         self._warn_zero_temp_rollout(kwargs.get("temperature"), kwargs.get("rollout_id"))
         if kwargs.get("rollout_id") is None:
             kwargs.pop("rollout_id", None)

--- a/tests/clients/test_lm.py
+++ b/tests/clients/test_lm.py
@@ -338,6 +338,48 @@ async def test_lm_preserves_existing_lm_error_without_self_cause_async():
     assert exc_info.value.__cause__ is None
 
 
+def test_lm_rejects_raw_streaming_at_construction():
+    with pytest.raises(dspy.LMUnsupportedFeatureError) as exc_info:
+        dspy.LM("openai/gpt-4o-mini", stream=True)
+
+    assert exc_info.value.code == "unsupported_feature"
+    assert exc_info.value.features == ["stream"]
+    assert exc_info.value.model == "openai/gpt-4o-mini"
+    assert exc_info.value.provider == "openai"
+    assert "dspy.streamify" in str(exc_info.value)
+
+    dspy.LM("openai/gpt-4o-mini", stream=False)
+
+
+def test_lm_rejects_raw_streaming_before_sync_cache_or_provider_access():
+    lm = dspy.LM("openai/gpt-4o-mini", cache=True)
+
+    with (
+        mock.patch.object(lm, "_get_cached_completion_fn") as cached_completion,
+        mock.patch("dspy.clients.lm.litellm_completion") as provider_completion,
+        pytest.raises(dspy.LMUnsupportedFeatureError, match=r"dspy\.streamify"),
+    ):
+        lm("question", stream=True)
+
+    cached_completion.assert_not_called()
+    provider_completion.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lm_rejects_raw_streaming_before_async_cache_or_provider_access():
+    lm = dspy.LM("openai/gpt-4o-mini", cache=True)
+
+    with (
+        mock.patch.object(lm, "_get_cached_completion_fn") as cached_completion,
+        mock.patch("dspy.clients.lm.alitellm_completion") as provider_completion,
+        pytest.raises(dspy.LMUnsupportedFeatureError, match=r"dspy\.streamify"),
+    ):
+        await lm.acall("question", stream=True)
+
+    cached_completion.assert_not_called()
+    provider_completion.assert_not_called()
+
+
 def test_retry_number_set_correctly():
     lm = dspy.LM("openai/gpt-4o-mini", num_retries=3)
     with mock.patch("litellm.completion") as mock_completion:


### PR DESCRIPTION
Reject direct provider streaming during LM construction and after per-call arguments are merged. Raise LMUnsupportedFeatureError with structured feature metadata and direct callers to dspy.streamify().

Validate before cache or provider access in both synchronous and asynchronous paths. Add regression coverage for construction, stream=False, public sync and async calls, and untouched cache and provider boundaries.

Fixes #10345