### PR TITLE
Isolate JSONAdapter structured-output schemas from provider mutation

### DIFF
--- a/dspy/adapters/json_adapter.py
+++ b/dspy/adapters/json_adapter.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 from typing import Any, get_origin
@@ -305,7 +306,8 @@ def _get_structured_outputs_response_format(
 
     enforce_required(schema)
 
-    # Override the model's JSON schema generation to return our precomputed schema.
-    pydantic_model.model_json_schema = lambda *args, **kwargs: schema
+    # Return a copy so LiteLLM/OpenAI strict conversion cannot mutate the cached schema
+    # and change DSPy's request cache key on the next identical call.
+    pydantic_model.model_json_schema = lambda *args, **kwargs: copy.deepcopy(schema)
 
     return pydantic_model

--- a/tests/adapters/test_json_adapter.py
+++ b/tests/adapters/test_json_adapter.py
@@ -1701,6 +1701,24 @@ In adhering to this structure, your objective is:\x20
     assert system_message == expected_system_message
 
 
+def test_structured_output_schema_is_isolated_from_callers():
+    from dspy.adapters.json_adapter import _get_structured_outputs_response_format
+
+    class OptionalAnswer(dspy.Signature):
+        """Return an optional answer."""
+
+        question: str = dspy.InputField()
+        answer: str | None = dspy.OutputField(default=None)
+
+    model = _get_structured_outputs_response_format(OptionalAnswer)
+    schema = model.model_json_schema()
+    answer_schema = schema.get("properties", {}).get("answer", {})
+    answer_schema.pop("default", None)
+
+    isolated = model.model_json_schema()
+    assert isolated.get("properties", {}).get("answer", {}).get("default", "missing") is None
+
+
 def test_missing_optional_output_fields_fall_back_to_defaults():
     from dspy.utils.exceptions import AdapterParseError
 


### PR DESCRIPTION
Fixes #10375.

JSONAdapter hands LiteLLM a Pydantic class whose `model_json_schema` returns one shared dict. OpenAI strict conversion mutates that dict (it drops `default: null` on optional fields). The cache then stores the result under a different key than the next identical lookup, so every call misses.

The schema method now returns a deepcopy. Mutating the converted request no longer changes the next cache key.

Tested with `tests/adapters/test_json_adapter.py::test_structured_output_schema_is_isolated_from_callers`.
