### PR TITLE
fix(lm15): wait 600s for completion headers and honor LM timeout on the native engine

### DIFF
--- a/docs/docs/community/normalized-lm-api-migration.md
+++ b/docs/docs/community/normalized-lm-api-migration.md
@@ -61,7 +61,9 @@ Engine selection:
 Authentication failures, timeouts and provider errors never cause a switch to
 another backend. Native capability errors also raise rather than dropping the
 requested feature. Text completions and client settings not implemented by the
-native integration remain on LiteLLM.
+native integration remain on LiteLLM. The `timeout` setting, in seconds or as an
+`httpx.Timeout`, stays native. It bounds the wait for response headers, and the
+native default is 600 seconds, the same as LiteLLM.
 
 ### Caching, retries, usage and streaming
 

--- a/docs/docs/community/normalized-lm-api-migration.md
+++ b/docs/docs/community/normalized-lm-api-migration.md
@@ -62,8 +62,8 @@ Authentication failures, timeouts and provider errors never cause a switch to
 another backend. Native capability errors also raise rather than dropping the
 requested feature. Text completions and client settings not implemented by the
 native integration remain on LiteLLM. The `timeout` setting, in seconds or as an
-`httpx.Timeout`, stays native. It bounds the wait for response headers, and the
-native default is 600 seconds, the same as LiteLLM.
+`httpx.Timeout`, stays native. It bounds the wait for response headers and for
+each streamed chunk, and the native default is 600 seconds, the same as LiteLLM.
 
 ### Caching, retries, usage and streaming
 

--- a/dspy/_vendor/lm15/providers/anthropic.py
+++ b/dspy/_vendor/lm15/providers/anthropic.py
@@ -69,7 +69,7 @@ from .base import (
     batch_entry_request,
     default_transport,
 )
-from .common import EFFORT_THINKING_BUDGETS, MEDIA_KINDS, anthropic_source, check_tool_result_media, iso_utc, model_infos_from_entries, multipart_form_body, parts_to_text, path_id, unnamed_tool_call_error
+from .common import COMPLETION_READ_TIMEOUT, EFFORT_THINKING_BUDGETS, MEDIA_KINDS, STREAM_READ_TIMEOUT, anthropic_source, check_tool_result_media, iso_utc, model_infos_from_entries, multipart_form_body, parts_to_text, path_id, unnamed_tool_call_error
 
 # Canonical builtin tool name → Anthropic tool format
 _ANTHROPIC_BUILTIN_MAP: dict[str, str] = {
@@ -764,7 +764,7 @@ class AnthropicLM(BaseProviderLM):
             endpoint="messages",
             stream=stream,
             model=request.model,
-            read_timeout=120.0 if stream else 60.0,
+            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/providers/anthropic.py
+++ b/dspy/_vendor/lm15/providers/anthropic.py
@@ -69,7 +69,7 @@ from .base import (
     batch_entry_request,
     default_transport,
 )
-from .common import COMPLETION_READ_TIMEOUT, EFFORT_THINKING_BUDGETS, MEDIA_KINDS, STREAM_READ_TIMEOUT, anthropic_source, check_tool_result_media, iso_utc, model_infos_from_entries, multipart_form_body, parts_to_text, path_id, unnamed_tool_call_error
+from .common import COMPLETION_READ_TIMEOUT, EFFORT_THINKING_BUDGETS, MEDIA_KINDS, anthropic_source, check_tool_result_media, iso_utc, model_infos_from_entries, multipart_form_body, parts_to_text, path_id, unnamed_tool_call_error
 
 # Canonical builtin tool name → Anthropic tool format
 _ANTHROPIC_BUILTIN_MAP: dict[str, str] = {
@@ -764,7 +764,7 @@ class AnthropicLM(BaseProviderLM):
             endpoint="messages",
             stream=stream,
             model=request.model,
-            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
+            read_timeout=COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/providers/common.py
+++ b/dspy/_vendor/lm15/providers/common.py
@@ -26,15 +26,14 @@ from ..types import (
 
 JsonPayload = dict[str, Any] | list[Any]
 
-# Completion requests wait for response headers with the transport's own
-# read timeout (``TransportRequest.read_timeout=None``), so a caller's
+# Completion requests, streamed or not, wait for response headers and for
+# each body read with the transport's own read timeout
+# (``TransportRequest.read_timeout=None``), so a caller's
 # ``RouterConfig(transport=StdlibTransport(read_timeout=...))`` governs the
 # time-to-first-byte.  The transports default to 600 seconds, matching the
 # LiteLLM request timeout, because reasoning models with large prompts
-# routinely take more than a minute before the first byte.  Streaming reads
-# are bounded per chunk instead.
+# routinely take more than a minute before the first byte.
 COMPLETION_READ_TIMEOUT: float | None = None
-STREAM_READ_TIMEOUT = 120.0
 
 
 # The FileReadiness fold for every OpenAI-shaped file object (api.openai.com,

--- a/dspy/_vendor/lm15/providers/common.py
+++ b/dspy/_vendor/lm15/providers/common.py
@@ -26,6 +26,16 @@ from ..types import (
 
 JsonPayload = dict[str, Any] | list[Any]
 
+# Completion requests wait for response headers with the transport's own
+# read timeout (``TransportRequest.read_timeout=None``), so a caller's
+# ``RouterConfig(transport=StdlibTransport(read_timeout=...))`` governs the
+# time-to-first-byte.  The transports default to 600 seconds, matching the
+# LiteLLM request timeout, because reasoning models with large prompts
+# routinely take more than a minute before the first byte.  Streaming reads
+# are bounded per chunk instead.
+COMPLETION_READ_TIMEOUT: float | None = None
+STREAM_READ_TIMEOUT = 120.0
+
 
 # The FileReadiness fold for every OpenAI-shaped file object (api.openai.com,
 # Azure OpenAI v1, Meta): spec/vocabularies.md FileReadiness, ratified

--- a/dspy/_vendor/lm15/providers/gemini.py
+++ b/dspy/_vendor/lm15/providers/gemini.py
@@ -104,7 +104,7 @@ from .base import (
     default_transport,
     resolve_credential,
 )
-from .common import COMPLETION_READ_TIMEOUT, EFFORT_THINKING_BUDGETS, MEDIA_KINDS, STREAM_READ_TIMEOUT, build_url, iso_utc, model_infos_from_entries, multipart_related_body, parts_to_text, path_id, unnamed_tool_call_error
+from .common import COMPLETION_READ_TIMEOUT, EFFORT_THINKING_BUDGETS, MEDIA_KINDS, build_url, iso_utc, model_infos_from_entries, multipart_related_body, parts_to_text, path_id, unnamed_tool_call_error
 
 # Canonical builtin tool name → Gemini tool key
 _GEMINI_BUILTIN_MAP: dict[str, str] = {
@@ -848,7 +848,7 @@ class GeminiLM(BaseProviderLM):
             headers=self._auth_headers({"Content-Type": "application/json"}),
             params=params,
             payload=self._payload(request),
-            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
+            read_timeout=COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/providers/gemini.py
+++ b/dspy/_vendor/lm15/providers/gemini.py
@@ -104,7 +104,7 @@ from .base import (
     default_transport,
     resolve_credential,
 )
-from .common import EFFORT_THINKING_BUDGETS, MEDIA_KINDS, build_url, iso_utc, model_infos_from_entries, multipart_related_body, parts_to_text, path_id, unnamed_tool_call_error
+from .common import COMPLETION_READ_TIMEOUT, EFFORT_THINKING_BUDGETS, MEDIA_KINDS, STREAM_READ_TIMEOUT, build_url, iso_utc, model_infos_from_entries, multipart_related_body, parts_to_text, path_id, unnamed_tool_call_error
 
 # Canonical builtin tool name → Gemini tool key
 _GEMINI_BUILTIN_MAP: dict[str, str] = {
@@ -848,7 +848,7 @@ class GeminiLM(BaseProviderLM):
             headers=self._auth_headers({"Content-Type": "application/json"}),
             params=params,
             payload=self._payload(request),
-            read_timeout=120.0 if stream else 60.0,
+            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/providers/openai.py
+++ b/dspy/_vendor/lm15/providers/openai.py
@@ -107,6 +107,8 @@ from .base import (
     resolve_credential_value,
 )
 from .common import (
+    COMPLETION_READ_TIMEOUT,
+    STREAM_READ_TIMEOUT,
     tool_result_error_text,
     tool_result_output_openai,
     iso_utc,
@@ -994,7 +996,7 @@ class OpenAILM(BaseProviderLM):
             model=request.model,
             headers=self._headers(),
             payload=self._payload(request, stream=stream),
-            read_timeout=120.0 if stream else 60.0,
+            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/providers/openai.py
+++ b/dspy/_vendor/lm15/providers/openai.py
@@ -108,7 +108,6 @@ from .base import (
 )
 from .common import (
     COMPLETION_READ_TIMEOUT,
-    STREAM_READ_TIMEOUT,
     tool_result_error_text,
     tool_result_output_openai,
     iso_utc,
@@ -996,7 +995,7 @@ class OpenAILM(BaseProviderLM):
             model=request.model,
             headers=self._headers(),
             payload=self._payload(request, stream=stream),
-            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
+            read_timeout=COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/providers/openai_chat.py
+++ b/dspy/_vendor/lm15/providers/openai_chat.py
@@ -63,7 +63,6 @@ from .base import BaseProviderLM, Credential, HttpResponse, SyncTransport, defau
 from .common import (
     COMPLETION_READ_TIMEOUT,
     MEDIA_KINDS,
-    STREAM_READ_TIMEOUT,
     check_tool_result_media,
     media_data_uri,
     tool_result_error_text,
@@ -1496,7 +1495,7 @@ class OpenAIChatLM(BaseProviderLM):
             model=request.model,
             headers=self._headers(),
             payload=self._payload(request, stream=stream),
-            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
+            read_timeout=COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/providers/openai_chat.py
+++ b/dspy/_vendor/lm15/providers/openai_chat.py
@@ -61,7 +61,9 @@ from ..types import (
 )
 from .base import BaseProviderLM, Credential, HttpResponse, SyncTransport, default_transport
 from .common import (
+    COMPLETION_READ_TIMEOUT,
     MEDIA_KINDS,
+    STREAM_READ_TIMEOUT,
     check_tool_result_media,
     media_data_uri,
     tool_result_error_text,
@@ -1494,7 +1496,7 @@ class OpenAIChatLM(BaseProviderLM):
             model=request.model,
             headers=self._headers(),
             payload=self._payload(request, stream=stream),
-            read_timeout=120.0 if stream else 60.0,
+            read_timeout=STREAM_READ_TIMEOUT if stream else COMPLETION_READ_TIMEOUT,
         )
 
     # ─── Response parsing ───────────────────────────────────────────

--- a/dspy/_vendor/lm15/transports/_async.py
+++ b/dspy/_vendor/lm15/transports/_async.py
@@ -42,7 +42,9 @@ from ._url import ParsedURL, parse_url
 
 
 _DEFAULT_CONNECT_TIMEOUT = 10.0
-_DEFAULT_READ_TIMEOUT = 60.0
+# Only completion requests leave read_timeout unset; the other endpoints
+# carry their own value.  600 matches the LiteLLM request timeout.
+_DEFAULT_READ_TIMEOUT = 600.0
 _DEFAULT_WRITE_TIMEOUT = 60.0
 _READ_CHUNK = 64 * 1024
 

--- a/dspy/_vendor/lm15/transports/_sync.py
+++ b/dspy/_vendor/lm15/transports/_sync.py
@@ -52,7 +52,9 @@ from ._url import ParsedURL, parse_url
 
 
 _DEFAULT_CONNECT_TIMEOUT = 10.0
-_DEFAULT_READ_TIMEOUT = 60.0
+# Only completion requests leave read_timeout unset; the other endpoints
+# carry their own value.  600 matches the LiteLLM request timeout.
+_DEFAULT_READ_TIMEOUT = 600.0
 _DEFAULT_WRITE_TIMEOUT = 60.0
 _READ_CHUNK = 64 * 1024
 

--- a/dspy/clients/backend_selection.py
+++ b/dspy/clients/backend_selection.py
@@ -13,7 +13,7 @@ from dspy.lm15 import RouterConfig, UnknownModelError, UnsupportedFeatureError
 
 CLIENT_KEYS = {"api_key", "api_base", "base_url", "headers", "extra_headers", "timeout", "api_version",
                "azure_ad_token_provider", "organization", "project", "extra_query", "custom_llm_provider"}
-NATIVE_CLIENT_KEYS = {"api_key", "api_base", "base_url"}
+NATIVE_CLIENT_KEYS = {"api_key", "api_base", "base_url", "timeout"}
 
 
 @dataclass(frozen=True)

--- a/dspy/clients/engines/lm15_engine.py
+++ b/dspy/clients/engines/lm15_engine.py
@@ -1,5 +1,6 @@
 """Native lm15 routing, with canonical errors and no retry policy."""
 
+import math
 import threading
 from collections.abc import AsyncIterator, Iterator
 from contextlib import AsyncExitStack, ExitStack
@@ -33,21 +34,27 @@ def _model_string(model: str, model_type: str) -> str:
     return model
 
 
+# No timeout setting. Distinct from None, which asks the transport for an
+# unbounded wait.
+UNSET = object()
+
+
 def read_timeout_seconds(timeout):
-    """Seconds to wait for response headers, from an LM ``timeout`` setting.
+    """Seconds to wait for each read, from an LM ``timeout`` setting.
 
     Accepts a number of seconds or an ``httpx.Timeout``, whose ``read``
-    component is the equivalent bound. ``None`` keeps the engine default.
+    component is the equivalent bound. No setting returns ``UNSET``; an
+    ``httpx.Timeout`` with ``read=None`` returns ``None``, an unbounded wait.
     """
     if timeout is None:
-        return None
+        return UNSET
     read = getattr(timeout, "read", timeout)
     if read is None:
         return None
     if isinstance(read, bool) or not isinstance(read, (int, float)):
         raise TypeError(f"timeout must be a number of seconds or an httpx.Timeout, not {type(timeout).__name__}")
-    if read <= 0:
-        raise ValueError("timeout must be positive")
+    if not math.isfinite(read) or read <= 0:
+        raise ValueError("timeout must be a positive finite number of seconds")
     return float(read)
 
 
@@ -60,7 +67,7 @@ class _Routing:
         # A caller-supplied transport keeps its own timeouts. Otherwise the
         # engine owns one transport, shared by every provider it builds.
         self._owned_transport = None
-        if read_timeout is not None and self.config.transport is None:
+        if read_timeout is not UNSET and self.config.transport is None:
             self._owned_transport = transport_cls(read_timeout=read_timeout)
             self.config = replace(self.config, transport=self._owned_transport)
         self._closed = False
@@ -103,7 +110,7 @@ class _Routing:
 class LM15Engine(_Routing):
     """One synchronous native attempt. Close after its active calls finish."""
 
-    def __init__(self, config: RouterConfig | None = None, *, model_type="chat", read_timeout=None):
+    def __init__(self, config: RouterConfig | None = None, *, model_type="chat", read_timeout=UNSET):
         self._init_routing(config, model_type, read_timeout, StdlibTransport)
         self.router = LMRouter(self.config)
 
@@ -134,7 +141,7 @@ class LM15Engine(_Routing):
 class AsyncLM15Engine(_Routing):
     """One async attempt; owned pools are confined to their event loop."""
 
-    def __init__(self, config: RouterConfig | None = None, *, model_type="chat", read_timeout=None):
+    def __init__(self, config: RouterConfig | None = None, *, model_type="chat", read_timeout=UNSET):
         self._init_routing(config, model_type, read_timeout, StdlibAsyncTransport)
         self.router = AsyncLMRouter(self.config)
 

--- a/dspy/clients/engines/lm15_engine.py
+++ b/dspy/clients/engines/lm15_engine.py
@@ -6,6 +6,7 @@ from contextlib import AsyncExitStack, ExitStack
 from dataclasses import replace
 
 from dspy._vendor.lm15.router import LITELLM_PROVIDER_PREFIXES
+from dspy._vendor.lm15.transports import StdlibAsyncTransport, StdlibTransport
 from dspy._vendor.lm15.types import StreamEvent
 from dspy.clients.engines.base import validate_request
 from dspy.clients.engines.lifecycle import aclosing_stream, closing_stream
@@ -32,12 +33,36 @@ def _model_string(model: str, model_type: str) -> str:
     return model
 
 
+def read_timeout_seconds(timeout):
+    """Seconds to wait for response headers, from an LM ``timeout`` setting.
+
+    Accepts a number of seconds or an ``httpx.Timeout``, whose ``read``
+    component is the equivalent bound. ``None`` keeps the engine default.
+    """
+    if timeout is None:
+        return None
+    read = getattr(timeout, "read", timeout)
+    if read is None:
+        return None
+    if isinstance(read, bool) or not isinstance(read, (int, float)):
+        raise TypeError(f"timeout must be a number of seconds or an httpx.Timeout, not {type(timeout).__name__}")
+    if read <= 0:
+        raise ValueError("timeout must be positive")
+    return float(read)
+
+
 class _Routing:
-    def _init_routing(self, config, model_type):
+    def _init_routing(self, config, model_type, read_timeout, transport_cls):
         if model_type not in {"chat", "responses"}:
             raise UnsupportedFeatureError("lm15 engines support chat and Responses APIs, not text completions.")
         self.model_type = model_type
         self.config = config if config is not None else RouterConfig()
+        # A caller-supplied transport keeps its own timeouts. Otherwise the
+        # engine owns one transport, shared by every provider it builds.
+        self._owned_transport = None
+        if read_timeout is not None and self.config.transport is None:
+            self._owned_transport = transport_cls(read_timeout=read_timeout)
+            self.config = replace(self.config, transport=self._owned_transport)
         self._closed = False
         self._lock = threading.RLock()
         self._providers = {}
@@ -78,8 +103,8 @@ class _Routing:
 class LM15Engine(_Routing):
     """One synchronous native attempt. Close after its active calls finish."""
 
-    def __init__(self, config: RouterConfig | None = None, *, model_type="chat"):
-        self._init_routing(config, model_type)
+    def __init__(self, config: RouterConfig | None = None, *, model_type="chat", read_timeout=None):
+        self._init_routing(config, model_type, read_timeout, StdlibTransport)
         self.router = LMRouter(self.config)
 
     def complete(self, request: Request) -> Response:
@@ -98,7 +123,9 @@ class LM15Engine(_Routing):
             providers = list(self._providers.values())
             self._providers.clear()
         self.router._lms.clear()
-        if self.config.transport is None:
+        if self._owned_transport is not None:
+            self._owned_transport.close()
+        elif self.config.transport is None:
             with ExitStack() as cleanup:
                 for provider in providers:
                     cleanup.callback(provider.close)
@@ -107,8 +134,8 @@ class LM15Engine(_Routing):
 class AsyncLM15Engine(_Routing):
     """One async attempt; owned pools are confined to their event loop."""
 
-    def __init__(self, config: RouterConfig | None = None, *, model_type="chat"):
-        self._init_routing(config, model_type)
+    def __init__(self, config: RouterConfig | None = None, *, model_type="chat", read_timeout=None):
+        self._init_routing(config, model_type, read_timeout, StdlibAsyncTransport)
         self.router = AsyncLMRouter(self.config)
 
     async def complete(self, request: Request) -> Response:
@@ -133,7 +160,9 @@ class AsyncLM15Engine(_Routing):
             providers = list(self._providers.values())
             self._providers.clear()
         self.router._lms.clear()
-        if self.config.transport is None:
+        if self._owned_transport is not None:
+            await self._owned_transport.aclose()
+        elif self.config.transport is None:
             async with AsyncExitStack() as cleanup:
                 for provider in providers:
                     cleanup.push_async_callback(provider.aclose)

--- a/dspy/clients/execution.py
+++ b/dspy/clients/execution.py
@@ -20,7 +20,7 @@ from dspy.clients.call_result import CACHE_FORMAT, CallResult, combine, usage_di
 from dspy.clients.engines.legacy_engine import AsyncLegacyEngine, LegacyEngine
 from dspy.clients.engines.lifecycle import aclosing_stream, closing_stream
 from dspy.clients.engines.litellm_engine import AsyncLiteLLMEngine, LiteLLMEngine
-from dspy.clients.engines.lm15_engine import AsyncLM15Engine, LM15Engine
+from dspy.clients.engines.lm15_engine import AsyncLM15Engine, LM15Engine, read_timeout_seconds
 from dspy.clients.engines.stream_guard import achecked_stream, checked_stream
 from dspy.clients.engines.streaming import ListenerBridge
 from dspy.clients.errors import error_boundary
@@ -223,7 +223,7 @@ def _select_engine(lm, call, asynchronous):
             url = clients.get("api_base") or clients.get("base_url")
             config = RouterConfig(api_keys=api_keys, base_urls={provider: url} if url else None)
             cls = AsyncLM15Engine if asynchronous else LM15Engine
-            backend = cls(config, model_type=lm.model_type)
+            backend = cls(config, model_type=lm.model_type, read_timeout=read_timeout_seconds(clients.get("timeout")))
             lm._engine_store[key] = backend
     return backend, canonical, resolution.provider
 

--- a/dspy/clients/execution.py
+++ b/dspy/clients/execution.py
@@ -213,8 +213,10 @@ def _select_engine(lm, call, asynchronous):
     # Long-lived sync pools and a separate async pool per event loop. Copies
     # share the store; a copy with changed client settings gets a distinct key.
     loop = asyncio.get_running_loop() if asynchronous else None
+    read_timeout = read_timeout_seconds(clients.get("timeout"))
+    settings = {**clients, "timeout": read_timeout} if "timeout" in clients else clients
     key = (loop, lm.model, lm.model_type, tuple(sorted((k, v if isinstance(v, (str, int, float, type(None))) else id(v))
-                                                   for k, v in clients.items())))
+                                                   for k, v in settings.items())))
     with lm._engine_lock:
         backend = lm._engine_store.get(key)
         if backend is None:
@@ -223,7 +225,7 @@ def _select_engine(lm, call, asynchronous):
             url = clients.get("api_base") or clients.get("base_url")
             config = RouterConfig(api_keys=api_keys, base_urls={provider: url} if url else None)
             cls = AsyncLM15Engine if asynchronous else LM15Engine
-            backend = cls(config, model_type=lm.model_type, read_timeout=read_timeout_seconds(clients.get("timeout")))
+            backend = cls(config, model_type=lm.model_type, read_timeout=read_timeout)
             lm._engine_store[key] = backend
     return backend, canonical, resolution.provider
 

--- a/tests/clients/test_backend_capabilities.py
+++ b/tests/clients/test_backend_capabilities.py
@@ -43,7 +43,6 @@ def conflicting_metadata(monkeypatch):
 @pytest.mark.parametrize("model,options", [
     ("openai/gpt-4o", {"custom_llm_provider": "alternate"}),
     ("openai/gpt-4o", {"headers": {"x-test": "yes"}}),
-    ("openai/gpt-4o", {"timeout": 10}),
     ("azure/gpt-4o", {"api_base": "https://example.invalid"}),
     ("unmapped/model", {}),
     ("openai/gpt-4o", {"model_type": "text"}),

--- a/tests/clients/test_lm15_read_timeout.py
+++ b/tests/clients/test_lm15_read_timeout.py
@@ -14,7 +14,7 @@ from dspy._vendor.lm15.transports import StdlibTransport
 from dspy._vendor.lm15.transports._async import StdlibAsyncTransport
 from dspy.clients.backend_selection import select_backend
 from dspy.clients.engines import AsyncLM15Engine, LiteLLMEngine, LM15Engine
-from dspy.clients.engines.lm15_engine import read_timeout_seconds
+from dspy.clients.engines.lm15_engine import UNSET, read_timeout_seconds
 from dspy.clients.execution import _engine, prepare
 from dspy.lm15 import Message, Request, RouterConfig
 
@@ -39,10 +39,10 @@ def test_completion_requests_defer_to_the_transport_read_timeout(dialect):
 
 
 @pytest.mark.parametrize("dialect", DIALECTS)
-def test_streaming_requests_keep_their_per_chunk_read_timeout(dialect):
+def test_streaming_requests_defer_to_the_transport_read_timeout(dialect):
     provider = provider_for(dialect, FakeTransport())
     wire = provider.build_request(request_for(dialect), stream=True)
-    assert wire.read_timeout == 120.0
+    assert wire.read_timeout is None
 
 
 @pytest.mark.parametrize("transport_cls", [StdlibTransport, StdlibAsyncTransport])
@@ -88,8 +88,9 @@ def chat_server():
         server.server_close()
 
 
-def test_router_transport_read_timeout_governs_completion_header_wait(chat_server):
-    transport = _RecordingTransport(read_timeout=900)
+@pytest.mark.parametrize("read_timeout", [900, None])
+def test_router_transport_read_timeout_governs_completion_header_wait(chat_server, read_timeout):
+    transport = _RecordingTransport(read_timeout=read_timeout)
     config = RouterConfig(env={}, api_keys={"openai-chat": "fake"}, base_urls={"openai-chat": chat_server},
                           transport=transport)
     provider = LMRouter(config).lm("openai-chat:gpt-5")
@@ -98,7 +99,7 @@ def test_router_transport_read_timeout_governs_completion_header_wait(chat_serve
     finally:
         transport.close()
     assert response.message.text == "hi"
-    assert transport.header_waits == [900]
+    assert transport.header_waits == [read_timeout]
 
 
 @pytest.fixture
@@ -128,6 +129,31 @@ def test_lm_httpx_timeout_uses_its_read_component(no_gateway_env):
         assert backend.config.transport._read_timeout == 450.0
     finally:
         backend.close()
+
+
+def test_lm_httpx_timeout_without_read_bound_waits_without_limit(no_gateway_env):
+    httpx = pytest.importorskip("httpx")
+    lm = dspy.LM("openai/gpt-5", api_key="fake", timeout=httpx.Timeout(None))
+    backend, _, _ = _engine(lm, prepare(lm, "hello", None, {}), False)
+    try:
+        assert backend.config.transport is not None
+        assert backend.config.transport._read_timeout is None
+    finally:
+        backend.close()
+
+
+def test_equal_httpx_timeouts_share_one_engine(no_gateway_env):
+    httpx = pytest.importorskip("httpx")
+    lm = dspy.LM("openai/gpt-5", api_key="fake")
+    backends = []
+    for _ in range(2):
+        call = prepare(lm, "hello", None, {"timeout": httpx.Timeout(10, read=450)})
+        backends.append(_engine(lm, call, False)[0])
+    try:
+        assert backends[0] is backends[1]
+        assert len(lm._engine_store) == 1
+    finally:
+        backends[0].close()
 
 
 def test_lm_without_timeout_keeps_the_router_default_transport(no_gateway_env):
@@ -161,11 +187,11 @@ def test_async_lm_timeout_configures_an_async_transport(no_gateway_env):
     asyncio.run(build())
 
 
-@pytest.mark.parametrize("timeout", [0, -5, "600", True])
+@pytest.mark.parametrize("timeout", [0, -5, "600", True, float("nan"), float("inf")])
 def test_read_timeout_seconds_rejects_unusable_values(timeout):
     with pytest.raises((TypeError, ValueError)):
         read_timeout_seconds(timeout)
 
 
 def test_read_timeout_seconds_keeps_the_default_for_none():
-    assert read_timeout_seconds(None) is None
+    assert read_timeout_seconds(None) is UNSET

--- a/tests/clients/test_lm15_read_timeout.py
+++ b/tests/clients/test_lm15_read_timeout.py
@@ -1,0 +1,171 @@
+"""Native completions wait for slow first bytes and honor a caller's timeout."""
+
+import asyncio
+import http.server
+import json
+import threading
+
+import pytest
+
+import dspy
+from dspy._vendor.lm15.router import LMRouter
+from dspy._vendor.lm15.testing import FakeTransport
+from dspy._vendor.lm15.transports import StdlibTransport
+from dspy._vendor.lm15.transports._async import StdlibAsyncTransport
+from dspy.clients.backend_selection import select_backend
+from dspy.clients.engines import AsyncLM15Engine, LiteLLMEngine, LM15Engine
+from dspy.clients.engines.lm15_engine import read_timeout_seconds
+from dspy.clients.execution import _engine, prepare
+from dspy.lm15 import Message, Request, RouterConfig
+
+DIALECTS = ["openai-chat", "openai", "anthropic", "gemini"]
+MODELS = {"openai-chat": "gpt-5", "openai": "gpt-5", "anthropic": "claude-opus-5", "gemini": "gemini-2.5-pro"}
+
+
+def provider_for(dialect, transport):
+    config = RouterConfig(env={}, api_keys={dialect: "fake"}, transport=transport)
+    return LMRouter(config).lm(f"{dialect}:{MODELS[dialect]}")
+
+
+def request_for(dialect):
+    return Request(model=MODELS[dialect], messages=(Message.user("hello"),))
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_completion_requests_defer_to_the_transport_read_timeout(dialect):
+    provider = provider_for(dialect, FakeTransport())
+    wire = provider.build_request(request_for(dialect), stream=False)
+    assert wire.read_timeout is None
+
+
+@pytest.mark.parametrize("dialect", DIALECTS)
+def test_streaming_requests_keep_their_per_chunk_read_timeout(dialect):
+    provider = provider_for(dialect, FakeTransport())
+    wire = provider.build_request(request_for(dialect), stream=True)
+    assert wire.read_timeout == 120.0
+
+
+@pytest.mark.parametrize("transport_cls", [StdlibTransport, StdlibAsyncTransport])
+def test_transport_default_read_timeout_matches_litellm(transport_cls):
+    assert transport_cls()._read_timeout == 600.0
+
+
+class _ChatServer(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        self.rfile.read(int(self.headers.get("Content-Length", 0)))
+        body = json.dumps({"id": "r", "model": "gpt-5", "choices": [
+            {"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}
+        ], "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+class _RecordingTransport(StdlibTransport):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.header_waits = []
+
+    def _read_head(self, conn, *, read_timeout):
+        self.header_waits.append(read_timeout)
+        return super()._read_head(conn, read_timeout=read_timeout)
+
+
+@pytest.fixture
+def chat_server():
+    server = http.server.HTTPServer(("127.0.0.1", 0), _ChatServer)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/v1"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_router_transport_read_timeout_governs_completion_header_wait(chat_server):
+    transport = _RecordingTransport(read_timeout=900)
+    config = RouterConfig(env={}, api_keys={"openai-chat": "fake"}, base_urls={"openai-chat": chat_server},
+                          transport=transport)
+    provider = LMRouter(config).lm("openai-chat:gpt-5")
+    try:
+        response = provider.complete(request_for("openai-chat"))
+    finally:
+        transport.close()
+    assert response.message.text == "hi"
+    assert transport.header_waits == [900]
+
+
+@pytest.fixture
+def no_gateway_env(monkeypatch):
+    for name in ("OPENAI_API_BASE", "OPENAI_BASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.mark.parametrize("timeout", [600, 600.0])
+def test_lm_timeout_stays_native_and_configures_the_transport(timeout, no_gateway_env):
+    lm = dspy.LM("openai/gpt-5", api_key="fake", timeout=timeout)
+    assert select_backend(lm).native is True
+    backend, _, _ = _engine(lm, prepare(lm, "hello", None, {}), False)
+    try:
+        assert isinstance(backend, LM15Engine)
+        assert backend.config.transport._read_timeout == 600.0
+    finally:
+        backend.close()
+
+
+def test_lm_httpx_timeout_uses_its_read_component(no_gateway_env):
+    httpx = pytest.importorskip("httpx")
+    lm = dspy.LM("openai/gpt-5", api_key="fake", timeout=httpx.Timeout(10, read=450))
+    assert select_backend(lm).native is True
+    backend, _, _ = _engine(lm, prepare(lm, "hello", None, {}), False)
+    try:
+        assert backend.config.transport._read_timeout == 450.0
+    finally:
+        backend.close()
+
+
+def test_lm_without_timeout_keeps_the_router_default_transport(no_gateway_env):
+    lm = dspy.LM("openai/gpt-5", api_key="fake")
+    backend, _, _ = _engine(lm, prepare(lm, "hello", None, {}), False)
+    try:
+        assert backend.config.transport is None
+    finally:
+        backend.close()
+
+
+def test_lm_timeout_on_litellm_engine_is_unchanged(no_gateway_env):
+    lm = dspy.LM("openai/gpt-5", engine="litellm", timeout=600)
+    assert select_backend(lm).native is False
+    backend, _, _ = _engine(lm, prepare(lm, "hello", None, {}), False)
+    assert isinstance(backend, LiteLLMEngine)
+    assert backend.client_options["timeout"] == 600
+
+
+def test_async_lm_timeout_configures_an_async_transport(no_gateway_env):
+    async def build():
+        lm = dspy.LM("openai/gpt-5", api_key="fake", timeout=600)
+        backend, _, _ = _engine(lm, prepare(lm, "hello", None, {}), True)
+        try:
+            assert isinstance(backend, AsyncLM15Engine)
+            assert isinstance(backend.config.transport, StdlibAsyncTransport)
+            assert backend.config.transport._read_timeout == 600.0
+        finally:
+            await backend.aclose()
+
+    asyncio.run(build())
+
+
+@pytest.mark.parametrize("timeout", [0, -5, "600", True])
+def test_read_timeout_seconds_rejects_unusable_values(timeout):
+    with pytest.raises((TypeError, ValueError)):
+        read_timeout_seconds(timeout)
+
+
+def test_read_timeout_seconds_keeps_the_default_for_none():
+    assert read_timeout_seconds(None) is None


### PR DESCRIPTION
## Symptom

A GEPA run with `dspy.LM("openai/gpt-5.6-sol")` as the reflection LM failed every reflection call after the first iteration on the native lm15 engine:

```
dspy.utils.exceptions.LMTransportError: [openai/gpt-5.6-sol] read timed out waiting for headers: The read operation timed out
```

Each failure took about four minutes. The engine waited 60 seconds for response headers, and DSPy retried three more times with backoff. The same prompts succeed with `engine="litellm"`, because LiteLLM waits 600 seconds by default. Reasoning models with large prompts often need more than a minute before the first byte.

## Cause

There were three parts.

1. Every dialect hardcoded `read_timeout=120.0 if stream else 60.0` in its `build_request`. This affected `openai.py`, `openai_chat.py`, `anthropic.py`, and `gemini.py`.
2. The transports resolve the timeout as `request.read_timeout or self._read_timeout`. Because the dialect always set the request value, a transport configured through `RouterConfig(transport=StdlibTransport(read_timeout=900))` was never consulted for completions. That is the remedy `router.py` names for the `timeout` keyword, so the documented remedy did not work.
3. On the DSPy side, `timeout` was in `CLIENT_KEYS` but not in `NATIVE_CLIENT_KEYS`. Passing `dspy.LM(model, timeout=600)` silently moved the whole LM to LiteLLM instead of applying the timeout natively.

## Change

For part A and part B, I chose the transport default approach. The four dialects now pass `read_timeout=None` for completions, streamed or not, through a shared `COMPLETION_READ_TIMEOUT` constant in `providers/common.py`, and both stdlib transports raise `_DEFAULT_READ_TIMEOUT` from 60 to 600 seconds. Every other endpoint in the four dialects passes its own explicit read timeout, so the module default only reaches completion requests. A caller's transport timeout now wins because the request no longer carries a value.

Streams use the same transport value for the header wait and for each chunk read. The transports apply one `read_timeout` to both, so an explicit per request value for streams would have overridden the caller's timeout for the first byte as well. The default gap between chunks is therefore 600 seconds instead of 120, which is also what LiteLLM's httpx read timeout allows on a stream.

For part C, `timeout` joins `NATIVE_CLIENT_KEYS`. `LM15Engine` and `AsyncLM15Engine` accept a `read_timeout` keyword. When one is given and the config has no transport, the engine builds a `StdlibTransport` or `StdlibAsyncTransport` with that read timeout, shares it across the providers it constructs, and closes it on `close()` or `aclose()`. A `RouterConfig` that already carries a transport is left alone. The new `read_timeout_seconds` helper accepts a positive finite int or float in seconds, or an `httpx.Timeout`, and reads its `.read` component the way LiteLLM does. An `httpx.Timeout` with `read=None` builds a transport with no read bound, matching httpx. Without `timeout`, no custom transport is built and the 600 second default applies. The engine store keys on the normalized seconds, so equal `httpx.Timeout` objects passed per call share one engine.

The `engine="litellm"` path is unchanged. `timeout` still reaches the LiteLLM engine as before.

## Why 600

LiteLLM's completion path defaults the request timeout to 600 seconds and applies it as the httpx read timeout. Users moving from LiteLLM to the native engine keep the same wait for the first byte.

## User facing changes

- `dspy.LM(model, timeout=N)` now works on the native engine. It no longer forces a fallback to LiteLLM.
- `RouterConfig(transport=StdlibTransport(read_timeout=N))` now controls the completion header wait.
- Completions on lm15 wait up to 600 seconds for headers instead of 60, and streams wait up to 600 seconds per chunk instead of 120. Anyone who relied on a fast failure at 60 seconds will see longer waits on a stalled request. DSPy's own retry loop still applies on top of this, so a stalled request with the default `num_retries=3` can take four attempts before the error surfaces. Pass `timeout=` to `dspy.LM` to restore a shorter bound.

## Vendored code

This PR edits files under `dspy/_vendor/lm15/` by hand. `dspy/_vendor/UPDATING.md` says not to do that and asks for changes to land in `cmpnd-ai/lm15-python` first. The vendored lm15 is at version `1.0.0a1`. Every earlier commit to that tree was a re-vendor with a provenance bump, so this would be the first local edit, and the updater script will stop on the next update until the same change lands upstream. The lm15 side of this change is small, so it should be easy to upstream. I can split the PR so the DSPy side waits on a re-vendor if maintainers prefer that.

## Tests

`tests/clients/test_lm15_read_timeout.py` adds the following. All of them failed before the change.

- Each of the four dialects produces a `TransportRequest` with `read_timeout` of `None`, for both streaming and non-streaming completions.
- Both stdlib transports default to a 600 second read timeout.
- A `StdlibTransport(read_timeout=900)` passed through `RouterConfig(transport=...)` waits 900 seconds for headers on a completion against a local HTTP server. The same test with `read_timeout=None` waits without a bound.
- `dspy.LM("openai/gpt-5", timeout=600)` still selects the native engine, and the engine's transport has a 600 second read timeout, for both the sync and async engines.
- An `httpx.Timeout` uses its `read` component, and `httpx.Timeout(None)` builds a transport with no read bound.
- Two calls with equal but distinct `httpx.Timeout` objects share one engine.
- Zero, negative, NaN, infinite, string, and boolean timeouts are rejected.
- `dspy.LM("openai/gpt-5", engine="litellm", timeout=600)` still goes to LiteLLM with `timeout` intact.

One existing case in `tests/clients/test_backend_capabilities.py` asserted that `timeout` forces LiteLLM, and I removed that case. `tests/clients`, `tests/test_vendored_lm15.py`, `tests/streaming`, `tests/callback`, and `tests/utils` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JUHrZgUg3mszx9zUi59Ytf
