### PR TITLE
fix(ci): install pytest-mock in release test environments

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           source test_before_testpypi/bin/activate
           # Install the locally built wheel and testing dependencies
-          pip install dist/*.whl pytest pytest-asyncio
+          pip install dist/*.whl pytest pytest-asyncio pytest-mock
           pytest tests/metadata/test_metadata.py tests/predict
           (cd "$RUNNER_TEMP" && python -c 'import dspy; assert dspy.PythonInterpreter().execute("6 * 7") == 42')
           deactivate
@@ -129,7 +129,7 @@ jobs:
         run: |
           source test_before_pypi/bin/activate
           # Install the locally built wheel and testing dependencies
-          pip install dist/*.whl pytest pytest-asyncio
+          pip install dist/*.whl pytest pytest-asyncio pytest-mock
           pytest tests/metadata/test_metadata.py tests/predict
           (cd "$RUNNER_TEMP" && python -c 'import dspy; assert dspy.PythonInterpreter().execute("6 * 7") == 42')
           deactivate


### PR DESCRIPTION
Install pytest-mock alongside pytest and pytest-asyncio in both isolated release-test environments. The release run failed with 35 missing-mocker fixture errors after ReActV2 tests began using the existing dev dependency in #10355 and #10356.

Failing run: https://github.com/stanfordnlp/dspy/actions/runs/34651096930/job/103433221043

Validation:
- `.venv/bin/pytest tests/metadata/test_metadata.py tests/predict -q`: 292 passed, 63 skipped.
- Disabling pytest-mock for ReActV2 reproduces the same 35 setup errors.
- `.venv/bin/pre-commit run --files .github/workflows/build_and_release.yml`: passed.
- The publishing workflow was not rerun.

AI assistance: isaacbmiller directed Amp to investigate the linked CI failure and prepare this fix. Prompt: “make this into a new pr. Where did this new dependency come from?” Conversation: https://ampcode.com/threads/T-01a09272-ca17-770a-a6e0-0f16f020514d