### PR TITLE
perf(dspy): defer anyio, openai and jiter to their use sites

### DIFF
--- a/dspy/clients/engines/lifecycle.py
+++ b/dspy/clients/engines/lifecycle.py
@@ -3,7 +3,9 @@
 import inspect
 from contextlib import asynccontextmanager, contextmanager
 
-import anyio
+from dspy.utils.lazy_import import require
+
+anyio = require("anyio")
 
 
 def _secondary(primary, cleanup):

--- a/dspy/clients/execution.py
+++ b/dspy/clients/execution.py
@@ -7,7 +7,6 @@ from contextlib import nullcontext
 from dataclasses import dataclass, replace
 from typing import Any
 
-import anyio
 import pydantic
 
 from dspy._vendor.lm15.result import StreamAccumulator
@@ -36,6 +35,9 @@ from dspy.lm15 import (
     request_from_openai_chat,
 )
 from dspy.utils.exceptions import LMUnsupportedFeatureError, is_retryable_lm_error
+from dspy.utils.lazy_import import require
+
+anyio = require("anyio")
 
 IGNORED_CACHE_KEYS = ["api_key", "api_base", "base_url"]
 

--- a/dspy/clients/lm.py
+++ b/dspy/clients/lm.py
@@ -4,10 +4,7 @@ import os
 import re
 import threading
 import warnings
-from typing import Any, Literal, cast
-
-import anyio.from_thread
-from anyio.streams.memory import MemoryObjectSendStream
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import dspy
 from dspy.clients._litellm import get_litellm
@@ -21,8 +18,14 @@ from dspy.clients.utils_finetune import TrainDataFormat
 from dspy.lm15 import CacheConfig
 from dspy.utils.callback import BaseCallback
 from dspy.utils.exceptions import LMConfigurationError, LMError, LMUnsupportedFeatureError
+from dspy.utils.lazy_import import require
 
 from .base_lm import BaseLM
+
+anyio = require("anyio")
+
+if TYPE_CHECKING:
+    from anyio.streams.memory import MemoryObjectSendStream
 
 logger = logging.getLogger(__name__)
 
@@ -452,7 +455,7 @@ def _get_stream_completion_fn(
         return None
 
     # The stream is already opened, and will be closed by the caller.
-    stream = cast(MemoryObjectSendStream, stream)
+    stream = cast("MemoryObjectSendStream", stream)
     caller_predict_id = id(caller_predict) if caller_predict else None
 
     if dspy.settings.track_usage:

--- a/dspy/clients/openai.py
+++ b/dspy/clients/openai.py
@@ -2,10 +2,11 @@ import time
 from datetime import datetime
 from typing import Any
 
-import openai
-
 from dspy.clients.provider import Provider, TrainingJob
 from dspy.clients.utils_finetune import TrainDataFormat, TrainingStatus, save_data
+from dspy.utils.lazy_import import require
+
+openai = require("openai")
 
 
 class TrainingJobOpenAI(TrainingJob):

--- a/dspy/streaming/messages.py
+++ b/dspy/streaming/messages.py
@@ -3,10 +3,11 @@ import concurrent.futures
 from dataclasses import dataclass
 from typing import Any
 
-import anyio.from_thread
-
 from dspy.dsp.utils.settings import settings
 from dspy.utils.callback import BaseCallback
+from dspy.utils.lazy_import import require
+
+anyio = require("anyio")
 
 
 @dataclass

--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -7,14 +7,15 @@ from queue import Queue
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Awaitable, Callable, Generator
 
 import orjson
-from anyio import create_memory_object_stream, create_task_group
-from anyio.streams.memory import MemoryObjectSendStream
 
 from dspy.dsp.utils.settings import settings
 from dspy.primitives.prediction import Prediction
 from dspy.streaming.messages import StatusMessage, StatusMessageProvider, StatusStreamingCallback
 from dspy.streaming.streaming_listener import StreamListener, find_predictor_for_stream_listeners
 from dspy.utils.asyncify import asyncify
+from dspy.utils.lazy_import import require
+
+anyio = require("anyio")
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,8 @@ def _is_litellm_model_response_stream(value: Any) -> bool:
 
 
 if TYPE_CHECKING:
+    from anyio.streams.memory import MemoryObjectSendStream
+
     from dspy.primitives.module import Module
 
 
@@ -174,15 +177,15 @@ def streamify(
     if not any(isinstance(c, StatusStreamingCallback) for c in callbacks):
         callbacks.append(status_streaming_callback)
 
-    async def generator(args, kwargs, stream: MemoryObjectSendStream):
+    async def generator(args, kwargs, stream: "MemoryObjectSendStream"):
         with settings.context(send_stream=stream, callbacks=callbacks, stream_listeners=stream_listeners):
             prediction = await program(*args, **kwargs)
 
         await stream.send(prediction)
 
     async def async_streamer(*args, **kwargs):
-        send_stream, receive_stream = create_memory_object_stream(16)
-        async with create_task_group() as tg, send_stream, receive_stream:
+        send_stream, receive_stream = anyio.create_memory_object_stream(16)
+        async with anyio.create_task_group() as tg, send_stream, receive_stream:
             tg.start_soon(generator, args, kwargs, send_stream)
 
             async for value in receive_stream:

--- a/dspy/streaming/streaming_listener.py
+++ b/dspy/streaming/streaming_listener.py
@@ -6,14 +6,15 @@ from collections import defaultdict
 from queue import Queue
 from typing import TYPE_CHECKING, Any
 
-import jiter
-
 from dspy.adapters.chat_adapter import ChatAdapter
 from dspy.adapters.json_adapter import JSONAdapter
 from dspy.adapters.types import Type
 from dspy.adapters.xml_adapter import XMLAdapter
 from dspy.dsp.utils.settings import settings
 from dspy.streaming.messages import StreamResponse
+from dspy.utils.lazy_import import require
+
+jiter = require("jiter")
 
 if TYPE_CHECKING:
     from litellm import ModelResponseStream

--- a/dspy/utils/asyncify.py
+++ b/dspy/utils/asyncify.py
@@ -1,8 +1,9 @@
 import functools
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
-import anyio
-from anyio import CapacityLimiter
+from dspy.utils.lazy_import import require
+
+anyio = require("anyio")
 
 if TYPE_CHECKING:
     from dspy.primitives.module import Module
@@ -21,7 +22,7 @@ def get_limiter():
 
     global _limiter
     if _limiter is None:
-        _limiter = CapacityLimiter(async_max_workers)
+        _limiter = anyio.CapacityLimiter(async_max_workers)
     elif _limiter.total_tokens != async_max_workers:
         _limiter.total_tokens = async_max_workers
 


### PR DESCRIPTION
This makes the core importable on CPython built for WebAssembly, which does not provide `ssl`, which `anyio` and `openai` need, and `jiter` is a compiled extension with no wheel for every target. Deferring them also speeds up importing dspy, from 1785 modules and 380 ms, down to 871 and 193 ms. 

Claude (Opus 5) produced this PR, and tested it in our wasm sandbox (componentize-py 0.25.0, CPython 3.14, wasmtime 46.0.1, wasi-sdk 30)