### PR TITLE
fix(streaming): close a partially consumed stream cleanly

### DIFF
--- a/dspy/streaming/streamify.py
+++ b/dspy/streaming/streamify.py
@@ -185,41 +185,52 @@ def streamify(
         async with create_task_group() as tg, send_stream, receive_stream:
             tg.start_soon(generator, args, kwargs, send_stream)
 
-            async for value in receive_stream:
-                if _is_litellm_model_response_stream(value):
-                    if len(predict_id_to_listener) == 0:
-                        # No listeners are configured, yield the chunk directly for backwards compatibility.
+            try:
+                async for value in receive_stream:
+                    if _is_litellm_model_response_stream(value):
+                        if len(predict_id_to_listener) == 0:
+                            # No listeners are configured, yield the chunk directly for backwards compatibility.
+                            yield value
+                        else:
+                            # We are receiving a chunk from the LM's response stream, delegate it to the listeners to
+                            # determine if we should yield a value to the user.
+                            for listener in predict_id_to_listener[value.predict_id]:
+                                # In some special cases such as Citation API, it is possible that multiple listeners
+                                # return values at the same time due to the chunk buffer of the listener.
+                                if output := listener.receive(value):
+                                    yield output
+                    elif isinstance(value, StatusMessage):
                         yield value
-                    else:
-                        # We are receiving a chunk from the LM's response stream, delegate it to the listeners to
-                        # determine if we should yield a value to the user.
-                        for listener in predict_id_to_listener[value.predict_id]:
-                            # In some special cases such as Citation API, it is possible that multiple listeners
-                            # return values at the same time due to the chunk buffer of the listener.
-                            if output := listener.receive(value):
-                                yield output
-                elif isinstance(value, StatusMessage):
-                    yield value
-                elif isinstance(value, Prediction):
-                    # Flush remaining buffered tokens before yielding the Prediction instance
-                    for listener in stream_listeners:
-                        if final_chunk := listener.finalize():
-                            yield final_chunk
+                    elif isinstance(value, Prediction):
+                        # Flush remaining buffered tokens before yielding the Prediction instance
+                        for listener in stream_listeners:
+                            if final_chunk := listener.finalize():
+                                yield final_chunk
 
-                    if include_final_prediction_in_output_stream:
+                        if include_final_prediction_in_output_stream:
+                            yield value
+                        elif (
+                            len(stream_listeners) == 0
+                            or any(listener.cache_hit for listener in stream_listeners)
+                            or not any(listener.stream_start for listener in stream_listeners)
+                        ):
+                            yield value
+                        return
+                    else:
+                        # This wildcard case allows for customized streaming behavior.
+                        # It is useful when a users have a custom LM which returns stream chunks in a custom format.
+                        # We let those chunks pass through to the user to handle them as needed.
                         yield value
-                    elif (
-                        len(stream_listeners) == 0
-                        or any(listener.cache_hit for listener in stream_listeners)
-                        or not any(listener.stream_start for listener in stream_listeners)
-                    ):
-                        yield value
-                    return
-                else:
-                    # This wildcard case allows for customized streaming behavior.
-                    # It is useful when a users have a custom LM which returns stream chunks in a custom format.
-                    # We let those chunks pass through to the user to handle them as needed.
-                    yield value
+            except GeneratorExit:
+                # aclose() on a partially consumed stream delivers GeneratorExit
+                # at a suspended yield. Cancel the producer's scope and leave by
+                # returning: letting GeneratorExit unwind through the task group
+                # made anyio collect it as an "unhandled error in a TaskGroup"
+                # and re-raise it wrapped in a BaseExceptionGroup (#10380).
+                # Exiting the generator normally satisfies aclose() per PEP 525,
+                # and the cancelled scope tears the producer task down.
+                tg.cancel_scope.cancel()
+                return
 
     if async_streaming:
         return async_streamer

--- a/tests/streaming/test_streaming.py
+++ b/tests/streaming/test_streaming.py
@@ -2078,3 +2078,43 @@ async def test_streaming_reasoning_fallback():
                 assert final_prediction.reasoning.content == "Let's think step by step about this question."
                 # Verify Reasoning object is str-like
                 assert str(final_prediction.reasoning) == "Let's think step by step about this question."
+
+
+@pytest.mark.anyio
+async def test_streamify_aclose_after_partial_consumption():
+    """Closing a partially consumed stream closes cleanly (#10380).
+
+    GeneratorExit used to unwind through the anyio task group, which collected
+    it as an "unhandled error in a TaskGroup" and re-raised it wrapped in a
+    BaseExceptionGroup instead of letting aclose() return.
+    """
+    program = dspy.streamify(
+        dspy.Predict("question->answer"),
+        stream_listeners=[dspy.streaming.StreamListener(signature_field_name="answer")],
+    )
+
+    async def long_stream(*args, **kwargs):
+        yield ModelResponseStream(
+            model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="[[ ## answer ## ]]\n"))]
+        )
+        for _ in range(50):
+            yield ModelResponseStream(model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="token "))])
+        yield ModelResponseStream(
+            model="gpt-4o-mini", choices=[StreamingChoices(delta=Delta(content="\n\n[[ ## completed ## ]]"))]
+        )
+
+    with mock.patch("litellm.acompletion", side_effect=long_stream):
+        with dspy.context(
+            lm=dspy.LM("openai/gpt-4o-mini", engine="litellm", cache=False), adapter=dspy.ChatAdapter()
+        ):
+            stream = program(question="What is the capital of France?")
+            received = None
+            async for value in stream:
+                if isinstance(value, StreamResponse):
+                    received = value
+                    break
+
+            assert received is not None, "expected at least one streamed token before closing"
+
+            # Must not raise: a consumer stopping early is normal cleanup.
+            await stream.aclose()


### PR DESCRIPTION
Fixes #10380

## Problem

`aclose()` on a partially consumed `streamify` async generator delivers
`GeneratorExit` at a suspended `yield` inside the anyio task group.
The group collects it as an "unhandled error in a TaskGroup" and re-raises it
wrapped in a `BaseExceptionGroup`, so a consumer stopping generation early —
ordinary cleanup — crashes with exit status 1 instead of closing.

Reproduced offline with a mocked `litellm.acompletion` token stream: consume
one `StreamResponse`, `break`, `await stream.aclose()` → the exact reported
traceback (`BaseExceptionGroup: unhandled errors in a TaskGroup (1
sub-exception)` → `GeneratorExit` at `yield output`).

## Change

Catch `GeneratorExit` around the consume loop in `async_streamer`, cancel the
producer's `tg.cancel_scope`, and exit the generator normally:

- returning from the generator satisfies `aclose()` per PEP 525, so no
  exception threads through the task group's `__aexit__` to be wrapped
- the cancelled scope tears down the producer task (blocked on
  `stream.send`) deterministically
- full consumption and the sync `apply_sync_streaming` path are unchanged

## Testing

- New `test_streamify_aclose_after_partial_consumption`: consumes one token
  from a 50-chunk mocked stream, closes, asserts a clean return. Fails with
  the wrapped `GeneratorExit` on the previous code (verified by
  stash-and-run).
- Full offline streaming suite: 34 passed (the two pre-existing errors are
  fixture-level, requiring a live `litellm_test_server`, unrelated to this
  change).
